### PR TITLE
增强 watcher 可靠性：防崩日志、PID 单实例、心跳文件、自愈重启

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,8 @@ Windows 可以注册一个常驻 watcher 解决这个问题。它会每 3 秒探
 
 - 每次 Codex 通过原生路径启动，仍可能先打开一瞬间，再被 kill，再被 launcher 带 CDP 重开；watcher 会通过等待、二次确认和失败 backoff 尽量减少频繁闪烁。
 - watcher 以 `pythonw.exe` 常驻运行，登录时自动启动（通过 `HKCU\...\Run` 和 Startup 文件夹双路径注册，后者防止某些注册表清理工具干扰）。
+- watcher 具备自动重启能力：如果因意外异常退出，会在几秒后自动恢复，无需手动干预。
+- 运行状态文件位于 `~/.codex-session-delete/`：`watcher.log`（日志）、`watcher.pid`（进程锁）、`watcher.heartbeat`（心跳）。
 
 ### 安装
 

--- a/codex_session_delete/cli.py
+++ b/codex_session_delete/cli.py
@@ -265,11 +265,14 @@ Write-Output ("watch-install: Startup shortcut = " + $ShortcutPath)
     if result.stdout:
         print(result.stdout.strip())
     # Start the watcher right now as well.
+    stderr_log = Path.home() / ".codex-session-delete" / "watcher.stderr.log"
+    stderr_log.parent.mkdir(parents=True, exist_ok=True)
+    stderr_file = stderr_log.open("a", encoding="utf-8")
     subprocess.Popen(
         [exe, "-m", "codex_session_delete", "watch", "--debug-port", str(debug_port)],
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stderr=stderr_file,
         close_fds=True,
         creationflags=(
             subprocess.CREATE_NEW_PROCESS_GROUP
@@ -306,7 +309,7 @@ def main(argv: list[str] | None = None) -> int:
         uninstall_watcher_logon_task()
         return 0
     if args.command == "watch":
-        return watcher.watch_loop(debug_port=args.debug_port)
+        return watcher.run_with_restart(debug_port=args.debug_port)
     if args.command == "watch-install":
         install_watcher_logon_task(args.debug_port)
         return 0

--- a/codex_session_delete/watcher.py
+++ b/codex_session_delete/watcher.py
@@ -32,11 +32,77 @@ def watcher_disabled_flag() -> Path:
     return data_root() / "watcher.disabled"
 
 
+def watcher_pid_path() -> Path:
+    return data_root() / "watcher.pid"
+
+
+def watcher_heartbeat_path() -> Path:
+    return data_root() / "watcher.heartbeat"
+
+
+def _is_process_alive(pid: int) -> bool:
+    if sys.platform != "win32":
+        try:
+            os.kill(pid, 0)
+            return True
+        except OSError:
+            return False
+    try:
+        import ctypes
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.OpenProcess(0x100000, False, pid)  # SYNCHRONIZE
+        if not handle:
+            return False
+        kernel32.CloseHandle(handle)
+        return True
+    except Exception:
+        return False
+
+
+def _acquire_singleton() -> bool:
+    pid_path = watcher_pid_path()
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    if pid_path.exists():
+        try:
+            existing_pid = int(pid_path.read_text(encoding="utf-8").strip())
+            if _is_process_alive(existing_pid) and existing_pid != os.getpid():
+                return False
+        except (ValueError, OSError):
+            pass
+    pid_path.write_text(str(os.getpid()), encoding="utf-8")
+    return True
+
+
+def _release_singleton() -> None:
+    try:
+        pid_path = watcher_pid_path()
+        if pid_path.exists():
+            pid_path.unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
+def _touch_heartbeat() -> None:
+    try:
+        hb = watcher_heartbeat_path()
+        hb.parent.mkdir(parents=True, exist_ok=True)
+        hb.write_text(str(time.time()), encoding="utf-8")
+    except Exception:
+        pass
+
+
 def log(line: str) -> None:
-    path = watcher_log_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(f"[{datetime.now().isoformat(timespec='seconds')}] {line}\n")
+    try:
+        path = watcher_log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(f"[{datetime.now().isoformat(timespec='seconds')}] {line}\n")
+    except Exception:
+        try:
+            import sys as _sys
+            _sys.stderr.write(f"[watcher-log-failed] {line}\n")
+        except Exception:
+            pass
 
 
 def cdp_listening(port: int) -> bool:
@@ -188,6 +254,10 @@ def watch_loop(debug_port: int = 9229) -> int:
         log("watcher only supported on Windows")
         return 1
 
+    if not _acquire_singleton():
+        log("another watcher instance is already running; exiting")
+        return 0
+
     log(f"watcher started (interval={WATCHER_INTERVAL_SECONDS}s)")
     last_state = None
     backoff_until = 0.0
@@ -195,82 +265,93 @@ def watch_loop(debug_port: int = 9229) -> int:
     candidate_pids: tuple[int, ...] | None = None
     candidate_since = 0.0
 
-    while True:
-        try:
-            if watcher_disabled_flag().exists():
-                if last_state != "disabled":
-                    log("disabled flag present; idling")
-                last_state = "disabled"
-                time.sleep(WATCHER_INTERVAL_SECONDS)
-                continue
+    try:
+        while True:
+            try:
+                if watcher_disabled_flag().exists():
+                    if last_state != "disabled":
+                        log("disabled flag present; idling")
+                    last_state = "disabled"
+                    _touch_heartbeat()
+                    time.sleep(WATCHER_INTERVAL_SECONDS)
+                    continue
 
-            if cdp_listening(debug_port):
-                if last_state != "cdp_ok":
-                    log("CDP is up")
-                last_state = "cdp_ok"
+                if cdp_listening(debug_port):
+                    if last_state != "cdp_ok":
+                        log("CDP is up")
+                    last_state = "cdp_ok"
+                    candidate_pids = None
+                    _touch_heartbeat()
+                    time.sleep(WATCHER_INTERVAL_SECONDS)
+                    continue
+
+                codex_pids = find_codex_processes()
+                if not codex_pids:
+                    if last_state != "idle":
+                        log("no Codex running; idling")
+                    last_state = "idle"
+                    candidate_pids = None
+                    _touch_heartbeat()
+                    time.sleep(WATCHER_INTERVAL_SECONDS)
+                    continue
+
+                now = time.time()
+                if now < cooldown_until:
+                    if last_state != "cooldown":
+                        log(f"in cooldown after takeover; {cooldown_until - now:.1f}s remaining")
+                    last_state = "cooldown"
+                    _touch_heartbeat()
+                    time.sleep(WATCHER_INTERVAL_SECONDS)
+                    continue
+
+                if now < backoff_until:
+                    if last_state != "backoff":
+                        log(f"in backoff after failed takeover; {backoff_until - now:.1f}s remaining")
+                    last_state = "backoff"
+                    _touch_heartbeat()
+                    time.sleep(WATCHER_INTERVAL_SECONDS)
+                    continue
+
+                codex_key = tuple(sorted(codex_pids))
+                if candidate_pids != codex_key:
+                    candidate_pids = codex_key
+                    candidate_since = now
+                    log(f"Codex running without CDP (pids={codex_pids}); waiting before takeover")
+                    last_state = "grace"
+                    _touch_heartbeat()
+                    time.sleep(WATCHER_INTERVAL_SECONDS)
+                    continue
+
+                if now - candidate_since < TAKEOVER_GRACE_SECONDS:
+                    if last_state != "grace":
+                        log(f"waiting for Codex CDP grace period (pids={codex_pids})")
+                    last_state = "grace"
+                    _touch_heartbeat()
+                    time.sleep(WATCHER_INTERVAL_SECONDS)
+                    continue
+
+                if cdp_listening(debug_port):
+                    candidate_pids = None
+                    last_state = "cdp_ok"
+                    continue
+
+                log(f"Codex running without CDP after grace period (pids={codex_pids}); attempting takeover")
+                last_state = "takeover"
+                success = takeover(debug_port)
                 candidate_pids = None
-                time.sleep(WATCHER_INTERVAL_SECONDS)
-                continue
+                if success:
+                    cooldown_until = time.time() + TAKEOVER_SUCCESS_COOLDOWN_SECONDS
+                    last_state = "cdp_ok"
+                else:
+                    backoff_until = time.time() + TAKEOVER_FAILURE_BACKOFF_SECONDS
+                    last_state = "failed"
+            except Exception as exc:
+                log("watch loop error: " + "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)))
 
-            codex_pids = find_codex_processes()
-            if not codex_pids:
-                if last_state != "idle":
-                    log("no Codex running; idling")
-                last_state = "idle"
-                candidate_pids = None
-                time.sleep(WATCHER_INTERVAL_SECONDS)
-                continue
-
-            now = time.time()
-            if now < cooldown_until:
-                if last_state != "cooldown":
-                    log(f"in cooldown after takeover; {cooldown_until - now:.1f}s remaining")
-                last_state = "cooldown"
-                time.sleep(WATCHER_INTERVAL_SECONDS)
-                continue
-
-            if now < backoff_until:
-                if last_state != "backoff":
-                    log(f"in backoff after failed takeover; {backoff_until - now:.1f}s remaining")
-                last_state = "backoff"
-                time.sleep(WATCHER_INTERVAL_SECONDS)
-                continue
-
-            codex_key = tuple(sorted(codex_pids))
-            if candidate_pids != codex_key:
-                candidate_pids = codex_key
-                candidate_since = now
-                log(f"Codex running without CDP (pids={codex_pids}); waiting before takeover")
-                last_state = "grace"
-                time.sleep(WATCHER_INTERVAL_SECONDS)
-                continue
-
-            if now - candidate_since < TAKEOVER_GRACE_SECONDS:
-                if last_state != "grace":
-                    log(f"waiting for Codex CDP grace period (pids={codex_pids})")
-                last_state = "grace"
-                time.sleep(WATCHER_INTERVAL_SECONDS)
-                continue
-
-            if cdp_listening(debug_port):
-                candidate_pids = None
-                last_state = "cdp_ok"
-                continue
-
-            log(f"Codex running without CDP after grace period (pids={codex_pids}); attempting takeover")
-            last_state = "takeover"
-            success = takeover(debug_port)
-            candidate_pids = None
-            if success:
-                cooldown_until = time.time() + TAKEOVER_SUCCESS_COOLDOWN_SECONDS
-                last_state = "cdp_ok"
-            else:
-                backoff_until = time.time() + TAKEOVER_FAILURE_BACKOFF_SECONDS
-                last_state = "failed"
-        except Exception as exc:
-            log("watch loop error: " + "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)))
-
-        time.sleep(WATCHER_INTERVAL_SECONDS)
+            _touch_heartbeat()
+            time.sleep(WATCHER_INTERVAL_SECONDS)
+    finally:
+        _release_singleton()
 
 
 def enable_watcher() -> None:
@@ -283,3 +364,26 @@ def disable_watcher() -> None:
     flag = watcher_disabled_flag()
     flag.parent.mkdir(parents=True, exist_ok=True)
     flag.touch()
+
+
+RESTART_MAX_ATTEMPTS = 10
+RESTART_WINDOW_SECONDS = 3600.0
+RESTART_DELAY_SECONDS = 5.0
+
+
+def run_with_restart(debug_port: int = 9229) -> int:
+    attempts: list[float] = []
+    while True:
+        now = time.time()
+        attempts = [t for t in attempts if now - t < RESTART_WINDOW_SECONDS]
+        if len(attempts) >= RESTART_MAX_ATTEMPTS:
+            log(f"watcher exceeded {RESTART_MAX_ATTEMPTS} restarts in {RESTART_WINDOW_SECONDS}s; giving up")
+            return 1
+        attempts.append(now)
+        try:
+            return watch_loop(debug_port)
+        except SystemExit:
+            return 0
+        except Exception as exc:
+            log(f"watcher crashed, restarting in {RESTART_DELAY_SECONDS}s: {exc}")
+            time.sleep(RESTART_DELAY_SECONDS)

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -118,3 +118,89 @@ def test_takeover_skips_kill_when_cdp_appears(monkeypatch):
 
 def test_takeover_failure_backoff_is_not_too_short():
     assert watcher.TAKEOVER_FAILURE_BACKOFF_SECONDS >= 30.0
+
+
+def test_log_does_not_raise_when_path_unwritable(tmp_path, monkeypatch):
+    unwritable = tmp_path / "no-such-dir" / "nested"
+    monkeypatch.setattr(watcher, "watcher_log_path", lambda: unwritable / "watcher.log")
+    monkeypatch.setattr(watcher, "data_root", lambda: unwritable)
+    # Make parent read-only on Windows by pointing to a file instead of dir
+    (tmp_path / "no-such-dir").write_text("block", encoding="utf-8")
+    # Should not raise
+    watcher.log("test message")
+
+
+def test_pid_file_written_and_singleton_acquired(tmp_path, monkeypatch):
+    monkeypatch.setattr(watcher, "data_root", lambda: tmp_path)
+    assert watcher._acquire_singleton() is True
+    pid_path = tmp_path / "watcher.pid"
+    assert pid_path.exists()
+    import os
+    assert pid_path.read_text(encoding="utf-8").strip() == str(os.getpid())
+    watcher._release_singleton()
+    assert not pid_path.exists()
+
+
+def test_singleton_rejects_duplicate_when_alive(tmp_path, monkeypatch):
+    monkeypatch.setattr(watcher, "data_root", lambda: tmp_path)
+    import os
+    real_pid = os.getpid()
+    pid_path = tmp_path / "watcher.pid"
+    pid_path.write_text(str(real_pid), encoding="utf-8")
+    monkeypatch.setattr(watcher, "_is_process_alive", lambda pid: True)
+    monkeypatch.setattr(watcher.os, "getpid", lambda: real_pid + 1)
+    assert watcher._acquire_singleton() is False
+
+
+def test_singleton_allows_stale_pid(tmp_path, monkeypatch):
+    monkeypatch.setattr(watcher, "data_root", lambda: tmp_path)
+    pid_path = tmp_path / "watcher.pid"
+    pid_path.write_text("99999", encoding="utf-8")
+    monkeypatch.setattr(watcher, "_is_process_alive", lambda pid: False)
+    assert watcher._acquire_singleton() is True
+
+
+def test_heartbeat_file_updated(tmp_path, monkeypatch):
+    monkeypatch.setattr(watcher, "data_root", lambda: tmp_path)
+    hb = tmp_path / "watcher.heartbeat"
+    assert not hb.exists()
+    watcher._touch_heartbeat()
+    assert hb.exists()
+    content = hb.read_text(encoding="utf-8")
+    assert float(content) > 0
+
+
+def test_run_with_restart_retries_on_crash(monkeypatch, tmp_path):
+    monkeypatch.setattr(watcher, "data_root", lambda: tmp_path)
+    attempts = []
+
+    def crashing_loop(debug_port=9229):
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise RuntimeError("simulated crash")
+        return 0
+
+    monkeypatch.setattr(watcher, "watch_loop", crashing_loop)
+    monkeypatch.setattr(watcher.time, "sleep", lambda s: None)
+
+    result = watcher.run_with_restart(debug_port=9229)
+
+    assert result == 0
+    assert len(attempts) == 3
+
+
+def test_run_with_restart_gives_up_after_max_attempts(monkeypatch, tmp_path):
+    monkeypatch.setattr(watcher, "data_root", lambda: tmp_path)
+    attempts = []
+
+    def always_crash(debug_port=9229):
+        attempts.append(1)
+        raise RuntimeError("always crash")
+
+    monkeypatch.setattr(watcher, "watch_loop", always_crash)
+    monkeypatch.setattr(watcher.time, "sleep", lambda s: None)
+
+    result = watcher.run_with_restart(debug_port=9229)
+
+    assert result == 1
+    assert len(attempts) == watcher.RESTART_MAX_ATTEMPTS


### PR DESCRIPTION
修复 watcher 进程意外退出后无法自动恢复的问题：log() 不再因 I/O 失败导致进程崩溃，新增 PID 文件防止重复实例，心跳文件便于外部监控，run_with_restart 在崩溃后自动重启。