### PR TITLE
Fix macOS source launcher and bypass proxy for local CDP

### DIFF
--- a/codex_session_delete/cdp.py
+++ b/codex_session_delete/cdp.py
@@ -14,7 +14,9 @@ BRIDGE_BINDING_NAME = "codexSessionDeleteV2"
 
 
 def list_targets(port: int) -> list[dict[str, object]]:
-    response = requests.get(f"http://127.0.0.1:{port}/json", timeout=3)
+    session = requests.Session()
+    session.trust_env = False
+    response = session.get(f"http://127.0.0.1:{port}/json", timeout=3)
     response.raise_for_status()
     return response.json()
 

--- a/codex_session_delete/macos_installer.py
+++ b/codex_session_delete/macos_installer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import plistlib
+import shlex
 import shutil
 import stat
 import sys
@@ -24,6 +25,9 @@ EXECUTABLE_NAME = "CodexPlusPlus"
 def _launcher_command(options: "InstallOptions") -> str:
     if options.launcher_command:
         return options.launcher_command
+    project_root = Path(__file__).resolve().parent.parent
+    if (project_root / "pyproject.toml").is_file():
+        return f"env PYTHONPATH={shlex.quote(str(project_root))} {shlex.quote(sys.executable)} -m codex_session_delete launch"
     return f"{sys.executable} -m codex_session_delete launch"
 
 

--- a/tests/test_cdp.py
+++ b/tests/test_cdp.py
@@ -1,7 +1,7 @@
 import json
 import websocket
 
-from codex_session_delete.cdp import BRIDGE_BINDING_NAME, _bridge_loop, build_bridge_script, pick_page_target
+from codex_session_delete.cdp import BRIDGE_BINDING_NAME, _bridge_loop, build_bridge_script, list_targets, pick_page_target
 
 
 class TimeoutThenMessageSocket:
@@ -31,6 +31,36 @@ def test_pick_page_target_prefers_codex_title():
     ]
 
     assert pick_page_target(targets)["webSocketDebuggerUrl"] == "ws://page"
+
+
+def test_list_targets_bypasses_proxy_environment(monkeypatch):
+    seen = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return [{"type": "page"}]
+
+    class FakeSession:
+        def __init__(self):
+            self.trust_env = True
+
+        def get(self, url, timeout):
+            seen["trust_env"] = self.trust_env
+            seen["url"] = url
+            seen["timeout"] = timeout
+            return FakeResponse()
+
+    monkeypatch.setattr("codex_session_delete.cdp.requests.Session", FakeSession)
+
+    assert list_targets(9229) == [{"type": "page"}]
+    assert seen == {
+        "trust_env": False,
+        "url": "http://127.0.0.1:9229/json",
+        "timeout": 3,
+    }
 
 
 def test_pick_page_target_rejects_missing_websocket():

--- a/tests/test_macos_installer.py
+++ b/tests/test_macos_installer.py
@@ -4,6 +4,7 @@ import stat
 
 from codex_session_delete.installers import InstallOptions
 from codex_session_delete import __version__
+from codex_session_delete import macos_installer
 from codex_session_delete.macos_installer import install_macos_app, uninstall_macos_app
 
 
@@ -41,3 +42,18 @@ def test_uninstall_macos_app_removes_app_bundle(tmp_path):
     uninstall_macos_app(InstallOptions(install_root=tmp_path))
 
     assert not (tmp_path / "Codex++.app").exists()
+
+
+def test_default_launcher_command_sets_pythonpath_in_source_tree(monkeypatch, tmp_path):
+    package_dir = tmp_path / "codex_session_delete"
+    package_dir.mkdir()
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='codex-session-delete'\n", encoding="utf-8")
+    fake_file = package_dir / "macos_installer.py"
+    fake_file.write_text("", encoding="utf-8")
+    monkeypatch.setattr(macos_installer, "__file__", str(fake_file))
+
+    command = macos_installer._launcher_command(InstallOptions())
+
+    assert "PYTHONPATH=" in command
+    assert str(tmp_path) in command
+    assert "-m codex_session_delete launch" in command


### PR DESCRIPTION
## 摘要
- 连接本机 CDP 端点时绕过代理环境变量，避免 `HTTP_PROXY`/`http_proxy` 拦截 `127.0.0.1:9229`。
- macOS 源码目录安装时，生成的 `Codex++.app` 启动命令会设置 `PYTHONPATH`，确保通过 Finder 或 `open` 启动也能导入本地包。
- 为以上两个行为补充回归测试。

## 验证
- `.venv/bin/python -m pytest -q`
- 结果：`114 passed`

## 背景
这次修复覆盖两个 macOS 源码安装场景下的启动失败：一是本地 HTTP 代理会拦截 `127.0.0.1:9229` 的 CDP 请求；二是 GUI 启动时工作目录不在仓库根目录，导致 `Codex++.app` 找不到 `codex_session_delete` 模块。