### PR TITLE
Fix macOS app failing to launch from Finder

### DIFF
--- a/codex_session_delete/macos_installer.py
+++ b/codex_session_delete/macos_installer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import plistlib
 import shutil
 import stat
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -16,7 +17,10 @@ EXECUTABLE_NAME = "CodexPlusPlus"
 
 
 def _launcher_command(options: "InstallOptions") -> str:
-    return options.launcher_command or "python -m codex_session_delete launch"
+    if options.launcher_command:
+        return options.launcher_command
+    python = shutil.which("python3") or shutil.which("python") or sys.executable
+    return f"{python} -m codex_session_delete launch"
 
 
 def _app_root(options: "InstallOptions") -> Path:

--- a/codex_session_delete/macos_installer.py
+++ b/codex_session_delete/macos_installer.py
@@ -19,8 +19,7 @@ EXECUTABLE_NAME = "CodexPlusPlus"
 def _launcher_command(options: "InstallOptions") -> str:
     if options.launcher_command:
         return options.launcher_command
-    python = shutil.which("python3") or shutil.which("python") or sys.executable
-    return f"{python} -m codex_session_delete launch"
+    return f"{sys.executable} -m codex_session_delete launch"
 
 
 def _app_root(options: "InstallOptions") -> Path:


### PR DESCRIPTION
Summary

  - python -m codex_session_delete setup 生成的 .app 启动脚本使用了裸命令 python，从 Finder/Launchpad 启动时由于没有用户 shell 的 PATH
  环境变量，导致找不到 python 而无法运行
  - 改用 sys.executable 写入启动脚本，确保使用执行 setup 时的 Python 解释器完整路径（如
  /Users/.../miniconda3/bin/python），该解释器一定安装了 codex_session_delete 模块
  - 避免了 shutil.which("python3") 可能解析到系统 Xcode Python（/Library/Developer/CommandLineTools/usr/bin/python3）导致 No module named
   codex_session_delete 的问题

  Test plan

  - 运行 python -m pytest tests/ 确认全部 56 个测试通过
  - 运行 python -m codex_session_delete setup 重新安装 app
  - 检查 /Applications/Codex++.app/Contents/MacOS/CodexPlusPlus 中的 Python 路径是否为完整绝对路径
  - 从 Finder 双击 Codex++.app 确认可以正常启动