### PR TITLE
fix: launch Windows Store Codex via app activation

### DIFF
--- a/codex_session_delete/app_paths.py
+++ b/codex_session_delete/app_paths.py
@@ -10,6 +10,26 @@ from pathlib import Path
 _VERSION_RE = re.compile(r"OpenAI\.Codex_([0-9.]+)_")
 
 
+def find_codex_app_user_model_id() -> str | None:
+    cmd = 'Get-AppxPackage -Name "OpenAI.Codex" | ForEach-Object { $_.PackageFamilyName + "!App" }'
+    try:
+        result = subprocess.run(
+            ["powershell", "-NoProfile", "-Command", cmd],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=8,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    app_user_model_id = result.stdout.strip()
+    if result.returncode != 0 or not app_user_model_id:
+        return None
+    return app_user_model_id
+
+
 def _version_tuple(path: Path) -> tuple[int, ...]:
     match = _VERSION_RE.search(path.name)
     if not match:

--- a/codex_session_delete/launcher.py
+++ b/codex_session_delete/launcher.py
@@ -146,7 +146,10 @@ def launch_and_inject(app_dir: Path | None, db_path: Path | None, backup_dir: Pa
         server.bridge_socket = inject_with_retry(debug_port, script_path, server.port, service)
         return server, codex_proc
     except Exception:
-        server.shutdown()
+        try:
+            server.shutdown()
+        finally:
+            server.server_close()
         raise
 
 

--- a/codex_session_delete/launcher.py
+++ b/codex_session_delete/launcher.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from codex_session_delete.app_paths import resolve_codex_app_dir
+from codex_session_delete.app_paths import find_codex_app_user_model_id, resolve_codex_app_dir
 from codex_session_delete.api_adapter import ApiAdapter, UnavailableApiAdapter
 from codex_session_delete.backup_store import BackupStore
 from codex_session_delete.cdp import inject_file
@@ -39,20 +39,79 @@ class InjectedHelperServer(HelperServer):
     bridge_socket: Any = None
 
 
-def launch_codex(app_dir: Path, debug_port: int) -> subprocess.Popen | None:
+def codex_launch_args(debug_port: int) -> list[str]:
+    return [
+        f"--remote-debugging-port={debug_port}",
+        f"--remote-allow-origins=http://127.0.0.1:{debug_port}",
+    ]
+
+
+def build_windows_activation_source() -> str:
+    return r'''
+using System;
+using System.Runtime.InteropServices;
+
+[ComImport]
+[Guid("2E941141-7F97-4756-BA1D-9DECDE894A3D")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+interface IApplicationActivationManager
+{
+    void ActivateApplication([MarshalAs(UnmanagedType.LPWStr)] string appUserModelId, [MarshalAs(UnmanagedType.LPWStr)] string arguments, uint options, out uint processId);
+    void ActivateForFile();
+    void ActivateForProtocol();
+}
+
+public class Launcher
+{
+    public static int Main(string[] args)
+    {
+        if (args.Length != 2) return 64;
+        var type = Type.GetTypeFromCLSID(new Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C"));
+        if (type == null) return 65;
+        var manager = (IApplicationActivationManager)Activator.CreateInstance(type);
+        uint processId;
+        manager.ActivateApplication(args[0], args[1], 0, out processId);
+        return 0;
+    }
+}
+'''.strip()
+
+
+def activate_windows_app(app_user_model_id: str, debug_port: int) -> None:
+    script = (
+        "$source = @'\n"
+        + build_windows_activation_source()
+        + "\n'@\n"
+        + "Add-Type -TypeDefinition $source -Language CSharp\n"
+        + "[Launcher]::Main(@($args[0], $args[1])) | Out-Null\n"
+    )
+    subprocess.run(
+        [
+            "powershell.exe",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            script,
+            app_user_model_id,
+            " ".join(codex_launch_args(debug_port)),
+        ],
+        check=True,
+    )
+
+
+def launch_codex(app_dir: Path | None, debug_port: int) -> subprocess.Popen | None:
+    if app_dir is None and sys.platform == "win32" and (app_user_model_id := find_codex_app_user_model_id()):
+        activate_windows_app(app_user_model_id, debug_port)
+        return None
+    if app_dir is None:
+        raise RuntimeError("Codex App directory not found")
     if app_dir.suffix == ".app":
-        subprocess.run(
-            ["open", "-a", str(app_dir), "--args", f"--remote-debugging-port={debug_port}", f"--remote-allow-origins=http://127.0.0.1:{debug_port}"],
-            check=True,
-        )
+        subprocess.run(["open", "-a", str(app_dir), "--args", *codex_launch_args(debug_port)], check=True)
         return None
     candidates = [app_dir / "Codex.exe", app_dir / "codex.exe"]
     exe = next((path for path in candidates if path.exists()), candidates[-1])
-    return subprocess.Popen([
-        str(exe),
-        f"--remote-debugging-port={debug_port}",
-        f"--remote-allow-origins=http://127.0.0.1:{debug_port}",
-    ])
+    return subprocess.Popen([str(exe), *codex_launch_args(debug_port)])
 
 
 def start_helper(service, host: str = "127.0.0.1", port: int = 57321) -> HelperServer:
@@ -76,15 +135,19 @@ def inject_with_retry(debug_port: int, script_path: Path, helper_port: int, serv
 
 
 def launch_and_inject(app_dir: Path | None, db_path: Path | None, backup_dir: Path, debug_port: int, helper_port: int) -> tuple[HelperServer, subprocess.Popen | None]:
-    resolved_app_dir = resolve_codex_app_dir(app_dir)
-    if resolved_app_dir is None:
+    resolved_app_dir = None if app_dir is None and sys.platform == "win32" else resolve_codex_app_dir(app_dir)
+    if resolved_app_dir is None and not (app_dir is None and sys.platform == "win32"):
         raise RuntimeError("Codex App directory not found")
     service = ApiFirstDeleteService(UnavailableApiAdapter(), db_path, backup_dir)
     server = start_helper(service, port=helper_port)
-    codex_proc = launch_codex(resolved_app_dir, debug_port)
-    script_path = Path(__file__).parent / "inject" / "renderer-inject.js"
-    server.bridge_socket = inject_with_retry(debug_port, script_path, server.port, service)
-    return server, codex_proc
+    try:
+        codex_proc = launch_codex(resolved_app_dir, debug_port)
+        script_path = Path(__file__).parent / "inject" / "renderer-inject.js"
+        server.bridge_socket = inject_with_retry(debug_port, script_path, server.port, service)
+        return server, codex_proc
+    except Exception:
+        server.shutdown()
+        raise
 
 
 def handle_bridge_request(service: ApiFirstDeleteService, path: str, payload: dict[str, object]) -> dict[str, object]:

--- a/tests/test_app_paths.py
+++ b/tests/test_app_paths.py
@@ -1,6 +1,19 @@
 from pathlib import Path
 
-from codex_session_delete.app_paths import find_latest_codex_app_dir, find_macos_codex_app, resolve_codex_app_dir, user_data_candidates
+from codex_session_delete.app_paths import find_codex_app_user_model_id, find_latest_codex_app_dir, find_macos_codex_app, resolve_codex_app_dir, user_data_candidates
+
+
+def test_find_codex_app_user_model_id_reads_package_family_name(monkeypatch):
+    class Result:
+        returncode = 0
+        stdout = "OpenAI.Codex_2p2nqsd0c76g0!App\n"
+
+    calls = []
+    monkeypatch.setattr("codex_session_delete.app_paths.subprocess.run", lambda *args, **kwargs: calls.append((args, kwargs)) or Result())
+
+    assert find_codex_app_user_model_id() == "OpenAI.Codex_2p2nqsd0c76g0!App"
+    assert "Get-AppxPackage" in calls[0][0][0][-1]
+
 
 
 def test_find_latest_codex_app_dir_uses_highest_version(tmp_path):

--- a/tests/test_launcher_cli.py
+++ b/tests/test_launcher_cli.py
@@ -3,11 +3,17 @@ from pathlib import Path
 import pytest
 
 from codex_session_delete import cli, launcher
-from codex_session_delete.launcher import launch_codex
+from codex_session_delete.launcher import build_windows_activation_source, launch_codex
 
 
 class FakeServer:
     port = 57321
+
+    def __init__(self):
+        self.shutdown_called = False
+
+    def shutdown(self):
+        self.shutdown_called = True
 
 
 def test_launch_codex_windows_adds_remote_debugging_port(monkeypatch):
@@ -30,6 +36,26 @@ def test_launch_codex_windows_allows_devtools_websocket_origin(monkeypatch):
     launch_codex(app_dir, 9229)
 
     assert "--remote-allow-origins=http://127.0.0.1:9229" in popen_calls[0]
+
+
+def test_launch_codex_windows_default_uses_app_user_model_id(monkeypatch):
+    launched = []
+    monkeypatch.setattr(launcher.sys, "platform", "win32")
+    monkeypatch.setattr(launcher, "find_codex_app_user_model_id", lambda: "OpenAI.Codex_abc!App")
+    monkeypatch.setattr(launcher, "activate_windows_app", lambda app_id, port: launched.append((app_id, port)))
+
+    proc = launch_codex(None, 9229)
+
+    assert proc is None
+    assert launched == [("OpenAI.Codex_abc!App", 9229)]
+
+
+def test_build_windows_activation_source_uses_app_activation_manager():
+    source = build_windows_activation_source()
+
+    assert "IApplicationActivationManager" in source
+    assert "ActivateApplication" in source
+    assert "45BA127D-10A8-46EA-8AB7-56EA9078943C" in source
 
 
 def test_launch_codex_macos_uses_open_command(monkeypatch, tmp_path):
@@ -95,6 +121,19 @@ def test_cli_uninstall_dispatches_to_platform_installer(monkeypatch, tmp_path):
     assert calls[0].remove_data is True
 
 
+def test_launch_shuts_down_helper_when_codex_activation_fails(monkeypatch, tmp_path):
+    server = FakeServer()
+    monkeypatch.setattr(launcher.sys, "platform", "win32")
+    monkeypatch.setattr(launcher, "start_helper", lambda *args, **kwargs: server)
+    monkeypatch.setattr(launcher, "launch_codex", lambda *args: (_ for _ in ()).throw(RuntimeError("activation failed")))
+
+    with pytest.raises(RuntimeError, match="activation failed"):
+        launcher.launch_and_inject(None, None, tmp_path / "backups", 9229, 57321)
+
+    assert server.shutdown_called is True
+
+
+
 def test_launch_retries_injection_until_codex_page_is_ready(monkeypatch, tmp_path):
     attempts = []
     monkeypatch.setattr(launcher, "resolve_codex_app_dir", lambda app_dir=None: tmp_path)
@@ -122,6 +161,7 @@ def test_launch_uses_resolved_app_dir(monkeypatch, tmp_path):
     executable = mac_app / "Contents" / "MacOS" / "Codex"
     executable.parent.mkdir(parents=True)
     executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(launcher.sys, "platform", "darwin")
     monkeypatch.setattr(launcher, "resolve_codex_app_dir", lambda app_dir=None: mac_app)
     monkeypatch.setattr(launcher, "start_helper", lambda *args, **kwargs: FakeServer())
     monkeypatch.setattr(launcher.subprocess, "run", lambda args, **kw: launched.append(args))


### PR DESCRIPTION
## Summary
- Launch Windows Store/MSIX Codex through its AppUserModelID instead of directly executing `WindowsApps/.../Codex.exe`.
- Pass Chromium remote debugging arguments through `IApplicationActivationManager.ActivateApplication` so CDP injection can still attach.
- Shut down the helper server if Codex activation or injection fails, avoiding a stale helper listener.

## Test plan
- [x] `python -m pytest -q`