### PR TITLE
fix: API Key 模式下自定义 model_provider 兼容性修复

### DIFF
--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -686,7 +686,6 @@
     if (!codexPlusSettings().pluginEntryUnlock) return;
     const pluginButton = pluginEntryButton();
     if (!pluginButton) return;
-    spoofChatGPTAuthMethod(pluginButton);
     pluginButton.disabled = false;
     pluginButton.removeAttribute("disabled");
     pluginButton.style.display = "";
@@ -701,7 +700,10 @@
     if (pluginButton.dataset.codexPluginEnabled === "true") return;
     pluginButton.dataset.codexPluginEnabled = "true";
     pluginButton.addEventListener("click", () => {
-      spoofChatGPTAuthMethod(pluginButton);
+      const reactPropsKey2 = Object.keys(pluginButton).find((key) => key.startsWith("__reactProps"));
+      if (reactPropsKey2 && typeof pluginButton[reactPropsKey2].onClick === "function") {
+        pluginButton[reactPropsKey2].onClick(new MouseEvent("click", { bubbles: true }));
+      }
     }, true);
   }
 

--- a/codex_session_delete/launcher.py
+++ b/codex_session_delete/launcher.py
@@ -155,6 +155,18 @@ def codex_process_environment() -> dict[str, str]:
         env.setdefault("HTTP_PROXY", proxy)
         env.setdefault("HTTPS_PROXY", proxy)
         env.setdefault("ALL_PROXY", proxy)
+        no_proxy = env.get("NO_PROXY", env.get("no_proxy", ""))
+        bypass = {"localhost", "127.0.0.1", "::1"}
+        from pathlib import Path as _P
+        for line in (_P.home() / ".codex" / "config.toml").read_text().splitlines() if _P.home().joinpath(".codex", "config.toml").exists() else []:
+            stripped = line.strip()
+            if stripped.startswith("base_url"):
+                import re as _re
+                m = _re.search(r"https?://([^\s:/\"]*)", stripped)
+                if m:
+                    bypass.add(m.group(1))
+        parts = [h for h in no_proxy.split(",") if h.strip()] + list(bypass)
+        env["NO_PROXY"] = ",".join(parts)
     return env
 
 


### PR DESCRIPTION
## Summary

- **renderer-inject.js**: 移除 `enablePluginEntry()` 中的全局 `spoofChatGPTAuthMethod` 调用。将共享 React auth context 从 `"api_key"` 改为 `"chatgpt"` 会导致 API 请求不再发送 `OPENAI_API_KEY`，破坏 CodexManager 等自定义端点；同时触发远程插件同步失败，清空本地 skills。插件按钮改为通过 DOM/React props 直接解锁。
- **launcher.py**: 从 `~/.codex/config.toml` 自动提取 `base_url` 主机加入 `NO_PROXY`，防止自动检测到的本地代理（如 Clash 7897）拦截发往自定义端点的请求导致 502。

## 问题描述

使用 CC Switch + CodexManager 自定义端点时，通过 Codex++ 启动 Codex 后：
1. CodexManager 返回 `missing api key`（authMethod 被 spoof 导致 API Key 不发送）
2. Skills 列表被清空（远程插件同步失败）
3. 502 Bad Gateway（Clash 代理拦截了 Tailscale 内网请求）

详细复现环境见 #59

## Test plan

- [x] CodexManager 自定义端点正常连接，不再报 missing api key / 502
- [x] Skills/Plugins 正常显示，不被远程同步失败清空
- [x] 插件按钮视觉解锁，点击可导航到插件页面
- [x] GitHub 技能资源通过代理正常加载

🤖 Generated with [Claude Code](https://claude.com/claude-code)