### PR TITLE
Fix Windows MSIX launch and English Plugins unlock

### DIFF
--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -322,7 +322,7 @@
   function enablePluginEntry() {
     if (!codexPlusSettings().pluginEntryUnlock) return;
     const buttons = Array.from(document.querySelectorAll("button"));
-    const pluginButton = buttons.find((element) => (element.textContent || "").trim() === "插件");
+    const pluginButton = buttons.find((element) => /^(插件|Plugins)$/i.test((element.textContent || "").trim()));
     if (!pluginButton) return;
     spoofChatGPTAuthMethod(pluginButton);
     pluginButton.disabled = false;

--- a/codex_session_delete/launcher.py
+++ b/codex_session_delete/launcher.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import ctypes
 import subprocess
+import sys
 import threading
 import time
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -38,17 +41,123 @@ class InjectedHelperServer(HelperServer):
     bridge_socket: Any = None
 
 
-def build_codex_command(app_dir: Path, debug_port: int) -> list[str]:
-    if app_dir.suffix == ".app":
-        exe = app_dir / "Contents" / "MacOS" / "Codex"
-    else:
-        candidates = [app_dir / "Codex.exe", app_dir / "codex.exe"]
-        exe = next((path for path in candidates if path.exists()), candidates[-1])
+def build_codex_arguments(debug_port: int) -> list[str]:
     return [
-        str(exe),
         f"--remote-debugging-port={debug_port}",
         f"--remote-allow-origins=http://127.0.0.1:{debug_port}",
     ]
+
+
+def build_codex_executable(app_dir: Path) -> Path:
+    if app_dir.suffix == ".app":
+        return app_dir / "Contents" / "MacOS" / "Codex"
+    else:
+        candidates = [app_dir / "Codex.exe", app_dir / "codex.exe"]
+        return next((path for path in candidates if path.exists()), candidates[-1])
+
+
+def build_codex_command(app_dir: Path, debug_port: int) -> list[str]:
+    return [str(build_codex_executable(app_dir)), *build_codex_arguments(debug_port)]
+
+
+def packaged_app_user_model_id(app_dir: Path) -> str | None:
+    package_dir = app_dir.parent if app_dir.name.lower() == "app" else app_dir
+    if not package_dir.name.startswith("OpenAI.Codex_") or "__" not in package_dir.name:
+        return None
+    identity_name = package_dir.name.split("_", 1)[0]
+    publisher_id = package_dir.name.rsplit("__", 1)[1]
+    if not publisher_id:
+        return None
+    return f"{identity_name}_{publisher_id}!App"
+
+
+class _GUID(ctypes.Structure):
+    _fields_ = [
+        ("Data1", ctypes.c_uint32),
+        ("Data2", ctypes.c_uint16),
+        ("Data3", ctypes.c_uint16),
+        ("Data4", ctypes.c_ubyte * 8),
+    ]
+
+    def __init__(self, value: str):
+        parsed = uuid.UUID(value)
+        data4 = bytes([parsed.clock_seq_hi_variant, parsed.clock_seq_low]) + parsed.node.to_bytes(6, "big")
+        super().__init__(parsed.time_low, parsed.time_mid, parsed.time_hi_version, (ctypes.c_ubyte * 8)(*data4))
+
+
+def _raise_for_hresult(hr: int, operation: str) -> None:
+    if hr < 0:
+        raise OSError(f"{operation} failed with HRESULT 0x{hr & 0xFFFFFFFF:08X}")
+
+
+def activate_packaged_app(app_user_model_id: str, arguments: str) -> int:
+    if sys.platform != "win32":
+        raise RuntimeError("Packaged app activation is only supported on Windows")
+
+    ole32 = ctypes.OleDLL("ole32")
+    ole32.CoInitializeEx.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+    ole32.CoInitializeEx.restype = ctypes.c_long
+    ole32.CoUninitialize.argtypes = []
+    ole32.CoUninitialize.restype = None
+    ole32.CoCreateInstance.argtypes = [
+        ctypes.POINTER(_GUID),
+        ctypes.c_void_p,
+        ctypes.c_ulong,
+        ctypes.POINTER(_GUID),
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+    ole32.CoCreateInstance.restype = ctypes.c_long
+
+    coinit_hr = ole32.CoInitializeEx(None, 2)
+    should_uninitialize = coinit_hr >= 0
+    if coinit_hr < 0 and coinit_hr != -2147417850:  # RPC_E_CHANGED_MODE
+        _raise_for_hresult(coinit_hr, "CoInitializeEx")
+
+    activation_manager = ctypes.c_void_p()
+    try:
+        clsid = _GUID("45BA127D-10A8-46EA-8AB7-56EA9078943C")
+        iid = _GUID("2e941141-7f97-4756-ba1d-9decde894a3d")
+        _raise_for_hresult(
+            ole32.CoCreateInstance(ctypes.byref(clsid), None, 1, ctypes.byref(iid), ctypes.byref(activation_manager)),
+            "CoCreateInstance(ApplicationActivationManager)",
+        )
+
+        activate_application_type = ctypes.WINFUNCTYPE(
+            ctypes.c_long,
+            ctypes.c_void_p,
+            ctypes.c_wchar_p,
+            ctypes.c_wchar_p,
+            ctypes.c_ulong,
+            ctypes.POINTER(ctypes.c_ulong),
+        )
+        release_type = ctypes.WINFUNCTYPE(ctypes.c_ulong, ctypes.c_void_p)
+
+        vtable = ctypes.cast(activation_manager, ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p))).contents
+        activate_application = activate_application_type(vtable[3])
+        release = release_type(vtable[2])
+
+        process_id = ctypes.c_ulong()
+        _raise_for_hresult(
+            activate_application(activation_manager, app_user_model_id, arguments, 0, ctypes.byref(process_id)),
+            "ActivateApplication",
+        )
+        return int(process_id.value)
+    finally:
+        if activation_manager.value:
+            release = ctypes.WINFUNCTYPE(ctypes.c_ulong, ctypes.c_void_p)(
+                ctypes.cast(activation_manager, ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p))).contents[2]
+            )
+            release(activation_manager)
+        if should_uninitialize:
+            ole32.CoUninitialize()
+
+
+def launch_codex_app(app_dir: Path, debug_port: int) -> int | None:
+    app_user_model_id = packaged_app_user_model_id(app_dir) if sys.platform == "win32" else None
+    if app_user_model_id:
+        return activate_packaged_app(app_user_model_id, subprocess.list2cmdline(build_codex_arguments(debug_port)))
+    subprocess.Popen(build_codex_command(app_dir, debug_port))
+    return None
 
 
 def start_helper(service, host: str = "127.0.0.1", port: int = 57321) -> HelperServer:
@@ -77,7 +186,7 @@ def launch_and_inject(app_dir: Path | None, db_path: Path | None, backup_dir: Pa
         raise RuntimeError("Codex App directory not found")
     service = ApiFirstDeleteService(UnavailableApiAdapter(), db_path, backup_dir)
     server = start_helper(service, port=helper_port)
-    subprocess.Popen(build_codex_command(resolved_app_dir, debug_port))
+    launch_codex_app(resolved_app_dir, debug_port)
     script_path = Path(__file__).parent / "inject" / "renderer-inject.js"
     server.bridge_socket = inject_with_retry(debug_port, script_path, server.port, service)
     return server

--- a/tests/test_launcher_cli.py
+++ b/tests/test_launcher_cli.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from codex_session_delete import cli, launcher
-from codex_session_delete.launcher import build_codex_command
+from codex_session_delete.launcher import build_codex_command, packaged_app_user_model_id
 
 
 class FakeServer:
@@ -40,6 +40,39 @@ def test_build_codex_command_supports_macos_app_bundle(tmp_path):
     assert command[0] == str(executable)
     assert "--remote-debugging-port=9229" in command
     assert "--remote-allow-origins=http://127.0.0.1:9229" in command
+
+
+def test_packaged_app_user_model_id_from_windowsapps_path():
+    app_dir = Path("C:/Program Files/WindowsApps/OpenAI.Codex_26.506.2212.0_x64__2p2nqsd0c76g0/app")
+
+    assert packaged_app_user_model_id(app_dir) == "OpenAI.Codex_2p2nqsd0c76g0!App"
+
+
+def test_packaged_app_user_model_id_ignores_non_packaged_path():
+    app_dir = Path("C:/Codex/app")
+
+    assert packaged_app_user_model_id(app_dir) is None
+
+
+def test_launch_uses_packaged_activation_for_windowsapps(monkeypatch):
+    app_dir = Path("C:/Program Files/WindowsApps/OpenAI.Codex_26.506.2212.0_x64__2p2nqsd0c76g0/app")
+    activated = []
+    launched = []
+    monkeypatch.setattr(launcher.sys, "platform", "win32")
+    monkeypatch.setattr(
+        launcher,
+        "activate_packaged_app",
+        lambda aumid, arguments: activated.append((aumid, arguments)) or 1234,
+    )
+    monkeypatch.setattr(launcher.subprocess, "Popen", lambda command: launched.append(command))
+
+    assert launcher.launch_codex_app(app_dir, 9229) == 1234
+
+    assert activated == [(
+        "OpenAI.Codex_2p2nqsd0c76g0!App",
+        "--remote-debugging-port=9229 --remote-allow-origins=http://127.0.0.1:9229",
+    )]
+    assert launched == []
 
 
 def test_cli_keeps_helper_server_alive_after_injection(monkeypatch):

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -37,6 +37,7 @@ def test_renderer_script_positions_delete_button_without_affecting_layout():
 def test_renderer_script_enables_plugin_entry_for_api_key_users():
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
     assert "enablePluginEntry" in text
+    assert "Plugins" in text
     assert "disabled = false" in text
     assert "removeAttribute(\"disabled\")" in text
     assert "setAuthMethod(\"chatgpt\")" in text


### PR DESCRIPTION
## Summary
- launch Windows Store/MSIX Codex installs through packaged app activation instead of direct WindowsApps executable startup
- keep the existing direct executable path for macOS and unpackaged installs
- unlock the plugin sidebar entry when the Codex UI label is English Plugins as well as Chinese 插件

## Problem fixed
On Windows, Codex++ could silently fail when the shortcut used pythonw.exe because launching C:\Program Files\WindowsApps\...\Codex.exe directly raised PermissionError: [WinError 5] Access is denied.

After launch was fixed, the plugin entry could still remain disabled for API key users because current Codex builds render the sidebar item as Plugins, while the injector only searched for 插件.

## Verification
- python -m pytest -q -> 63 passed
- 
ode --check codex_session_delete\\inject\\renderer-inject.js
- Manual Windows verification: Codex++ launched Codex on remote debugging port 9229, injected the helper, and enabled Plugins with auth method spoofed to chatgpt.