### PR TITLE
Add history export for Codex sessions

### DIFF
--- a/codex_session_delete/helper_server.py
+++ b/codex_session_delete/helper_server.py
@@ -4,7 +4,7 @@ import json
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Protocol
 
-from codex_session_delete.models import DeleteResult, DeleteStatus, SessionRef
+from codex_session_delete.models import DeleteResult, DeleteStatus, ExportResult, ExportStatus, SessionRef
 
 
 class DeleteService(Protocol):
@@ -13,17 +13,23 @@ class DeleteService(Protocol):
     def find_archived_thread_by_title(self, title: str) -> SessionRef | None: ...
 
 
+class ExportService(Protocol):
+    def export(self, session: SessionRef) -> ExportResult: ...
+
+
 class HelperServer(ThreadingHTTPServer):
     def __init__(
         self,
         host: str,
         port: int,
         service: DeleteService,
+        export_service: ExportService | None = None,
         *,
         allow_http_mutation: bool = False,
         http_mutation_token: str | None = None,
     ):
         self.service = service
+        self.export_service = export_service
         self.allow_http_mutation = allow_http_mutation
         self.http_mutation_token = http_mutation_token
         super().__init__((host, port), _Handler)
@@ -48,7 +54,7 @@ class _Handler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:
         try:
             payload = self._read_json()
-            if self.path in {"/delete", "/undo", "/archived-thread"} and not self._is_mutation_authorized():
+            if self.path in {"/delete", "/undo", "/archived-thread", "/export-markdown"} and not self._is_mutation_authorized():
                 self._send_json({"error": "forbidden"}, status=403)
                 return
             if self.path == "/delete":
@@ -63,9 +69,24 @@ class _Handler(BaseHTTPRequestHandler):
                 session = self.server.service.find_archived_thread_by_title(str(payload.get("title", "")))
                 self._send_json({"session_id": session.session_id, "title": session.title} if session else {"session_id": "", "title": ""})
                 return
+            if self.path == "/export-markdown":
+                if self.server.export_service is None:
+                    self._send_json(
+                        ExportResult(ExportStatus.FAILED, str(payload.get("session_id", "")), "Markdown 导出不可用").to_dict(),
+                        status=400,
+                    )
+                    return
+                session = SessionRef(session_id=str(payload.get("session_id", "")), title=str(payload.get("title", "")))
+                self._send_json(self.server.export_service.export(session).to_dict())
+                return
             self._send_json({"error": "not found"}, status=404)
         except Exception as exc:
-            result = DeleteResult(DeleteStatus.FAILED, str(payload.get("session_id", "")) if "payload" in locals() else "", str(exc))
+            session_id = str(payload.get("session_id", "")) if "payload" in locals() else ""
+            if self.path == "/export-markdown":
+                result = ExportResult(ExportStatus.FAILED, session_id, str(exc))
+                self._send_json(result.to_dict(), status=400)
+                return
+            result = DeleteResult(DeleteStatus.FAILED, session_id, str(exc))
             self._send_json(result.to_dict(), status=400)
 
     def log_message(self, format: str, *args: object) -> None:

--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -741,7 +741,8 @@
     const fallbackId = row.getAttribute("data-session-id") || row.getAttribute("data-testid") || "";
     const sessionId = codexThreadId || (idMatch && idMatch[1]) || fallbackId;
     const titleNode = row.querySelector(selectors.threadTitle);
-    const title = ((titleNode || row).textContent || "Untitled session").replace("导出", "").replace("删除", "").trim().slice(0, 160);
+    const rawTitle = (titleNode?.textContent || (titleNode ? "" : (row.textContent || "Untitled session")));
+    const title = (titleNode ? rawTitle : rawTitle.replace("导出", "").replace("删除", "")).trim().slice(0, 160);
     return { session_id: sessionId, title };
   }
 

--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -1,10 +1,16 @@
 (() => {
   const helperBase = window.__CODEX_SESSION_DELETE_HELPER__ || "http://127.0.0.1:57321";
   const buttonClass = "codex-delete-button";
+  const exportButtonClass = "codex-export-button";
+  const actionButtonClass = "codex-session-action-button";
+  const actionGroupClass = "codex-session-actions";
   const styleId = "codex-delete-style";
-  const codexDeleteStyleVersion = "4";
+  const codexDeleteStyleVersion = "5";
   const codexPlusMenuId = "codex-plus-menu";
-  const codexDeleteVersion = "5";
+  const codexDeleteVersion = "6";
+  const codexExportVersion = "1";
+  const codexActionGroupVersion = "1";
+  const codexArchiveRowActionsVersion = "1";
   const codexArchiveDeleteAllVersion = "2";
   const codexPlusVersion = "1.0.5";;
   const codexPlusSettingsKey = "codexPlusSettings";
@@ -27,24 +33,48 @@
     style.id = styleId;
     style.dataset.codexDeleteStyleVersion = codexDeleteStyleVersion;
     style.textContent = `
-      .${buttonClass} {
+      .${actionGroupClass} {
         position: absolute;
         right: 28px;
         top: 50%;
         transform: translateY(-50%);
         z-index: 20;
         opacity: 0;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .${actionButtonClass},
+      .codex-archive-row-button {
         border: 1px solid #ef4444;
         border-radius: 6px;
-        background: #fee2e2;
-        color: #991b1b;
+        background: #f3f4f6;
+        color: #374151;
         font-size: 12px;
         line-height: 16px;
         padding: 1px 6px;
         cursor: pointer;
       }
-      [data-codex-delete-row="true"]:hover .${buttonClass} { opacity: 1; }
-      [data-codex-delete-row="true"].codex-archive-confirm-visible .${buttonClass} { right: 66px; }
+      .codex-archive-row-button {
+        border-radius: 7px;
+        font: 12px system-ui, sans-serif;
+        line-height: 16px;
+        padding: 3px 8px;
+      }
+      .${buttonClass},
+      .codex-archive-row-button.${buttonClass} {
+        border-color: #ef4444;
+        background: #fee2e2;
+        color: #991b1b;
+      }
+      .${exportButtonClass},
+      .codex-archive-row-button.${exportButtonClass} {
+        border-color: #93c5fd;
+        background: #dbeafe;
+        color: #1d4ed8;
+      }
+      [data-codex-delete-row="true"]:hover .${actionGroupClass} { opacity: 1; }
+      [data-codex-delete-row="true"].codex-archive-confirm-visible .${actionGroupClass} { right: 66px; }
       .codex-archive-delete-all {
         border: 1px solid #ef4444;
         border-radius: 7px;
@@ -239,7 +269,7 @@
   }
 
   function defaultCodexPlusSettings() {
-    return { pluginEntryUnlock: true, forcePluginInstall: true, sessionDelete: true, nativeMenuPlacement: true };
+    return { pluginEntryUnlock: true, forcePluginInstall: true, sessionDelete: true, markdownExport: true, nativeMenuPlacement: true };
   }
 
   function codexPlusSettings() {
@@ -391,6 +421,10 @@
             <div class="codex-plus-row">
               <div><div class="codex-plus-row-title">会话删除</div><div class="codex-plus-row-description">在会话列表悬停显示删除按钮，并支持撤销。</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="sessionDelete"><span></span></button>
+            </div>
+            <div class="codex-plus-row">
+              <div><div class="codex-plus-row-title">Markdown 导出</div><div class="codex-plus-row-description">在会话列表显示导出按钮，按本地 rollout 导出带时间戳的 Markdown。</div></div>
+              <button type="button" class="codex-plus-toggle" data-codex-plus-setting="markdownExport"><span></span></button>
             </div>
             <div class="codex-plus-row">
               <div><div class="codex-plus-row-title">原生菜单栏位置</div><div class="codex-plus-row-description">把 Codex++ 菜单插入顶部原生菜单栏；默认关闭以避免页面重渲染冲突。</div></div>
@@ -707,15 +741,30 @@
     const fallbackId = row.getAttribute("data-session-id") || row.getAttribute("data-testid") || "";
     const sessionId = codexThreadId || (idMatch && idMatch[1]) || fallbackId;
     const titleNode = row.querySelector(selectors.threadTitle);
-    const title = ((titleNode || row).textContent || "Untitled session").replace("删除", "").trim().slice(0, 160);
+    const title = ((titleNode || row).textContent || "Untitled session").replace("导出", "").replace("删除", "").trim().slice(0, 160);
     return { session_id: sessionId, title };
   }
 
   async function postJson(path, payload) {
     if (!window.__codexSessionDeleteBridge) {
-      return { status: "failed", message: "删除桥接不可用，请重启启动器" };
+      return { status: "failed", message: "桥接不可用，请重启启动器" };
     }
     return await window.__codexSessionDeleteBridge(path, payload);
+  }
+
+  function downloadMarkdown(filename, markdown) {
+    if (!filename || typeof markdown !== "string") {
+      throw new Error("导出结果不完整");
+    }
+    const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }
 
   function showToast(message, undoToken) {
@@ -825,7 +874,7 @@
         const rect = button.getBoundingClientRect();
         const label = button.getAttribute("aria-label") || "";
         const text = (button.textContent || "").trim();
-        if (button.classList.contains(buttonClass) || label === "归档对话" || label === "置顶对话") return false;
+        if (button.classList.contains(buttonClass) || button.classList.contains(exportButtonClass) || label === "归档对话" || label === "置顶对话") return false;
         return text === "确认" || (text.length > 0 && rect.width > 0 && rect.width <= 36 && rect.x > row.getBoundingClientRect().right - 50);
       });
       row.classList.toggle("codex-archive-confirm-visible", hasArchiveConfirm);
@@ -850,6 +899,16 @@
     });
   }
 
+  async function exportMarkdown(ref) {
+    const result = await postJson("/export-markdown", ref);
+    if (result.status === "exported" && result.filename && typeof result.markdown === "string") {
+      downloadMarkdown(result.filename, result.markdown);
+      showToast(result.message || "导出成功", null);
+      return;
+    }
+    showToast(result.message || "导出失败", null);
+  }
+
   function installDeleteButtonEventDelegation() {
     document.removeEventListener("pointerup", window.__codexSessionDeleteDocumentDeleteHandler, true);
     document.removeEventListener("click", window.__codexSessionDeleteDocumentDeleteHandler, true);
@@ -866,44 +925,88 @@
     document.addEventListener("click", handler, true);
   }
 
+  function actionGroupFromRow(row) {
+    return row.querySelector(`.${actionGroupClass}`);
+  }
+
+  function removeActionGroups(row) {
+    row.querySelectorAll(`.${actionGroupClass}`).forEach((group) => group.remove());
+  }
+
+  function stopActionButtonEvent(row, button, event) {
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation?.();
+    releaseDeleteFocus(row, button);
+  }
+
+  function installActionButtonEvents(row, button, onActivate) {
+    ["pointerdown", "mousedown", "mouseup", "touchstart"].forEach((eventName) => {
+      button.addEventListener(eventName, (event) => stopActionButtonEvent(row, button, event), true);
+    });
+    button.addEventListener("pointerup", onActivate, true);
+    button.addEventListener("click", onActivate, true);
+  }
+
+  function refreshActionButton(originalButton, row, onActivate) {
+    if (!originalButton.isConnected) return;
+    const replacement = originalButton.cloneNode(true);
+    installActionButtonEvents(row, replacement, onActivate);
+    originalButton.replaceWith(replacement);
+  }
+
   function attachButton(row) {
-    if (!codexPlusSettings().sessionDelete) return;
-    const existingDeleteButtons = Array.from(row.querySelectorAll(`.${buttonClass}`));
-    if (existingDeleteButtons.length === 1 && existingDeleteButtons[0].dataset.codexDeleteVersion === codexDeleteVersion) return;
-    existingDeleteButtons.forEach((button) => button.remove());
+    const settings = codexPlusSettings();
+    if (!settings.sessionDelete && !settings.markdownExport) {
+      removeActionGroups(row);
+      row.dataset.codexDeleteRow = "false";
+      return;
+    }
+    const existingGroup = actionGroupFromRow(row);
+    const existingDeleteButton = existingGroup?.querySelector(`.${buttonClass}`);
+    const existingExportButton = existingGroup?.querySelector(`.${exportButtonClass}`);
+    const hasUnexpectedDelete = !settings.sessionDelete && !!existingDeleteButton;
+    const hasUnexpectedExport = !settings.markdownExport && !!existingExportButton;
+    const missingDelete = settings.sessionDelete && !existingDeleteButton;
+    const missingExport = settings.markdownExport && !existingExportButton;
+    const deleteReady = !settings.sessionDelete || existingDeleteButton?.dataset.codexDeleteVersion === codexDeleteVersion;
+    const exportReady = !settings.markdownExport || existingExportButton?.dataset.codexExportVersion === codexExportVersion;
+    const groupReady = existingGroup?.dataset.codexActionGroupVersion === codexActionGroupVersion;
+    if (groupReady && deleteReady && exportReady && !hasUnexpectedDelete && !hasUnexpectedExport && !missingDelete && !missingExport) return;
+    removeActionGroups(row);
     row.dataset.codexDeleteRow = "false";
     const ref = sessionRefFromRow(row);
     if (!ref.session_id) return;
     row.dataset.codexDeleteRow = "true";
-    const button = document.createElement("button");
-    button.type = "button";
-    button.className = buttonClass;
-    button.dataset.codexDeleteVersion = codexDeleteVersion;
-    button.textContent = "删除";
-    const stopDeleteButtonEvent = (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      event.stopImmediatePropagation?.();
-      releaseDeleteFocus(row, button);
-    };
-    ["pointerdown", "mousedown", "mouseup", "touchstart"].forEach((eventName) => {
-      button.addEventListener(eventName, stopDeleteButtonEvent, true);
-    });
-    const openDeleteConfirm = (event) => openDeleteConfirmForRow(row, button, ref, event);
-    button.addEventListener("pointerup", openDeleteConfirm, true);
-    button.addEventListener("click", openDeleteConfirm, true);
-    row.appendChild(button);
-    const refreshDeleteButton = (originalButton) => {
-      if (!originalButton.isConnected) return;
-      const replacement = originalButton.cloneNode(true);
-      ["pointerdown", "mousedown", "mouseup", "touchstart"].forEach((eventName) => {
-        replacement.addEventListener(eventName, stopDeleteButtonEvent, true);
-      });
-      replacement.addEventListener("pointerup", openDeleteConfirm, true);
-      replacement.addEventListener("click", openDeleteConfirm, true);
-      originalButton.replaceWith(replacement);
-    };
-    setTimeout(() => refreshDeleteButton(button), 0);
+    const group = document.createElement("div");
+    group.className = actionGroupClass;
+    group.dataset.codexActionGroupVersion = codexActionGroupVersion;
+    if (settings.markdownExport) {
+      const exportButton = document.createElement("button");
+      exportButton.type = "button";
+      exportButton.className = `${actionButtonClass} ${exportButtonClass}`;
+      exportButton.dataset.codexExportVersion = codexExportVersion;
+      exportButton.textContent = "导出";
+      const openExport = (event) => {
+        stopActionButtonEvent(row, exportButton, event);
+        exportMarkdown(ref);
+      };
+      installActionButtonEvents(row, exportButton, openExport);
+      group.appendChild(exportButton);
+      setTimeout(() => refreshActionButton(exportButton, row, openExport), 0);
+    }
+    if (settings.sessionDelete) {
+      const deleteButton = document.createElement("button");
+      deleteButton.type = "button";
+      deleteButton.className = `${actionButtonClass} ${buttonClass}`;
+      deleteButton.dataset.codexDeleteVersion = codexDeleteVersion;
+      deleteButton.textContent = "删除";
+      const openDeleteConfirm = (event) => openDeleteConfirmForRow(row, deleteButton, ref, event);
+      installActionButtonEvents(row, deleteButton, openDeleteConfirm);
+      group.appendChild(deleteButton);
+      setTimeout(() => refreshActionButton(deleteButton, row, openDeleteConfirm), 0);
+    }
+    row.appendChild(group);
   }
 
   function tryAttachButton(row) {
@@ -993,37 +1096,63 @@
   }
 
   function attachArchivedPageDeleteButton(row) {
-    if (!codexPlusSettings().sessionDelete) return;
-    if (row.dataset.codexArchiveDeleteRow === "true") return;
-    row.dataset.codexArchiveDeleteRow = "true";
+    const settings = codexPlusSettings();
+    row.querySelectorAll("[data-codex-archive-row-action]").forEach((button) => button.remove());
+    row.dataset.codexArchiveDeleteRow = "false";
+    if (!settings.sessionDelete && !settings.markdownExport) return;
     const unarchiveButton = Array.from(row.querySelectorAll("button")).find((button) => (button.textContent || "").trim() === "取消归档");
     if (!unarchiveButton) return;
-    const button = document.createElement("button");
-    button.type = "button";
-    button.className = "codex-archive-delete-all";
-    button.textContent = "删除";
-    ["pointerdown", "mousedown", "mouseup", "touchstart"].forEach((eventName) => {
-      button.addEventListener(eventName, stopArchivedButtonEvent, true);
-    });
-    button.addEventListener("click", async (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      event.stopImmediatePropagation?.();
-      const ref = await resolveArchivedThread(row);
-      if (!ref.session_id) {
-        showToast("删除失败：未找到归档会话 ID", null);
-        return;
-      }
-      if (!(await confirmDelete(ref.title))) return;
-      const result = await postJson("/delete", ref);
-      if (result.status === "server_deleted" || result.status === "local_deleted") {
-        row.remove();
-        showToast(result.message || "删除成功", result.undo_token);
-      } else {
-        showToast(result.message || "删除失败", null);
-      }
-    }, true);
-    unarchiveButton.insertAdjacentElement("afterend", button);
+    row.dataset.codexArchiveDeleteRow = "true";
+    row.dataset.codexArchiveRowActionsVersion = codexArchiveRowActionsVersion;
+    let insertionPoint = unarchiveButton;
+    if (settings.markdownExport) {
+      const exportButton = document.createElement("button");
+      exportButton.type = "button";
+      exportButton.className = `codex-archive-delete-all codex-archive-row-button ${exportButtonClass}`;
+      exportButton.dataset.codexArchiveRowAction = "export";
+      exportButton.textContent = "导出";
+      ["pointerdown", "mousedown", "mouseup", "touchstart"].forEach((eventName) => {
+        exportButton.addEventListener(eventName, stopArchivedButtonEvent, true);
+      });
+      exportButton.addEventListener("click", async (event) => {
+        stopArchivedButtonEvent(event);
+        const ref = await resolveArchivedThread(row);
+        if (!ref.session_id) {
+          showToast("导出失败：未找到归档会话 ID", null);
+          return;
+        }
+        await exportMarkdown(ref);
+      }, true);
+      insertionPoint.insertAdjacentElement("afterend", exportButton);
+      insertionPoint = exportButton;
+    }
+    if (settings.sessionDelete) {
+      const deleteButton = document.createElement("button");
+      deleteButton.type = "button";
+      deleteButton.className = `codex-archive-delete-all codex-archive-row-button ${buttonClass}`;
+      deleteButton.dataset.codexArchiveRowAction = "delete";
+      deleteButton.textContent = "删除";
+      ["pointerdown", "mousedown", "mouseup", "touchstart"].forEach((eventName) => {
+        deleteButton.addEventListener(eventName, stopArchivedButtonEvent, true);
+      });
+      deleteButton.addEventListener("click", async (event) => {
+        stopArchivedButtonEvent(event);
+        const ref = await resolveArchivedThread(row);
+        if (!ref.session_id) {
+          showToast("删除失败：未找到归档会话 ID", null);
+          return;
+        }
+        if (!(await confirmDelete(ref.title))) return;
+        const result = await postJson("/delete", ref);
+        if (result.status === "server_deleted" || result.status === "local_deleted") {
+          row.remove();
+          showToast(result.message || "删除成功", result.undo_token);
+        } else {
+          showToast(result.message || "删除失败", null);
+        }
+      }, true);
+      insertionPoint.insertAdjacentElement("afterend", deleteButton);
+    }
   }
 
   function installArchivedDeleteAllButton() {

--- a/codex_session_delete/launcher.py
+++ b/codex_session_delete/launcher.py
@@ -18,6 +18,7 @@ from codex_session_delete.api_adapter import ApiAdapter, UnavailableApiAdapter
 from codex_session_delete.backup_store import BackupStore
 from codex_session_delete.cdp import evaluate_user_scripts, inject_file, open_devtools
 from codex_session_delete.helper_server import HelperServer
+from codex_session_delete.markdown_exporter import MarkdownExportService
 from codex_session_delete.models import DeleteResult, DeleteStatus, SessionRef
 from codex_session_delete.storage_adapter import SQLiteStorageAdapter
 from codex_session_delete.user_scripts import UserScriptManager
@@ -264,8 +265,8 @@ def launch_codex_app(app_dir: Path, debug_port: int) -> Any:
     return subprocess.Popen(build_codex_command(app_dir, debug_port), env=env)
 
 
-def start_helper(service, host: str = "127.0.0.1", port: int = 57321) -> HelperServer:
-    server = InjectedHelperServer(host, port, service)
+def start_helper(service, export_service: MarkdownExportService | None = None, host: str = "127.0.0.1", port: int = 57321) -> HelperServer:
+    server = InjectedHelperServer(host, port, service, export_service=export_service)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     return server
@@ -276,11 +277,25 @@ def shutdown_helper(server: HelperServer) -> None:
     server.server_close()
 
 
-def inject_with_retry(debug_port: int, script_path: Path, helper_port: int, service: ApiFirstDeleteService, runtime: CodexPlusRuntime, attempts: int = 20, delay: float = 0.5) -> Any:
+def inject_with_retry(
+    debug_port: int,
+    script_path: Path,
+    helper_port: int,
+    service: ApiFirstDeleteService,
+    export_service: MarkdownExportService,
+    runtime: CodexPlusRuntime,
+    attempts: int = 20,
+    delay: float = 0.5,
+) -> Any:
     last_error: Exception | None = None
     for _ in range(attempts):
         try:
-            injection = inject_file(debug_port, script_path, helper_port, lambda path, payload: handle_bridge_request(service, path, payload, runtime))
+            injection = inject_file(
+                debug_port,
+                script_path,
+                helper_port,
+                lambda path, payload: handle_bridge_request(service, export_service, path, payload, runtime),
+            )
             runtime.websocket_url = injection.websocket_url
             evaluate_user_scripts(injection.websocket_url, runtime.user_scripts.build_enabled_bundle())
             return injection.bridge_socket or injection.result
@@ -299,16 +314,17 @@ def launch_and_inject(app_dir: Path | None, db_path: Path | None, backup_dir: Pa
     debug_port = select_windows_loopback_port(debug_port)
     helper_port = select_windows_loopback_port(helper_port)
     service = ApiFirstDeleteService(UnavailableApiAdapter(), db_path, backup_dir)
+    export_service = MarkdownExportService(db_path)
     script_path = Path(__file__).parent / "inject" / "renderer-inject.js"
     builtin_user_scripts_dir = Path(__file__).parent / "user_scripts"
     user_config_dir = user_scripts_config_dir()
     user_script_manager = UserScriptManager(builtin_user_scripts_dir, user_config_dir / "user_scripts", user_config_dir / "user_scripts.json")
     runtime = CodexPlusRuntime(None, user_script_manager, debug_port)
-    server = start_helper(service, port=helper_port)
+    server = start_helper(service, export_service, port=helper_port)
     codex_proc = None
     try:
         codex_proc = launch_codex_app(resolved_app_dir, debug_port)
-        server.bridge_socket = inject_with_retry(debug_port, script_path, server.port, service, runtime)
+        server.bridge_socket = inject_with_retry(debug_port, script_path, server.port, service, export_service, runtime)
         return server, codex_proc
     except Exception:
         shutdown_helper(server)
@@ -336,7 +352,13 @@ def launch_and_inject(app_dir: Path | None, db_path: Path | None, backup_dir: Pa
         raise
 
 
-def handle_bridge_request(service: ApiFirstDeleteService, path: str, payload: dict[str, object], runtime: CodexPlusRuntime | None = None) -> dict[str, object]:
+def handle_bridge_request(
+    service: ApiFirstDeleteService,
+    export_service: MarkdownExportService,
+    path: str,
+    payload: dict[str, object],
+    runtime: CodexPlusRuntime | None = None,
+) -> dict[str, object]:
     if path == "/user-scripts/list" and runtime:
         return runtime.user_scripts.inventory()
     if path == "/user-scripts/set-enabled" and runtime:
@@ -361,4 +383,7 @@ def handle_bridge_request(service: ApiFirstDeleteService, path: str, payload: di
     if path == "/archived-thread":
         session = service.find_archived_thread_by_title(str(payload.get("title", "")))
         return {"session_id": session.session_id, "title": session.title} if session else {"session_id": "", "title": ""}
+    if path == "/export-markdown":
+        session = SessionRef(session_id=str(payload.get("session_id", "")), title=str(payload.get("title", "")))
+        return export_service.export(session).to_dict()
     return {"status": DeleteStatus.FAILED.value, "session_id": str(payload.get("session_id", "")), "message": "Unknown bridge path"}

--- a/codex_session_delete/markdown_exporter.py
+++ b/codex_session_delete/markdown_exporter.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+from codex_session_delete.models import ExportResult, ExportStatus, SessionRef
+
+
+_WINDOWS_FILENAME_CHARS_RE = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+class MarkdownExportService:
+    def __init__(self, db_path: Path | None):
+        self.db_path = db_path
+
+    def export(self, session: SessionRef) -> ExportResult:
+        if self.db_path is None:
+            return self._failed(session.session_id, "未配置本地 Codex 数据库")
+        if not self.db_path.exists():
+            return self._failed(session.session_id, f"数据库不存在：{self.db_path}")
+
+        thread_id = self._normalize_session_id(session.session_id)
+        try:
+            with sqlite3.connect(self.db_path) as db:
+                db.row_factory = sqlite3.Row
+                if not self._supports_codex_threads(db):
+                    return self._failed(thread_id, "不支持当前本地存储结构")
+                row = db.execute("SELECT id, title, rollout_path FROM threads WHERE id = ?", (thread_id,)).fetchone()
+        except sqlite3.Error as exc:
+            return self._failed(thread_id, f"读取本地数据库失败：{exc}")
+
+        if row is None:
+            return self._failed(thread_id, "未找到对应会话")
+
+        title = self._display_title(str(row["title"] or session.title or ""))
+        rollout_path_value = str(row["rollout_path"] or "")
+        if not rollout_path_value:
+            return self._failed(thread_id, "会话缺少 rollout 文件路径")
+        rollout_path = Path(rollout_path_value)
+        if not rollout_path.is_file():
+            return self._failed(thread_id, f"rollout 文件不存在：{rollout_path}")
+
+        try:
+            messages = self._load_messages(rollout_path)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            return self._failed(thread_id, f"读取 rollout 失败：{exc}")
+
+        if not messages:
+            return self._failed(thread_id, "未找到可导出的用户或助手消息")
+
+        filename = self._build_filename(title, thread_id)
+        markdown = self._render_markdown(title, messages)
+        return ExportResult(
+            status=ExportStatus.EXPORTED,
+            session_id=thread_id,
+            message=f"已导出为 Markdown：{filename}",
+            filename=filename,
+            markdown=markdown,
+        )
+
+    def _supports_codex_threads(self, db: sqlite3.Connection) -> bool:
+        tables = {row[0] for row in db.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+        if "threads" not in tables:
+            return False
+        columns = {row[1] for row in db.execute('PRAGMA table_info("threads")')}
+        return {"id", "title", "rollout_path"}.issubset(columns)
+
+    def _load_messages(self, rollout_path: Path) -> list[tuple[str, str | None, str]]:
+        messages: list[tuple[str, str | None, str]] = []
+        with rollout_path.open("r", encoding="utf-8") as handle:
+            for raw_line in handle:
+                if not raw_line.strip():
+                    continue
+                event = json.loads(raw_line)
+                if event.get("type") != "response_item":
+                    continue
+                payload = event.get("payload")
+                if not isinstance(payload, dict):
+                    continue
+                if payload.get("type") != "message":
+                    continue
+                role = payload.get("role")
+                if role not in {"user", "assistant"}:
+                    continue
+                body = self._serialize_message_content(payload.get("content"))
+                if not body:
+                    continue
+                speaker = "User" if role == "user" else "Assistant"
+                messages.append((speaker, self._format_timestamp(event.get("timestamp")), body))
+        return messages
+
+    def _serialize_message_content(self, content: object) -> str:
+        if not isinstance(content, list):
+            return ""
+        blocks: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type")
+            if block_type in {"input_text", "output_text"}:
+                text = self._normalize_newlines(str(block.get("text") or "")).strip("\n")
+                if text.strip():
+                    blocks.append(text)
+                continue
+            if block_type == "input_image":
+                image_url = str(block.get("image_url") or "").strip()
+                if image_url and not image_url.startswith("data:"):
+                    blocks.append(f"> Image attachment\n[Image link](<{image_url}>)")
+                else:
+                    blocks.append("> Image attachment")
+        return "\n\n".join(block for block in blocks if block.strip()).strip()
+
+    def _format_timestamp(self, value: object) -> str | None:
+        if not isinstance(value, str) or not value.strip():
+            return None
+        try:
+            timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return timestamp.astimezone().strftime("%Y-%m-%d %H:%M:%S")
+
+    def _display_title(self, value: str) -> str:
+        normalized = _WHITESPACE_RE.sub(" ", self._normalize_newlines(value)).strip()
+        return normalized or "Untitled session"
+
+    def _build_filename(self, title: str, thread_id: str) -> str:
+        cleaned_title = _WINDOWS_FILENAME_CHARS_RE.sub(" ", title)
+        cleaned_title = _WHITESPACE_RE.sub(" ", cleaned_title).strip(" .")
+        safe_title = (cleaned_title or "Untitled session")[:80]
+        safe_thread_id = _WINDOWS_FILENAME_CHARS_RE.sub("-", thread_id).strip() or "thread"
+        return f"{safe_title}-{safe_thread_id}.md"
+
+    def _render_markdown(self, title: str, messages: list[tuple[str, str | None, str]]) -> str:
+        lines = [f"# {title}", ""]
+        for speaker, timestamp, body in messages:
+            lines.append(f"### {speaker}")
+            if timestamp:
+                lines.append(f"_{timestamp}_")
+            lines.append("")
+            lines.append(body.rstrip())
+            lines.append("")
+        return "\n".join(lines).rstrip() + "\n"
+
+    def _normalize_session_id(self, session_id: str) -> str:
+        return session_id.removeprefix("local:")
+
+    def _normalize_newlines(self, value: str) -> str:
+        return value.replace("\r\n", "\n").replace("\r", "\n")
+
+    def _failed(self, session_id: str, message: str) -> ExportResult:
+        return ExportResult(
+            status=ExportStatus.FAILED,
+            session_id=session_id,
+            message=message,
+            filename=None,
+            markdown=None,
+        )

--- a/codex_session_delete/markdown_exporter.py
+++ b/codex_session_delete/markdown_exporter.py
@@ -130,7 +130,7 @@ class MarkdownExportService:
     def _build_filename(self, title: str, thread_id: str) -> str:
         cleaned_title = _WINDOWS_FILENAME_CHARS_RE.sub(" ", title)
         cleaned_title = _WHITESPACE_RE.sub(" ", cleaned_title).strip(" .")
-        safe_title = (cleaned_title or "Untitled session")[:80]
+        safe_title = (cleaned_title or "Untitled session")[:80].rstrip(" .") or "Untitled session"
         safe_thread_id = _WINDOWS_FILENAME_CHARS_RE.sub("-", thread_id).strip() or "thread"
         return f"{safe_title}-{safe_thread_id}.md"
 

--- a/codex_session_delete/models.py
+++ b/codex_session_delete/models.py
@@ -12,6 +12,11 @@ class DeleteStatus(str, Enum):
     UNDONE = "undone"
 
 
+class ExportStatus(str, Enum):
+    EXPORTED = "exported"
+    FAILED = "failed"
+
+
 @dataclass(frozen=True)
 class SessionRef:
     session_id: str
@@ -37,4 +42,22 @@ class DeleteResult:
             "message": self.message,
             "undo_token": self.undo_token,
             "backup_path": self.backup_path,
+        }
+
+
+@dataclass(frozen=True)
+class ExportResult:
+    status: ExportStatus
+    session_id: str
+    message: str
+    filename: str | None = None
+    markdown: str | None = None
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {
+            "status": self.status.value,
+            "session_id": self.session_id,
+            "message": self.message,
+            "filename": self.filename,
+            "markdown": self.markdown,
         }

--- a/tests/test_helper_server.py
+++ b/tests/test_helper_server.py
@@ -4,7 +4,7 @@ import urllib.error
 import urllib.request
 
 from codex_session_delete.helper_server import HelperServer
-from codex_session_delete.models import DeleteResult, DeleteStatus, SessionRef
+from codex_session_delete.models import DeleteResult, DeleteStatus, ExportResult, ExportStatus, SessionRef
 
 
 class FakeDeleteService:
@@ -24,6 +24,15 @@ class FakeDeleteService:
     def find_archived_thread_by_title(self, title: str):
         self.archived_title_queries.append(title)
         return SessionRef(session_id="archived-t1", title=title)
+
+
+class FakeExportService:
+    def __init__(self):
+        self.exported = []
+
+    def export(self, session: SessionRef):
+        self.exported.append(session)
+        return ExportResult(ExportStatus.EXPORTED, session.session_id, "Exported", filename="thread.md", markdown="# Thread\n")
 
 
 def post_json(url, payload, headers=None):
@@ -70,6 +79,24 @@ def test_helper_server_resolves_archived_thread_by_title():
     assert service.archived_title_queries == ["Codex Thread"]
 
 
+def test_helper_server_exports_markdown_when_authorized():
+    delete_service = FakeDeleteService()
+    export_service = FakeExportService()
+    server = HelperServer("127.0.0.1", 0, delete_service, export_service, allow_http_mutation=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        base = f"http://127.0.0.1:{server.port}"
+        exported = post_json(base + "/export-markdown", {"session_id": "s1", "title": "First"})
+    finally:
+        server.shutdown()
+        thread.join(timeout=3)
+
+    assert exported["status"] == "exported"
+    assert exported["filename"] == "thread.md"
+    assert export_service.exported[0].session_id == "s1"
+
+
 def test_helper_server_rejects_http_mutation_by_default():
     service = FakeDeleteService()
     server = HelperServer("127.0.0.1", 0, service)
@@ -79,6 +106,11 @@ def test_helper_server_rejects_http_mutation_by_default():
         base = f"http://127.0.0.1:{server.port}"
         try:
             post_json(base + "/delete", {"session_id": "s1", "title": "First"})
+            assert False, "expected forbidden response"
+        except urllib.error.HTTPError as exc:
+            assert exc.code == 403
+        try:
+            post_json(base + "/export-markdown", {"session_id": "s1", "title": "First"})
             assert False, "expected forbidden response"
         except urllib.error.HTTPError as exc:
             assert exc.code == 403

--- a/tests/test_launcher_user_scripts.py
+++ b/tests/test_launcher_user_scripts.py
@@ -1,4 +1,5 @@
 from codex_session_delete.launcher import handle_bridge_request
+from codex_session_delete.models import ExportResult, ExportStatus
 from codex_session_delete.user_scripts import UserScriptManager
 
 
@@ -11,6 +12,11 @@ class FakeDeleteService:
 
     def find_archived_thread_by_title(self, title):
         return None
+
+
+class FakeExportService:
+    def export(self, session):
+        return ExportResult(ExportStatus.EXPORTED, session.session_id, "Exported", filename="thread.md", markdown="# Thread\n")
 
 
 class FakeRuntime:
@@ -45,7 +51,7 @@ def test_handle_bridge_request_lists_user_scripts(tmp_path):
     manager = UserScriptManager(builtin, user, tmp_path / "config.json")
     runtime = FakeRuntime(manager)
 
-    result = handle_bridge_request(FakeDeleteService(), "/user-scripts/list", {}, runtime)
+    result = handle_bridge_request(FakeDeleteService(), FakeExportService(), "/user-scripts/list", {}, runtime)
 
     assert result["enabled"] is True
     assert result["scripts"][0]["key"] == "builtin:demo.js"
@@ -55,8 +61,8 @@ def test_handle_bridge_request_updates_user_script_toggles(tmp_path):
     manager = UserScriptManager(tmp_path / "builtin", tmp_path / "user", tmp_path / "config.json")
     runtime = FakeRuntime(manager)
 
-    global_result = handle_bridge_request(FakeDeleteService(), "/user-scripts/set-enabled", {"enabled": False}, runtime)
-    script_result = handle_bridge_request(FakeDeleteService(), "/user-scripts/set-script-enabled", {"key": "user:a.js", "enabled": False}, runtime)
+    global_result = handle_bridge_request(FakeDeleteService(), FakeExportService(), "/user-scripts/set-enabled", {"enabled": False}, runtime)
+    script_result = handle_bridge_request(FakeDeleteService(), FakeExportService(), "/user-scripts/set-script-enabled", {"key": "user:a.js", "enabled": False}, runtime)
 
     assert global_result["enabled"] is False
     assert script_result["scripts"] == []
@@ -67,11 +73,20 @@ def test_handle_bridge_request_reports_and_repairs_backend_status(tmp_path):
     manager = UserScriptManager(tmp_path / "builtin", tmp_path / "user", tmp_path / "config.json")
     runtime = FakeRuntime(manager)
 
-    status = handle_bridge_request(FakeDeleteService(), "/backend/status", {}, runtime)
-    repaired = handle_bridge_request(FakeDeleteService(), "/backend/repair", {}, runtime)
+    status = handle_bridge_request(FakeDeleteService(), FakeExportService(), "/backend/status", {}, runtime)
+    repaired = handle_bridge_request(FakeDeleteService(), FakeExportService(), "/backend/repair", {}, runtime)
 
     assert status == {"status": "ok", "message": "后端已连接"}
     assert runtime.repaired is True
     assert repaired == {"status": "ok", "message": "后端已修复"}
 
+
+def test_handle_bridge_request_exports_markdown(tmp_path):
+    manager = UserScriptManager(tmp_path / "builtin", tmp_path / "user", tmp_path / "config.json")
+    runtime = FakeRuntime(manager)
+
+    exported = handle_bridge_request(FakeDeleteService(), FakeExportService(), "/export-markdown", {"session_id": "s1", "title": "First"}, runtime)
+
+    assert exported["status"] == "exported"
+    assert exported["filename"] == "thread.md"
 

--- a/tests/test_markdown_exporter.py
+++ b/tests/test_markdown_exporter.py
@@ -1,0 +1,162 @@
+import sqlite3
+
+from codex_session_delete.markdown_exporter import MarkdownExportService
+from codex_session_delete.models import ExportStatus, SessionRef
+
+
+def create_codex_thread_db(path, rollout_path, *, thread_id="t1", title="Codex Thread"):
+    with sqlite3.connect(path) as db:
+        db.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT, title TEXT, archived INTEGER, archived_at INTEGER)")
+        db.execute(
+            "INSERT INTO threads (id, rollout_path, title, archived, archived_at) VALUES (?, ?, ?, 0, NULL)",
+            (thread_id, str(rollout_path), title),
+        )
+
+
+def test_markdown_exporter_exports_user_and_assistant_messages_with_timestamps(tmp_path):
+    db_path = tmp_path / "state_5.sqlite"
+    rollout_path = tmp_path / "rollout.jsonl"
+    rollout_path.write_text(
+        "\n".join([
+            '{"type":"session_meta","timestamp":"2026-05-10T13:00:00Z"}',
+            '{"type":"response_item","timestamp":"2026-05-10T13:12:06Z","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Hello"}]}}',
+            '{"type":"response_item","timestamp":"2026-05-10T13:12:09Z","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hi there"}]}}',
+            "",
+        ]),
+        encoding="utf-8",
+    )
+    create_codex_thread_db(db_path, rollout_path)
+
+    result = MarkdownExportService(db_path).export(SessionRef(session_id="t1", title="Ignored title"))
+
+    assert result.status == ExportStatus.EXPORTED
+    assert result.filename == "Codex Thread-t1.md"
+    assert result.markdown == (
+        "# Codex Thread\n\n"
+        "### User\n"
+        "_2026-05-10 21:12:06_\n\n"
+        "Hello\n\n"
+        "### Assistant\n"
+        "_2026-05-10 21:12:09_\n\n"
+        "Hi there\n"
+    )
+
+
+def test_markdown_exporter_ignores_non_message_and_non_user_assistant_items(tmp_path):
+    db_path = tmp_path / "state_5.sqlite"
+    rollout_path = tmp_path / "rollout.jsonl"
+    rollout_path.write_text(
+        "\n".join([
+            '{"type":"response_item","timestamp":"2026-05-10T13:12:06Z","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"ignore"}]}}',
+            '{"type":"response_item","timestamp":"2026-05-10T13:12:07Z","payload":{"type":"reasoning","summary":[]}}',
+            '{"type":"response_item","timestamp":"2026-05-10T13:12:08Z","payload":{"type":"function_call","name":"tool"}}',
+            '{"type":"response_item","timestamp":"2026-05-10T13:12:09Z","payload":{"type":"function_call_output","output":"ok"}}',
+            '{"type":"response_item","timestamp":"2026-05-10T13:12:10Z","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Keep"}]}}',
+            "",
+        ]),
+        encoding="utf-8",
+    )
+    create_codex_thread_db(db_path, rollout_path)
+
+    result = MarkdownExportService(db_path).export(SessionRef(session_id="t1", title="Codex Thread"))
+
+    assert result.status == ExportStatus.EXPORTED
+    assert "Keep" in (result.markdown or "")
+    assert "ignore" not in (result.markdown or "")
+    assert "function_call" not in (result.markdown or "")
+
+
+def test_markdown_exporter_serializes_images_without_inlining_data_urls(tmp_path):
+    db_path = tmp_path / "state_5.sqlite"
+    rollout_path = tmp_path / "rollout.jsonl"
+    rollout_path.write_text(
+        "\n".join([
+            '{"type":"response_item","timestamp":"2026-05-10T13:12:06Z","payload":{"type":"message","role":"user","content":[{"type":"input_image","image_url":"data:image/png;base64,AAAA"},{"type":"input_image","image_url":"https://example.com/image.png"}]}}',
+            "",
+        ]),
+        encoding="utf-8",
+    )
+    create_codex_thread_db(db_path, rollout_path)
+
+    result = MarkdownExportService(db_path).export(SessionRef(session_id="t1", title="Codex Thread"))
+
+    assert result.status == ExportStatus.EXPORTED
+    assert result.markdown is not None
+    assert result.markdown.count("> Image attachment") == 2
+    assert "[Image link](<https://example.com/image.png>)" in result.markdown
+    assert "data:image/png;base64" not in result.markdown
+
+
+def test_markdown_exporter_supports_local_prefixed_session_id(tmp_path):
+    db_path = tmp_path / "state_5.sqlite"
+    rollout_path = tmp_path / "rollout.jsonl"
+    rollout_path.write_text(
+        '{"type":"response_item","timestamp":"2026-05-10T13:12:06Z","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hello"}]}}\n',
+        encoding="utf-8",
+    )
+    create_codex_thread_db(db_path, rollout_path, thread_id="t1")
+
+    result = MarkdownExportService(db_path).export(SessionRef(session_id="local:t1", title="Codex Thread"))
+
+    assert result.status == ExportStatus.EXPORTED
+    assert result.session_id == "t1"
+
+
+def test_markdown_exporter_sanitizes_filename_and_appends_thread_id(tmp_path):
+    db_path = tmp_path / "state_5.sqlite"
+    rollout_path = tmp_path / "rollout.jsonl"
+    rollout_path.write_text(
+        '{"type":"response_item","timestamp":"2026-05-10T13:12:06Z","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hello"}]}}\n',
+        encoding="utf-8",
+    )
+    create_codex_thread_db(
+        db_path,
+        rollout_path,
+        thread_id="thread:1",
+        title='  A  title  with  bad<>:"/\\\\|?*chars and a very long suffix that should still be trimmed safely for file names  ',
+    )
+
+    result = MarkdownExportService(db_path).export(SessionRef(session_id="thread:1", title="ignored"))
+
+    assert result.status == ExportStatus.EXPORTED
+    assert result.filename is not None
+    assert result.filename.endswith("-thread-1.md")
+    assert "<" not in result.filename
+    assert len(result.filename.split("-thread-1.md")[0]) <= 80
+
+
+def test_markdown_exporter_skips_invalid_timestamp_but_keeps_body(tmp_path):
+    db_path = tmp_path / "state_5.sqlite"
+    rollout_path = tmp_path / "rollout.jsonl"
+    rollout_path.write_text(
+        '{"type":"response_item","timestamp":"not-a-timestamp","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hello"}]}}\n',
+        encoding="utf-8",
+    )
+    create_codex_thread_db(db_path, rollout_path)
+
+    result = MarkdownExportService(db_path).export(SessionRef(session_id="t1", title="Codex Thread"))
+
+    assert result.status == ExportStatus.EXPORTED
+    assert result.markdown == "# Codex Thread\n\n### Assistant\n\nHello\n"
+
+
+def test_markdown_exporter_fails_when_thread_missing_rollout_missing_or_no_messages(tmp_path):
+    db_path = tmp_path / "state_5.sqlite"
+    missing_rollout_db = tmp_path / "missing.sqlite"
+    create_codex_thread_db(missing_rollout_db, tmp_path / "missing.jsonl")
+    no_messages_db = tmp_path / "no_messages.sqlite"
+    empty_rollout = tmp_path / "empty.jsonl"
+    empty_rollout.write_text('{"type":"response_item","timestamp":"2026-05-10T13:12:06Z","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"ignore"}]}}\n', encoding="utf-8")
+    create_codex_thread_db(no_messages_db, empty_rollout)
+
+    missing_db_service = MarkdownExportService(db_path)
+    missing_rollout_service = MarkdownExportService(missing_rollout_db)
+    no_messages_service = MarkdownExportService(no_messages_db)
+
+    missing_thread = missing_db_service.export(SessionRef(session_id="t1", title="Codex Thread"))
+    missing_rollout = missing_rollout_service.export(SessionRef(session_id="t1", title="Codex Thread"))
+    no_messages = no_messages_service.export(SessionRef(session_id="t1", title="Codex Thread"))
+
+    assert missing_thread.status == ExportStatus.FAILED
+    assert missing_rollout.status == ExportStatus.FAILED
+    assert no_messages.status == ExportStatus.FAILED

--- a/tests/test_markdown_exporter.py
+++ b/tests/test_markdown_exporter.py
@@ -1,4 +1,5 @@
 import sqlite3
+from datetime import datetime
 
 from codex_session_delete.markdown_exporter import MarkdownExportService
 from codex_session_delete.models import ExportStatus, SessionRef
@@ -28,16 +29,18 @@ def test_markdown_exporter_exports_user_and_assistant_messages_with_timestamps(t
     create_codex_thread_db(db_path, rollout_path)
 
     result = MarkdownExportService(db_path).export(SessionRef(session_id="t1", title="Ignored title"))
+    expected_user_time = datetime.fromisoformat("2026-05-10T13:12:06+00:00").astimezone().strftime("%Y-%m-%d %H:%M:%S")
+    expected_assistant_time = datetime.fromisoformat("2026-05-10T13:12:09+00:00").astimezone().strftime("%Y-%m-%d %H:%M:%S")
 
     assert result.status == ExportStatus.EXPORTED
     assert result.filename == "Codex Thread-t1.md"
     assert result.markdown == (
         "# Codex Thread\n\n"
         "### User\n"
-        "_2026-05-10 21:12:06_\n\n"
+        f"_{expected_user_time}_\n\n"
         "Hello\n\n"
         "### Assistant\n"
-        "_2026-05-10 21:12:09_\n\n"
+        f"_{expected_assistant_time}_\n\n"
         "Hi there\n"
     )
 
@@ -123,6 +126,23 @@ def test_markdown_exporter_sanitizes_filename_and_appends_thread_id(tmp_path):
     assert result.filename.endswith("-thread-1.md")
     assert "<" not in result.filename
     assert len(result.filename.split("-thread-1.md")[0]) <= 80
+
+
+def test_markdown_exporter_strips_trailing_space_or_dot_after_truncation(tmp_path):
+    db_path = tmp_path / "state_5.sqlite"
+    rollout_path = tmp_path / "rollout.jsonl"
+    rollout_path.write_text(
+        '{"type":"response_item","timestamp":"2026-05-10T13:12:06Z","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hello"}]}}\n',
+        encoding="utf-8",
+    )
+    create_codex_thread_db(db_path, rollout_path, thread_id="t1", title=("A" * 79) + ".")
+
+    result = MarkdownExportService(db_path).export(SessionRef(session_id="t1", title="ignored"))
+
+    assert result.status == ExportStatus.EXPORTED
+    assert result.filename is not None
+    assert not result.filename.startswith((" ", "."))
+    assert not result.filename.split("-t1.md")[0].endswith((" ", "."))
 
 
 def test_markdown_exporter_skips_invalid_timestamp_but_keeps_body(tmp_path):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,4 @@
-from codex_session_delete.models import DeleteResult, DeleteStatus, SessionRef
+from codex_session_delete.models import DeleteResult, DeleteStatus, ExportResult, ExportStatus, SessionRef
 
 
 def test_session_ref_requires_session_id():
@@ -25,4 +25,22 @@ def test_delete_result_serializes_to_json_dict():
         "message": "Deleted locally",
         "undo_token": "undo-1",
         "backup_path": "C:/tmp/backup.json",
+    }
+
+
+def test_export_result_serializes_to_json_dict():
+    result = ExportResult(
+        status=ExportStatus.EXPORTED,
+        session_id="abc123",
+        message="Exported",
+        filename="example.md",
+        markdown="# Example\n",
+    )
+
+    assert result.to_dict() == {
+        "status": "exported",
+        "session_id": "abc123",
+        "message": "Exported",
+        "filename": "example.md",
+        "markdown": "# Example\n",
     }

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -12,6 +12,7 @@ def test_renderer_script_exists_and_parses_with_node():
 def test_renderer_script_contains_hover_delete_contract():
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
     assert "codex-delete-button" in text
+    assert "codex-session-actions" in text
     assert "MutationObserver" in text
     assert "confirmDelete" in text
     assert "/delete" in text
@@ -41,6 +42,7 @@ def test_renderer_script_positions_delete_button_without_affecting_layout():
     assert "right: 28px" in text
     assert "top: 50%" in text
     assert "transform: translateY(-50%)" in text
+    assert "display: inline-flex" in text
 
 
 
@@ -178,26 +180,26 @@ def test_renderer_script_toast_does_not_capture_page_interactions():
 def test_renderer_script_sidebar_delete_opens_on_pointerup_when_click_is_unreliable():
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
     assert "openDeleteConfirm" in text
-    assert "codexDeleteVersion = \"5\"" in text
-    assert "existingDeleteButtons.length === 1" in text
-    assert "existingDeleteButtons[0].dataset.codexDeleteVersion === codexDeleteVersion" in text
-    assert "existingDeleteButtons.forEach((button) => button.remove())" in text
+    assert "codexDeleteVersion = \"6\"" in text
+    assert "actionGroupFromRow" in text
+    assert "removeActionGroups(row)" in text
     assert "row.dataset.codexDeleteRow = \"false\"" in text
     assert "installDeleteButtonEventDelegation" in text
     assert "codexSessionDeleteDocumentDeleteHandler" in text
     assert "document.addEventListener(\"pointerup\", handler, true)" in text
     assert "document.addEventListener(\"click\", handler, true)" in text
-    assert "button.addEventListener(\"pointerup\", openDeleteConfirm, true)" in text
+    assert "deleteButton.dataset.codexDeleteVersion = codexDeleteVersion" in text
 
 
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
     assert "updateDeleteButtonOffsets" in text
-    assert "codexDeleteStyleVersion = \"4\"" in text
+    assert "codexDeleteStyleVersion = \"5\"" in text
     assert "right: 66px" in text
     assert "确认" in text
     assert "归档对话" in text
     assert "button.getAttribute(\"aria-label\")" in text
     assert "label === \"归档对话\"" in text
+    assert "button.classList.contains(exportButtonClass)" in text
 
 
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
@@ -256,6 +258,11 @@ def test_renderer_script_sidebar_delete_opens_on_pointerup_when_click_is_unrelia
     assert "archiveRowFromUnarchiveButton" in text
     assert "[role=\"listitem\"], [role=\"row\"]" in text
     assert "Archived conversations" in text
+    assert "data-codex-archive-row-action" in text
+    assert "textContent = \"导出\"" in text
+    assert "textContent = \"删除\"" in text
+    assert "insertAdjacentElement(\"afterend\", exportButton)" in text
+    assert "insertAdjacentElement(\"afterend\", deleteButton)" in text
 
 
 def test_renderer_script_uses_bridge_only_helper_calls():
@@ -266,6 +273,8 @@ def test_renderer_script_uses_bridge_only_helper_calls():
     assert "postJson(\"/delete\"" in text
     assert "postJson(\"/undo\"" in text
     assert "postJson(\"/archived-thread\"" in text
+    assert "postJson(\"/export-markdown\"" in text
+    assert "Blob([markdown]" in text
 
 
 def test_renderer_script_uses_chinese_delete_toast_fallbacks():
@@ -345,6 +354,7 @@ def test_renderer_script_includes_user_script_manager_ui_contract():
     assert "插件选项解锁" in text
     assert "特殊插件强制安装" in text
     assert "会话删除" in text
+    assert "Markdown 导出" in text
     assert "原生菜单栏位置" in text
     assert "nativeMenuPlacement: true" in text
     assert "关于 Codex++" in text
@@ -353,6 +363,7 @@ def test_renderer_script_includes_user_script_manager_ui_contract():
     assert "pluginEntryUnlock" in text
     assert "forcePluginInstall" in text
     assert "sessionDelete" in text
+    assert "markdownExport" in text
     assert "codex-plus-modal-overlay" in text
     assert "codex-plus-modal-content" in text
     assert "codex-plus-modal-header" in text


### PR DESCRIPTION
## Summary

This PR adds local Markdown export support to Codex++.

The export is implemented entirely based on local Codex session data.
It adds an `导出` button next to the existing `删除` button in both sidebar session rows and archived session rows, and exports user/assistant messages as Markdown with per-message timestamps. Within the Markdown format, it also supports image messages and code messages.

## Changes

### Backend

- Added a dedicated `MarkdownExportService`
- Added a new bridge/helper route: `/export-markdown`
- The export data source is strictly limited to local Codex data:
  - `state_5.sqlite`
  - `threads.rollout_path`
  - the corresponding `rollout.jsonl`

### Export behavior

- Only exports records matching:
  - `type == "response_item"`
  - `payload.type == "message"`
  - `payload.role in {"user", "assistant"}`
- Ignores non-body content such as:
  - `developer`
  - `reasoning`
  - `function_call`
  - `function_call_output`
  - other non-message events
- Uses the top-level event `timestamp` for each exported message
- Formats timestamps in local time as:
  - `YYYY-MM-DD HH:MM:SS`
- Image handling rules:
  - `input_image` is exported as `> Image attachment`
  - non-`data:` image URLs are exported as clickable links
  - base64 data is not inlined

### Frontend

- Added a separate `markdownExport` setting
- Added an `导出` button next to the `删除` button
- Export triggers a direct in-page Markdown download using `Blob` and `<a download>`

## Design notes

This implementation intentionally avoids broader refactoring.

Specifically:

- `ApiFirstDeleteService` remains focused on delete/undo behavior
- export logic is implemented in a dedicated service
- bridge dispatch is extended explicitly instead of folding export into delete semantics

This keeps the change narrower and makes it easier to review and maintain upstream.

## Testing

Added and updated tests covering:

- Markdown export from Codex-style local rollout data
- correct rendering of per-message timestamps
- filtering of non-user/assistant content
- image placeholder and link export behavior
- `local:<id>` session ID handling
- filename sanitization
- failure cases such as missing thread, missing rollout, or empty export output
- helper server export route
- bridge dispatch for the export path
- injected UI strings and export button mounting logic

Full test result:

- `145 passed`

## Screenshots
<img width="2120" height="1432" alt="a16c37fea8fbffec4fa72fde0c0edc0c" src="https://github.com/user-attachments/assets/e2d2c867-c1d4-4913-8f0e-3b3a2e8bc156" />

## Last
Thanks to the maintainers for their contributions to the open-source project.
