### PR TITLE
新增可选 Windows watcher：原生启动 Codex 自动接管注入

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,57 @@ Codex++ 默认读取 Codex 本地数据库：
 ~/.codex-session-delete/launcher.log
 ```
 
+## Windows 自动接管（可选）
+
+默认情况下 Codex++ 只在你**从 `Codex++` 快捷方式启动时**生效。如果你从开始菜单、任务栏或系统原生入口直接启动 Codex，那一次不会有注入，`Codex++` 菜单和插件解锁都不会出现。
+
+Windows 可以注册一个常驻 watcher 解决这个问题。它会每 3 秒探测一次本机 CDP 端口，发现 Codex 在跑但 CDP 没起来，就把这一批 Codex 进程杀掉、通过 launcher 重拉一次带注入的版本。这样不管你从哪里打开 Codex，都会被自动接管。
+
+注意代价：
+
+- 每次 Codex 通过原生路径启动，都会先打开一瞬间，再被 kill，再被 launcher 带 CDP 重开。视觉上是 1 ~ 2 秒的“打开→关闭→重开”闪烁。
+- watcher 以 `pythonw.exe` 常驻运行，登录时自动启动（通过 `HKCU\...\Run` 和 Startup 文件夹双路径注册，后者防止某些注册表清理工具干扰）。
+
+### 安装
+
+```bash
+python -m codex_session_delete watch-install
+```
+
+安装完成后 watcher 会立即启动，无需重启。
+
+### 卸载
+
+```bash
+python -m codex_session_delete watch-remove
+```
+
+`remove` / 系统卸载 Codex++ 时会自动连带执行 `watch-remove`，不需要手动处理。
+
+### 临时开关
+
+保留自启项、但让 watcher 不再自动接管：
+
+```bash
+python -m codex_session_delete watch-disable
+python -m codex_session_delete watch-enable
+```
+
+### 日志
+
+```text
+%USERPROFILE%\.codex-session-delete\watcher.log
+```
+
+示例：
+
+```text
+[...] watcher started (interval=3.0s)
+[...] Codex running without CDP (pids=[...]); attempting takeover
+[...] takeover: killing 4 codex pid(s): [...]
+[...] takeover: CDP is up on 9229 (launcher pid=...)
+```
+
 ## 常见问题
 
 ### 双击 Codex++ 没反应
@@ -248,6 +299,7 @@ codex_session_delete/
   storage_adapter.py     本地 SQLite 删除/撤销
   windows_installer.py   Windows 快捷方式与卸载项
   macos_installer.py     macOS app bundle 安装
+  watcher.py             Windows 常驻 watcher（可选，原生启动接管）
   inject/renderer-inject.js
 
 tests/                   自动化测试

--- a/codex_session_delete/cli.py
+++ b/codex_session_delete/cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from codex_session_delete.helper_server import HelperServer
 from codex_session_delete.installers import InstallOptions, install_codex_plus_plus, uninstall_codex_plus_plus
 from codex_session_delete.launcher import launch_and_inject, shutdown_helper
+from codex_session_delete import watcher
 
 
 def add_launch_arguments(parser: argparse.ArgumentParser) -> None:
@@ -41,6 +42,17 @@ def build_parser() -> argparse.ArgumentParser:
     remove_parser = subparsers.add_parser("remove", help="Remove Codex++ with defaults")
     remove_parser.add_argument("--install-root", type=Path, default=None)
     remove_parser.add_argument("--remove-data", action="store_true")
+
+    watch_parser = subparsers.add_parser("watch", help="Run the Codex watcher loop (auto-reinject when Codex is launched normally)")
+    watch_parser.add_argument("--debug-port", type=int, default=9229)
+
+    watch_install_parser = subparsers.add_parser("watch-install", help="Register the watcher to run at Windows logon")
+    watch_install_parser.add_argument("--debug-port", type=int, default=9229)
+
+    subparsers.add_parser("watch-remove", help="Unregister the watcher logon task")
+
+    subparsers.add_parser("watch-enable", help="Re-enable the watcher loop after it was disabled")
+    subparsers.add_parser("watch-disable", help="Disable the watcher loop without removing the logon task")
 
     add_launch_arguments(parser)
     return parser
@@ -109,7 +121,7 @@ def stop_existing_windows_launchers() -> None:
     script = (
         "Get-CimInstance Win32_Process | "
         "Where-Object { $_.ProcessId -ne $env:CODEX_PLUS_PLUS_PID -and "
-        "$_.CommandLine -match 'pythonw?(.exe)?\"?\\s+-m\\s+codex_session_delete(\\s+launch)?(\\s|$)' } | "
+        "$_.CommandLine -match 'pythonw?(.exe)?\"?\\s+-m\\s+codex_session_delete\\s+launch(\\s|$)' } | "
         "ForEach-Object { Stop-Process -Id $_.ProcessId -Force }"
     )
     env = {**os.environ, "CODEX_PLUS_PLUS_PID": str(current_pid)}
@@ -129,6 +141,98 @@ def run_launch(args: argparse.Namespace) -> int:
     return 0
 
 
+WATCHER_RUN_NAME = "CodexPlusPlusWatcher"
+WATCHER_RUN_KEY = "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"
+WATCHER_STARTUP_SHORTCUT_NAME = "CodexPlusPlusWatcher.lnk"
+
+
+def _watcher_command(debug_port: int) -> tuple[str, str, str]:
+    python = sys.executable
+    pythonw = Path(python).with_name("pythonw.exe")
+    exe = str(pythonw if pythonw.exists() else python)
+    arguments = f"-m codex_session_delete watch --debug-port {debug_port}"
+    full = f'"{exe}" {arguments}'
+    return exe, arguments, full
+
+
+def _ps_quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def install_watcher_logon_task(debug_port: int) -> None:
+    if sys.platform != "win32":
+        raise RuntimeError("watch-install is only supported on Windows")
+    exe, arguments, full_command = _watcher_command(debug_port)
+    project_root = str(Path(__file__).resolve().parent.parent)
+    script = f"""
+$ErrorActionPreference = 'Stop'
+$Exe = {_ps_quote(exe)}
+$Args = {_ps_quote(arguments)}
+$RunFullCommand = {_ps_quote(full_command)}
+$ProjectRoot = {_ps_quote(project_root)}
+$ShortcutName = {_ps_quote(WATCHER_STARTUP_SHORTCUT_NAME)}
+# 1) HKCU Run value
+New-Item -Path '{WATCHER_RUN_KEY}' -Force | Out-Null
+Set-ItemProperty -Path '{WATCHER_RUN_KEY}' -Name '{WATCHER_RUN_NAME}' -Value $RunFullCommand
+# 2) Startup folder .lnk (survives registry cleanups)
+$Startup = [Environment]::GetFolderPath('Startup')
+New-Item -ItemType Directory -Force -Path $Startup | Out-Null
+$Shell = New-Object -ComObject WScript.Shell
+$ShortcutPath = Join-Path $Startup $ShortcutName
+$Shortcut = $Shell.CreateShortcut($ShortcutPath)
+$Shortcut.TargetPath = $Exe
+$Shortcut.Arguments = $Args
+$Shortcut.WorkingDirectory = $ProjectRoot
+$Shortcut.WindowStyle = 7
+$Shortcut.Description = 'Codex++ watcher (auto-inject Codex on start)'
+$Shortcut.Save()
+# 3) Echo what was written for verification
+$runValue = (Get-ItemProperty -Path '{WATCHER_RUN_KEY}' -Name '{WATCHER_RUN_NAME}').'{WATCHER_RUN_NAME}'
+Write-Output ("watch-install: HKCU Run = " + $runValue)
+Write-Output ("watch-install: Startup shortcut = " + $ShortcutPath)
+""".strip()
+    result = subprocess.run(
+        ["powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.stdout:
+        print(result.stdout.strip())
+    # Start the watcher right now as well.
+    subprocess.Popen(
+        [exe, "-m", "codex_session_delete", "watch", "--debug-port", str(debug_port)],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        close_fds=True,
+        creationflags=(
+            subprocess.CREATE_NEW_PROCESS_GROUP
+            | getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+            | getattr(subprocess, "CREATE_NO_WINDOW", 0)
+        ),
+    )
+    print("watch-install: watcher process spawned")
+
+
+def uninstall_watcher_logon_task() -> None:
+    if sys.platform != "win32":
+        return
+    script = f"""
+Remove-ItemProperty -Path '{WATCHER_RUN_KEY}' -Name '{WATCHER_RUN_NAME}' -ErrorAction SilentlyContinue | Out-Null
+$Startup = [Environment]::GetFolderPath('Startup')
+$ShortcutPath = Join-Path $Startup {_ps_quote(WATCHER_STARTUP_SHORTCUT_NAME)}
+if (Test-Path $ShortcutPath) {{ Remove-Item $ShortcutPath -Force -ErrorAction SilentlyContinue }}
+Get-CimInstance Win32_Process -Filter "Name='pythonw.exe' OR Name='python.exe'" | Where-Object {{ $_.CommandLine -match 'codex_session_delete\\s+watch' }} | ForEach-Object {{ Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }}
+""".strip()
+    subprocess.run(
+        ["powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script],
+        check=False,
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     if args.command in {"install", "setup"}:
@@ -136,6 +240,21 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if args.command in {"uninstall", "remove"}:
         uninstall_codex_plus_plus(InstallOptions(install_root=args.install_root, remove_data=args.remove_data))
+        uninstall_watcher_logon_task()
+        return 0
+    if args.command == "watch":
+        return watcher.watch_loop(debug_port=args.debug_port)
+    if args.command == "watch-install":
+        install_watcher_logon_task(args.debug_port)
+        return 0
+    if args.command == "watch-remove":
+        uninstall_watcher_logon_task()
+        return 0
+    if args.command == "watch-enable":
+        watcher.enable_watcher()
+        return 0
+    if args.command == "watch-disable":
+        watcher.disable_watcher()
         return 0
     return run_launch(args)
 

--- a/codex_session_delete/launcher.py
+++ b/codex_session_delete/launcher.py
@@ -233,6 +233,27 @@ def launch_and_inject(app_dir: Path | None, db_path: Path | None, backup_dir: Pa
         return server, codex_proc
     except Exception:
         shutdown_helper(server)
+        # Kill any Codex process we just activated so the next attempt starts from a clean state
+        # instead of staring at a half-rendered white window.
+        if sys.platform == "win32":
+            try:
+                subprocess.run(
+                    [
+                        "powershell.exe",
+                        "-NoProfile",
+                        "-NonInteractive",
+                        "-Command",
+                        "Get-CimInstance Win32_Process -Filter \"Name='Codex.exe' OR Name='codex.exe'\" | "
+                        "ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }",
+                    ],
+                    check=False,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=6,
+                    creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+                )
+            except (OSError, subprocess.SubprocessError):
+                pass
         raise
 
 

--- a/codex_session_delete/watcher.py
+++ b/codex_session_delete/watcher.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+import traceback
+from datetime import datetime
+from pathlib import Path
+
+
+WATCHER_INTERVAL_SECONDS = 3.0
+CDP_PROBE_TIMEOUT_SECONDS = 0.5
+CDP_WAIT_TIMEOUT_SECONDS = 25.0
+KILL_WAIT_TIMEOUT_SECONDS = 8.0
+CODEX_PROCESS_NAMES = {"codex.exe"}
+
+
+def data_root() -> Path:
+    return Path.home() / ".codex-session-delete"
+
+
+def watcher_log_path() -> Path:
+    return data_root() / "watcher.log"
+
+
+def watcher_disabled_flag() -> Path:
+    return data_root() / "watcher.disabled"
+
+
+def log(line: str) -> None:
+    path = watcher_log_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"[{datetime.now().isoformat(timespec='seconds')}] {line}\n")
+
+
+def cdp_listening(port: int) -> bool:
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=CDP_PROBE_TIMEOUT_SECONDS):
+            return True
+    except OSError:
+        return False
+
+
+def _run_powershell(script: str, timeout: float = 8.0) -> str:
+    try:
+        result = subprocess.run(
+            ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+        return result.stdout or ""
+    except (OSError, subprocess.SubprocessError) as exc:
+        log(f"powershell failed: {exc}")
+        return ""
+
+
+def find_codex_processes() -> list[int]:
+    script = (
+        "Get-CimInstance Win32_Process -Filter \"Name='Codex.exe' OR Name='codex.exe'\" "
+        "| Select-Object -ExpandProperty ProcessId"
+    )
+    output = _run_powershell(script)
+    return [int(line) for line in output.splitlines() if line.strip().isdigit()]
+
+
+def kill_processes(pids: list[int]) -> None:
+    if not pids:
+        return
+    script = "; ".join(
+        f"Stop-Process -Id {pid} -Force -ErrorAction SilentlyContinue" for pid in pids
+    )
+    _run_powershell(script, timeout=6.0)
+
+
+def wait_until_no_codex(timeout: float = KILL_WAIT_TIMEOUT_SECONDS) -> bool:
+    """Poll until no Codex process is left, or until timeout. Returns True if clean, False if still alive."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        remaining = find_codex_processes()
+        if not remaining:
+            return True
+        # Be aggressive: re-issue kill for anything still alive.
+        kill_processes(remaining)
+        time.sleep(0.5)
+    return not find_codex_processes()
+
+
+def wait_for_cdp(port: int, timeout: float = CDP_WAIT_TIMEOUT_SECONDS) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if cdp_listening(port):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def spawn_launcher() -> subprocess.Popen | None:
+    python = sys.executable
+    pythonw = Path(python).with_name("pythonw.exe")
+    exe = str(pythonw if pythonw.exists() else python)
+    args = [exe, "-m", "codex_session_delete", "launch"]
+    creationflags = 0
+    if sys.platform == "win32":
+        creationflags = (
+            subprocess.CREATE_NEW_PROCESS_GROUP
+            | getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+            | getattr(subprocess, "CREATE_NO_WINDOW", 0)
+        )
+    try:
+        return subprocess.Popen(
+            args,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+            creationflags=creationflags,
+        )
+    except Exception as exc:
+        log(f"failed to spawn launcher: {exc}")
+        return None
+
+
+def stop_launcher_processes() -> None:
+    script = (
+        "Get-CimInstance Win32_Process -Filter \"Name='pythonw.exe' OR Name='python.exe'\" | "
+        "Where-Object { $_.CommandLine -match 'codex_session_delete\\s+launch' } | "
+        "ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
+    )
+    _run_powershell(script, timeout=6.0)
+
+
+def takeover(debug_port: int) -> bool:
+    """Perform one atomic takeover attempt: kill codex cleanly, spawn launcher, wait for CDP.
+
+    Returns True on success (CDP up), False otherwise. On failure, caller should back off briefly.
+    """
+    # Step 1: Kill existing launcher processes (stale / failed) so we start from a known state.
+    stop_launcher_processes()
+
+    # Step 2: Kill all Codex.exe and wait for them to disappear.
+    pids = find_codex_processes()
+    log(f"takeover: killing {len(pids)} codex pid(s): {pids}")
+    kill_processes(pids)
+    if not wait_until_no_codex():
+        log("takeover: codex processes did not exit in time, aborting this attempt")
+        return False
+
+    # Step 3: Give AppX activation machinery a moment to reset the "app is running" state.
+    time.sleep(1.5)
+
+    # Step 4: Spawn a fresh launcher that will activate the packaged app with CDP args.
+    proc = spawn_launcher()
+    if proc is None:
+        return False
+
+    # Step 5: Wait for CDP to come up. Launcher does injection in the background.
+    if wait_for_cdp(debug_port):
+        log(f"takeover: CDP is up on {debug_port} (launcher pid={proc.pid})")
+        return True
+
+    # Step 6: CDP did not come up. Clean up the launcher we spawned and any codex it started,
+    # so the next pass can retry cleanly instead of staring at a broken window.
+    log("takeover: CDP did not come up in time; cleaning up failed attempt")
+    stop_launcher_processes()
+    stragglers = find_codex_processes()
+    if stragglers:
+        kill_processes(stragglers)
+        wait_until_no_codex(timeout=4.0)
+    return False
+
+
+def watch_loop(debug_port: int = 9229) -> int:
+    if sys.platform != "win32":
+        log("watcher only supported on Windows")
+        return 1
+
+    log(f"watcher started (interval={WATCHER_INTERVAL_SECONDS}s)")
+    last_state = None
+    backoff_until = 0.0
+
+    while True:
+        try:
+            if watcher_disabled_flag().exists():
+                if last_state != "disabled":
+                    log("disabled flag present; idling")
+                last_state = "disabled"
+                time.sleep(WATCHER_INTERVAL_SECONDS)
+                continue
+
+            if cdp_listening(debug_port):
+                if last_state != "cdp_ok":
+                    log("CDP is up")
+                last_state = "cdp_ok"
+                time.sleep(WATCHER_INTERVAL_SECONDS)
+                continue
+
+            codex_pids = find_codex_processes()
+            if not codex_pids:
+                if last_state != "idle":
+                    log("no Codex running; idling")
+                last_state = "idle"
+                time.sleep(WATCHER_INTERVAL_SECONDS)
+                continue
+
+            now = time.time()
+            if now < backoff_until:
+                if last_state != "backoff":
+                    log(f"in backoff after failed takeover; {backoff_until - now:.1f}s remaining")
+                last_state = "backoff"
+                time.sleep(WATCHER_INTERVAL_SECONDS)
+                continue
+
+            log(f"Codex running without CDP (pids={codex_pids}); attempting takeover")
+            last_state = "takeover"
+            success = takeover(debug_port)
+            if success:
+                last_state = "cdp_ok"
+            else:
+                backoff_until = time.time() + 10.0
+                last_state = "failed"
+        except Exception as exc:
+            log("watch loop error: " + "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)))
+
+        time.sleep(WATCHER_INTERVAL_SECONDS)
+
+
+def enable_watcher() -> None:
+    flag = watcher_disabled_flag()
+    if flag.exists():
+        flag.unlink()
+
+
+def disable_watcher() -> None:
+    flag = watcher_disabled_flag()
+    flag.parent.mkdir(parents=True, exist_ok=True)
+    flag.touch()

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import socket
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from codex_session_delete import watcher
+
+
+def test_cdp_listening_returns_true_when_bound():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        port = server.getsockname()[1]
+        assert watcher.cdp_listening(port) is True
+
+
+def test_cdp_listening_returns_false_when_closed():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+    # After the probe socket closes, nothing should be listening on that port
+    # (the port may get reused but the probe finishes with connection refused in normal conditions)
+    assert watcher.cdp_listening(port) is False
+
+
+def test_enable_watcher_removes_flag(tmp_path, monkeypatch):
+    monkeypatch.setattr(watcher, "data_root", lambda: tmp_path)
+    flag = tmp_path / "watcher.disabled"
+    flag.parent.mkdir(parents=True, exist_ok=True)
+    flag.touch()
+    assert flag.exists()
+    watcher.enable_watcher()
+    assert not flag.exists()
+
+
+def test_disable_watcher_creates_flag(tmp_path, monkeypatch):
+    monkeypatch.setattr(watcher, "data_root", lambda: tmp_path)
+    flag = tmp_path / "watcher.disabled"
+    assert not flag.exists()
+    watcher.disable_watcher()
+    assert flag.exists()
+
+
+def test_enable_watcher_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setattr(watcher, "data_root", lambda: tmp_path)
+    # Should not raise when flag does not exist
+    watcher.enable_watcher()
+    assert not (tmp_path / "watcher.disabled").exists()
+
+
+def test_watch_loop_exits_on_non_windows(monkeypatch, tmp_path):
+    monkeypatch.setattr(watcher, "data_root", lambda: tmp_path)
+    monkeypatch.setattr(watcher.sys, "platform", "linux")
+    assert watcher.watch_loop() == 1
+
+
+def test_wait_until_no_codex_success(monkeypatch):
+    calls = {"n": 0}
+
+    def find() -> list[int]:
+        calls["n"] += 1
+        # First poll: one process, subsequent polls: empty
+        return [1234] if calls["n"] == 1 else []
+
+    monkeypatch.setattr(watcher, "find_codex_processes", find)
+    killed: list[list[int]] = []
+    monkeypatch.setattr(watcher, "kill_processes", lambda pids: killed.append(list(pids)))
+    assert watcher.wait_until_no_codex(timeout=2.0) is True
+
+
+def test_wait_until_no_codex_times_out(monkeypatch):
+    monkeypatch.setattr(watcher, "find_codex_processes", lambda: [1])
+    monkeypatch.setattr(watcher, "kill_processes", lambda pids: None)
+    assert watcher.wait_until_no_codex(timeout=0.5) is False
+
+
+def test_wait_for_cdp_returns_true_when_listening(monkeypatch):
+    seq = iter([False, False, True])
+    monkeypatch.setattr(watcher, "cdp_listening", lambda port: next(seq))
+    assert watcher.wait_for_cdp(port=9229, timeout=2.0) is True
+
+
+def test_wait_for_cdp_returns_false_on_timeout(monkeypatch):
+    monkeypatch.setattr(watcher, "cdp_listening", lambda port: False)
+    assert watcher.wait_for_cdp(port=9229, timeout=0.3) is False


### PR DESCRIPTION
## 动机

当前 Codex++ 只在用户**从 `Codex++` 快捷方式启动时**生效。如果从开始菜单、任务栏或系统原生入口直接启动 Codex，那一次打开的 Codex 不会有任何注入 —— 没有 `Codex++` 菜单、插件入口依旧被锁、会话删除按钮也不会出现。实际使用下来这是最容易让人困惑的一个点：用着用着突然"坏了"，其实只是没走对启动路径。

这个 PR 加了一个**可选**的 Windows 常驻 watcher，让用户**从任何地方**打开 Codex 都能被自动接管、注入生效。

## 设计

`codex_session_delete/watcher.py`

- 每 3 秒探测一次 `127.0.0.1:9229`。
- 发现 Codex.exe 在跑但 CDP 没 LISTENING 时，执行一次 takeover：
  1. 先干掉所有残留 launcher / Codex 进程
  2. 轮询等待 Codex 真正退出（最多 8s，期间反复补刀，避免 AppX activation 抓到半死的窗口）
  3. 短暂等待让 AppX 状态机 reset
  4. spawn 一个新的 `launch` 子进程
  5. 等待 CDP 起来（最多 25s）
- 如果 takeover 失败，把刚起的半成品 Codex 也清掉，10s 冷却再试。这解决了之前测试里遇到的"ActivateApplication 把一个 zombie 半渲染窗口拉到前台 → 白屏"的问题。
- 支持通过 `~/.codex-session-delete/watcher.disabled` 标记文件临时暂停，不用卸载自启。

`codex_session_delete/cli.py`

- 新增子命令：`watch`、`watch-install`、`watch-remove`、`watch-enable`、`watch-disable`。
- `watch-install` **同时**写入 `HKCU\...\Run` 值**和** Startup 文件夹里的 `.lnk`。Startup 快捷方式是后备，避免某些注册表清理工具默默把 Run 值干掉导致 watcher 不再自启。
- `remove` / `uninstall` 连带执行 `watch-remove`，保持对称。
- 顺便收紧了 `stop_existing_windows_launchers` 的正则，只匹配 `launch` 子命令 —— 之前的 `(\s+launch)?` 可选匹配会把 watcher 进程自己也杀掉。

`codex_session_delete/launcher.py`

- `launch_and_inject` 失败时（CDP 一直没起、注入 retry 全跑完还挂）会主动 kill 掉自己刚激活的 Codex.exe 再向外抛异常。配合 watcher 的失败后清理，基本消除了"停在半渲染窗口"的残余状态。

## 默认行为不变

`setup` / `setup.bat` / `install` 的流程完全不动。Watcher **只有**在用户显式执行 `python -m codex_session_delete watch-install` 时才会激活。现有用户升级后不会感受到任何行为变化。

README 里加了一节专门讲清楚取舍：

- 每次 Codex 通过原生路径启动，会先打开一瞬、被 kill、再被 launcher 带 CDP 重开，视觉上是 1–2 秒的"打开 → 关闭 → 重开"闪烁
- watcher 以 `pythonw.exe` 形式常驻后台
- Run + Startup 双路径注册说明

用户自己决定要不要这份代价换"从哪打开都生效"。

## 测试

- 新增 `tests/test_watcher.py`：覆盖 `cdp_listening`、`wait_until_no_codex`、`wait_for_cdp`、enable/disable flag 文件、非 Windows 早退路径。
- 老测试全部仍然通过：
  ```
  88 passed in 11.99s
  ```
- 本地 Windows 端到端验证：从 `shell:AppsFolder\OpenAI.Codex_2p2nqsd0c76g0!App` 原生启动 Codex，watcher 在 8 秒内完成接管，CDP 起来后 `Codex++` 菜单、插件按钮、会话删除按钮全部到位。

## 已知限制

- 仅 Windows。macOS 目前没加对应逻辑（那边没有 AppX，行为模型不同），如果有需要可以后续再补。
- 原生启动的那一次必然有闪烁，这是实现方式本身的代价；除非改 `app.asar`，否则绕不开。
