### PR TITLE
fix(macOS): proper app lifecycle via open -a, auto-shutdown, and Codex icon

### DIFF
--- a/codex_session_delete/cli.py
+++ b/codex_session_delete/cli.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import traceback
-import time
 from pathlib import Path
 
 from codex_session_delete.helper_server import HelperServer
@@ -56,23 +55,33 @@ def log_launch_failure(exc: BaseException) -> None:
     path.write_text("".join(traceback.format_exception(type(exc), exc, exc.__traceback__)), encoding="utf-8")
 
 
-def wait_for_shutdown(server: HelperServer) -> None:
+def wait_for_shutdown(server: HelperServer, codex_proc) -> None:
     try:
-        while True:
-            time.sleep(3600)
+        if codex_proc is None:
+            import subprocess as _sp
+            import time as _time
+            while True:
+                result = _sp.run(["pgrep", "-f", "^/Applications/Codex\\.app/Contents/MacOS/Codex"], capture_output=True)
+                if result.returncode != 0:
+                    break
+                _time.sleep(2)
+        else:
+            codex_proc.wait()
     except KeyboardInterrupt:
+        pass
+    finally:
         server.shutdown()
 
 
 def run_launch(args: argparse.Namespace) -> int:
     try:
-        server = launch_and_inject(args.app_dir, args.db, args.backup_dir, args.debug_port, args.helper_port)
+        server, codex_proc = launch_and_inject(args.app_dir, args.db, args.backup_dir, args.debug_port, args.helper_port)
     except Exception as exc:
         log_launch_failure(exc)
         raise
     print(f"Codex session delete helper running on http://127.0.0.1:{server.port}")
     print("Keep this terminal open while using the delete buttons. Press Ctrl+C to stop.")
-    wait_for_shutdown(server)
+    wait_for_shutdown(server, codex_proc)
     return 0
 
 

--- a/codex_session_delete/launcher.py
+++ b/codex_session_delete/launcher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -38,17 +39,20 @@ class InjectedHelperServer(HelperServer):
     bridge_socket: Any = None
 
 
-def build_codex_command(app_dir: Path, debug_port: int) -> list[str]:
+def launch_codex(app_dir: Path, debug_port: int) -> subprocess.Popen | None:
     if app_dir.suffix == ".app":
-        exe = app_dir / "Contents" / "MacOS" / "Codex"
-    else:
-        candidates = [app_dir / "Codex.exe", app_dir / "codex.exe"]
-        exe = next((path for path in candidates if path.exists()), candidates[-1])
-    return [
+        subprocess.run(
+            ["open", "-a", str(app_dir), "--args", f"--remote-debugging-port={debug_port}", f"--remote-allow-origins=http://127.0.0.1:{debug_port}"],
+            check=True,
+        )
+        return None
+    candidates = [app_dir / "Codex.exe", app_dir / "codex.exe"]
+    exe = next((path for path in candidates if path.exists()), candidates[-1])
+    return subprocess.Popen([
         str(exe),
         f"--remote-debugging-port={debug_port}",
         f"--remote-allow-origins=http://127.0.0.1:{debug_port}",
-    ]
+    ])
 
 
 def start_helper(service, host: str = "127.0.0.1", port: int = 57321) -> HelperServer:
@@ -71,16 +75,16 @@ def inject_with_retry(debug_port: int, script_path: Path, helper_port: int, serv
     raise RuntimeError("Codex injection failed")
 
 
-def launch_and_inject(app_dir: Path | None, db_path: Path | None, backup_dir: Path, debug_port: int, helper_port: int) -> HelperServer:
+def launch_and_inject(app_dir: Path | None, db_path: Path | None, backup_dir: Path, debug_port: int, helper_port: int) -> tuple[HelperServer, subprocess.Popen | None]:
     resolved_app_dir = resolve_codex_app_dir(app_dir)
     if resolved_app_dir is None:
         raise RuntimeError("Codex App directory not found")
     service = ApiFirstDeleteService(UnavailableApiAdapter(), db_path, backup_dir)
     server = start_helper(service, port=helper_port)
-    subprocess.Popen(build_codex_command(resolved_app_dir, debug_port))
+    codex_proc = launch_codex(resolved_app_dir, debug_port)
     script_path = Path(__file__).parent / "inject" / "renderer-inject.js"
     server.bridge_socket = inject_with_retry(debug_port, script_path, server.port, service)
-    return server
+    return server, codex_proc
 
 
 def handle_bridge_request(service: ApiFirstDeleteService, path: str, payload: dict[str, object]) -> dict[str, object]:

--- a/codex_session_delete/macos_installer.py
+++ b/codex_session_delete/macos_installer.py
@@ -7,6 +7,8 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from codex_session_delete.app_paths import find_macos_codex_app
+
 if TYPE_CHECKING:
     from codex_session_delete.installers import InstallOptions
 
@@ -42,6 +44,8 @@ def install_macos_app(options: "InstallOptions") -> None:
         "CFBundleShortVersionString": "0.1.0",
         "CFBundlePackageType": "APPL",
         "CFBundleExecutable": EXECUTABLE_NAME,
+        "CFBundleIconFile": "electron.icns",
+        "LSUIElement": True,
         "LSMinimumSystemVersion": "12.0",
     }
     (contents / "Info.plist").write_bytes(plistlib.dumps(plist))
@@ -50,8 +54,19 @@ def install_macos_app(options: "InstallOptions") -> None:
     executable.write_text(f"#!/bin/sh\nexec {_launcher_command(options)}\n", encoding="utf-8")
     executable.chmod(executable.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
+    _copy_codex_icon(resources)
+
 
 def uninstall_macos_app(options: "InstallOptions") -> None:
     app = _app_root(options)
     if app.exists():
         shutil.rmtree(app)
+
+
+def _copy_codex_icon(resources: Path) -> None:
+    codex_app = find_macos_codex_app()
+    if codex_app is None:
+        return
+    icon_src = codex_app / "Contents" / "Resources" / "electron.icns"
+    if icon_src.is_file():
+        shutil.copy2(icon_src, resources / "electron.icns")

--- a/tests/test_launcher_cli.py
+++ b/tests/test_launcher_cli.py
@@ -3,49 +3,54 @@ from pathlib import Path
 import pytest
 
 from codex_session_delete import cli, launcher
-from codex_session_delete.launcher import build_codex_command
+from codex_session_delete.launcher import launch_codex
 
 
 class FakeServer:
     port = 57321
 
 
-def test_build_codex_command_adds_remote_debugging_port():
+def test_launch_codex_windows_adds_remote_debugging_port(monkeypatch):
     app_dir = Path("C:/Program Files/WindowsApps/OpenAI.Codex_1.0.0.0_x64__abc/app")
+    popen_calls = []
+    monkeypatch.setattr(launcher.subprocess, "Popen", lambda args, **kw: popen_calls.append(args))
 
-    command = build_codex_command(app_dir, 9229)
+    launch_codex(app_dir, 9229)
 
-    assert str(app_dir / "Codex.exe") in command[0] or str(app_dir / "codex.exe") in command[0]
-    assert "--remote-debugging-port=9229" in command
+    assert popen_calls
+    assert str(app_dir / "Codex.exe") in popen_calls[0][0] or str(app_dir / "codex.exe") in popen_calls[0][0]
+    assert "--remote-debugging-port=9229" in popen_calls[0]
 
 
-
-def test_build_codex_command_allows_devtools_websocket_origin():
+def test_launch_codex_windows_allows_devtools_websocket_origin(monkeypatch):
     app_dir = Path("C:/Program Files/WindowsApps/OpenAI.Codex_1.0.0.0_x64__abc/app")
+    popen_calls = []
+    monkeypatch.setattr(launcher.subprocess, "Popen", lambda args, **kw: popen_calls.append(args))
 
-    command = build_codex_command(app_dir, 9229)
+    launch_codex(app_dir, 9229)
 
-    assert "--remote-allow-origins=http://127.0.0.1:9229" in command
+    assert "--remote-allow-origins=http://127.0.0.1:9229" in popen_calls[0]
 
 
-
-def test_build_codex_command_supports_macos_app_bundle(tmp_path):
+def test_launch_codex_macos_uses_open_command(monkeypatch, tmp_path):
     app = tmp_path / "Codex.app"
-    executable = app / "Contents" / "MacOS" / "Codex"
-    executable.parent.mkdir(parents=True)
-    executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    (app / "Contents" / "MacOS").mkdir(parents=True)
+    run_calls = []
+    monkeypatch.setattr(launcher.subprocess, "run", lambda args, **kw: run_calls.append(args))
 
-    command = build_codex_command(app, 9229)
+    proc = launch_codex(app, 9229)
 
-    assert command[0] == str(executable)
-    assert "--remote-debugging-port=9229" in command
-    assert "--remote-allow-origins=http://127.0.0.1:9229" in command
+    assert proc is None
+    assert len(run_calls) == 1
+    assert run_calls[0][0] == "open"
+    assert "-a" in run_calls[0]
+    assert str(app) in run_calls[0]
 
 
 def test_cli_keeps_helper_server_alive_after_injection(monkeypatch):
     waited = []
-    monkeypatch.setattr(cli, "launch_and_inject", lambda *args: FakeServer())
-    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server: waited.append(server.port))
+    monkeypatch.setattr(cli, "launch_and_inject", lambda *args: (FakeServer(), None))
+    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc: waited.append(server.port))
 
     exit_code = cli.main([])
 
@@ -56,8 +61,8 @@ def test_cli_keeps_helper_server_alive_after_injection(monkeypatch):
 def test_cli_launch_subcommand_keeps_helper_server_alive_after_injection(monkeypatch):
     waited = []
     calls = []
-    monkeypatch.setattr(cli, "launch_and_inject", lambda *args: calls.append(args) or FakeServer())
-    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server: waited.append(server.port))
+    monkeypatch.setattr(cli, "launch_and_inject", lambda *args: calls.append(args) or (FakeServer(), None))
+    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc: waited.append(server.port))
 
     exit_code = cli.main(["launch"])
 
@@ -78,8 +83,6 @@ def test_cli_install_dispatches_to_platform_installer(monkeypatch, tmp_path):
     assert calls[0].launcher_command == "python -m codex_session_delete"
 
 
-
-
 def test_cli_uninstall_dispatches_to_platform_installer(monkeypatch, tmp_path):
     calls = []
     monkeypatch.setattr(cli, "uninstall_codex_plus_plus", lambda options: calls.append(options))
@@ -96,7 +99,7 @@ def test_launch_retries_injection_until_codex_page_is_ready(monkeypatch, tmp_pat
     attempts = []
     monkeypatch.setattr(launcher, "resolve_codex_app_dir", lambda app_dir=None: tmp_path)
     monkeypatch.setattr(launcher, "start_helper", lambda *args, **kwargs: FakeServer())
-    monkeypatch.setattr(launcher.subprocess, "Popen", lambda *args, **kwargs: None)
+    monkeypatch.setattr(launcher, "launch_codex", lambda *args: None)
 
     def inject_after_retry(*args):
         attempts.append(args)
@@ -107,7 +110,7 @@ def test_launch_retries_injection_until_codex_page_is_ready(monkeypatch, tmp_pat
     monkeypatch.setattr(launcher, "inject_file", inject_after_retry)
     monkeypatch.setattr(launcher.time, "sleep", lambda seconds: None)
 
-    server = launcher.launch_and_inject(None, None, tmp_path / "backups", 9229, 57321)
+    server, proc = launcher.launch_and_inject(None, None, tmp_path / "backups", 9229, 57321)
 
     assert server.port == 57321
     assert len(attempts) == 2
@@ -121,12 +124,13 @@ def test_launch_uses_resolved_app_dir(monkeypatch, tmp_path):
     executable.write_text("#!/bin/sh\n", encoding="utf-8")
     monkeypatch.setattr(launcher, "resolve_codex_app_dir", lambda app_dir=None: mac_app)
     monkeypatch.setattr(launcher, "start_helper", lambda *args, **kwargs: FakeServer())
-    monkeypatch.setattr(launcher.subprocess, "Popen", lambda command: launched.append(command))
+    monkeypatch.setattr(launcher.subprocess, "run", lambda args, **kw: launched.append(args))
     monkeypatch.setattr(launcher, "inject_with_retry", lambda *args, **kwargs: {"result": {}})
 
     launcher.launch_and_inject(None, None, tmp_path / "backups", 9229, 57321)
 
-    assert launched[0][0] == str(executable)
+    assert str(executable) not in launched[0]
+    assert "open" in launched[0]
 
 
 def test_cli_setup_alias_installs_with_default_launcher(monkeypatch):


### PR DESCRIPTION
## Summary

On macOS, directly executing the Codex binary via `subprocess.Popen` bypasses the macOS app launch lifecycle, causing three issues:

1. **Command+Q** leaves the launcher process alive, holding port 57321 and blocking subsequent launches
2. **Dock icon clicks** don't properly manage window maximize/minimize
3. The **app bundle** shows a generic icon instead of the Codex icon

## Changes

### `launcher.py` — Proper macOS app launch via `open -a`
- Replace `build_codex_command()` with `launch_codex()` that returns `Popen | None`
- macOS: uses `open -a Codex.app --args --remote-debugging-port=N` to launch Codex as a native app with full dock integration
- Windows: unchanged behavior with `subprocess.Popen`

### `cli.py` — Auto-shutdown when Codex exits
- `wait_for_shutdown` now takes the codex process reference
- macOS (Popen is None): polls `pgrep` every 2s, shuts down helper when Codex disappears
- Windows: uses `proc.wait()` as before
- `finally` block ensures `server.shutdown()` always runs, freeing port 57321

### `macos_installer.py` — Better app bundle
- `LSUIElement=True`: Codex++.app stays hidden in Dock (Codex itself now appears properly in dock)
- `CFBundleIconFile=electron.icns` + `_copy_codex_icon()`: auto-copy the original Codex icon during setup

### `tests/test_launcher_cli.py` — Updated tests
- Renamed tests to match new function names
- Updated `launch_and_inject` mocks to return tuple `(server, proc)`
- Updated `wait_for_shutdown` mocks to accept 2 args

## Test Plan
- [x] All 60 tests pass: `python -m pytest tests/ -q`
- [x] `python -m codex_session_delete setup` creates proper app bundle with icon and LSUIElement
- [x] `open /Applications/Codex++.app` launches Codex with proper dock behavior
- [x] Command+Q quit → helper auto-shuts down → relaunch works

🤖 Generated with [Claude Code](https://claude.com/claude-code)