### PR TITLE
fix(launcher)：改进 Windows 启动等待与端口回退

### DIFF
--- a/codex_session_delete/cli.py
+++ b/codex_session_delete/cli.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import sys
 import traceback
 from pathlib import Path
 
 from codex_session_delete.helper_server import HelperServer
 from codex_session_delete.installers import InstallOptions, install_codex_plus_plus, uninstall_codex_plus_plus
-from codex_session_delete.launcher import launch_and_inject
+from codex_session_delete.launcher import launch_and_inject, shutdown_helper
 
 
 def add_launch_arguments(parser: argparse.ArgumentParser) -> None:
@@ -55,9 +56,35 @@ def log_launch_failure(exc: BaseException) -> None:
     path.write_text("".join(traceback.format_exception(type(exc), exc, exc.__traceback__)), encoding="utf-8")
 
 
+def wait_for_windows_process_id(process_id: int) -> None:
+    if sys.platform != "win32":
+        return
+    import ctypes
+
+    synchronize = 0x00100000
+    infinite = 0xFFFFFFFF
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = [ctypes.c_ulong, ctypes.c_int, ctypes.c_ulong]
+    kernel32.OpenProcess.restype = ctypes.c_void_p
+    kernel32.WaitForSingleObject.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+    kernel32.WaitForSingleObject.restype = ctypes.c_ulong
+    kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
+    kernel32.CloseHandle.restype = ctypes.c_int
+
+    handle = kernel32.OpenProcess(synchronize, False, process_id)
+    if not handle:
+        return
+    try:
+        kernel32.WaitForSingleObject(handle, infinite)
+    finally:
+        kernel32.CloseHandle(handle)
+
+
 def wait_for_shutdown(server: HelperServer, codex_proc) -> None:
     try:
-        if codex_proc is None:
+        if isinstance(codex_proc, int):
+            wait_for_windows_process_id(codex_proc)
+        elif codex_proc is None and sys.platform == "darwin":
             import subprocess as _sp
             import time as _time
             while True:
@@ -65,12 +92,12 @@ def wait_for_shutdown(server: HelperServer, codex_proc) -> None:
                 if result.returncode != 0:
                     break
                 _time.sleep(2)
-        else:
+        elif codex_proc is not None:
             codex_proc.wait()
     except KeyboardInterrupt:
         pass
     finally:
-        server.shutdown()
+        shutdown_helper(server)
 
 
 def run_launch(args: argparse.Namespace) -> int:

--- a/codex_session_delete/launcher.py
+++ b/codex_session_delete/launcher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ctypes
+import socket
 import subprocess
 import sys
 import threading
@@ -44,6 +45,33 @@ class ApiFirstDeleteService:
 
 class InjectedHelperServer(HelperServer):
     bridge_socket: Any = None
+
+
+def _can_bind_loopback_port(port: int) -> bool:
+    if port == 0:
+        return True
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            if sys.platform == "win32" and hasattr(socket, "SO_EXCLUSIVEADDRUSE"):
+                probe.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+            probe.bind(("127.0.0.1", port))
+            return True
+    except OSError:
+        return False
+
+
+def _find_available_loopback_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        if sys.platform == "win32" and hasattr(socket, "SO_EXCLUSIVEADDRUSE"):
+            probe.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+def select_windows_loopback_port(requested_port: int) -> int:
+    if sys.platform != "win32" or _can_bind_loopback_port(requested_port):
+        return requested_port
+    return _find_available_loopback_port()
 
 
 def build_codex_arguments(debug_port: int) -> list[str]:
@@ -154,15 +182,14 @@ def activate_packaged_app(app_user_model_id: str, arguments: str) -> int:
             ole32.CoUninitialize()
 
 
-def launch_codex_app(app_dir: Path, debug_port: int) -> int | None:
+def launch_codex_app(app_dir: Path, debug_port: int) -> Any:
     app_user_model_id = packaged_app_user_model_id(app_dir) if sys.platform == "win32" else None
     if app_user_model_id:
         return activate_packaged_app(app_user_model_id, subprocess.list2cmdline(build_codex_arguments(debug_port)))
     if app_dir.suffix == ".app":
         subprocess.run(["open", "-a", str(app_dir), "--args", *build_codex_arguments(debug_port)], check=True)
         return None
-    subprocess.Popen(build_codex_command(app_dir, debug_port))
-    return None
+    return subprocess.Popen(build_codex_command(app_dir, debug_port))
 
 
 def start_helper(service, host: str = "127.0.0.1", port: int = 57321) -> HelperServer:
@@ -170,6 +197,11 @@ def start_helper(service, host: str = "127.0.0.1", port: int = 57321) -> HelperS
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     return server
+
+
+def shutdown_helper(server: HelperServer) -> None:
+    server.shutdown()
+    server.server_close()
 
 
 def inject_with_retry(debug_port: int, script_path: Path, helper_port: int, service: ApiFirstDeleteService, attempts: int = 20, delay: float = 0.5) -> Any:
@@ -185,16 +217,23 @@ def inject_with_retry(debug_port: int, script_path: Path, helper_port: int, serv
     raise RuntimeError("Codex injection failed")
 
 
-def launch_and_inject(app_dir: Path | None, db_path: Path | None, backup_dir: Path, debug_port: int, helper_port: int) -> tuple[HelperServer, None]:
+def launch_and_inject(app_dir: Path | None, db_path: Path | None, backup_dir: Path, debug_port: int, helper_port: int) -> tuple[HelperServer, Any]:
     resolved_app_dir = resolve_codex_app_dir(app_dir)
     if resolved_app_dir is None:
         raise RuntimeError("Codex App directory not found")
+    debug_port = select_windows_loopback_port(debug_port)
+    helper_port = select_windows_loopback_port(helper_port)
     service = ApiFirstDeleteService(UnavailableApiAdapter(), db_path, backup_dir)
     server = start_helper(service, port=helper_port)
-    launch_codex_app(resolved_app_dir, debug_port)
-    script_path = Path(__file__).parent / "inject" / "renderer-inject.js"
-    server.bridge_socket = inject_with_retry(debug_port, script_path, server.port, service)
-    return server, None
+    codex_proc = None
+    try:
+        codex_proc = launch_codex_app(resolved_app_dir, debug_port)
+        script_path = Path(__file__).parent / "inject" / "renderer-inject.js"
+        server.bridge_socket = inject_with_retry(debug_port, script_path, server.port, service)
+        return server, codex_proc
+    except Exception:
+        shutdown_helper(server)
+        raise
 
 
 def handle_bridge_request(service: ApiFirstDeleteService, path: str, payload: dict[str, object]) -> dict[str, object]:

--- a/tests/test_launcher_cli.py
+++ b/tests/test_launcher_cli.py
@@ -9,6 +9,24 @@ from codex_session_delete.launcher import build_codex_command, launch_codex_app,
 class FakeServer:
     port = 57321
 
+    def __init__(self):
+        self.shutdown_called = False
+        self.server_close_called = False
+
+    def shutdown(self):
+        self.shutdown_called = True
+
+    def server_close(self):
+        self.server_close_called = True
+
+
+class FakeProcess:
+    def __init__(self):
+        self.waited = False
+
+    def wait(self):
+        self.waited = True
+
 
 def test_launch_codex_windows_adds_remote_debugging_port(monkeypatch):
     app_dir = Path("C:/Codex/app")
@@ -80,6 +98,21 @@ def test_launch_uses_packaged_activation_for_windowsapps(monkeypatch):
     assert launched == []
 
 
+def test_windows_port_selector_uses_ephemeral_port_when_default_is_busy(monkeypatch):
+    monkeypatch.setattr(launcher.sys, "platform", "win32")
+    monkeypatch.setattr(launcher, "_can_bind_loopback_port", lambda port: port != 9229)
+    monkeypatch.setattr(launcher, "_find_available_loopback_port", lambda: 43001)
+
+    assert launcher.select_windows_loopback_port(9229) == 43001
+
+
+def test_non_windows_port_selector_keeps_requested_port(monkeypatch):
+    monkeypatch.setattr(launcher.sys, "platform", "darwin")
+    monkeypatch.setattr(launcher, "_can_bind_loopback_port", lambda port: False)
+
+    assert launcher.select_windows_loopback_port(9229) == 9229
+
+
 def test_cli_keeps_helper_server_alive_after_injection(monkeypatch):
     waited = []
     monkeypatch.setattr(cli, "launch_and_inject", lambda *args: (FakeServer(), None))
@@ -149,6 +182,32 @@ def test_launch_retries_injection_until_codex_page_is_ready(monkeypatch, tmp_pat
     assert len(attempts) == 2
 
 
+def test_launch_and_inject_returns_windows_packaged_process_id(monkeypatch, tmp_path):
+    monkeypatch.setattr(launcher, "resolve_codex_app_dir", lambda app_dir=None: tmp_path)
+    monkeypatch.setattr(launcher, "start_helper", lambda *args, **kwargs: FakeServer())
+    monkeypatch.setattr(launcher, "launch_codex_app", lambda *args: 1234)
+    monkeypatch.setattr(launcher, "inject_with_retry", lambda *args, **kwargs: {"result": {}})
+
+    server, proc = launcher.launch_and_inject(None, None, tmp_path / "backups", 9229, 57321)
+
+    assert server.port == 57321
+    assert proc == 1234
+
+
+def test_launch_and_inject_closes_helper_when_injection_fails(monkeypatch, tmp_path):
+    server = FakeServer()
+    monkeypatch.setattr(launcher, "resolve_codex_app_dir", lambda app_dir=None: tmp_path)
+    monkeypatch.setattr(launcher, "start_helper", lambda *args, **kwargs: server)
+    monkeypatch.setattr(launcher, "launch_codex_app", lambda *args: 1234)
+    monkeypatch.setattr(launcher, "inject_with_retry", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("inject failed")))
+
+    with pytest.raises(RuntimeError, match="inject failed"):
+        launcher.launch_and_inject(None, None, tmp_path / "backups", 9229, 57321)
+
+    assert server.shutdown_called is True
+    assert server.server_close_called is True
+
+
 def test_launch_uses_resolved_app_dir(monkeypatch, tmp_path):
     launched = []
     mac_app = tmp_path / "Applications" / "OpenAI Codex.app"
@@ -199,3 +258,27 @@ def test_cli_logs_launch_failure_for_hidden_pythonw(monkeypatch, tmp_path):
         cli.main(["launch"])
 
     assert "inject failed" in log_path.read_text(encoding="utf-8")
+
+
+def test_wait_for_shutdown_waits_for_windows_process_id(monkeypatch):
+    server = FakeServer()
+    waited = []
+    monkeypatch.setattr(cli.sys, "platform", "win32")
+    monkeypatch.setattr(cli, "wait_for_windows_process_id", lambda process_id: waited.append(process_id))
+
+    cli.wait_for_shutdown(server, 1234)
+
+    assert waited == [1234]
+    assert server.shutdown_called is True
+    assert server.server_close_called is True
+
+
+def test_wait_for_shutdown_waits_for_popen_like_process():
+    server = FakeServer()
+    proc = FakeProcess()
+
+    cli.wait_for_shutdown(server, proc)
+
+    assert proc.waited is True
+    assert server.shutdown_called is True
+    assert server.server_close_called is True


### PR DESCRIPTION
## 概要

修复 Windows 下 Codex++ 启动器生命周期管理问题，避免关闭 Codex 后残留 `pythonw.exe` helper 进程和端口占用。

## 问题背景

Windows 下 Codex++ 通过 packaged app activation 方式启动 Codex。这个启动路径会返回 Codex 进程 PID，但之前代码没有保留该 PID，而是最终把 `None` 返回给 CLI。

结果是 CLI 无法可靠等待 Codex 退出。某些情况下，尤其是通过桌面快捷方式管理器启动时，隐藏的 `pythonw.exe -m codex_session_delete launch` 会在 Codex 关闭后继续残留，导致 `57321` helper 端口被占用；同时 `9229` CDP 调试端口也可能进入异常状态。

下一次启动时，Codex 本体可以打开，但 Codex++ 无法通过 CDP 注入 renderer 脚本，表现为顶部 `Codex++` 菜单、插件解锁和删除按钮都不出现。之前通常需要重启 Windows 才能恢复。

## 修复内容

- 保留 `activate_packaged_app()` 返回的 Windows Codex 进程 PID。
- CLI 在 Windows 下根据该 PID 等待 Codex 退出。
- Codex 退出后主动关闭 helper server，并调用 `server_close()` 释放端口。
- CDP 注入失败时，也会清理 helper，避免失败后留下 `57321` 监听。
- Windows 下启动前检测默认端口是否可用；如果 `9229` 或 `57321` 已被占用，则自动选择可用本地端口。
- macOS 启动逻辑保持不变，避免影响现有 mac 端功能。

## 验证

新增回归测试覆盖：

- Windows packaged app PID 正确传回 CLI。
- Windows PID 等待逻辑。
- 注入失败时 helper 会被关闭。
- Windows 端口占用时自动选择可用端口。
- 非 Windows 平台保持原端口行为不变。

全量测试通过：

```text
75 passed in 2.61s
```

## 手动验证

修复前，关闭 Codex 后可能残留：

```text
57321 -> pythonw.exe helper 仍在 Listen
9229  -> CDP 端口异常占用
```

修复后：

```text
Codex 运行时：
57321 -> pythonw.exe Codex++ helper
9229  -> Codex.exe CDP endpoint

关闭 Codex 后：
57321 -> 无 Listen
9229  -> 无 Listen，仅可能短暂存在 TIME_WAIT
```

结论：Windows 下关闭 Codex 后，Codex++ helper 能正确退出，不再需要通过重启系统恢复功能。