### PR TITLE
Add sidebar project move support

### DIFF
--- a/codex_session_delete/cdp.py
+++ b/codex_session_delete/cdp.py
@@ -76,6 +76,24 @@ def open_devtools(port: int) -> dict[str, object]:
     return {"status": "ok", "target_id": target_id}
 
 
+def add_script_to_new_documents(websocket_url: str, script: str) -> dict[str, object]:
+    ws = websocket.create_connection(websocket_url, timeout=5)
+    try:
+        return _add_script_to_new_documents_on_socket(ws, script, 1)
+    finally:
+        ws.close()
+
+
+def _add_script_to_new_documents_on_socket(ws: websocket.WebSocket, script: str, message_id: int) -> dict[str, object]:
+    payload = {
+        "id": message_id,
+        "method": "Page.addScriptToEvaluateOnNewDocument",
+        "params": {"source": script},
+    }
+    ws.send(json.dumps(payload))
+    return _wait_for_id(ws, message_id)
+
+
 def build_bridge_script(binding_name: str) -> str:
     return f"""
 (() => {{
@@ -100,14 +118,23 @@ def build_bridge_script(binding_name: str) -> str:
   }});
 }})();
 """
-def install_bridge(websocket_url: str, binding_name: str, handler: BridgeHandler) -> websocket.WebSocket:
+
+
+def install_bridge(websocket_url: str, binding_name: str, handler: BridgeHandler, new_document_scripts: list[str] | None = None) -> websocket.WebSocket:
     ws = websocket.create_connection(websocket_url, timeout=5)
     ws.send(json.dumps({"id": 1, "method": "Runtime.enable", "params": {}}))
     _wait_for_id(ws, 1)
-    ws.send(json.dumps({"id": 2, "method": "Runtime.addBinding", "params": {"name": binding_name}}))
+    ws.send(json.dumps({"id": 2, "method": "Runtime.removeBinding", "params": {"name": binding_name}}))
     _wait_for_id(ws, 2)
-    ws.send(json.dumps({"id": 3, "method": "Runtime.evaluate", "params": {"expression": build_bridge_script(binding_name), "awaitPromise": False, "allowUnsafeEvalBlockedByCSP": True}}))
+    ws.send(json.dumps({"id": 3, "method": "Runtime.addBinding", "params": {"name": binding_name}}))
     _wait_for_id(ws, 3)
+    bridge_script = build_bridge_script(binding_name)
+    ws.send(json.dumps({"id": 4, "method": "Page.addScriptToEvaluateOnNewDocument", "params": {"source": bridge_script}}))
+    _wait_for_id(ws, 4)
+    ws.send(json.dumps({"id": 5, "method": "Runtime.evaluate", "params": {"expression": bridge_script, "awaitPromise": False, "allowUnsafeEvalBlockedByCSP": True}}))
+    _wait_for_id(ws, 5)
+    for script in new_document_scripts or []:
+        _add_script_to_new_documents_on_socket(ws, script, _next_id())
     thread = threading.Thread(target=_bridge_loop, args=(ws, handler), daemon=True)
     thread.start()
     return ws
@@ -117,11 +144,15 @@ def inject_file(port: int, script_path: Path, helper_port: int, handler: BridgeH
     targets = list_targets(port)
     target = pick_page_target(targets)
     websocket_url = str(target["webSocketDebuggerUrl"])
-    bridge_socket = install_bridge(websocket_url, BRIDGE_BINDING_NAME, handler) if handler else None
     script = script_path.read_text(encoding="utf-8")
     prefix = f"window.__CODEX_SESSION_DELETE_HELPER__ = 'http://127.0.0.1:{helper_port}';\n"
-    result = evaluate_script(websocket_url, prefix + script)
+    full_script = prefix + script
+    bridge_socket = install_bridge(websocket_url, BRIDGE_BINDING_NAME, handler, [full_script]) if handler else None
+    if not bridge_socket:
+        add_script_to_new_documents(websocket_url, full_script)
+    result = evaluate_script(websocket_url, full_script)
     return InjectionResult(websocket_url=websocket_url, bridge_socket=bridge_socket, result=result)
+
 
 def _bridge_loop(ws: websocket.WebSocket, handler: BridgeHandler) -> None:
     while True:

--- a/codex_session_delete/cli.py
+++ b/codex_session_delete/cli.py
@@ -103,11 +103,9 @@ def wait_for_shutdown(server: HelperServer, codex_proc) -> None:
         if isinstance(codex_proc, int):
             wait_for_windows_process_id(codex_proc)
         elif codex_proc is None and sys.platform == "darwin":
-            import subprocess as _sp
             import time as _time
             while True:
-                result = _sp.run(["pgrep", "-f", "^/Applications/Codex\\.app/Contents/MacOS/Codex"], capture_output=True)
-                if result.returncode != 0:
+                if not is_macos_codex_running():
                     break
                 _time.sleep(2)
         elif codex_proc is not None:
@@ -116,6 +114,11 @@ def wait_for_shutdown(server: HelperServer, codex_proc) -> None:
         pass
     finally:
         shutdown_helper(server)
+
+
+def is_macos_codex_running() -> bool:
+    result = subprocess.run(["ps", "-axo", "pid=,command="], capture_output=True, text=True, check=False)
+    return any("/Codex.app/Contents/MacOS/Codex " in f"{line} " for line in result.stdout.splitlines())
 
 
 def stop_existing_windows_launchers() -> None:

--- a/codex_session_delete/helper_server.py
+++ b/codex_session_delete/helper_server.py
@@ -11,6 +11,9 @@ class DeleteService(Protocol):
     def delete(self, session: SessionRef) -> DeleteResult: ...
     def undo(self, token: str) -> DeleteResult: ...
     def find_archived_thread_by_title(self, title: str) -> SessionRef | None: ...
+    def move_thread_workspace(self, session: SessionRef, target_cwd: str) -> dict[str, object]: ...
+    def thread_sort_key(self, session: SessionRef) -> dict[str, object]: ...
+    def thread_sort_keys(self, sessions: list[SessionRef]) -> dict[str, object]: ...
 
 
 class ExportService(Protocol):
@@ -65,10 +68,6 @@ class _Handler(BaseHTTPRequestHandler):
                 token = str(payload.get("undo_token", ""))
                 self._send_json(self.server.service.undo(token).to_dict())
                 return
-            if self.path == "/archived-thread":
-                session = self.server.service.find_archived_thread_by_title(str(payload.get("title", "")))
-                self._send_json({"session_id": session.session_id, "title": session.title} if session else {"session_id": "", "title": ""})
-                return
             if self.path == "/export-markdown":
                 if self.server.export_service is None:
                     self._send_json(
@@ -78,6 +77,27 @@ class _Handler(BaseHTTPRequestHandler):
                     return
                 session = SessionRef(session_id=str(payload.get("session_id", "")), title=str(payload.get("title", "")))
                 self._send_json(self.server.export_service.export(session).to_dict())
+                return
+            if self.path == "/archived-thread":
+                session = self.server.service.find_archived_thread_by_title(str(payload.get("title", "")))
+                self._send_json({"session_id": session.session_id, "title": session.title} if session else {"session_id": "", "title": ""})
+                return
+            if self.path == "/move-thread-workspace":
+                session = SessionRef(session_id=str(payload.get("session_id", "")), title=str(payload.get("title", "")))
+                self._send_json(self.server.service.move_thread_workspace(session, str(payload.get("target_cwd", ""))))
+                return
+            if self.path == "/thread-sort-key":
+                session = SessionRef(session_id=str(payload.get("session_id", "")), title=str(payload.get("title", "")))
+                self._send_json(self.server.service.thread_sort_key(session))
+                return
+            if self.path == "/thread-sort-keys":
+                raw_sessions = payload.get("sessions", [])
+                sessions = [
+                    SessionRef(session_id=str(item.get("session_id", "")), title=str(item.get("title", "")))
+                    for item in raw_sessions
+                    if isinstance(item, dict)
+                ] if isinstance(raw_sessions, list) else []
+                self._send_json(self.server.service.thread_sort_keys(sessions))
                 return
             self._send_json({"error": "not found"}, status=404)
         except Exception as exc:

--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -2,18 +2,34 @@
   const helperBase = window.__CODEX_SESSION_DELETE_HELPER__ || "http://127.0.0.1:57321";
   const buttonClass = "codex-delete-button";
   const exportButtonClass = "codex-export-button";
+  const projectMoveButtonClass = "codex-project-move-button";
+  const projectMoveOverlayClass = "codex-project-move-overlay";
   const actionButtonClass = "codex-session-action-button";
   const actionGroupClass = "codex-session-actions";
+  const projectMoveProjectionKey = "codexProjectMoveProjection";
+  const legacyProjectMoveOverridesKey = "codexProjectMoveOverrides";
+  const projectMoveProjectionTtlMs = 24 * 60 * 60 * 1000;
+  const projectMoveProjectionSettleMs = 5 * 60 * 1000;
+  const projectMoveRefreshDelaysMs = [50, 250, 750, 1500];
+  const chatsSortRefreshIntervalMs = 1500;
+  const chatsSortDbRefreshIntervalMs = 5000;
   const styleId = "codex-delete-style";
-  const codexDeleteStyleVersion = "5";
+  const codexDeleteStyleVersion = "6";
   const codexPlusMenuId = "codex-plus-menu";
   const codexDeleteVersion = "6";
   const codexExportVersion = "1";
-  const codexActionGroupVersion = "1";
+  const codexProjectMoveVersion = "1";
+  const codexActionGroupVersion = "2";
   const codexArchiveRowActionsVersion = "1";
   const codexArchiveDeleteAllVersion = "2";
-  const codexPlusVersion = "1.0.5";;
+  const codexPlusVersion = "1.0.5";
   const codexPlusSettingsKey = "codexPlusSettings";
+  window.__codexProjectMoveRuntimeId = (window.__codexProjectMoveRuntimeId || 0) + 1;
+  const codexProjectMoveRuntimeId = window.__codexProjectMoveRuntimeId;
+  clearTimeout(window.__codexProjectMoveProjectionTimer);
+  clearTimeout(window.__codexProjectMoveChatsSortTimer);
+  window.__codexProjectMoveProjectionTimer = null;
+  window.__codexProjectMoveChatsSortTimer = null;
   const selectors = {
     sidebarThread: "[data-app-action-sidebar-thread-id]",
     threadTitle: "[data-thread-title]",
@@ -73,8 +89,52 @@
         background: #dbeafe;
         color: #1d4ed8;
       }
+      .${projectMoveButtonClass} {
+        border-color: #10a37f;
+        background: #d1fae5;
+        color: #065f46;
+      }
       [data-codex-delete-row="true"]:hover .${actionGroupClass} { opacity: 1; }
       [data-codex-delete-row="true"].codex-archive-confirm-visible .${actionGroupClass} { right: 66px; }
+      .${projectMoveOverlayClass} {
+        position: fixed;
+        inset: 0;
+        z-index: 2147483200;
+        background: rgba(15,23,42,.28);
+      }
+      .codex-project-move-panel {
+        position: fixed;
+        width: min(360px, calc(100vw - 32px));
+        max-height: min(520px, calc(100vh - 32px));
+        overflow: hidden;
+        border: 1px solid rgba(15,23,42,.14);
+        border-radius: 10px;
+        background: #ffffff;
+        color: #111827;
+        font: 13px system-ui, sans-serif;
+        box-shadow: 0 18px 60px rgba(15,23,42,.25);
+      }
+      .codex-project-move-header { border-bottom: 1px solid #e5e7eb; padding: 10px 12px; }
+      .codex-project-move-title { font-weight: 650; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      .codex-project-move-list { max-height: min(440px, calc(100vh - 110px)); overflow-y: auto; padding: 6px; }
+      .codex-project-move-item {
+        display: block;
+        width: 100%;
+        border: 0;
+        border-radius: 7px;
+        background: transparent;
+        color: #111827;
+        padding: 8px 9px;
+        text-align: left;
+        cursor: pointer;
+      }
+      .codex-project-move-item:hover,
+      .codex-project-move-item:focus-visible { background: #f3f4f6; outline: none; }
+      .codex-project-move-item-title { font-weight: 550; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      .codex-project-move-item-path { margin-top: 2px; color: #6b7280; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      .codex-project-move-empty { padding: 18px 12px; color: #6b7280; text-align: center; }
+      .codex-project-move-hidden { display: none !important; }
+      [data-codex-project-move-injected-list="true"] { display: flex; flex-direction: column; }
       .codex-archive-delete-all {
         border: 1px solid #ef4444;
         border-radius: 7px;
@@ -269,7 +329,7 @@
   }
 
   function defaultCodexPlusSettings() {
-    return { pluginEntryUnlock: true, forcePluginInstall: true, sessionDelete: true, markdownExport: true, nativeMenuPlacement: true };
+    return { pluginEntryUnlock: true, forcePluginInstall: true, sessionDelete: true, markdownExport: true, projectMove: true, nativeMenuPlacement: true };
   }
 
   function codexPlusSettings() {
@@ -425,6 +485,10 @@
             <div class="codex-plus-row">
               <div><div class="codex-plus-row-title">Markdown 导出</div><div class="codex-plus-row-description">在会话列表显示导出按钮，按本地 rollout 导出带时间戳的 Markdown。</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="markdownExport"><span></span></button>
+            </div>
+            <div class="codex-plus-row">
+              <div><div class="codex-plus-row-title">会话项目移动</div><div class="codex-plus-row-description">在会话列表悬停显示移动按钮，可移动到普通对话或其他本地项目。</div></div>
+              <button type="button" class="codex-plus-toggle" data-codex-plus-setting="projectMove"><span></span></button>
             </div>
             <div class="codex-plus-row">
               <div><div class="codex-plus-row-title">原生菜单栏位置</div><div class="codex-plus-row-description">把 Codex++ 菜单插入顶部原生菜单栏；默认关闭以避免页面重渲染冲突。</div></div>
@@ -740,9 +804,9 @@
     const codexThreadId = row.getAttribute("data-app-action-sidebar-thread-id") || "";
     const fallbackId = row.getAttribute("data-session-id") || row.getAttribute("data-testid") || "";
     const sessionId = codexThreadId || (idMatch && idMatch[1]) || fallbackId;
-    const titleNode = row.querySelector(selectors.threadTitle);
+    const titleNode = row.querySelector(`${selectors.threadTitle}, .truncate.select-none, .truncate.text-base`);
     const rawTitle = (titleNode?.textContent || (titleNode ? "" : (row.textContent || "Untitled session")));
-    const title = (titleNode ? rawTitle : rawTitle.replace("导出", "").replace("删除", "")).trim().slice(0, 160);
+    const title = (titleNode ? rawTitle : rawTitle.replace(/\s*(导出|删除|移动|移出项目)(\s*(导出|删除|移动|移出项目))*$/g, "")).trim().slice(0, 160);
     return { session_id: sessionId, title };
   }
 
@@ -766,6 +830,826 @@
     anchor.click();
     anchor.remove();
     setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+
+  let codexStateApiPromise = null;
+  let chatsSortInFlight = false;
+  let chatsSortSignature = "";
+  let chatsSortLastFetchAt = 0;
+
+  async function codexStateApi() {
+    codexStateApiPromise = codexStateApiPromise || import("./assets/vscode-api-Dc9pX2Bc.js");
+    const api = await codexStateApiPromise;
+    if (typeof api.n !== "function") throw new Error("Codex 状态 API 不可用");
+    return api.n;
+  }
+
+  async function codexStateCall(method, params) {
+    const call = await codexStateApi();
+    return await call(method, params);
+  }
+
+  async function getCodexGlobalState(key) {
+    const result = await codexStateCall("get-global-state", { params: { key } });
+    return result && Object.prototype.hasOwnProperty.call(result, "value") ? result.value : result;
+  }
+
+  async function setCodexGlobalState(key, value) {
+    return await codexStateCall("set-global-state", { params: { key, value } });
+  }
+
+  function objectGlobalState(value) {
+    return value && typeof value === "object" && !Array.isArray(value) ? { ...value } : {};
+  }
+
+  function uniqueValues(values) {
+    return Array.from(new Set(values.filter((value) => typeof value === "string" && value.trim().length > 0)));
+  }
+
+  function threadIdVariants(sessionId) {
+    if (typeof sessionId !== "string" || !sessionId.trim()) return [];
+    const id = sessionId.trim();
+    const bareId = id.startsWith("local:") ? id.slice("local:".length) : id;
+    return uniqueValues([id, bareId, `local:${bareId}`]);
+  }
+
+  function projectMoveSessionKey(sessionId) {
+    const variants = threadIdVariants(sessionId);
+    const bareId = variants.find((id) => !id.startsWith("local:"));
+    return bareId || variants[0] || "";
+  }
+
+  function uuidV7TimestampMs(sessionId) {
+    const id = projectMoveSessionKey(sessionId).replaceAll("-", "");
+    if (!/^[0-9a-fA-F]{12}/.test(id)) return 0;
+    const timestamp = Number.parseInt(id.slice(0, 12), 16);
+    return Number.isFinite(timestamp) ? timestamp : 0;
+  }
+
+  function numericTimestamp(value) {
+    const timestamp = Number(value);
+    return Number.isFinite(timestamp) && timestamp > 0 ? timestamp : 0;
+  }
+
+  function timestampValueToMs(value) {
+    const timestamp = numericTimestamp(value);
+    if (!timestamp) return 0;
+    return timestamp < 1000000000000 ? timestamp * 1000 : timestamp;
+  }
+
+  function sortMsForSession(sessionId, preferredValue) {
+    return numericTimestamp(preferredValue) || uuidV7TimestampMs(sessionId);
+  }
+
+  function timestampMsFromPayload(payload) {
+    return numericTimestamp(payload?.updated_at_ms) || timestampValueToMs(payload?.updated_at) || numericTimestamp(payload?.created_at_ms);
+  }
+
+  function relativeTimeLabel(timestampMs, nowMs = Date.now()) {
+    const timestamp = numericTimestamp(timestampMs);
+    if (!timestamp) return "";
+    const elapsedSeconds = Math.max(0, Math.floor((nowMs - timestamp) / 1000));
+    if (elapsedSeconds < 60) return "刚刚";
+    const elapsedMinutes = Math.floor(elapsedSeconds / 60);
+    if (elapsedMinutes < 60) return `${elapsedMinutes} 分`;
+    const elapsedHours = Math.floor(elapsedMinutes / 60);
+    if (elapsedHours < 24) return `${elapsedHours} 小时`;
+    const elapsedDays = Math.floor(elapsedHours / 24);
+    if (elapsedDays < 7) return `${elapsedDays} 天`;
+    const elapsedWeeks = Math.floor(elapsedDays / 7);
+    if (elapsedWeeks < 5) return `${elapsedWeeks} 周`;
+    const elapsedMonths = Math.floor(elapsedDays / 30);
+    if (elapsedMonths < 12) return `${Math.max(1, elapsedMonths)} 月`;
+    return `${Math.floor(elapsedDays / 365)} 年`;
+  }
+
+  function normalizeWorkspacePath(path) {
+    const normalized = String(path || "").trim().replace(/\\/g, "/").replace(/\/+$/, "");
+    return normalized || String(path || "").trim();
+  }
+
+  function sameWorkspacePath(left, right) {
+    const leftPath = normalizeWorkspacePath(left);
+    const rightPath = normalizeWorkspacePath(right);
+    return !!leftPath && !!rightPath && leftPath === rightPath;
+  }
+
+  function displayProjectName(path) {
+    const trimmed = String(path || "").replace(/\/+$/, "");
+    return trimmed.split(/[\\/]+/).filter(Boolean).pop() || trimmed || "未命名项目";
+  }
+
+  function normalizeProjectLabel(value) {
+    return String(value || "").replace(/\s+/g, " ").trim();
+  }
+
+  function projectsSection() {
+    return document.querySelector('[data-app-action-sidebar-section-heading="Projects"]');
+  }
+
+  function chatsSection() {
+    return document.querySelector('[data-app-action-sidebar-section-heading="Chats"]');
+  }
+
+  function projectRowListItem(projectRow) {
+    return projectRow.closest?.('[role="listitem"][aria-label]') || projectRow.closest?.('[role="listitem"]') || projectRow;
+  }
+
+  function nativeProjectTargets() {
+    const section = projectsSection();
+    const seen = new Set();
+    const targets = [];
+    Array.from(document.querySelectorAll('[data-app-action-sidebar-project-row]')).forEach((row) => {
+      if (section && !section.contains(row)) return;
+      const path = row.getAttribute("data-app-action-sidebar-project-id") || "";
+      const normalizedPath = normalizeWorkspacePath(path);
+      if (!normalizedPath || seen.has(normalizedPath)) return;
+      const label = row.getAttribute("data-app-action-sidebar-project-label") || row.getAttribute("aria-label") || displayProjectName(path);
+      seen.add(normalizedPath);
+      targets.push({ kind: "project", label: String(label || displayProjectName(path)), description: path, path, normalizedPath, row, listItem: projectRowListItem(row) });
+    });
+    return targets;
+  }
+
+  function serializableProjectTarget(target) {
+    return { kind: target.kind, label: target.label, description: target.description, path: target.path, normalizedPath: target.normalizedPath || normalizeWorkspacePath(target.path) };
+  }
+
+  function projectMoveTargets() {
+    return [
+      { kind: "projectless", label: "普通对话", description: "不属于任何项目", path: "", normalizedPath: "" },
+      ...nativeProjectTargets().map(serializableProjectTarget),
+    ];
+  }
+
+  function readLegacyProjectMoveProjection() {
+    try {
+      const parsed = JSON.parse(localStorage.getItem(legacyProjectMoveOverridesKey) || "{}");
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+      const now = Date.now();
+      const next = {};
+      for (const [key, value] of Object.entries(parsed)) {
+        if (!value || typeof value !== "object" || !value.targetCwd) continue;
+        const sessionId = projectMoveSessionKey(value.sessionId || key);
+        if (!sessionId) continue;
+        next[sessionId] = {
+          sessionId,
+          targetKind: "project",
+          targetCwd: String(value.targetCwd),
+          targetLabel: String(value.targetLabel || displayProjectName(value.targetCwd)),
+          title: String(value.title || ""),
+          sortMs: sortMsForSession(sessionId, value.sortMs || value.updatedAtMs || value.updated_at_ms),
+          sortMsTrusted: false,
+          at: typeof value.at === "number" ? value.at : now,
+        };
+      }
+      return next;
+    } catch {
+      return {};
+    }
+  }
+
+  function readProjectMoveProjection() {
+    try {
+      const parsed = JSON.parse(localStorage.getItem(projectMoveProjectionKey) || "{}");
+      const raw = parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+      const merged = { ...readLegacyProjectMoveProjection(), ...raw };
+      const now = Date.now();
+      const projection = {};
+      for (const [key, value] of Object.entries(merged)) {
+        if (!value || typeof value !== "object") continue;
+        const sessionId = projectMoveSessionKey(value.sessionId || key);
+        if (!sessionId) continue;
+        if (typeof value.at === "number" && now - value.at > projectMoveProjectionTtlMs) continue;
+        const targetKind = value.targetKind === "projectless" ? "projectless" : "project";
+        const targetCwd = String(value.targetCwd || value.path || "");
+        if (targetKind === "project" && !targetCwd) continue;
+        projection[sessionId] = {
+          sessionId,
+          targetKind,
+          targetCwd,
+          targetLabel: String(value.targetLabel || value.label || (targetKind === "projectless" ? "普通对话" : displayProjectName(targetCwd))),
+          title: String(value.title || ""),
+          sortMs: sortMsForSession(sessionId, value.sortMs || value.updatedAtMs || value.updated_at_ms),
+          sortMsTrusted: value.sortMsTrusted === true,
+          at: typeof value.at === "number" ? value.at : now,
+        };
+      }
+      return projection;
+    } catch {
+      return readLegacyProjectMoveProjection();
+    }
+  }
+
+  function writeProjectMoveProjection(projection) {
+    try {
+      localStorage.setItem(projectMoveProjectionKey, JSON.stringify(projection || {}));
+      localStorage.removeItem(legacyProjectMoveOverridesKey);
+    } catch (error) {
+      window.__codexProjectMoveProjectionFailures = window.__codexProjectMoveProjectionFailures || [];
+      window.__codexProjectMoveProjectionFailures.push(String(error?.stack || error));
+    }
+  }
+
+  function saveProjectMoveProjection(ref, target, sortMs) {
+    const id = projectMoveSessionKey(ref.session_id);
+    if (!id || !target) return;
+    const projection = readProjectMoveProjection();
+    projection[id] = {
+      sessionId: id,
+      targetKind: target.kind === "projectless" ? "projectless" : "project",
+      targetCwd: target.path || "",
+      targetLabel: target.label || (target.kind === "projectless" ? "普通对话" : displayProjectName(target.path)),
+      title: ref.title || "",
+      sortMs: sortMsForSession(ref.session_id, sortMs || target.sortMs),
+      sortMsTrusted: target.sortMsTrusted === true,
+      at: Date.now(),
+    };
+    writeProjectMoveProjection(projection);
+  }
+
+  function clearProjectMoveProjection(ref) {
+    const projection = readProjectMoveProjection();
+    const keys = threadIdVariants(ref.session_id).map(projectMoveSessionKey).filter(Boolean);
+    let changed = false;
+    keys.forEach((key) => {
+      if (Object.prototype.hasOwnProperty.call(projection, key)) {
+        delete projection[key];
+        changed = true;
+      }
+    });
+    if (changed) writeProjectMoveProjection(projection);
+  }
+
+  function projectionForSessionId(sessionId, projection = readProjectMoveProjection()) {
+    const key = projectMoveSessionKey(sessionId);
+    return key ? projection[key] || null : null;
+  }
+
+  function projectRowFromListItem(projectItem) {
+    if (!projectItem) return null;
+    if (projectItem.matches?.("[data-app-action-sidebar-project-row]")) return projectItem;
+    return projectItem.querySelector?.("[data-app-action-sidebar-project-row]") || null;
+  }
+
+  function targetPath(target) {
+    return target?.path || target?.targetCwd || "";
+  }
+
+  function targetLabel(target) {
+    return target?.label || target?.targetLabel || displayProjectName(targetPath(target));
+  }
+
+  function projectItemMatchesTarget(projectItem, target) {
+    const projectRow = projectRowFromListItem(projectItem);
+    const projectPath = projectRow?.getAttribute?.("data-app-action-sidebar-project-id") || "";
+    if (projectPath && sameWorkspacePath(projectPath, targetPath(target))) return true;
+    const actual = normalizeProjectLabel(projectRow?.getAttribute?.("data-app-action-sidebar-project-label") || projectItem?.getAttribute?.("aria-label"));
+    const labels = uniqueValues([targetLabel(target), displayProjectName(targetPath(target))]).map(normalizeProjectLabel).filter(Boolean);
+    return !!actual && labels.includes(actual);
+  }
+
+  function findProjectListItem(target) {
+    const nativeTarget = nativeProjectTargets().find((project) => sameWorkspacePath(project.path, targetPath(target)));
+    if (nativeTarget?.listItem) return nativeTarget.listItem;
+    const section = projectsSection();
+    if (!section) return null;
+    return Array.from(section.querySelectorAll('[role="listitem"][aria-label]')).find((item) => projectItemMatchesTarget(item, target)) || null;
+  }
+
+  function closestProjectListItem(row) {
+    const item = row.closest?.('[role="listitem"][aria-label]');
+    return item?.closest?.('[data-app-action-sidebar-section-heading="Projects"]') ? item : null;
+  }
+
+  function rowIsInChats(row) {
+    return !!row.closest?.('[data-app-action-sidebar-section-heading="Chats"]');
+  }
+
+  function chatsThreadList() {
+    return chatsSection()?.querySelector?.('[role="list"][aria-label="对话"], [role="list"]') || null;
+  }
+
+  function rowIsUnderTargetProject(row, target) {
+    const item = closestProjectListItem(row);
+    return !!item && projectItemMatchesTarget(item, target);
+  }
+
+  function rowIsUnderTarget(row, target) {
+    return target?.targetKind === "projectless" || target?.kind === "projectless" ? rowIsInChats(row) : rowIsUnderTargetProject(row, target);
+  }
+
+  function rowListItem(row) {
+    return row.closest?.('[role="listitem"]') || row;
+  }
+
+  function rowContentRoot(row) {
+    return Array.from(row?.children || []).find((child) => String(child.className || "").includes("h-full w-full items-center")) || null;
+  }
+
+  function normalizedText(node) {
+    return String(node?.textContent || "").replace(/\s+/g, " ").trim();
+  }
+
+  function classNameText(node) {
+    return String(node?.className || "");
+  }
+
+  function isRelativeTimeText(text) {
+    const value = String(text || "").replace(/\s+/g, " ").trim();
+    return /^(刚刚|just now|\d+\s*(秒|秒钟|分|分钟|小时|天|日|周|星期|个月|月|年|sec|secs|second|seconds|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days|w|wk|wks|week|weeks|mo|mos|month|months|y|yr|yrs|year|years))$/i.test(value);
+  }
+
+  function nodeIsThreadTitle(row, node) {
+    return Array.from(row?.querySelectorAll?.('[data-thread-title], .truncate.select-none, .truncate.text-base') || [])
+      .some((titleNode) => titleNode === node || titleNode.contains(node));
+  }
+
+  function closestTimeWrapper(row, node) {
+    const root = rowContentRoot(row) || row;
+    let current = node?.parentElement || null;
+    while (current && current !== root && current !== row) {
+      const className = classNameText(current);
+      if (current.dataset?.codexProjectMoveTimeWrapper === "true" || (className.includes("ml-[3px]") && className.includes("min-w-[26px]"))) return current;
+      current = current.parentElement;
+    }
+    return null;
+  }
+
+  function nodeInsideStatusIcon(row, node) {
+    const stop = closestTimeWrapper(row, node) || rowContentRoot(row) || row;
+    let current = node || null;
+    while (current && current !== stop && current !== row) {
+      const className = classNameText(current);
+      if (className.includes("animate-spin")) return true;
+      if (className.includes("size-5") && className.includes("shrink-0")) return true;
+      if (className.includes("contain-paint") && className.includes("contain-layout")) return true;
+      current = current.parentElement;
+    }
+    return false;
+  }
+
+  function cleanupManagedStatusIconTimeNodes(row) {
+    Array.from(row?.querySelectorAll?.('[data-codex-project-move-time="true"]') || []).forEach((node) => {
+      if (!nodeInsideStatusIcon(row, node)) return;
+      const text = normalizedText(node);
+      delete node.dataset.codexProjectMoveTime;
+      delete node.dataset.codexProjectMoveTimeMs;
+      if (node.children.length === 0 && isRelativeTimeText(text)) node.textContent = "";
+    });
+  }
+
+  function nodeLooksLikeTimeLabel(row, node) {
+    if (nodeInsideStatusIcon(row, node)) return false;
+    if (node?.dataset?.codexProjectMoveTime === "true") return true;
+    if (node.children.length > 0) return false;
+    const text = normalizedText(node);
+    const className = classNameText(node);
+    if ((className.includes("tabular-nums") || className.includes("text-token-description-foreground")) && text.length <= 24) return true;
+    if (!isRelativeTimeText(text)) return false;
+    const rowRect = row?.getBoundingClientRect?.();
+    const nodeRect = node?.getBoundingClientRect?.();
+    if (!rowRect || !nodeRect || rowRect.width <= 0 || nodeRect.width <= 0) return false;
+    return nodeRect.left >= rowRect.left + rowRect.width * 0.45 || nodeRect.right >= rowRect.right - 96;
+  }
+
+  function rowTimeLabelCandidates(row) {
+    cleanupManagedStatusIconTimeNodes(row);
+    const root = rowContentRoot(row) || row;
+    const raw = Array.from(root?.querySelectorAll?.("div, span, time, small") || []).filter((node) => {
+      if (nodeIsThreadTitle(row, node)) return false;
+      return nodeLooksLikeTimeLabel(row, node);
+    });
+    return raw.filter((node) => !raw.some((other) => other !== node && node.contains(other)));
+  }
+
+  function rowTimeLabelNode(row) {
+    const candidates = rowTimeLabelCandidates(row);
+    return candidates.find((node) => node.dataset?.codexProjectMoveTime !== "true" && !node.closest?.('[data-codex-project-move-time-wrapper="true"]')) || candidates[0] || null;
+  }
+
+  function removeTimeLabelNode(row, node) {
+    if (!node || !row?.contains?.(node)) return;
+    const wrapper = node.closest?.('[data-codex-project-move-time-wrapper="true"]') || closestTimeWrapper(row, node);
+    if (wrapper && wrapper !== row && row.contains(wrapper)) {
+      wrapper.remove();
+      return;
+    }
+    node.remove();
+  }
+
+  function cleanupRowTimeLabels(row, keepNode) {
+    if (!keepNode) return;
+    rowTimeLabelCandidates(row).forEach((node) => {
+      if (node === keepNode) return;
+      if (node.dataset?.codexProjectMoveTime === "true" || node.closest?.('[data-codex-project-move-time-wrapper="true"]')) removeTimeLabelNode(row, node);
+    });
+  }
+
+  function ensureRowTimeLabelNode(row) {
+    const existing = rowTimeLabelNode(row);
+    if (existing) {
+      cleanupRowTimeLabels(row, existing);
+      return existing;
+    }
+    const root = rowContentRoot(row);
+    if (!root) return null;
+    const wrapper = document.createElement("div");
+    wrapper.className = "ml-[3px] flex items-center justify-end gap-1 min-w-[26px]";
+    wrapper.dataset.codexProjectMoveTimeWrapper = "true";
+    const inner = document.createElement("div");
+    const label = document.createElement("div");
+    label.className = "text-token-description-foreground text-sm leading-4 empty:hidden tabular-nums overflow-visible truncate text-right group-focus-within:opacity-0 group-hover:opacity-0";
+    label.dataset.codexProjectMoveTime = "true";
+    inner.appendChild(label);
+    wrapper.appendChild(inner);
+    root.appendChild(wrapper);
+    return label;
+  }
+
+  function updateRowTimeLabel(row, sortMs) {
+    const label = ensureRowTimeLabelNode(row);
+    if (!label) return;
+    const timestamp = numericTimestamp(sortMs);
+    const text = relativeTimeLabel(timestamp);
+    label.dataset.codexProjectMoveTime = "true";
+    label.dataset.codexProjectMoveTimeMs = String(timestamp || 0);
+    if (text && label.textContent !== text) label.textContent = text;
+    cleanupRowTimeLabels(row, label);
+  }
+
+  function rowProjectionKind(row) {
+    return row?.dataset?.codexProjectMoveTargetKind || rowListItem(row)?.dataset?.codexProjectMoveTargetKind || "";
+  }
+
+  function rowSortMs(row, ref = sessionRefFromRow(row), target = null) {
+    return sortMsForSession(ref.session_id, target?.sortMs || row?.dataset?.codexProjectMoveSortMs || rowListItem(row)?.dataset?.codexProjectMoveSortMs);
+  }
+
+  function threadRowFromListItem(item) {
+    if (!item) return null;
+    if (item.matches?.("[data-app-action-sidebar-thread-id]")) return item;
+    return item.querySelector?.("[data-app-action-sidebar-thread-id]") || null;
+  }
+
+  function rowPinned(row) {
+    return row?.getAttribute?.("data-app-action-sidebar-thread-pinned") === "true" || rowListItem(row)?.getAttribute?.("data-app-action-sidebar-thread-pinned") === "true";
+  }
+
+  function insertRowItemByTime(list, item, row, target) {
+    const ref = sessionRefFromRow(row);
+    const sortMs = rowSortMs(row, ref, target);
+    item.dataset.codexProjectMoveSortMs = String(sortMs || 0);
+    row.dataset.codexProjectMoveSortMs = String(sortMs || 0);
+    if (target?.sortMsTrusted) updateRowTimeLabel(row, sortMs);
+    const pinned = rowPinned(row);
+    const sessionKey = projectMoveSessionKey(ref.session_id);
+    const existingItems = Array.from(list.children).filter((child) => child !== item);
+    let firstNonThreadItem = null;
+    for (const child of existingItems) {
+      const childRow = threadRowFromListItem(child);
+      if (!childRow) {
+        firstNonThreadItem = firstNonThreadItem || child;
+        continue;
+      }
+      const childPinned = rowPinned(childRow);
+      if (childPinned && !pinned) continue;
+      if (!childPinned && pinned) {
+        list.insertBefore(item, child);
+        return;
+      }
+      const childRef = sessionRefFromRow(childRow);
+      const childSortMs = rowSortMs(childRow, childRef);
+      const childKey = projectMoveSessionKey(childRef.session_id);
+      if (sortMs > childSortMs || (sortMs === childSortMs && sessionKey > childKey)) {
+        list.insertBefore(item, child);
+        return;
+      }
+    }
+    if (firstNonThreadItem) {
+      list.insertBefore(item, firstNonThreadItem);
+      return;
+    }
+    list.appendChild(item);
+  }
+
+  function projectMoveInjectedList(projectItem) {
+    let list = projectItem.querySelector('[data-codex-project-move-injected-list="true"]');
+    if (!list) {
+      const body = Array.from(projectItem.children).find((child) => child.classList?.contains("overflow-hidden")) || projectItem;
+      list = document.createElement("div");
+      list.setAttribute("role", "list");
+      list.setAttribute("data-codex-project-move-injected-list", "true");
+      list.className = "flex flex-col";
+      body.appendChild(list);
+    }
+    return list;
+  }
+
+  function projectThreadList(projectItem, target) {
+    const targetCwd = targetPath(target);
+    const projectLists = Array.from(projectItem.querySelectorAll("[data-app-action-sidebar-project-list-id]"));
+    return projectLists.find((list) => sameWorkspacePath(list.getAttribute("data-app-action-sidebar-project-list-id"), targetCwd))
+      || projectLists[0]
+      || projectMoveInjectedList(projectItem);
+  }
+
+  function projectEmptyStateNodes(projectItem) {
+    const emptyLabels = new Set(["暂无对话", "No conversations"]);
+    return Array.from(projectItem.querySelectorAll("div, span")).filter((node) => {
+      if (node.classList?.contains("overflow-hidden")) return false;
+      if (node.closest('[data-app-action-sidebar-thread-id], [data-codex-project-move-injected-list="true"]')) return false;
+      return emptyLabels.has(normalizeProjectLabel(node.textContent));
+    });
+  }
+
+  function setProjectEmptyStateHidden(projectItem, hidden) {
+    projectEmptyStateNodes(projectItem).forEach((node) => {
+      if (hidden) {
+        node.dataset.codexProjectMoveEmptyHidden = "true";
+        node.classList.add("codex-project-move-hidden");
+      } else if (node.dataset.codexProjectMoveEmptyHidden === "true") {
+        delete node.dataset.codexProjectMoveEmptyHidden;
+        node.classList.remove("codex-project-move-hidden");
+      }
+    });
+  }
+
+  function updateProjectMoveEmptyStates() {
+    document.querySelectorAll('[data-codex-project-move-injected-list="true"]').forEach((list) => {
+      const projectItem = list.closest('[role="listitem"][aria-label]');
+      const hasRows = Array.from(list.children).some((child) => child.querySelector?.("[data-app-action-sidebar-thread-id]") || child.matches?.("[data-app-action-sidebar-thread-id]"));
+      if (!hasRows) list.remove();
+      if (projectItem) setProjectEmptyStateHidden(projectItem, hasRows);
+    });
+    document.querySelectorAll('[data-codex-project-move-empty-hidden="true"]').forEach((node) => {
+      const projectItem = node.closest('[role="listitem"][aria-label]');
+      const list = projectItem?.querySelector?.('[data-codex-project-move-injected-list="true"]');
+      if (!list || list.children.length === 0) {
+        delete node.dataset.codexProjectMoveEmptyHidden;
+        node.classList.remove("codex-project-move-hidden");
+      }
+    });
+  }
+
+  function moveRowToProjectList(row, target) {
+    const projectItem = findProjectListItem(target);
+    if (!projectItem) return false;
+    const list = projectThreadList(projectItem, target);
+    const item = rowListItem(row);
+    if (!list) return false;
+    insertRowItemByTime(list, item, row, target);
+    cachedSessionRowsAt = 0;
+    item.dataset.codexProjectMoveTargetKind = "project";
+    item.dataset.codexProjectMoveTargetCwd = targetPath(target);
+    row.dataset.codexProjectMoveTargetKind = "project";
+    row.dataset.codexProjectMoveTargetCwd = targetPath(target);
+    setProjectEmptyStateHidden(projectItem, true);
+    return true;
+  }
+
+  function moveRowToChats(row, target = null) {
+    const list = chatsThreadList();
+    if (!list) return false;
+    const item = rowListItem(row);
+    insertRowItemByTime(list, item, row, target);
+    cachedSessionRowsAt = 0;
+    item.dataset.codexProjectMoveTargetKind = "projectless";
+    row.dataset.codexProjectMoveTargetKind = "projectless";
+    delete item.dataset.codexProjectMoveTargetCwd;
+    delete row.dataset.codexProjectMoveTargetCwd;
+    updateProjectMoveEmptyStates();
+    return true;
+  }
+
+  function applyProjectMoveProjection() {
+    if (!codexPlusSettings().projectMove) return;
+    const projection = readProjectMoveProjection();
+    const targetRowsById = new Map();
+    const settledRefs = [];
+    const now = Date.now();
+    const rows = sessionRows(true);
+    rows.forEach((row) => {
+      const ref = sessionRefFromRow(row);
+      const target = projectionForSessionId(ref.session_id, projection);
+      if (target && rowIsUnderTarget(row, target)) {
+        const rowId = projectMoveSessionKey(ref.session_id);
+        const hadProjectionKind = !!rowProjectionKind(row);
+        const existingRow = targetRowsById.get(rowId);
+        if (existingRow && existingRow !== row) {
+          const existingIsProjection = !!rowProjectionKind(existingRow);
+          const currentIsProjection = !!rowProjectionKind(row);
+          const rowToRemove = existingIsProjection && !currentIsProjection ? existingRow : row;
+          rowListItem(rowToRemove).remove();
+          if (rowToRemove === existingRow) targetRowsById.set(rowId, row);
+          if (rowToRemove === row) return;
+        } else {
+          targetRowsById.set(rowId, row);
+        }
+        if (!hadProjectionKind && typeof target.at === "number" && now - target.at > projectMoveProjectionSettleMs) settledRefs.push(ref);
+        const moved = target.targetKind === "projectless" ? moveRowToChats(row, target) : moveRowToProjectList(row, target);
+        if (moved) targetRowsById.set(rowId, row);
+        const projectItem = closestProjectListItem(row);
+        if (projectItem) setProjectEmptyStateHidden(projectItem, true);
+      }
+    });
+    rows.forEach((row) => {
+      const ref = sessionRefFromRow(row);
+      const rowId = projectMoveSessionKey(ref.session_id);
+      const target = projectionForSessionId(ref.session_id, projection);
+      if (!target) {
+        const item = rowListItem(row);
+        delete row.dataset.codexProjectMoveTargetKind;
+        delete row.dataset.codexProjectMoveTargetCwd;
+        delete item.dataset.codexProjectMoveTargetKind;
+        delete item.dataset.codexProjectMoveTargetCwd;
+        return;
+      }
+      if (rowIsUnderTarget(row, target)) return;
+      if (targetRowsById.has(rowId)) {
+        rowListItem(row).remove();
+        return;
+      }
+      const moved = target.targetKind === "projectless" ? moveRowToChats(row, target) : moveRowToProjectList(row, target);
+      if (moved) targetRowsById.set(rowId, row);
+    });
+    settledRefs.forEach(clearProjectMoveProjection);
+    updateProjectMoveEmptyStates();
+  }
+
+  function scheduleProjectMoveProjection() {
+    if (!codexPlusSettings().projectMove || window.__codexProjectMoveProjectionTimer) return;
+    window.__codexProjectMoveProjectionTimer = setTimeout(() => {
+      if (window.__codexProjectMoveRuntimeId !== codexProjectMoveRuntimeId) return;
+      window.__codexProjectMoveProjectionTimer = null;
+      applyProjectMoveProjection();
+    }, 80);
+  }
+
+  async function refreshRecentConversationsForHost() {
+    try {
+      const signals = await import("./assets/app-server-manager-signals-C1h8B-R-.js");
+      if (typeof signals.rn === "function") await signals.rn("refresh-recent-conversations-for-host", { hostId: "local", sortKey: "updated_at" });
+    } catch (error) {
+      window.__codexProjectMoveRefreshFailures = window.__codexProjectMoveRefreshFailures || [];
+      window.__codexProjectMoveRefreshFailures.push(String(error?.stack || error));
+    }
+  }
+
+  function refreshAfterProjectMove() {
+    const refreshVisibleSidebar = () => {
+      applyProjectMoveProjection();
+      scheduleChatsSortCorrection(0);
+    };
+    refreshVisibleSidebar();
+    refreshRecentConversationsForHost().finally(() => {
+      projectMoveRefreshDelaysMs.forEach((delay) => setTimeout(refreshVisibleSidebar, delay));
+    });
+  }
+
+  function visibleChatsRows() {
+    const list = chatsThreadList();
+    if (!list) return [];
+    return Array.from(list.children).map(threadRowFromListItem).filter(Boolean).filter((row) => rowIsInChats(row));
+  }
+
+  function chatsSortNeedsCorrection(rows) {
+    let previousPinned = true;
+    let previousSortMs = Infinity;
+    let previousKey = "\uffff";
+    for (const row of rows) {
+      const pinned = rowPinned(row);
+      const ref = sessionRefFromRow(row);
+      const sortMs = rowSortMs(row, ref);
+      const key = projectMoveSessionKey(ref.session_id);
+      if (previousPinned && !pinned) {
+        previousPinned = false;
+        previousSortMs = sortMs;
+        previousKey = key;
+        continue;
+      }
+      if (!previousPinned && pinned) return true;
+      if (sortMs > previousSortMs || (sortMs === previousSortMs && key > previousKey)) return true;
+      previousSortMs = sortMs;
+      previousKey = key;
+    }
+    return false;
+  }
+
+  function reorderChatsRows(rows) {
+    const list = chatsThreadList();
+    if (!list || rows.length < 2) return;
+    const rowItems = new Set(rows.map(rowListItem));
+    const firstNonThreadItem = Array.from(list.children).find((child) => !rowItems.has(child) && !threadRowFromListItem(child));
+    const orderedRows = [...rows].sort((left, right) => {
+      const leftPinned = rowPinned(left);
+      const rightPinned = rowPinned(right);
+      if (leftPinned !== rightPinned) return leftPinned ? -1 : 1;
+      const leftRef = sessionRefFromRow(left);
+      const rightRef = sessionRefFromRow(right);
+      const leftSortMs = rowSortMs(left, leftRef);
+      const rightSortMs = rowSortMs(right, rightRef);
+      if (leftSortMs !== rightSortMs) return rightSortMs - leftSortMs;
+      return projectMoveSessionKey(rightRef.session_id).localeCompare(projectMoveSessionKey(leftRef.session_id));
+    });
+    orderedRows.forEach((row) => list.insertBefore(rowListItem(row), firstNonThreadItem || null));
+    cachedSessionRowsAt = 0;
+  }
+
+  async function applyChatsSortCorrection() {
+    if (!codexPlusSettings().projectMove || chatsSortInFlight) return;
+    const rows = visibleChatsRows();
+    if (rows.length < 2) return;
+    const refs = rows.map(sessionRefFromRow).filter((ref) => ref.session_id);
+    const signature = refs.map((ref) => projectMoveSessionKey(ref.session_id)).join("|");
+    const allRowsHaveSortMs = rows.every((row) => numericTimestamp(row.dataset.codexProjectMoveSortMs || rowListItem(row).dataset.codexProjectMoveSortMs));
+    const shouldRefreshSortKeys = signature !== chatsSortSignature || !allRowsHaveSortMs || Date.now() - chatsSortLastFetchAt > chatsSortDbRefreshIntervalMs;
+    if (!shouldRefreshSortKeys && !chatsSortNeedsCorrection(rows)) return;
+    chatsSortInFlight = true;
+    try {
+      if (shouldRefreshSortKeys) {
+        const result = await postJson("/thread-sort-keys", { sessions: refs }).catch(() => ({ status: "failed", sort_keys: [] }));
+        chatsSortLastFetchAt = Date.now();
+        const byId = new Map();
+        if (result?.status === "ok" && Array.isArray(result?.sort_keys)) {
+          result.sort_keys.forEach((item) => {
+            const key = projectMoveSessionKey(String(item?.session_id || ""));
+            if (key) byId.set(key, item);
+          });
+        }
+        rows.forEach((row) => {
+          const ref = sessionRefFromRow(row);
+          const payload = byId.get(projectMoveSessionKey(ref.session_id));
+          const trustedSortMs = timestampMsFromPayload(payload);
+          const sortMs = trustedSortMs || sortMsForSession(ref.session_id, row.dataset.codexProjectMoveSortMs || rowListItem(row).dataset.codexProjectMoveSortMs);
+          row.dataset.codexProjectMoveSortMs = String(sortMs || 0);
+          rowListItem(row).dataset.codexProjectMoveSortMs = String(sortMs || 0);
+          if (trustedSortMs) updateRowTimeLabel(row, trustedSortMs);
+        });
+      }
+      if (chatsSortNeedsCorrection(rows)) reorderChatsRows(rows);
+      chatsSortSignature = visibleChatsRows().map((row) => projectMoveSessionKey(sessionRefFromRow(row).session_id)).join("|");
+    } finally {
+      chatsSortInFlight = false;
+    }
+  }
+
+  function scheduleChatsSortCorrection(delay = chatsSortRefreshIntervalMs) {
+    if (!codexPlusSettings().projectMove || window.__codexProjectMoveChatsSortTimer) return;
+    window.__codexProjectMoveChatsSortTimer = setTimeout(() => {
+      if (window.__codexProjectMoveRuntimeId !== codexProjectMoveRuntimeId) return;
+      window.__codexProjectMoveChatsSortTimer = null;
+      applyChatsSortCorrection().catch((error) => {
+        window.__codexProjectMoveSortFailures = window.__codexProjectMoveSortFailures || [];
+        window.__codexProjectMoveSortFailures.push(String(error?.stack || error));
+      }).finally(() => {
+        if (codexPlusSettings().projectMove) scheduleChatsSortCorrection();
+      });
+    }, delay);
+  }
+
+  async function setProjectlessThreadIds(ref, mode) {
+    const variants = threadIdVariants(ref.session_id);
+    if (variants.length === 0) throw new Error("未找到会话 ID");
+    const existingIds = await getCodexGlobalState("projectless-thread-ids").catch(() => []);
+    const ids = Array.isArray(existingIds) ? existingIds : [];
+    const variantSet = new Set(variants);
+    const nextIds = mode === "add" ? uniqueValues([...ids, ...variants]) : ids.filter((id) => !variantSet.has(id));
+    if (nextIds.length !== ids.length || nextIds.some((id, index) => id !== ids[index])) await setCodexGlobalState("projectless-thread-ids", nextIds);
+  }
+
+  async function clearThreadWorkspaceHints(ref) {
+    const variants = threadIdVariants(ref.session_id);
+    if (variants.length === 0) return;
+    const hints = objectGlobalState(await getCodexGlobalState("thread-workspace-root-hints").catch(() => ({})));
+    const hintKeys = variants.filter((id) => Object.prototype.hasOwnProperty.call(hints, id));
+    if (hintKeys.length > 0) {
+      hintKeys.forEach((id) => delete hints[id]);
+      await setCodexGlobalState("thread-workspace-root-hints", hints);
+    }
+  }
+
+  async function moveSessionToProjectless(ref) {
+    if (!ref.session_id) throw new Error("未找到会话 ID");
+    await setProjectlessThreadIds(ref, "add");
+    await clearThreadWorkspaceHints(ref);
+    const sortKey = await postJson("/thread-sort-key", ref).catch(() => ({}));
+    return { status: "moved", session_id: ref.session_id, updated_at: sortKey?.updated_at, updated_at_ms: sortKey?.updated_at_ms, created_at_ms: sortKey?.created_at_ms };
+  }
+
+  function isNativeProjectTarget(target) {
+    return target?.kind === "project" && nativeProjectTargets().some((project) => sameWorkspacePath(project.path, target.path));
+  }
+
+  async function moveSessionToProject(ref, target) {
+    if (!ref.session_id) throw new Error("未找到会话 ID");
+    if (!target?.path) throw new Error("目标项目路径为空");
+    if (!isNativeProjectTarget(target)) throw new Error("目标项目不在 Codex 项目列表中");
+    const result = await postJson("/move-thread-workspace", { ...ref, target_cwd: target.path });
+    if (result.status !== "moved") throw new Error(result.message || "移动项目失败");
+    await setProjectlessThreadIds(ref, "remove");
+    await clearThreadWorkspaceHints(ref);
+    return result;
   }
 
   function showToast(message, undoToken) {
@@ -910,6 +1794,103 @@
     showToast(result.message || "导出失败", null);
   }
 
+  function sortStateFromMoveResult(result, ref, row) {
+    const trustedSortMs = timestampMsFromPayload(result);
+    return { sortMs: trustedSortMs || rowSortMs(row, ref), sortMsTrusted: !!trustedSortMs };
+  }
+
+  function finishProjectMove(row, button, ref, target, message) {
+    releaseDeleteFocus(row, button);
+    button.disabled = false;
+    button.textContent = "移动";
+    saveProjectMoveProjection(ref, target, target.sortMs || rowSortMs(row, ref, target));
+    if (target.kind === "projectless") moveRowToChats(row, target);
+    refreshAfterProjectMove();
+    showToast(message, null);
+  }
+
+  async function applyProjectMove(row, button, ref, target) {
+    button.disabled = true;
+    button.textContent = "移动中";
+    try {
+      if (target.kind === "projectless") {
+        const result = await moveSessionToProjectless(ref);
+        finishProjectMove(row, button, ref, { ...target, ...sortStateFromMoveResult(result, ref, row) }, `已移动到普通对话：“${ref.title || ref.session_id}”`);
+      } else {
+        const result = await moveSessionToProject(ref, target);
+        finishProjectMove(row, button, ref, { ...target, ...sortStateFromMoveResult(result, ref, row) }, `已移动到“${target.label}”：“${ref.title || ref.session_id}”`);
+      }
+    } catch (error) {
+      button.disabled = false;
+      button.textContent = "移动";
+      showToast(`移动失败：${error?.message || error}`, null);
+    }
+  }
+
+  async function openProjectMoveMenuForRow(row, button, ref, event) {
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation?.();
+    releaseDeleteFocus(row, button);
+    document.querySelectorAll(`.${projectMoveOverlayClass}`).forEach((node) => node.remove());
+    const overlay = document.createElement("div");
+    overlay.className = projectMoveOverlayClass;
+    overlay.innerHTML = `
+      <div class="codex-project-move-panel" role="dialog" aria-modal="true" aria-label="移动对话">
+        <div class="codex-project-move-header">
+          <div class="codex-project-move-title">移动“${escapeHtml(ref.title || ref.session_id)}”</div>
+        </div>
+        <div class="codex-project-move-list"><div class="codex-project-move-empty">加载项目中...</div></div>
+      </div>
+    `;
+    const panel = overlay.querySelector(".codex-project-move-panel");
+    const rect = button.getBoundingClientRect();
+    const panelWidth = Math.min(360, Math.max(240, window.innerWidth - 32));
+    panel.style.left = `${Math.max(16, Math.min(window.innerWidth - panelWidth - 16, rect.right - panelWidth))}px`;
+    panel.style.top = `${Math.max(16, Math.min(window.innerHeight - 120, rect.bottom + 6))}px`;
+    const close = () => overlay.remove();
+    overlay.addEventListener("click", (clickEvent) => {
+      if (clickEvent.target === overlay) close();
+    }, true);
+    overlay.addEventListener("keydown", (keyEvent) => {
+      if (keyEvent.key === "Escape") {
+        keyEvent.preventDefault();
+        close();
+      }
+    }, true);
+    document.body.appendChild(overlay);
+    try {
+      const targets = projectMoveTargets();
+      const list = overlay.querySelector(".codex-project-move-list");
+      if (!list) return;
+      list.innerHTML = "";
+      if (targets.length === 0) {
+        list.innerHTML = `<div class="codex-project-move-empty">没有可用目标</div>`;
+        return;
+      }
+      for (const target of targets) {
+        const item = document.createElement("button");
+        item.type = "button";
+        item.className = "codex-project-move-item";
+        item.innerHTML = `
+          <div class="codex-project-move-item-title">${escapeHtml(target.label)}</div>
+          <div class="codex-project-move-item-path">${escapeHtml(target.description)}</div>
+        `;
+        item.addEventListener("click", async (selectEvent) => {
+          selectEvent.preventDefault();
+          selectEvent.stopPropagation();
+          close();
+          await applyProjectMove(row, button, ref, target);
+        }, true);
+        list.appendChild(item);
+      }
+      list.querySelector("button")?.focus();
+    } catch (error) {
+      close();
+      showToast(`加载项目失败：${error?.message || error}`, null);
+    }
+  }
+
   function installDeleteButtonEventDelegation() {
     document.removeEventListener("pointerup", window.__codexSessionDeleteDocumentDeleteHandler, true);
     document.removeEventListener("click", window.__codexSessionDeleteDocumentDeleteHandler, true);
@@ -958,30 +1939,48 @@
 
   function attachButton(row) {
     const settings = codexPlusSettings();
-    if (!settings.sessionDelete && !settings.markdownExport) {
+    if (!settings.sessionDelete && !settings.markdownExport && !settings.projectMove) {
       removeActionGroups(row);
       row.dataset.codexDeleteRow = "false";
+      row.dataset.codexProjectMoveRow = "false";
       return;
     }
     const existingGroup = actionGroupFromRow(row);
     const existingDeleteButton = existingGroup?.querySelector(`.${buttonClass}`);
     const existingExportButton = existingGroup?.querySelector(`.${exportButtonClass}`);
+    const existingMoveButton = existingGroup?.querySelector(`.${projectMoveButtonClass}`);
     const hasUnexpectedDelete = !settings.sessionDelete && !!existingDeleteButton;
     const hasUnexpectedExport = !settings.markdownExport && !!existingExportButton;
+    const hasUnexpectedMove = !settings.projectMove && !!existingMoveButton;
     const missingDelete = settings.sessionDelete && !existingDeleteButton;
     const missingExport = settings.markdownExport && !existingExportButton;
+    const missingMove = settings.projectMove && !existingMoveButton;
     const deleteReady = !settings.sessionDelete || existingDeleteButton?.dataset.codexDeleteVersion === codexDeleteVersion;
     const exportReady = !settings.markdownExport || existingExportButton?.dataset.codexExportVersion === codexExportVersion;
+    const moveReady = !settings.projectMove || existingMoveButton?.dataset.codexProjectMoveVersion === codexProjectMoveVersion;
     const groupReady = existingGroup?.dataset.codexActionGroupVersion === codexActionGroupVersion;
-    if (groupReady && deleteReady && exportReady && !hasUnexpectedDelete && !hasUnexpectedExport && !missingDelete && !missingExport) return;
+    if (groupReady && deleteReady && exportReady && moveReady && !hasUnexpectedDelete && !hasUnexpectedExport && !hasUnexpectedMove && !missingDelete && !missingExport && !missingMove) return;
     removeActionGroups(row);
     row.dataset.codexDeleteRow = "false";
+    row.dataset.codexProjectMoveRow = "false";
     const ref = sessionRefFromRow(row);
     if (!ref.session_id) return;
     row.dataset.codexDeleteRow = "true";
+    row.dataset.codexProjectMoveRow = String(!!settings.projectMove);
     const group = document.createElement("div");
     group.className = actionGroupClass;
     group.dataset.codexActionGroupVersion = codexActionGroupVersion;
+    if (settings.projectMove) {
+      const moveButton = document.createElement("button");
+      moveButton.type = "button";
+      moveButton.className = `${actionButtonClass} ${projectMoveButtonClass}`;
+      moveButton.dataset.codexProjectMoveVersion = codexProjectMoveVersion;
+      moveButton.textContent = "移动";
+      const openProjectMove = (event) => openProjectMoveMenuForRow(row, moveButton, ref, event);
+      installActionButtonEvents(row, moveButton, openProjectMove);
+      group.appendChild(moveButton);
+      setTimeout(() => refreshActionButton(moveButton, row, openProjectMove), 0);
+    }
     if (settings.markdownExport) {
       const exportButton = document.createElement("button");
       exportButton.type = "button";
@@ -1219,6 +2218,8 @@
     unblockPluginInstallButtons();
     sessionRows().forEach(tryAttachButton);
     updateDeleteButtonOffsets();
+    scheduleProjectMoveProjection();
+    scheduleChatsSortCorrection();
     archivedPageRows().forEach(attachArchivedPageDeleteButton);
     installArchivedDeleteAllButton();
   }
@@ -1238,11 +2239,14 @@
   }
 
   function isExtensionUiNode(node) {
-    return !!node?.closest?.(".codex-delete-toast, .codex-delete-confirm-overlay, .codex-plus-modal-overlay, #codex-plus-menu");
+    return !!node?.closest?.(`.codex-delete-toast, .codex-delete-confirm-overlay, .codex-plus-modal-overlay, .${projectMoveOverlayClass}, #codex-plus-menu`);
   }
 
   const scanRelevantSelector = [
     selectors.sidebarThread,
+    '[data-app-action-sidebar-section-heading="Chats"]',
+    '[data-app-action-sidebar-section-heading="Projects"]',
+    '[data-codex-project-move-row="true"]',
     '[data-codex-archive-page-row="true"]',
     "[data-codex-archive-delete-all]",
     selectors.appHeader,
@@ -1289,6 +2293,10 @@
   }
 
   scan();
+  window.__codexProjectMoveApplyProjection = applyProjectMoveProjection;
+  window.__codexProjectMoveReadProjection = readProjectMoveProjection;
+  window.__codexProjectMoveTargets = projectMoveTargets;
+  window.__codexProjectMoveSortChats = applyChatsSortCorrection;
   window.__codexSessionDeleteObserver?.disconnect();
   window.__codexSessionDeleteObserver = new MutationObserver(scheduleScan);
   window.__codexSessionDeleteObserver.observe(document.body || document.documentElement, { childList: true, subtree: true });

--- a/codex_session_delete/launcher.py
+++ b/codex_session_delete/launcher.py
@@ -47,6 +47,21 @@ class ApiFirstDeleteService:
             return None
         return self.local_adapter.find_archived_thread_by_title(title)
 
+    def move_thread_workspace(self, session: SessionRef, target_cwd: str) -> dict[str, object]:
+        if self.local_adapter is None:
+            return {"status": DeleteStatus.FAILED.value, "session_id": session.session_id, "message": "No local database configured"}
+        return self.local_adapter.move_codex_thread_workspace(session, target_cwd)
+
+    def thread_sort_key(self, session: SessionRef) -> dict[str, object]:
+        if self.local_adapter is None:
+            return {"status": DeleteStatus.FAILED.value, "session_id": session.session_id, "message": "No local database configured"}
+        return self.local_adapter.codex_thread_sort_key(session)
+
+    def thread_sort_keys(self, sessions: list[SessionRef]) -> dict[str, object]:
+        if self.local_adapter is None:
+            return {"status": DeleteStatus.FAILED.value, "message": "No local database configured", "sort_keys": []}
+        return self.local_adapter.codex_thread_sort_keys(sessions)
+
 
 class InjectedHelperServer(HelperServer):
     bridge_socket: Any = None
@@ -380,10 +395,24 @@ def handle_bridge_request(
         return service.delete(session).to_dict()
     if path == "/undo":
         return service.undo(str(payload.get("undo_token", ""))).to_dict()
-    if path == "/archived-thread":
-        session = service.find_archived_thread_by_title(str(payload.get("title", "")))
-        return {"session_id": session.session_id, "title": session.title} if session else {"session_id": "", "title": ""}
     if path == "/export-markdown":
         session = SessionRef(session_id=str(payload.get("session_id", "")), title=str(payload.get("title", "")))
         return export_service.export(session).to_dict()
+    if path == "/archived-thread":
+        session = service.find_archived_thread_by_title(str(payload.get("title", "")))
+        return {"session_id": session.session_id, "title": session.title} if session else {"session_id": "", "title": ""}
+    if path == "/move-thread-workspace":
+        session = SessionRef(session_id=str(payload.get("session_id", "")), title=str(payload.get("title", "")))
+        return service.move_thread_workspace(session, str(payload.get("target_cwd", "")))
+    if path == "/thread-sort-key":
+        session = SessionRef(session_id=str(payload.get("session_id", "")), title=str(payload.get("title", "")))
+        return service.thread_sort_key(session)
+    if path == "/thread-sort-keys":
+        raw_sessions = payload.get("sessions", [])
+        sessions = [
+            SessionRef(session_id=str(item.get("session_id", "")), title=str(item.get("title", "")))
+            for item in raw_sessions
+            if isinstance(item, dict)
+        ] if isinstance(raw_sessions, list) else []
+        return service.thread_sort_keys(sessions)
     return {"status": DeleteStatus.FAILED.value, "session_id": str(payload.get("session_id", "")), "message": "Unknown bridge path"}

--- a/codex_session_delete/storage_adapter.py
+++ b/codex_session_delete/storage_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import json
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -64,6 +65,81 @@ class SQLiteStorageAdapter:
             ).fetchone()
             return SessionRef(session_id=str(row["id"]), title=str(row["title"] or title)) if row else None
 
+    def move_codex_thread_workspace(self, session: SessionRef, target_cwd: str) -> dict[str, object]:
+        target = target_cwd.strip()
+        if not target:
+            return {"status": "failed", "session_id": session.session_id, "message": "目标项目路径为空"}
+        if not self.db_path.exists():
+            return {"status": "failed", "session_id": session.session_id, "message": f"Database not found: {self.db_path}"}
+
+        with sqlite3.connect(self.db_path) as db:
+            db.row_factory = sqlite3.Row
+            if self._schema_kind(db) != "codex_threads" or not self._has_columns(db, "threads", {"cwd", "rollout_path"}):
+                return {"status": "failed", "session_id": session.session_id, "message": "Unsupported local storage schema"}
+            thread_id = self._normalize_codex_thread_id(session.session_id)
+            columns = ["id", "title", "cwd", "rollout_path", *self._codex_thread_timestamp_columns(db)]
+            row = db.execute(f"SELECT {', '.join(columns)} FROM threads WHERE id = ?", (thread_id,)).fetchone()
+            if row is None:
+                return {"status": "failed", "session_id": thread_id, "message": "Thread not found in local storage"}
+            previous_cwd = str(row["cwd"] or "")
+            db.execute("UPDATE threads SET cwd = ? WHERE id = ?", (target, thread_id))
+            db.commit()
+
+        rollout_result = self._update_rollout_session_meta_cwd(str(row["rollout_path"] or ""), thread_id, target)
+        return {
+            "status": "moved",
+            "session_id": thread_id,
+            "message": "已移动对话",
+            "previous_cwd": previous_cwd,
+            "target_cwd": target,
+            "rollout_updated": rollout_result["updated"],
+            "rollout_error": rollout_result["error"],
+            **self._codex_thread_timestamp_payload(row),
+        }
+
+    def codex_thread_sort_key(self, session: SessionRef) -> dict[str, object]:
+        if not self.db_path.exists():
+            return {"status": "failed", "session_id": session.session_id, "message": f"Database not found: {self.db_path}"}
+
+        with sqlite3.connect(self.db_path) as db:
+            db.row_factory = sqlite3.Row
+            if self._schema_kind(db) != "codex_threads":
+                return {"status": "failed", "session_id": session.session_id, "message": "Unsupported local storage schema"}
+            thread_id = self._normalize_codex_thread_id(session.session_id)
+            columns = ["id", *self._codex_thread_timestamp_columns(db)]
+            row = db.execute(f"SELECT {', '.join(columns)} FROM threads WHERE id = ?", (thread_id,)).fetchone()
+            if row is None:
+                return {"status": "failed", "session_id": thread_id, "message": "Thread not found in local storage"}
+            return {
+                "status": "ok",
+                "session_id": thread_id,
+                **self._codex_thread_timestamp_payload(row),
+            }
+
+    def codex_thread_sort_keys(self, sessions: list[SessionRef]) -> dict[str, object]:
+        if not self.db_path.exists():
+            return {"status": "failed", "message": f"Database not found: {self.db_path}", "sort_keys": []}
+
+        thread_ids = list(dict.fromkeys(self._normalize_codex_thread_id(session.session_id) for session in sessions if session.session_id))[:200]
+        if not thread_ids:
+            return {"status": "ok", "sort_keys": []}
+
+        with sqlite3.connect(self.db_path) as db:
+            db.row_factory = sqlite3.Row
+            if self._schema_kind(db) != "codex_threads":
+                return {"status": "failed", "message": "Unsupported local storage schema", "sort_keys": []}
+            columns = ["id", *self._codex_thread_timestamp_columns(db)]
+            placeholders = ", ".join("?" for _ in thread_ids)
+            rows_by_id = {
+                str(row["id"]): {
+                    "session_id": str(row["id"]),
+                    **self._codex_thread_timestamp_payload(row),
+                }
+                for row in db.execute(f"SELECT {', '.join(columns)} FROM threads WHERE id IN ({placeholders})", tuple(thread_ids)).fetchall()
+            }
+            sort_keys = [rows_by_id[thread_id] for thread_id in thread_ids if thread_id in rows_by_id]
+            return {"status": "ok", "sort_keys": sort_keys}
+
     def _delete_generic_session(self, db: sqlite3.Connection, session: SessionRef) -> DeleteResult:
         session_rows = self._select_dicts(db, "SELECT * FROM sessions WHERE id = ?", (session.session_id,))
         if not session_rows:
@@ -123,6 +199,14 @@ class SQLiteStorageAdapter:
     def _normalize_codex_thread_id(self, session_id: str) -> str:
         return session_id.removeprefix("local:")
 
+    def _codex_thread_timestamp_columns(self, db: sqlite3.Connection) -> list[str]:
+        existing = {row[1] for row in db.execute('PRAGMA table_info("threads")')}
+        return [column for column in ("updated_at", "updated_at_ms", "created_at_ms") if column in existing]
+
+    def _codex_thread_timestamp_payload(self, row: sqlite3.Row) -> dict[str, object]:
+        keys = set(row.keys())
+        return {column: row[column] if column in keys else None for column in ("updated_at", "updated_at_ms", "created_at_ms")}
+
     def _schema_kind(self, db: sqlite3.Connection) -> str | None:
         tables = {row[0] for row in db.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
         if "sessions" in tables:
@@ -156,6 +240,35 @@ class SQLiteStorageAdapter:
             if path.is_file():
                 file_backups.append({"path": str(path), "content_b64": base64.b64encode(path.read_bytes()).decode("ascii")})
         return file_backups
+
+    def _update_rollout_session_meta_cwd(self, rollout_path: str, thread_id: str, target_cwd: str) -> dict[str, object]:
+        if not rollout_path:
+            return {"updated": False, "error": ""}
+        path = Path(rollout_path)
+        if not path.is_file():
+            return {"updated": False, "error": ""}
+        changed = False
+        lines = []
+        try:
+            for raw_line in path.read_text(encoding="utf-8").splitlines(keepends=True):
+                line_body = raw_line[:-1] if raw_line.endswith("\n") else raw_line
+                line_end = "\n" if raw_line.endswith("\n") else ""
+                try:
+                    item = json.loads(line_body)
+                except json.JSONDecodeError:
+                    lines.append(raw_line)
+                    continue
+                payload = item.get("payload")
+                if item.get("type") == "session_meta" and isinstance(payload, dict) and payload.get("id") == thread_id and payload.get("cwd") != target_cwd:
+                    payload["cwd"] = target_cwd
+                    raw_line = json.dumps(item, ensure_ascii=False, separators=(",", ":")) + line_end
+                    changed = True
+                lines.append(raw_line)
+            if changed:
+                path.write_text("".join(lines), encoding="utf-8")
+            return {"updated": changed, "error": ""}
+        except OSError as exc:
+            return {"updated": False, "error": str(exc)}
 
     def _local_deleted(self, session_id: str, token: str) -> DeleteResult:
         return DeleteResult(

--- a/tests/test_cdp.py
+++ b/tests/test_cdp.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import codex_session_delete.cdp as cdp
 import websocket
 
-from codex_session_delete.cdp import BRIDGE_BINDING_NAME, _bridge_loop, build_bridge_script, evaluate_user_scripts, install_bridge, list_targets, open_devtools, pick_page_target
+from codex_session_delete.cdp import BRIDGE_BINDING_NAME, _bridge_loop, add_script_to_new_documents, build_bridge_script, evaluate_user_scripts, install_bridge, list_targets, open_devtools, pick_page_target
 
 
 class TimeoutThenMessageSocket:
@@ -31,15 +31,16 @@ class TimeoutThenMessageSocket:
 class SingleResponseSocket:
     def __init__(self):
         self.sent = []
+        self.closed = False
 
     def send(self, payload):
         self.sent.append(json.loads(payload))
 
     def recv(self):
-        return json.dumps({"id": 1, "result": {}})
+        return json.dumps({"id": 1, "result": {"identifier": "script-1"}})
 
     def close(self):
-        pass
+        self.closed = True
 
 
 class BridgeInstallSocket:
@@ -116,15 +117,31 @@ def test_bridge_binding_name_is_versioned_for_reinjection():
     assert BRIDGE_BINDING_NAME == "codexSessionDeleteV2"
 
 
+def test_add_script_to_new_documents_registers_reload_injection(monkeypatch):
+    ws = SingleResponseSocket()
+    monkeypatch.setattr(websocket, "create_connection", lambda *args, **kwargs: ws)
+
+    result = add_script_to_new_documents("ws://page", "window.__codexPlusTest = true;")
+
+    assert result["result"]["identifier"] == "script-1"
+    assert ws.sent[0]["method"] == "Page.addScriptToEvaluateOnNewDocument"
+    assert ws.sent[0]["params"]["source"] == "window.__codexPlusTest = true;"
+    assert ws.closed is True
+
+
 def test_install_bridge_enables_runtime_before_adding_binding(monkeypatch):
     ws = BridgeInstallSocket()
     monkeypatch.setattr(websocket, "create_connection", lambda url, timeout: ws)
     monkeypatch.setattr(cdp.threading, "Thread", lambda **kwargs: type("FakeThread", (), {"start": lambda self: None})())
 
-    install_bridge("ws://page", BRIDGE_BINDING_NAME, lambda path, payload: {})
+    install_bridge("ws://page", BRIDGE_BINDING_NAME, lambda path, payload: {}, ["window.__codexPlusTest = true;"])
 
     assert ws.sent[0] == {"id": 1, "method": "Runtime.enable", "params": {}}
-    assert ws.sent[1]["method"] == "Runtime.addBinding"
+    assert ws.sent[1]["method"] == "Runtime.removeBinding"
+    assert ws.sent[2]["method"] == "Runtime.addBinding"
+    assert ws.sent[3]["method"] == "Page.addScriptToEvaluateOnNewDocument"
+    assert ws.sent[5]["method"] == "Page.addScriptToEvaluateOnNewDocument"
+    assert ws.sent[5]["params"]["source"] == "window.__codexPlusTest = true;"
 
 
 def test_open_devtools_opens_chrome_devtools_frontend(monkeypatch):

--- a/tests/test_helper_server.py
+++ b/tests/test_helper_server.py
@@ -25,6 +25,15 @@ class FakeDeleteService:
         self.archived_title_queries.append(title)
         return SessionRef(session_id="archived-t1", title=title)
 
+    def move_thread_workspace(self, session: SessionRef, target_cwd: str):
+        return {"status": "moved", "session_id": session.session_id, "target_cwd": target_cwd}
+
+    def thread_sort_key(self, session: SessionRef):
+        return {"status": "ok", "session_id": session.session_id, "updated_at_ms": 123}
+
+    def thread_sort_keys(self, sessions: list[SessionRef]):
+        return {"status": "ok", "sort_keys": [{"session_id": session.session_id, "updated_at_ms": index + 1} for index, session in enumerate(sessions)]}
+
 
 class FakeExportService:
     def __init__(self):
@@ -140,6 +149,51 @@ def test_helper_server_accepts_http_mutation_token():
 
     assert deleted["status"] == "local_deleted"
     assert service.deleted[0].session_id == "s1"
+
+
+def test_helper_server_moves_thread_workspace_without_http_mutation_token():
+    service = FakeDeleteService()
+    server = HelperServer("127.0.0.1", 0, service)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        base = f"http://127.0.0.1:{server.port}"
+        moved = post_json(base + "/move-thread-workspace", {"session_id": "s1", "title": "First", "target_cwd": "/project/a"})
+    finally:
+        server.shutdown()
+        thread.join(timeout=3)
+
+    assert moved == {"status": "moved", "session_id": "s1", "target_cwd": "/project/a"}
+
+
+def test_helper_server_returns_thread_sort_key():
+    service = FakeDeleteService()
+    server = HelperServer("127.0.0.1", 0, service)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        base = f"http://127.0.0.1:{server.port}"
+        sort_key = post_json(base + "/thread-sort-key", {"session_id": "s1", "title": "First"})
+    finally:
+        server.shutdown()
+        thread.join(timeout=3)
+
+    assert sort_key == {"status": "ok", "session_id": "s1", "updated_at_ms": 123}
+
+
+def test_helper_server_returns_thread_sort_keys():
+    service = FakeDeleteService()
+    server = HelperServer("127.0.0.1", 0, service)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        base = f"http://127.0.0.1:{server.port}"
+        sort_keys = post_json(base + "/thread-sort-keys", {"sessions": [{"session_id": "s1", "title": "First"}, {"session_id": "s2", "title": "Second"}]})
+    finally:
+        server.shutdown()
+        thread.join(timeout=3)
+
+    assert sort_keys == {"status": "ok", "sort_keys": [{"session_id": "s1", "updated_at_ms": 1}, {"session_id": "s2", "updated_at_ms": 2}]}
 
 
 def test_helper_server_allows_private_network_preflight():

--- a/tests/test_launcher_cli.py
+++ b/tests/test_launcher_cli.py
@@ -447,3 +447,12 @@ def test_wait_for_shutdown_waits_for_popen_like_process():
     assert proc.waited is True
     assert server.shutdown_called is True
     assert server.server_close_called is True
+
+
+def test_is_macos_codex_running_uses_ps_comm(monkeypatch):
+    class Result:
+        stdout = "123 /Applications/Codex.app/Contents/MacOS/Codex --remote-debugging-port=9229\n456 /usr/bin/other\n"
+
+    monkeypatch.setattr(cli.subprocess, "run", lambda *args, **kwargs: Result())
+
+    assert cli.is_macos_codex_running() is True

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -109,7 +109,8 @@ def test_renderer_script_debounces_mutation_observer_scan():
     assert "new MutationObserver(scheduleScan)" in text
     assert "new MutationObserver(scan)" not in text
     assert "scan();" in text
-    assert "  scan();\n  window.__codexSessionDeleteObserver" in text
+    assert "window.__codexProjectMoveApplyProjection" in text
+    assert "window.__codexSessionDeleteObserver" in text
 
 
 def test_renderer_script_ignores_chat_content_mutations_before_scheduling_scan():
@@ -193,7 +194,7 @@ def test_renderer_script_sidebar_delete_opens_on_pointerup_when_click_is_unrelia
 
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
     assert "updateDeleteButtonOffsets" in text
-    assert "codexDeleteStyleVersion = \"5\"" in text
+    assert "codexDeleteStyleVersion = \"6\"" in text
     assert "right: 66px" in text
     assert "确认" in text
     assert "归档对话" in text
@@ -364,6 +365,9 @@ def test_renderer_script_includes_user_script_manager_ui_contract():
     assert "forcePluginInstall" in text
     assert "sessionDelete" in text
     assert "markdownExport" in text
+    assert "projectMove" in text
+    assert "会话项目移动" in text
+    assert "移动按钮" in text
     assert "codex-plus-modal-overlay" in text
     assert "codex-plus-modal-content" in text
     assert "codex-plus-modal-header" in text
@@ -388,3 +392,81 @@ def test_renderer_script_includes_user_script_manager_ui_contract():
     assert "codexPlusMenuVersion = \"5\"" in text
     assert "codexPlusTriggerInstalled = \"5\"" in text
     assert ".codex-plus-trigger:hover" not in text
+
+
+def test_renderer_script_can_move_sidebar_threads_between_projects():
+    text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
+
+    assert "codex-project-move-button" in text
+    assert "codex-project-move-overlay" in text
+    assert "codexProjectMoveVersion = \"1\"" in text
+    assert "function moveSessionToProjectless" in text
+    assert "function moveSessionToProject" in text
+    assert "function projectMoveTargets" in text
+    assert "function nativeProjectTargets" in text
+    assert "data-app-action-sidebar-project-row" in text
+    assert "data-app-action-sidebar-project-id" in text
+    assert "data-app-action-sidebar-project-label" in text
+    assert "get-global-state" in text
+    assert "set-global-state" in text
+    assert "projectless-thread-ids" in text
+    assert "thread-workspace-root-hints" in text
+    assert "electron-saved-workspace-roots" not in text
+    assert "active-workspace-roots" not in text
+    assert "project-order" not in text
+    assert "function threadIdVariants" in text
+    assert '`local:${bareId}`' in text
+    assert "uniqueValues([...ids, ...variants])" in text
+    assert "const variantSet = new Set(variants)" in text
+    assert "ids.filter((id) => !variantSet.has(id))" in text
+    assert "/thread-workspaces" not in text
+    assert "/move-thread-workspace" in text
+    assert "/thread-sort-key" in text
+    assert "/thread-sort-keys" in text
+    assert "hintKeys.forEach((id) => delete hints[id])" in text
+    assert "hints[id] = targetCwd" not in text
+    assert "codexProjectMoveProjection" in text
+    assert "legacyProjectMoveOverridesKey" in text
+    assert "function applyProjectMoveProjection" in text
+    assert "scheduleProjectMoveProjection" in text
+    assert "saveProjectMoveProjection(ref, target, target.sortMs || rowSortMs(row, ref, target))" in text
+    assert "clearProjectMoveProjection(ref)" in text
+    assert "refresh-recent-conversations-for-host" in text
+    assert "function refreshAfterProjectMove" in text
+    assert "function insertRowItemByTime" in text
+    assert "function sortStateFromMoveResult" in text
+    assert "function timestampMsFromPayload" in text
+    assert "function relativeTimeLabel" in text
+    assert "function updateRowTimeLabel" in text
+    assert "dataset.codexProjectMoveTime" in text
+    assert "function rowTimeLabelCandidates" in text
+    assert "function cleanupRowTimeLabels" in text
+    assert "function cleanupManagedStatusIconTimeNodes" in text
+    assert "function nodeInsideStatusIcon" in text
+    assert "function nodeLooksLikeTimeLabel" in text
+    assert "className.includes(\"animate-spin\")" in text
+    assert "node.children.length > 0" in text
+    assert "data-codex-project-move-time-wrapper" in text
+    assert "node.dataset?.codexProjectMoveTime !== \"true\"" in text
+    assert "function rowSortMs" in text
+    assert "function uuidV7TimestampMs" in text
+    assert "function projectThreadList" in text
+    assert "function applyChatsSortCorrection" in text
+    assert "function scheduleChatsSortCorrection" in text
+    assert "function reorderChatsRows" in text
+    assert "window.__codexProjectMoveSortChats" in text
+    assert "window.__codexProjectMoveRuntimeId" in text
+    assert "__codexProjectMoveChatsSortTimer" in text
+    assert "sortMsTrusted" in text
+    assert "chatsSortDbRefreshIntervalMs" in text
+    assert "data-app-action-sidebar-section-heading=\"Chats\"" in text
+    assert "data-app-action-sidebar-project-list-id" in text
+    assert "codexProjectMoveSortMs" in text
+    assert "data-codex-project-move-injected-list" in text
+    assert "codex-project-move-hidden" in text
+    assert "window.__codexProjectMoveApplyProjection" in text
+    assert "window.__codexProjectMoveTargets" in text
+    assert "projectMoveButtonClass" in text
+    assert "openProjectMoveMenuForRow" in text
+    assert "existingMoveButton" in text
+    assert "普通对话" in text

--- a/tests/test_storage_adapter.py
+++ b/tests/test_storage_adapter.py
@@ -15,13 +15,13 @@ def create_supported_db(path):
 
 def create_codex_thread_db(path, rollout_path):
     with sqlite3.connect(path) as db:
-        db.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT, title TEXT, archived INTEGER, archived_at INTEGER)")
+        db.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT, title TEXT, cwd TEXT, archived INTEGER, archived_at INTEGER, updated_at INTEGER, updated_at_ms INTEGER)")
         db.execute("CREATE TABLE thread_dynamic_tools (thread_id TEXT NOT NULL, tool_name TEXT NOT NULL)")
         db.execute("CREATE TABLE thread_goals (thread_id TEXT NOT NULL, goal TEXT NOT NULL)")
         db.execute("CREATE TABLE thread_spawn_edges (parent_thread_id TEXT NOT NULL, child_thread_id TEXT NOT NULL, status TEXT NOT NULL)")
         db.execute("CREATE TABLE stage1_outputs (thread_id TEXT NOT NULL, output TEXT NOT NULL)")
         db.execute("CREATE TABLE agent_job_items (id TEXT PRIMARY KEY, assigned_thread_id TEXT)")
-        db.execute("INSERT INTO threads (id, rollout_path, title, archived, archived_at) VALUES ('t1', ?, 'Codex Thread', 0, NULL)", (str(rollout_path),))
+        db.execute("INSERT INTO threads (id, rollout_path, title, cwd, archived, archived_at, updated_at, updated_at_ms) VALUES ('t1', ?, 'Codex Thread', '/old/project', 0, NULL, 100, 100000)", (str(rollout_path),))
         db.execute("INSERT INTO thread_dynamic_tools (thread_id, tool_name) VALUES ('t1', 'Read')")
         db.execute("INSERT INTO thread_goals (thread_id, goal) VALUES ('t1', 'delete me')")
         db.execute("INSERT INTO thread_spawn_edges (parent_thread_id, child_thread_id, status) VALUES ('t1', 'child', 'running')")
@@ -196,3 +196,64 @@ def test_delete_unsupported_schema_fails(tmp_path):
 
     assert result.status == DeleteStatus.FAILED
     assert "Unsupported" in result.message
+
+
+def test_move_codex_thread_workspace_updates_db_and_rollout_session_meta(tmp_path):
+    db_path = tmp_path / "state_5.sqlite"
+    rollout_path = tmp_path / "rollout.jsonl"
+    rollout_path.write_text(
+        '{"type":"session_meta","payload":{"id":"t1","cwd":"/old/project","title":"Codex Thread"}}\n'
+        '{"type":"session_meta","payload":{"id":"other","cwd":"/old/project"}}\n',
+        encoding="utf-8",
+    )
+    create_codex_thread_db(db_path, rollout_path)
+    adapter = SQLiteStorageAdapter(db_path, BackupStore(tmp_path / "backups"))
+
+    result = adapter.move_codex_thread_workspace(SessionRef(session_id="local:t1", title="Codex Thread"), "/new/project")
+
+    assert result["status"] == "moved"
+    assert result["previous_cwd"] == "/old/project"
+    assert result["target_cwd"] == "/new/project"
+    assert result["rollout_updated"] is True
+    assert result["rollout_error"] == ""
+    assert result["updated_at"] == 100
+    assert result["updated_at_ms"] == 100000
+    with sqlite3.connect(db_path) as db:
+        assert db.execute("SELECT cwd FROM threads WHERE id = 't1'").fetchone()[0] == "/new/project"
+    text = rollout_path.read_text(encoding="utf-8")
+    assert '"id":"t1","cwd":"/new/project"' in text
+    assert '"id":"other","cwd":"/old/project"' in text
+
+
+def test_codex_thread_sort_key_returns_thread_timestamps(tmp_path):
+    db_path = tmp_path / "state_5.sqlite"
+    rollout_path = tmp_path / "rollout.jsonl"
+    create_codex_thread_db(db_path, rollout_path)
+    adapter = SQLiteStorageAdapter(db_path, BackupStore(tmp_path / "backups"))
+
+    result = adapter.codex_thread_sort_key(SessionRef(session_id="local:t1", title="Codex Thread"))
+
+    assert result["status"] == "ok"
+    assert result["session_id"] == "t1"
+    assert result["updated_at"] == 100
+    assert result["updated_at_ms"] == 100000
+
+
+def test_codex_thread_sort_keys_returns_batch_thread_timestamps(tmp_path):
+    db_path = tmp_path / "state_5.sqlite"
+    rollout_path = tmp_path / "rollout.jsonl"
+    create_codex_thread_db(db_path, rollout_path)
+    with sqlite3.connect(db_path) as db:
+        db.execute("INSERT INTO threads (id, rollout_path, title, cwd, archived, archived_at, updated_at, updated_at_ms) VALUES ('t2', ?, 'Second', '/other/project', 0, NULL, 200, 200000)", (str(rollout_path),))
+    adapter = SQLiteStorageAdapter(db_path, BackupStore(tmp_path / "backups"))
+
+    result = adapter.codex_thread_sort_keys([
+        SessionRef(session_id="local:t2", title="Second"),
+        SessionRef(session_id="local:t1", title="Codex Thread"),
+    ])
+
+    assert result["status"] == "ok"
+    assert result["sort_keys"] == [
+        {"session_id": "t2", "updated_at": 200, "updated_at_ms": 200000, "created_at_ms": None},
+        {"session_id": "t1", "updated_at": 100, "updated_at_ms": 100000, "created_at_ms": None},
+    ]


### PR DESCRIPTION
## Summary
- Add a Codex++ sidebar move action for moving sessions between ordinary chats and visible Codex projects
- Persist workspace changes in local DB and rollout metadata, then refresh sidebar/project projections
- Correct visible Chats ordering and time labels after moves without duplicating time text

## Tests
- node --check codex_session_delete/inject/renderer-inject.js
- python -m pytest
- git diff --check HEAD~1..HEAD
