### PR TITLE
fix(windows): protect ancestor processes from self-kill in launcher

### DIFF
--- a/codex_session_delete/cli.py
+++ b/codex_session_delete/cli.py
@@ -121,14 +121,25 @@ def wait_for_shutdown(server: HelperServer, codex_proc) -> None:
 def stop_existing_windows_launchers() -> None:
     if sys.platform != "win32":
         return
-    current_pid = os.getpid()
+    # Protect our own process AND every ancestor up the chain. venv's python.exe
+    # is a stub that re-spawns a second python.exe child (same CommandLine), and
+    # shells/bash also carry launcher command lines in their ancestry. Killing
+    # any of them (e.g. the stub parent) tears down stdio for the real worker
+    # and aborts the launch before Codex is activated.
     script = (
+        "$self = [int]$env:CODEX_PLUS_PLUS_PID; "
+        "$protect = New-Object System.Collections.Generic.HashSet[int]; "
+        "$cur = $self; "
+        "while ($cur -ne 0 -and $protect.Add($cur)) { "
+        "$p = Get-CimInstance Win32_Process -Filter \"ProcessId=$cur\" -ErrorAction SilentlyContinue; "
+        "if ($null -eq $p) { break }; $cur = [int]$p.ParentProcessId "
+        "} "
         "Get-CimInstance Win32_Process | "
-        "Where-Object { $_.ProcessId -ne $env:CODEX_PLUS_PLUS_PID -and "
-        "$_.CommandLine -match 'pythonw?(.exe)?\"?\\s+-m\\s+codex_session_delete\\s+launch(\\s|$)' } | "
-        "ForEach-Object { Stop-Process -Id $_.ProcessId -Force }"
+        "Where-Object { -not $protect.Contains([int]$_.ProcessId) -and "
+        "$_.CommandLine -match 'pythonw?(\\.exe)?\"?\\s+(-[A-Za-z]+\\s+)*-m\\s+codex_session_delete\\s+launch(\\s|$)' } | "
+        "ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }"
     )
-    env = {**os.environ, "CODEX_PLUS_PLUS_PID": str(current_pid)}
+    env = {**os.environ, "CODEX_PLUS_PLUS_PID": str(os.getpid())}
     subprocess.run(["powershell", "-NoProfile", "-Command", script], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
 
 


### PR DESCRIPTION
## 问题
双击快捷方式无反应, 有issue: https://github.com/BigPizzaV3/CodexPlusPlus/issues/40
在 Windows 上,使用 venv 的 `python.exe -m codex_session_delete launch` 无法正常启动 Codex: 日志不写、Codex 不弹窗、进程静默退出。加 `-u` 却能成功。

## 根因

`stop_existing_windows_launchers()` 用 `CommandLine` 正则 + 当前 PID自检来清理旧 launcher,但:

1. venv 的 `python.exe` 是 stub,实际会再 spawn 一个真正的 `pythonXYZ.exe` 子进程。
2. WMI 对 stub 父进程和真实子进程返回**完全相同**的 CommandLine。
3. 真正跑 cli.py 的是子进程,它把 `CODEX_PLUS_PLUS_PID` 设成**自己的**PID, 只排除了自己 —— stub 父进程**没被排除,被 force kill**。
4. 父进程被杀后,子进程 stdio 断链,在 `launch_codex_app` 之前就挂掉了,Codex 根本来不及被激活。

加 `-u` 之所以"能跑",是因为 `-u` 打断了 `python\s+-m` 的正则,
两个 python 进程都不匹配,于是都不被杀 —— 纯属巧合。

## 修复
- 遍历当前进程的整条祖先链,把所有 PID 加入保护集合。
- 正则允许 `-m` 前出现任意短选项(`-u`、`-v` 等)。

## 验证
- 不加 `-u` 复现:Codex 无反应、无日志、exit 127。
- 应用本补丁后:不加 `-u` 启动,Codex 正常弹窗,helper server 正常打印。