### PR TITLE
修复 Windows 端 setup.bat 安装失败：改走项目内 venv 并显式声明 packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Windows shell scripts require CRLF for cmd.exe label parsing
+# (LF-only .bat files break `goto label` at runtime).
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ test = ["pytest>=8.0"]
 [project.scripts]
 codex-session-delete = "codex_session_delete.cli:main"
 
+[tool.setuptools]
+packages = ["codex_session_delete"]
+
 [tool.setuptools.package-data]
 codex_session_delete = ["assets/*", "inject/*.js"]
 

--- a/setup.bat
+++ b/setup.bat
@@ -2,6 +2,9 @@
 setlocal
 cd /d "%~dp0"
 
+set "VENV_DIR=%~dp0.venv"
+set "VENV_PY=%VENV_DIR%\Scripts\python.exe"
+
 :menu
 cls
 echo ========================================
@@ -27,12 +30,14 @@ goto menu
 
 :install
 echo.
-echo Installing Python package...
-python -m pip install -e .
+call :ensure_venv
+if errorlevel 1 goto error
+echo Installing Codex++ into venv...
+"%VENV_PY%" -m pip install -e .
 if errorlevel 1 goto error
 echo.
 echo Installing Codex++ shortcut and uninstall entry...
-python -m codex_session_delete setup
+"%VENV_PY%" -m codex_session_delete setup
 if errorlevel 1 goto error
 echo.
 echo Codex++ installed successfully.
@@ -42,8 +47,14 @@ goto end
 
 :uninstall
 echo.
+if exist "%VENV_PY%" (
+    set "RUNPY=%VENV_PY%"
+) else (
+    echo Codex++ venv not found, falling back to system python.
+    set "RUNPY=python"
+)
 echo Uninstalling Codex++ shortcut and uninstall entry...
-python -m codex_session_delete remove
+"%RUNPY%" -m codex_session_delete remove
 if errorlevel 1 goto error
 echo.
 echo Codex++ uninstalled successfully.
@@ -52,13 +63,29 @@ goto end
 
 :update
 echo.
+call :ensure_venv
+if errorlevel 1 goto error
 echo Updating Codex++ from GitHub Release...
-python -m codex_session_delete update
+"%VENV_PY%" -m codex_session_delete update
 if errorlevel 1 goto error
 echo.
 echo Codex++ update finished.
 pause
 goto end
+
+:ensure_venv
+if exist "%VENV_PY%" exit /b 0
+echo.
+echo Creating Python virtual environment at "%VENV_DIR%"...
+python -m venv "%VENV_DIR%"
+if errorlevel 1 (
+    echo Failed to create venv. Make sure Python 3.11+ is installed and available on PATH.
+    exit /b 1
+)
+echo Upgrading pip / setuptools / wheel inside venv...
+"%VENV_PY%" -m pip install --upgrade pip setuptools wheel
+if errorlevel 1 exit /b 1
+exit /b 0
 
 :error
 echo.


### PR DESCRIPTION
## 背景

在中文 Windows + PowerShell 环境运行 `setup.bat` 选 1 装失败，截到的关键报错是 pip 子进程退出码 `3221225477`（即 `0xC0000005`，Windows 访问冲突）。逐层定位后发现是 3 个独立问题叠加，本 PR 一次性修掉。

## 修复内容

### 1. `pyproject.toml`：显式声明 packages

```toml
[tool.setuptools]
packages = [\"codex_session_delete\"]
```

- 仓库根目录的 `logs/` 是运行时目录（已被 `.gitignore`），但 setuptools ≥ 61 在 flat-layout 自动发现里会把它和 `codex_session_delete/` 一起当成顶层包，于是拒绝构建并报 `Multiple top-level packages discovered`。
- 老 setuptools（如 65.5.0）尚能容忍，但全新环境（如 setuptools 82）下必然失败。

### 2. `setup.bat`：改走项目内 `.venv/`

- 旧版直接 `python -m pip install -e .` 装到全局。一旦用户全局 site-packages 损坏（典型表现：`import setuptools` 抛 `TypeError: catching classes that do not inherit from BaseException`、`wheel` 缺失），pip 的 PEP 517 构建隔离子进程一启动就被解释器层面拖崩，OS 直接给 `0xC0000005`，整个安装链终止。
- 新版在仓库根创建 `.venv/`，新增 `:ensure_venv` 子例程负责创建 venv + 升级 `pip/setuptools/wheel`，install/update 全部走 `.venv\Scripts\python.exe`。
- `codex_session_delete/windows_installer.py` 里桌面快捷方式 / 注册表卸载条目的 Python 路径是用 `(Get-Command python).Source` 解析的，所以从 venv 调用 `python -m codex_session_delete setup` 时，路径会自动锚定到 venv，无需改 Python 端。
- 卸载分支保留对历史全局安装的回退：venv 不存在时回落到系统 `python`。

### 3. 新增 `.gitattributes`：强制 `*.bat *.cmd *.ps1` 用 CRLF

- cmd.exe 对 `.bat` 标签解析依赖 CRLF，LF-only 时 `goto <第二个标签>` 会报 `系统找不到指定的批处理标签`（开发过程中已实际踩到过）。

## 测试

- 环境：Windows 11 / Python 3.11.2 / cmd.exe 中文 locale。
- 完整跑通：
  - `setup.bat` 选 1 → 自动建 `.venv/`、升级 pip/setuptools/wheel、`pip install -e .`、创建桌面快捷方式 + `HKCU\...\Uninstall\CodexPlusPlus`。
  - `setup.bat` 选 2 → 用 venv 的 python 调 `remove`，删快捷方式与注册表条目。
- `pyproject.toml` 改动同时被 setuptools 65.5.0 与 82.0.1 验证可用。

## 风险

- 仓库目录必须可写以创建 `.venv/`，放在 UAC 受保护的目录（如 `C:\Program Files\...`）会失败——但旧版直接装全局也同样会失败，不算回归。
- `.venv/` 约 30 MB；之后若搬动仓库目录，venv 内绝对路径会失效，删 `.venv/` 重跑 `setup.bat` 即可重建。