### PR TITLE
feat(delete): 优化会话删除确认与删除后页面稳定性

### DIFF
--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -464,6 +464,7 @@
 
   let cachedSessionRows = [];
   let cachedSessionRowsAt = 0;
+  const locallyDeletedSessionIds = new Set();
 
   function sessionRows(forceRefresh = false) {
     const now = Date.now();
@@ -520,6 +521,36 @@
     return { session_id: sessionId, title };
   }
 
+  function normalizedSessionId(sessionId) {
+    return String(sessionId || "").replace(/^local:/, "");
+  }
+
+  function rememberDeletedSession(ref) {
+    const sessionId = normalizedSessionId(ref?.session_id);
+    if (!sessionId) return;
+    locallyDeletedSessionIds.add(sessionId);
+    locallyDeletedSessionIds.add(`local:${sessionId}`);
+  }
+
+  function forgetDeletedSession(sessionId) {
+    const normalized = normalizedSessionId(sessionId);
+    if (!normalized) return;
+    locallyDeletedSessionIds.delete(normalized);
+    locallyDeletedSessionIds.delete(`local:${normalized}`);
+  }
+
+  function isLocallyDeletedSession(ref) {
+    return locallyDeletedSessionIds.has(normalizedSessionId(ref?.session_id)) || locallyDeletedSessionIds.has(String(ref?.session_id || ""));
+  }
+
+  function pruneLocallyDeletedSessionRows() {
+    sessionRows(true).forEach((row) => {
+      const ref = sessionRefFromRow(row);
+      if (isLocallyDeletedSession(ref)) row.remove();
+    });
+    cachedSessionRows = cachedSessionRows.filter((row) => row.isConnected);
+  }
+
   async function postJson(path, payload) {
     if (!window.__codexSessionDeleteBridge) {
       return { status: "failed", message: "删除桥接不可用，请重启启动器" };
@@ -537,6 +568,10 @@
       undo.textContent = "撤销";
       undo.addEventListener("click", async () => {
         const result = await postJson("/undo", { undo_token: undoToken });
+        if (result.status === "undone") {
+          forgetDeletedSession(result.session_id);
+          scan();
+        }
         toast.textContent = result.message || "撤销完成";
         setTimeout(() => toast.remove(), 5000);
       });
@@ -662,9 +697,11 @@
   }
 
   function removeDeletedRow(row, button, ref) {
+    rememberDeletedSession(ref);
     releaseDeleteFocus(row, button);
     const shouldReload = isCurrentSessionRow(row, ref);
     row.remove();
+    cachedSessionRows = cachedSessionRows.filter((cachedRow) => cachedRow !== row && cachedRow.isConnected);
     if (shouldReload) {
       window.location.reload();
     }
@@ -930,6 +967,7 @@
   function scanDeferred() {
     enablePluginEntry();
     unblockPluginInstallButtons();
+    pruneLocallyDeletedSessionRows();
     sessionRows().forEach(tryAttachButton);
     updateDeleteButtonOffsets();
     archivedPageRows().forEach(attachArchivedPageDeleteButton);

--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -2,9 +2,9 @@
   const helperBase = window.__CODEX_SESSION_DELETE_HELPER__ || "http://127.0.0.1:57321";
   const buttonClass = "codex-delete-button";
   const styleId = "codex-delete-style";
-  const codexDeleteStyleVersion = "4";
+  const codexDeleteStyleVersion = "5";
   const codexPlusMenuId = "codex-plus-menu";
-  const codexDeleteVersion = "5";
+  const codexDeleteVersion = "6";
   const codexArchiveDeleteAllVersion = "2";
   const codexPlusVersion = "1.0.4";
   const codexPlusSettingsKey = "codexPlusSettings";
@@ -66,44 +66,55 @@
         pointer-events: none;
       }
       .codex-delete-toast button { margin-left: 10px; pointer-events: auto; }
-      .codex-delete-confirm-overlay {
+      .codex-delete-confirm-popover {
         position: fixed;
-        inset: 0;
         z-index: 2147483200;
         display: flex;
         align-items: center;
-        justify-content: center;
-        background: rgba(15,23,42,.28);
-      }
-      .codex-delete-confirm-content {
-        width: min(420px, calc(100vw - 48px));
+        gap: 6px;
+        padding: 6px;
         border: 1px solid rgba(15,23,42,.12);
-        border-radius: 12px;
+        border-radius: 8px;
         background: #ffffff;
         color: #111827;
-        font: 14px system-ui, sans-serif;
-        box-shadow: 0 24px 80px rgba(15,23,42,.22);
-        padding: 18px;
+        font: 12px system-ui, sans-serif;
+        box-shadow: 0 12px 32px rgba(15,23,42,.22);
+        -webkit-app-region: no-drag;
       }
-      .codex-delete-confirm-title { font-size: 16px; font-weight: 650; }
-      .codex-delete-confirm-message { margin-top: 8px; color: #4b5563; line-height: 1.45; }
-      .codex-delete-confirm-actions {
-        display: flex;
-        justify-content: flex-end;
-        gap: 10px;
-        margin-top: 18px;
+      .codex-delete-confirm-popover::before {
+        content: "";
+        position: absolute;
+        left: -5px;
+        top: 50%;
+        width: 8px;
+        height: 8px;
+        transform: translateY(-50%) rotate(45deg);
+        border-left: 1px solid rgba(15,23,42,.12);
+        border-bottom: 1px solid rgba(15,23,42,.12);
+        background: #ffffff;
       }
-      .codex-delete-confirm-actions button {
+      .codex-delete-confirm-popover[data-placement="left"]::before {
+        left: auto;
+        right: -5px;
+        border-left: 0;
+        border-bottom: 0;
+        border-right: 1px solid rgba(15,23,42,.12);
+        border-top: 1px solid rgba(15,23,42,.12);
+      }
+      .codex-delete-confirm-popover button {
         border: 1px solid #d1d5db;
-        border-radius: 7px;
-        padding: 6px 12px;
+        border-radius: 6px;
+        padding: 4px 8px;
         background: #ffffff;
         color: #111827;
-        font: 13px system-ui, sans-serif;
+        font: 12px system-ui, sans-serif;
+        line-height: 16px;
+        cursor: pointer;
       }
-      .codex-delete-confirm-actions [data-codex-delete-confirm="true"] {
+      .codex-delete-confirm-popover [data-codex-delete-confirm="true"] {
         border-color: #ef4444;
         background: #dc2626;
+        color: #ffffff;
       }
       #${codexPlusMenuId}.codex-plus-menu-floating {
         position: fixed;
@@ -535,39 +546,70 @@
     setTimeout(() => toast.remove(), 10000);
   }
 
-  function escapeHtml(value) {
-    return String(value)
-      .replaceAll("&", "&amp;")
-      .replaceAll("<", "&lt;")
-      .replaceAll(">", "&gt;")
-      .replaceAll('"', "&quot;")
-      .replaceAll("'", "&#39;");
-  }
-
-  function confirmDelete(title) {
-    document.querySelectorAll(".codex-delete-confirm-overlay").forEach((node) => node.remove());
+  function confirmDelete(title, anchor) {
+    window.__codexSessionDeleteConfirmCleanup?.();
+    document.querySelectorAll(".codex-delete-confirm-popover, .codex-delete-confirm-overlay").forEach((node) => node.remove());
     return new Promise((resolve) => {
-      const overlay = document.createElement("div");
-      overlay.className = "codex-delete-confirm-overlay";
-      overlay.innerHTML = `
-        <div class="codex-delete-confirm-content" role="dialog" aria-modal="true" aria-label="删除会话">
-          <div class="codex-delete-confirm-title">删除会话</div>
-          <div class="codex-delete-confirm-message">删除“${escapeHtml(title)}”？</div>
-          <div class="codex-delete-confirm-actions">
-            <button type="button" data-codex-delete-cancel="true">取消</button>
-            <button type="button" data-codex-delete-confirm="true">删除</button>
-          </div>
-        </div>
+      const popover = document.createElement("div");
+      popover.className = "codex-delete-confirm-popover";
+      popover.setAttribute("role", "dialog");
+      popover.setAttribute("aria-modal", "false");
+      popover.setAttribute("aria-label", `删除会话：${title}`);
+      popover.style.visibility = "hidden";
+      popover.innerHTML = `
+        <button type="button" data-codex-delete-cancel="true">取消</button>
+        <button type="button" data-codex-delete-confirm="true">确认</button>
       `;
+      const place = () => {
+        const rect = anchor?.getBoundingClientRect?.();
+        if (!rect) return;
+        const gap = 8;
+        const margin = 8;
+        let left = rect.right + gap;
+        let placement = "right";
+        if (left + popover.offsetWidth > window.innerWidth - margin) {
+          left = Math.max(margin, rect.left - popover.offsetWidth - gap);
+          placement = "left";
+        }
+        const top = Math.max(margin, Math.min(window.innerHeight - popover.offsetHeight - margin, rect.top + rect.height / 2 - popover.offsetHeight / 2));
+        popover.dataset.placement = placement;
+        popover.style.left = `${left}px`;
+        popover.style.top = `${top}px`;
+        popover.style.visibility = "visible";
+      };
+      let outsideHandler = null;
+      let keyHandler = null;
+      let settled = false;
+      const cleanup = () => {
+        popover.remove();
+        if (outsideHandler) document.removeEventListener("pointerdown", outsideHandler, true);
+        if (keyHandler) document.removeEventListener("keydown", keyHandler, true);
+        window.removeEventListener("resize", place, true);
+        window.removeEventListener("scroll", place, true);
+        if (window.__codexSessionDeleteConfirmCleanup === cancelCurrent) {
+          window.__codexSessionDeleteConfirmCleanup = null;
+        }
+      };
       const finish = (value, event) => {
+        if (settled) return;
+        settled = true;
         event?.preventDefault();
         event?.stopPropagation();
         event?.target?.blur?.();
-        overlay.remove();
+        cleanup();
         resolve(value);
       };
-      overlay.addEventListener("click", (event) => {
-        if (event.target === overlay || event.target.closest("[data-codex-delete-cancel]")) {
+      const cancelCurrent = () => finish(false);
+      window.__codexSessionDeleteConfirmCleanup = cancelCurrent;
+      popover.addEventListener("pointerdown", (event) => {
+        event.stopPropagation();
+        event.stopImmediatePropagation?.();
+      }, true);
+      popover.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation?.();
+        if (event.target.closest("[data-codex-delete-cancel]")) {
           finish(false, event);
           return;
         }
@@ -575,11 +617,22 @@
           finish(true, event);
         }
       }, true);
-      overlay.addEventListener("keydown", (event) => {
+      outsideHandler = (event) => {
+        if (!popover.contains(event.target) && event.target !== anchor) finish(false, event);
+      };
+      keyHandler = (event) => {
         if (event.key === "Escape") finish(false, event);
-      }, true);
-      document.body.appendChild(overlay);
-      overlay.querySelector("[data-codex-delete-cancel]")?.focus();
+      };
+      document.body.appendChild(popover);
+      place();
+      window.addEventListener("resize", place, true);
+      window.addEventListener("scroll", place, true);
+      setTimeout(() => {
+        if (settled || window.__codexSessionDeleteConfirmCleanup !== cancelCurrent) return;
+        document.addEventListener("pointerdown", outsideHandler, true);
+        document.addEventListener("keydown", keyHandler, true);
+      }, 0);
+      popover.querySelector("[data-codex-delete-cancel]")?.focus();
     });
   }
 
@@ -635,7 +688,7 @@
     event.stopPropagation();
     event.stopImmediatePropagation?.();
     releaseDeleteFocus(row, button);
-    confirmDelete(ref.title).then(async (confirmed) => {
+    confirmDelete(ref.title, button).then(async (confirmed) => {
       if (!confirmed) return;
       releaseDeleteFocus(row, button);
       const result = await postJson("/delete", ref);
@@ -805,7 +858,7 @@
         showToast("删除失败：未找到归档会话 ID", null);
         return;
       }
-      if (!(await confirmDelete(ref.title))) return;
+      if (!(await confirmDelete(ref.title, button))) return;
       const result = await postJson("/delete", ref);
       if (result.status === "server_deleted" || result.status === "local_deleted") {
         row.remove();
@@ -855,7 +908,7 @@
       event.stopImmediatePropagation?.();
       const currentRows = archivedRows();
       if (currentRows.length === 0) return;
-      if (!(await confirmDelete(`全部 ${currentRows.length} 个归档会话`))) return;
+      if (!(await confirmDelete(`全部 ${currentRows.length} 个归档会话`, button))) return;
       await deleteArchivedSessions(currentRows);
     };
     button.addEventListener("pointerup", openArchivedDeleteAllConfirm, true);
@@ -898,7 +951,7 @@
   }
 
   function isExtensionUiNode(node) {
-    return !!node?.closest?.(".codex-delete-toast, .codex-delete-confirm-overlay, .codex-plus-modal-overlay, #codex-plus-menu");
+    return !!node?.closest?.(".codex-delete-toast, .codex-delete-confirm-popover, .codex-delete-confirm-overlay, .codex-plus-modal-overlay, #codex-plus-menu");
   }
 
   const scanRelevantSelector = '[data-app-action-sidebar-thread-id], [data-codex-archive-page-row="true"], [data-codex-archive-delete-all], .app-header-tint, button[aria-label="已归档对话"], button[aria-label="Archived conversations"], button:disabled.w-full.justify-center, [role="button"][aria-disabled="true"].cursor-not-allowed';

--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -66,6 +66,9 @@
         pointer-events: none;
       }
       .codex-delete-toast button { margin-left: 10px; pointer-events: auto; }
+      [data-codex-locally-deleted="true"] {
+        display: none !important;
+      }
       .codex-delete-confirm-popover {
         position: fixed;
         z-index: 2147483200;
@@ -493,12 +496,12 @@
       row.dataset.codexArchivePageRow = "true";
       row.setAttribute("data-codex-archive-page-row", "true");
     });
-    return rows;
+    return rows.filter((row) => row.dataset.codexLocallyDeleted !== "true");
   }
 
   function archivedSessionRows() {
     if (!archivePageHintVisible()) return [];
-    return sessionRows().filter((row) => row.querySelector('button[aria-label="取消归档对话"]') || row.outerHTML.includes("取消归档") || row.outerHTML.includes("unarchive"));
+    return sessionRows().filter((row) => row.dataset.codexLocallyDeleted !== "true" && (row.querySelector('button[aria-label="取消归档对话"]') || row.outerHTML.includes("取消归档") || row.outerHTML.includes("unarchive")));
   }
 
   function archivedRows() {
@@ -543,10 +546,24 @@
     return locallyDeletedSessionIds.has(normalizedSessionId(ref?.session_id)) || locallyDeletedSessionIds.has(String(ref?.session_id || ""));
   }
 
+  function hideDeletedRow(row) {
+    row.dataset.codexLocallyDeleted = "true";
+    row.setAttribute("data-codex-locally-deleted", "true");
+  }
+
+  function showRestoredRow(row) {
+    delete row.dataset.codexLocallyDeleted;
+    row.removeAttribute("data-codex-locally-deleted");
+  }
+
   function pruneLocallyDeletedSessionRows() {
     sessionRows(true).forEach((row) => {
       const ref = sessionRefFromRow(row);
-      if (isLocallyDeletedSession(ref)) row.remove();
+      if (isLocallyDeletedSession(ref)) {
+        hideDeletedRow(row);
+      } else if (row.dataset.codexLocallyDeleted === "true") {
+        showRestoredRow(row);
+      }
     });
     cachedSessionRows = cachedSessionRows.filter((row) => row.isConnected);
   }
@@ -699,11 +716,11 @@
   function removeDeletedRow(row, button, ref) {
     rememberDeletedSession(ref);
     releaseDeleteFocus(row, button);
-    const shouldReload = isCurrentSessionRow(row, ref);
-    row.remove();
-    cachedSessionRows = cachedSessionRows.filter((cachedRow) => cachedRow !== row && cachedRow.isConnected);
-    if (shouldReload) {
-      window.location.reload();
+    const shouldLeaveCurrentSession = isCurrentSessionRow(row, ref);
+    hideDeletedRow(row);
+    cachedSessionRows = cachedSessionRows.filter((cachedRow) => cachedRow.isConnected);
+    if (shouldLeaveCurrentSession) {
+      window.location.assign(new URL("/", window.location.href).href);
     }
   }
 
@@ -866,10 +883,12 @@
       if (!ref.session_id) continue;
       const result = await postJson("/delete", ref);
       if (result.status === "server_deleted" || result.status === "local_deleted") {
-        row.remove();
+        rememberDeletedSession(ref);
+        hideDeletedRow(row);
         deleted += 1;
       }
     }
+    scan();
     showToast(`已删除 ${deleted} 个归档会话`, null);
   }
 
@@ -898,7 +917,9 @@
       if (!(await confirmDelete(ref.title, button))) return;
       const result = await postJson("/delete", ref);
       if (result.status === "server_deleted" || result.status === "local_deleted") {
-        row.remove();
+        rememberDeletedSession(ref);
+        hideDeletedRow(row);
+        scan();
         showToast(result.message || "删除成功", result.undo_token);
       } else {
         showToast(result.message || "删除失败", null);

--- a/codex_session_delete/storage_adapter.py
+++ b/codex_session_delete/storage_adapter.py
@@ -92,6 +92,7 @@ class SQLiteStorageAdapter:
         self._backup_related_rows(db, tables, "thread_spawn_edges", "parent_thread_id = ? OR child_thread_id = ?", (thread_id, thread_id))
         self._backup_related_rows(db, tables, "stage1_outputs", "thread_id = ?", (thread_id,))
         self._backup_related_rows(db, tables, "agent_job_items", "assigned_thread_id = ?", (thread_id,))
+        self._backup_orphaned_codex_rows(db, tables)
 
         file_backups = self._rollout_file_backups(thread_rows)
         if file_backups:
@@ -103,6 +104,7 @@ class SQLiteStorageAdapter:
         self._delete_related_rows(db, "thread_goals", "thread_id = ?", (thread_id,))
         self._delete_related_rows(db, "thread_spawn_edges", "parent_thread_id = ? OR child_thread_id = ?", (thread_id, thread_id))
         self._delete_related_rows(db, "stage1_outputs", "thread_id = ?", (thread_id,))
+        self._delete_orphaned_codex_rows(db)
         if self._has_table(db, "agent_job_items") and self._has_columns(db, "agent_job_items", {"assigned_thread_id"}):
             db.execute("UPDATE agent_job_items SET assigned_thread_id = NULL WHERE assigned_thread_id = ?", (thread_id,))
         db.execute("DELETE FROM threads WHERE id = ?", (thread_id,))
@@ -140,11 +142,66 @@ class SQLiteStorageAdapter:
 
     def _backup_related_rows(self, db: sqlite3.Connection, tables: dict[str, list[dict[str, Any]]], table: str, where: str, params: tuple[Any, ...]) -> None:
         if self._has_table(db, table):
-            tables[table] = self._select_dicts(db, f'SELECT * FROM "{table}" WHERE {where}', params)
+            tables.setdefault(table, [])
+            self._append_backup_rows(tables, table, self._select_dicts(db, f'SELECT * FROM "{table}" WHERE {where}', params))
 
     def _delete_related_rows(self, db: sqlite3.Connection, table: str, where: str, params: tuple[Any, ...]) -> None:
         if self._has_table(db, table):
             db.execute(f'DELETE FROM "{table}" WHERE {where}', params)
+
+    def _backup_orphaned_codex_rows(self, db: sqlite3.Connection, tables: dict[str, list[dict[str, Any]]]) -> None:
+        if self._has_table(db, "thread_spawn_edges"):
+            rows = self._select_dicts(
+                db,
+                """
+                SELECT e.* FROM thread_spawn_edges e
+                LEFT JOIN threads parent ON parent.id = e.parent_thread_id
+                LEFT JOIN threads child ON child.id = e.child_thread_id
+                WHERE parent.id IS NULL OR child.id IS NULL
+                """,
+                (),
+            )
+            if rows:
+                self._append_backup_rows(tables, "thread_spawn_edges", rows)
+        if self._has_table(db, "agent_job_items") and self._has_columns(db, "agent_job_items", {"assigned_thread_id"}):
+            rows = self._select_dicts(
+                db,
+                """
+                SELECT i.* FROM agent_job_items i
+                LEFT JOIN threads t ON t.id = i.assigned_thread_id
+                WHERE i.assigned_thread_id IS NOT NULL AND t.id IS NULL
+                """,
+                (),
+            )
+            if rows:
+                self._append_backup_rows(tables, "agent_job_items", rows)
+
+    def _append_backup_rows(self, tables: dict[str, list[dict[str, Any]]], table: str, rows: list[dict[str, Any]]) -> None:
+        if not rows:
+            return
+        existing = tables.setdefault(table, [])
+        for row in rows:
+            if row not in existing:
+                existing.append(row)
+
+    def _delete_orphaned_codex_rows(self, db: sqlite3.Connection) -> None:
+        if self._has_table(db, "thread_spawn_edges"):
+            db.execute(
+                """
+                DELETE FROM thread_spawn_edges
+                WHERE parent_thread_id NOT IN (SELECT id FROM threads)
+                   OR child_thread_id NOT IN (SELECT id FROM threads)
+                """
+            )
+        if self._has_table(db, "agent_job_items") and self._has_columns(db, "agent_job_items", {"assigned_thread_id"}):
+            db.execute(
+                """
+                UPDATE agent_job_items
+                SET assigned_thread_id = NULL
+                WHERE assigned_thread_id IS NOT NULL
+                  AND assigned_thread_id NOT IN (SELECT id FROM threads)
+                """
+            )
 
     def _rollout_file_backups(self, thread_rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
         file_backups = []

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -134,7 +134,7 @@ def test_renderer_script_chat_filter_keeps_relevant_node_escape_hatch():
     assert "[role=\"button\"][aria-disabled=\"true\"].cursor-not-allowed" in relevant_code
 
 
-def test_renderer_script_clears_focus_and_removes_deleted_rows():
+def test_renderer_script_clears_focus_and_hides_deleted_rows_without_detaching_react_nodes():
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
     assert "removeDeletedRow(row, button, ref)" in text
     assert "function releaseDeleteFocus" in text
@@ -146,8 +146,15 @@ def test_renderer_script_clears_focus_and_removes_deleted_rows():
     assert "button.blur()" in text
     assert "document.activeElement.blur()" in text
     assert "rememberDeletedSession(ref)" in text
-    assert "row.remove()" in text
-    assert "row.style.display = \"none\"" not in text
+    assert "function hideDeletedRow" in text
+    assert "function showRestoredRow" in text
+    assert "data-codex-locally-deleted" in text
+    assert "hideDeletedRow(row)" in text
+    assert "showRestoredRow(row)" in text
+    assert "row.removeAttribute(\"data-codex-locally-deleted\")" in text
+    remove_deleted_start = text.index("function removeDeletedRow")
+    remove_deleted_end = text.index("\n\n  function updateDeleteButtonOffsets", remove_deleted_start)
+    assert "row.remove()" not in text[remove_deleted_start:remove_deleted_end]
 
 
 def test_renderer_script_uses_in_page_confirm_and_stops_early_pointer_events():
@@ -166,11 +173,12 @@ def test_renderer_script_uses_in_page_confirm_and_stops_early_pointer_events():
     assert "\"pointerdown\", \"mousedown\", \"mouseup\", \"touchstart\"" in text
 
 
-def test_renderer_script_reloads_after_deleting_current_session():
+def test_renderer_script_leaves_deleted_current_session():
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
     assert "isCurrentSessionRow" in text
     assert "window.location.href.includes(ref.session_id)" in text
-    assert "window.location.reload()" in text
+    assert "window.location.assign(new URL(\"/\", window.location.href).href)" in text
+    assert "window.location.reload()" not in text
 
 
 def test_renderer_script_toast_does_not_capture_page_interactions():
@@ -253,6 +261,8 @@ def test_renderer_script_sidebar_delete_opens_on_pointerup_when_click_is_unrelia
     assert "cursor: \"pointer\"" in text
     assert "position: \"static\"" in text
     assert "data-codex-archive-page-row" in text
+    assert "row.dataset.codexLocallyDeleted !== \"true\"" in text
+    assert "scan();\n    showToast(`" in text
     assert "data-app-action-sidebar-thread-id" in text
     assert "取消归档" in text
     assert "已归档对话" in text

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -138,9 +138,14 @@ def test_renderer_script_clears_focus_and_removes_deleted_rows():
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
     assert "removeDeletedRow(row, button, ref)" in text
     assert "function releaseDeleteFocus" in text
+    assert "const locallyDeletedSessionIds = new Set()" in text
+    assert "function rememberDeletedSession" in text
+    assert "function pruneLocallyDeletedSessionRows" in text
+    assert "pruneLocallyDeletedSessionRows()" in text
     assert "releaseDeleteFocus(row, button)" in text
     assert "button.blur()" in text
     assert "document.activeElement.blur()" in text
+    assert "rememberDeletedSession(ref)" in text
     assert "row.remove()" in text
     assert "row.style.display = \"none\"" not in text
 

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -148,8 +148,15 @@ def test_renderer_script_clears_focus_and_removes_deleted_rows():
 def test_renderer_script_uses_in_page_confirm_and_stops_early_pointer_events():
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
     assert "confirm(" not in text
-    assert "codex-delete-confirm-overlay" in text
-    assert "escapeHtml(title)" in text
+    assert "codex-delete-confirm-popover" in text
+    assert "left = rect.right + gap" in text
+    assert "确认" in text
+    assert "取消" in text
+    popover_html = text[text.index("popover.innerHTML"):text.index("const place", text.index("popover.innerHTML"))]
+    assert popover_html.index('data-codex-delete-cancel="true"') < popover_html.index('data-codex-delete-confirm="true"')
+    assert "window.__codexSessionDeleteConfirmCleanup?.()" in text
+    assert "window.__codexSessionDeleteConfirmCleanup = cancelCurrent" in text
+    assert "window.__codexSessionDeleteConfirmCleanup !== cancelCurrent" in text
     assert "stopImmediatePropagation" in text
     assert "\"pointerdown\", \"mousedown\", \"mouseup\", \"touchstart\"" in text
 
@@ -169,7 +176,7 @@ def test_renderer_script_toast_does_not_capture_page_interactions():
 def test_renderer_script_sidebar_delete_opens_on_pointerup_when_click_is_unreliable():
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
     assert "openDeleteConfirm" in text
-    assert "codexDeleteVersion = \"5\"" in text
+    assert "codexDeleteVersion = \"6\"" in text
     assert "existingDeleteButtons.length === 1" in text
     assert "existingDeleteButtons[0].dataset.codexDeleteVersion === codexDeleteVersion" in text
     assert "existingDeleteButtons.forEach((button) => button.remove())" in text
@@ -183,7 +190,7 @@ def test_renderer_script_sidebar_delete_opens_on_pointerup_when_click_is_unrelia
 
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
     assert "updateDeleteButtonOffsets" in text
-    assert "codexDeleteStyleVersion = \"4\"" in text
+    assert "codexDeleteStyleVersion = \"5\"" in text
     assert "right: 66px" in text
     assert "确认" in text
     assert "归档对话" in text

--- a/tests/test_storage_adapter.py
+++ b/tests/test_storage_adapter.py
@@ -81,6 +81,39 @@ def test_delete_codex_thread_schema_creates_backup_and_removes_thread_rows(tmp_p
         assert db.execute("SELECT assigned_thread_id FROM agent_job_items WHERE id = 'job1'").fetchone()[0] is None
 
 
+def test_delete_codex_thread_schema_prunes_stale_codex_references(tmp_path):
+    db_path = tmp_path / "state_5.sqlite"
+    rollout_path = tmp_path / "rollout.jsonl"
+    rollout_path.write_text('{"type":"message"}\n', encoding="utf-8")
+    create_codex_thread_db(db_path, rollout_path)
+    with sqlite3.connect(db_path) as db:
+        db.execute("INSERT INTO threads (id, rollout_path, title, archived, archived_at) VALUES ('t2', '', 'Other Thread', 0, NULL)")
+        db.execute("INSERT INTO thread_spawn_edges (parent_thread_id, child_thread_id, status) VALUES ('missing-parent', 't2', 'open')")
+        db.execute("INSERT INTO agent_job_items (id, assigned_thread_id) VALUES ('job2', 'missing-thread')")
+    adapter = SQLiteStorageAdapter(db_path, BackupStore(tmp_path / "backups"))
+
+    result = adapter.delete_local(SessionRef(session_id="t1", title="Codex Thread"))
+
+    assert result.status == DeleteStatus.LOCAL_DELETED
+    with sqlite3.connect(db_path) as db:
+        assert db.execute(
+            """
+            SELECT COUNT(*) FROM thread_spawn_edges e
+            LEFT JOIN threads parent ON parent.id = e.parent_thread_id
+            LEFT JOIN threads child ON child.id = e.child_thread_id
+            WHERE parent.id IS NULL OR child.id IS NULL
+            """
+        ).fetchone()[0] == 0
+        assert db.execute("SELECT assigned_thread_id FROM agent_job_items WHERE id = 'job2'").fetchone()[0] is None
+
+    restored = adapter.undo(result.undo_token or "")
+
+    assert restored.status == DeleteStatus.UNDONE
+    with sqlite3.connect(db_path) as db:
+        assert db.execute("SELECT COUNT(*) FROM thread_spawn_edges WHERE parent_thread_id = 'missing-parent' AND child_thread_id = 't2'").fetchone()[0] == 1
+        assert db.execute("SELECT assigned_thread_id FROM agent_job_items WHERE id = 'job2'").fetchone()[0] == "missing-thread"
+
+
 def test_undo_restores_deleted_codex_thread_schema_and_rollout_file(tmp_path):
     db_path = tmp_path / "state_5.sqlite"
     rollout_path = tmp_path / "rollout.jsonl"


### PR DESCRIPTION
## 概括
优化 Codex++ 的会话删除交互，并修复删除会话后继续使用 Codex 其他页面时可能触发错误页的问题。

## 变更

- 将删除确认从屏幕中央弹窗改为删除按钮旁的轻量确认弹窗
- 删除会话后不再直接移除 Codex/React 管理的 DOM 节点，改为标记并隐藏，避免后续页面切换触发 React 错误边界
- 修复本地删除后会话行可能重复出现的问题
- 清理 Codex 本地 SQLite 中悬空的 thread 引用，降低历史残留数据导致页面异常的概率
- 补充 renderer 注入脚本和 storage adapter 相关测试

## 验证

- `node --check codex_session_delete/inject/renderer-inject.js`
- `python -m pytest tests/test_renderer_script.py tests/test_storage_adapter.py`


