### PR TITLE
Add context guard handoff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,9 +406,13 @@ python -m codex_session_delete launch
 python -m codex_session_delete context-guard handoff <thread-id-or-rollout-file>
 python -m codex_session_delete context-guard handoff <thread-id> --copy
 python -m codex_session_delete context-guard watch-once --copy
+python -m codex_session_delete context-guard steward --cwd <path>
+python -m codex_session_delete context-guard steward-once --cwd <path>
 ```
 
 这个能力提炼自 [codex-context-guard](https://github.com/zjq12333/codex-context-guard)。Codex++ 集成的是保守 UI handoff 流程：只写本地 Markdown 交接文件、可选复制提示，不直接修改 Codex Desktop 内部数据库，不自动打开或重启 Codex Desktop，也不会替用户自动发送消息。
+
+实验性的“睡觉托管”默认关闭，需要在 Codex++ 面板里手动开启。它只在看到明确的 context window 报错时尝试接管到新对话；token 压力高时只预生成 handoff。托管日志和醒来总结会写入 `.codex/context-guard/overnight-runs/`，状态写入 `.codex/context-guard/steward-state.json`。遇到删除、发布、提交 PR、改系统配置、安装全局服务等高风险动作会停止并留下总结。
 
 ### Windows 系统卸载失败
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ python -m codex_session_delete setup
 - 特殊插件强制安装：解除 App unavailable / 应用不可用导致的前端安装禁用。
 - 会话删除：在会话列表悬停显示删除按钮，删除前确认并支持撤销。
 - Markdown 导出：按本地 rollout 导出带时间戳的会话 Markdown。
+- Context Guard / UI handoff：线程接近上下文窗口上限时，生成轻量交接文件，辅助在新聊天里继续任务。
 - 会话项目移动：把会话移动到普通对话或其他本地项目。
 - 对话 Timeline：在对话右侧显示用户提问时间线，悬停查看摘要并快速跳转。
 - Provider 同步：切换 model_provider 或供应商时不丢历史会话。
@@ -396,6 +397,18 @@ python -m codex_session_delete launch
 ### 切换供应商后旧会话不见了
 
 打开 `Codex++` 设置面板，启用 `Provider 同步` 后重新启动 Codex++。它会在启动 Codex 前同步当前 `model_provider`，让历史会话重新匹配当前供应商。
+
+### 长任务提示 context window 不够
+
+当 Codex 报出 `Codex ran out of room in the model's context window` 时，可以生成一个轻量交接包，再开新聊天继续，不需要把旧 rollout、完整日志或 base64 图片重新塞进上下文。
+
+```bash
+python -m codex_session_delete context-guard handoff <thread-id-or-rollout-file>
+python -m codex_session_delete context-guard handoff <thread-id> --copy
+python -m codex_session_delete context-guard watch-once --copy
+```
+
+这个能力提炼自 [codex-context-guard](https://github.com/zjq12333/codex-context-guard)。Codex++ 集成的是保守 UI handoff 流程：只写本地 Markdown 交接文件、可选复制提示，不直接修改 Codex Desktop 内部数据库，不自动打开或重启 Codex Desktop，也不会替用户自动发送消息。
 
 ### Windows 系统卸载失败
 

--- a/codex_session_delete/cli.py
+++ b/codex_session_delete/cli.py
@@ -74,6 +74,17 @@ def build_parser() -> argparse.ArgumentParser:
     watch_context_parser.add_argument("--token-ratio", type=float, default=context_guard.DEFAULT_TOKEN_RATIO)
     watch_context_parser.add_argument("--copy", action="store_true", help="Copy a short new-thread prompt to the clipboard")
 
+    steward_parser = context_subparsers.add_parser("steward", help="Run conservative overnight handoff steward mode")
+    steward_parser.add_argument("--cwd", type=Path, required=True)
+    steward_parser.add_argument("--max-handoffs", type=int, default=context_guard.DEFAULT_MAX_HANDOFFS)
+    steward_parser.add_argument("--interval-seconds", type=float, default=context_guard.DEFAULT_STEWARD_INTERVAL_SECONDS)
+
+    steward_once_parser = context_subparsers.add_parser("steward-once", help="Run one conservative steward scan")
+    steward_once_parser.add_argument("--cwd", type=Path, required=True)
+    steward_once_parser.add_argument("--max-handoffs", type=int, default=context_guard.DEFAULT_MAX_HANDOFFS)
+    steward_once_parser.add_argument("--recent", type=int, default=context_guard.DEFAULT_RECENT)
+    steward_once_parser.add_argument("--no-copy", action="store_true", help="Do not copy the takeover prompt to the clipboard")
+
     add_launch_arguments(parser)
     return parser
 
@@ -242,6 +253,27 @@ def run_context_guard(args: argparse.Namespace) -> int:
         for output in outputs:
             print(f"handoff written: {output}")
         return 0
+    if args.context_command == "steward-once":
+        result = context_guard.steward_once(
+            cwd=str(args.cwd),
+            max_handoffs=args.max_handoffs,
+            recent=args.recent,
+            copy=not args.no_copy,
+        )
+        print(result.message)
+        if result.handoff_path:
+            print(f"handoff written: {result.handoff_path}")
+        if result.log_path:
+            print(f"log: {result.log_path}")
+        if result.summary_path:
+            print(f"summary: {result.summary_path}")
+        return 0
+    if args.context_command == "steward":
+        return context_guard.steward_loop(
+            cwd=str(args.cwd),
+            max_handoffs=args.max_handoffs,
+            interval_seconds=args.interval_seconds,
+        )
     raise ValueError(f"unknown context guard command: {args.context_command}")
 
 

--- a/codex_session_delete/cli.py
+++ b/codex_session_delete/cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from codex_session_delete.helper_server import HelperServer
 from codex_session_delete.installers import InstallOptions, install_codex_plus_plus, uninstall_codex_plus_plus
 from codex_session_delete.launcher import launch_and_inject, shutdown_helper
+from codex_session_delete import context_guard
 from codex_session_delete import updater
 from codex_session_delete import watcher
 
@@ -57,6 +58,21 @@ def build_parser() -> argparse.ArgumentParser:
 
     subparsers.add_parser("check-update", help="Check GitHub Releases for a newer Codex++ version")
     subparsers.add_parser("update", help="Update Codex++ from the latest GitHub Release")
+
+    context_parser = subparsers.add_parser("context-guard", help="Create lightweight handoffs for Codex threads that hit the context window")
+    context_subparsers = context_parser.add_subparsers(dest="context_command", required=True)
+
+    handoff_parser = context_subparsers.add_parser("handoff", help="Write a handoff for a rollout or thread id")
+    handoff_parser.add_argument("target", nargs="?", help="Rollout path, filename substring, or thread id. Defaults to the newest rollout.")
+    handoff_parser.add_argument("--messages", type=int, default=context_guard.DEFAULT_MESSAGES)
+    handoff_parser.add_argument("--message-chars", type=int, default=context_guard.DEFAULT_MESSAGE_CHARS)
+    handoff_parser.add_argument("--copy", action="store_true", help="Copy a short new-thread prompt to the clipboard")
+
+    watch_context_parser = context_subparsers.add_parser("watch-once", help="Scan recent rollouts once and prepare UI handoffs when needed")
+    watch_context_parser.add_argument("--recent", type=int, default=context_guard.DEFAULT_RECENT)
+    watch_context_parser.add_argument("--max-age-seconds", type=int, default=context_guard.DEFAULT_MAX_AGE_SECONDS)
+    watch_context_parser.add_argument("--token-ratio", type=float, default=context_guard.DEFAULT_TOKEN_RATIO)
+    watch_context_parser.add_argument("--copy", action="store_true", help="Copy a short new-thread prompt to the clipboard")
 
     add_launch_arguments(parser)
     return parser
@@ -204,6 +220,31 @@ def run_update() -> int:
     return 0
 
 
+def run_context_guard(args: argparse.Namespace) -> int:
+    if args.context_command == "handoff":
+        output = context_guard.handoff(
+            args.target,
+            copy=args.copy,
+            messages=args.messages,
+            message_chars=args.message_chars,
+        )
+        print(f"handoff written: {output}")
+        return 0
+    if args.context_command == "watch-once":
+        outputs = context_guard.watch_once(
+            recent=args.recent,
+            max_age_seconds=args.max_age_seconds,
+            token_ratio=args.token_ratio,
+            copy=args.copy,
+        )
+        if not outputs:
+            print("no context handoffs needed")
+        for output in outputs:
+            print(f"handoff written: {output}")
+        return 0
+    raise ValueError(f"unknown context guard command: {args.context_command}")
+
+
 WATCHER_RUN_NAME = "CodexPlusPlusWatcher"
 WATCHER_RUN_KEY = "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"
 WATCHER_STARTUP_SHORTCUT_NAME = "CodexPlusPlusWatcher.lnk"
@@ -323,6 +364,8 @@ def main(argv: list[str] | None = None) -> int:
         return run_check_update()
     if args.command == "update":
         return run_update()
+    if args.command == "context-guard":
+        return run_context_guard(args)
     return run_launch(args)
 
 

--- a/codex_session_delete/context_guard.py
+++ b/codex_session_delete/context_guard.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+
+DEFAULT_MESSAGES = 14
+DEFAULT_MESSAGE_CHARS = 1200
+DEFAULT_TOKEN_RATIO = 0.72
+DEFAULT_MAX_AGE_SECONDS = 30 * 60
+DEFAULT_RECENT = 20
+CONTEXT_ERROR_MARKERS = (
+    "ran out of room in the model's context window",
+    "start a new thread or clear earlier history",
+)
+
+
+@dataclass
+class RolloutStats:
+    path: Path
+    size: int
+    thread_id: str = ""
+    cwd: str = ""
+    lines: int = 0
+    turns: int = 0
+    large_lines: list[tuple[int, int, str]] = field(default_factory=list)
+
+
+@dataclass
+class HandoffMessage:
+    line_no: int
+    role: str
+    text: str
+
+
+@dataclass
+class HandoffReport:
+    stats: RolloutStats
+    messages: list[HandoffMessage]
+    last_token_count: dict[str, Any] | None
+    context_error: bool
+
+
+def codex_home() -> Path:
+    return Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex").expanduser().resolve()
+
+
+def iter_rollouts(root: Path | None = None) -> Iterable[Path]:
+    sessions = (root or codex_home()) / "sessions"
+    if sessions.exists():
+        yield from sessions.rglob("*.jsonl")
+
+
+def recent_rollouts(limit: int, root: Path | None = None) -> list[Path]:
+    paths = list(iter_rollouts(root))
+    paths.sort(key=lambda path: path.stat().st_mtime if path.exists() else 0, reverse=True)
+    return paths[:limit]
+
+
+def resolve_rollout(target: str | None, root: Path | None = None) -> Path:
+    if not target:
+        rollouts = recent_rollouts(1, root)
+        if not rollouts:
+            raise FileNotFoundError("No Codex rollout files found")
+        return rollouts[0]
+
+    candidate = Path(target).expanduser()
+    if candidate.exists():
+        return candidate.resolve()
+
+    matches: list[Path] = []
+    for path in iter_rollouts(root):
+        if target.lower() in path.name.lower():
+            matches.append(path)
+            continue
+        try:
+            first = path.open("r", encoding="utf-8", errors="replace").readline()
+        except OSError:
+            continue
+        if target in first:
+            matches.append(path)
+
+    if not matches:
+        raise FileNotFoundError(f"No rollout matched target: {target}")
+    if len(matches) > 1:
+        raise ValueError("Multiple rollouts matched; use a longer thread id or file path")
+    return matches[0].resolve()
+
+
+def event_type(obj: Any) -> str:
+    return str(obj.get("type", "")) if isinstance(obj, dict) else ""
+
+
+def event_role(obj: Any) -> str:
+    payload = obj.get("payload", {}) if isinstance(obj, dict) else {}
+    return str(payload.get("role") or payload.get("type") or "") if isinstance(payload, dict) else ""
+
+
+def normalize_text(text: str, limit: int) -> str:
+    text = "\n".join(part.rstrip() for part in text.replace("\r\n", "\n").replace("\r", "\n").split("\n")).strip()
+    if len(text) > limit:
+        return text[:limit].rstrip() + "\n...[truncated]"
+    return text
+
+
+def extract_message_text(payload: dict[str, Any], max_chars: int) -> str:
+    content = payload.get("content")
+    parts: list[str] = []
+    if isinstance(content, str):
+        parts.append(content)
+    elif isinstance(content, list):
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            if isinstance(item.get("text"), str):
+                parts.append(item["text"])
+            elif item.get("type") in {"input_image", "local_image"}:
+                parts.append(f"[{item.get('type')} omitted]")
+    return normalize_text("\n".join(parts), max_chars)
+
+
+def analyze_rollout(path: Path, large_line_bytes: int = 64 * 1024) -> RolloutStats:
+    stats = RolloutStats(path=path, size=path.stat().st_size)
+    filename_ids = re.findall(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", path.name, re.IGNORECASE)
+    if filename_ids:
+        stats.thread_id = filename_ids[-1]
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for line_no, line in enumerate(handle, start=1):
+            stats.lines += 1
+            raw_bytes = len(line.encode("utf-8", errors="replace"))
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                if raw_bytes >= large_line_bytes:
+                    stats.large_lines.append((line_no, raw_bytes, "parse_error"))
+                continue
+            typ = event_type(obj)
+            if typ == "session_meta":
+                payload = obj.get("payload", {})
+                if isinstance(payload, dict):
+                    stats.thread_id = stats.thread_id or str(payload.get("id") or "")
+                    stats.cwd = str(payload.get("cwd") or "")
+            elif typ == "turn_context":
+                stats.turns += 1
+            if raw_bytes >= large_line_bytes:
+                stats.large_lines.append((line_no, raw_bytes, f"{typ}/{event_role(obj)}".rstrip("/")))
+    return stats
+
+
+def collect_handoff_report(path: Path, messages: int = DEFAULT_MESSAGES, message_chars: int = DEFAULT_MESSAGE_CHARS) -> HandoffReport:
+    stats = analyze_rollout(path)
+    found_messages: list[HandoffMessage] = []
+    last_token_count: dict[str, Any] | None = None
+    context_error = False
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for line_no, line in enumerate(handle, start=1):
+            lower = line.lower()
+            if any(marker in lower for marker in CONTEXT_ERROR_MARKERS):
+                context_error = True
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            payload = obj.get("payload", {}) if isinstance(obj, dict) else {}
+            if event_type(obj) == "response_item" and isinstance(payload, dict):
+                if payload.get("type") == "message" and payload.get("role") in {"user", "assistant"}:
+                    text = extract_message_text(payload, message_chars)
+                    if text:
+                        found_messages.append(HandoffMessage(line_no, str(payload.get("role")), text))
+            if event_type(obj) == "event_msg" and isinstance(payload, dict) and payload.get("type") == "token_count":
+                info = payload.get("info")
+                if isinstance(info, dict):
+                    last_token_count = info
+    return HandoffReport(stats, found_messages[-messages:] if messages > 0 else found_messages, last_token_count, context_error)
+
+
+def token_pressure(token_count: dict[str, Any] | None, ratio: float = DEFAULT_TOKEN_RATIO) -> bool:
+    if not token_count:
+        return False
+    window = token_count.get("model_context_window")
+    last = token_count.get("last_token_usage")
+    total = token_count.get("total_token_usage")
+    try:
+        if window is not None and isinstance(last, dict) and int(last.get("input_tokens", 0)) >= int(window) * ratio:
+            return True
+        if window is not None and isinstance(total, dict) and int(total.get("total_tokens", 0)) >= int(window):
+            return True
+    except (TypeError, ValueError):
+        return False
+    return False
+
+
+def handoff_output_path(report: HandoffReport, root: Path | None = None) -> Path:
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    thread = re.sub(r"[^A-Za-z0-9_.-]+", "-", report.stats.thread_id or "unknown-thread").strip("-")
+    return (root or codex_home()) / "handoffs" / f"{stamp}-{thread}-handoff.md"
+
+
+def render_handoff(report: HandoffReport) -> str:
+    stats = report.stats
+    lines = [
+        "# Codex Thread Handoff",
+        "",
+        "Use this in a new Codex thread. Keep the old thread as reference only; do not paste full logs or base64 data.",
+        "",
+        "## Source",
+        "",
+        f"- thread_id: `{stats.thread_id or '(unknown)'}`",
+        f"- rollout: `{stats.path}`",
+        f"- cwd: `{stats.cwd or '(unknown)'}`",
+        f"- size_bytes: `{stats.size}`",
+        f"- lines: `{stats.lines}`",
+        f"- turns: `{stats.turns}`",
+        f"- large_lines: `{len(stats.large_lines)}`",
+        f"- context_error_seen: `{report.context_error}`",
+        f"- token_pressure_seen: `{token_pressure(report.last_token_count)}`",
+        "",
+        "## Recent Conversation",
+        "",
+    ]
+    if report.messages:
+        for message in report.messages:
+            lines.extend([f"### {message.role} line {message.line_no}", "", "```text", message.text, "```", ""])
+    else:
+        lines.append("No recent user/assistant text messages were found.")
+    lines.extend(
+        [
+            "## New Thread Instruction",
+            "",
+            "Continue from this handoff. Read only the files and commands needed for the next step. Do not load the old rollout or full logs unless explicitly requested.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_handoff(report: HandoffReport, output: Path | None = None) -> Path:
+    output_path = output or handoff_output_path(report)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(render_handoff(report), encoding="utf-8")
+    return output_path
+
+
+def clipboard_prompt(path: Path) -> str:
+    return (
+        "Please continue the task from this handoff. Read only what is needed for the next step, "
+        "and do not load the old rollout or full logs unless I explicitly ask.\n\n"
+        f"Handoff file:\n{path}\n"
+    )
+
+
+def copy_to_clipboard(text: str) -> bool:
+    if sys_platform() != "win32":
+        return False
+    try:
+        completed = subprocess.run(
+            ["powershell.exe", "-NoProfile", "-Command", "Set-Clipboard -Value ([Console]::In.ReadToEnd())"],
+            input=text,
+            text=True,
+            encoding="utf-8",
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except OSError:
+        return False
+    return completed.returncode == 0
+
+
+def sys_platform() -> str:
+    import sys
+
+    return sys.platform
+
+
+def handoff(target: str | None, *, copy: bool = False, messages: int = DEFAULT_MESSAGES, message_chars: int = DEFAULT_MESSAGE_CHARS) -> Path:
+    report = collect_handoff_report(resolve_rollout(target), messages=messages, message_chars=message_chars)
+    output = write_handoff(report)
+    if copy:
+        copy_to_clipboard(clipboard_prompt(output))
+    return output
+
+
+def watch_once(*, recent: int = DEFAULT_RECENT, max_age_seconds: int = DEFAULT_MAX_AGE_SECONDS, token_ratio: float = DEFAULT_TOKEN_RATIO, copy: bool = False) -> list[Path]:
+    now = time.time()
+    outputs: list[Path] = []
+    for path in recent_rollouts(recent):
+        stat = path.stat()
+        if max_age_seconds > 0 and now - stat.st_mtime > max_age_seconds:
+            continue
+        report = collect_handoff_report(path)
+        if not report.context_error and not token_pressure(report.last_token_count, token_ratio):
+            continue
+        output = write_handoff(report)
+        outputs.append(output)
+        if copy:
+            copy_to_clipboard(clipboard_prompt(output))
+    return outputs

--- a/codex_session_delete/context_guard.py
+++ b/codex_session_delete/context_guard.py
@@ -31,8 +31,10 @@ HIGH_RISK_MARKERS = (
     "publish",
     "release",
     "deploy",
-    "delete ",
-    "remove ",
+    "delete file",
+    "delete data",
+    "remove file",
+    "remove data",
     "rm -rf",
     "stop-process",
     "set-itemproperty",
@@ -543,6 +545,15 @@ def report_contains_high_risk_action(report: HandoffReport) -> bool:
     return any(marker in text for marker in HIGH_RISK_MARKERS)
 
 
+def high_risk_marker(report: HandoffReport) -> str:
+    user_messages = [message.text for message in report.messages if message.role == "user"]
+    text = (user_messages[-1] if user_messages else "").lower()
+    for marker in HIGH_RISK_MARKERS:
+        if marker in text:
+            return marker
+    return ""
+
+
 def steward_once(
     *,
     cwd: str,
@@ -569,8 +580,11 @@ def steward_once(
 
     state["source_thread_id"] = state.get("source_thread_id") or report.stats.thread_id
     thread_id = report.stats.thread_id or str(report.stats.path)
-    if report_contains_high_risk_action(report):
-        state["last_error"] = "high-risk action detected"
+    marker = high_risk_marker(report)
+    if marker:
+        state["source_thread_id"] = thread_id
+        state["last_error"] = f"high-risk action detected: {marker}"
+        save_steward_state(state, root)
         stopped = stop_steward("high-risk action detected", root=root)
         return StewardResult(
             status="stopped",

--- a/codex_session_delete/context_guard.py
+++ b/codex_session_delete/context_guard.py
@@ -16,9 +16,35 @@ DEFAULT_MESSAGE_CHARS = 1200
 DEFAULT_TOKEN_RATIO = 0.72
 DEFAULT_MAX_AGE_SECONDS = 30 * 60
 DEFAULT_RECENT = 20
+DEFAULT_STEWARD_INTERVAL_SECONDS = 15.0
+DEFAULT_MAX_HANDOFFS = 2
 CONTEXT_ERROR_MARKERS = (
     "ran out of room in the model's context window",
     "start a new thread or clear earlier history",
+)
+HIGH_RISK_MARKERS = (
+    "git push",
+    "gh pr create",
+    "gh pr merge",
+    "submit pr",
+    "create pr",
+    "publish",
+    "release",
+    "deploy",
+    "delete ",
+    "remove ",
+    "rm -rf",
+    "stop-process",
+    "set-itemproperty",
+    "scheduledtask",
+    "提交pr",
+    "创建pr",
+    "合并pr",
+    "发布",
+    "部署",
+    "删除",
+    "卸载",
+    "系统配置",
 )
 
 
@@ -46,6 +72,37 @@ class HandoffReport:
     messages: list[HandoffMessage]
     last_token_count: dict[str, Any] | None
     context_error: bool
+
+
+@dataclass
+class StewardResult:
+    status: str
+    message: str
+    handoff_path: str = ""
+    prompt: str = ""
+    copied: bool = False
+    trigger: str = ""
+    stop_reason: str = ""
+    log_path: str = ""
+    summary_path: str = ""
+    thread_id: str = ""
+    cwd: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "message": self.message,
+            "handoff_path": self.handoff_path,
+            "path": self.handoff_path,
+            "prompt": self.prompt,
+            "copied": self.copied,
+            "trigger": self.trigger,
+            "stop_reason": self.stop_reason,
+            "log_path": self.log_path,
+            "summary_path": self.summary_path,
+            "thread_id": self.thread_id,
+            "cwd": self.cwd,
+        }
 
 
 def codex_home() -> Path:
@@ -256,6 +313,19 @@ def clipboard_prompt(path: Path) -> str:
     )
 
 
+def takeover_prompt(path: Path, report: HandoffReport) -> str:
+    cwd = report.stats.cwd or "(unknown)"
+    return (
+        "Continue the same task from this handoff in the same working folder.\n\n"
+        f"Handoff file:\n{path}\n"
+        f"Working directory:\n{cwd}\n\n"
+        "First read the handoff file and inspect only the files or commands needed for the next step. "
+        "Confirm the current working directory and git status before changing files. Continue the original task only; "
+        "do not expand scope. Stop and report if the next action would delete data, publish/deploy, submit or merge a PR, "
+        "change system configuration, install a global service, or otherwise require user approval."
+    )
+
+
 def copy_to_clipboard(text: str) -> bool:
     if sys_platform() != "win32":
         return False
@@ -288,6 +358,23 @@ def handoff(target: str | None, *, copy: bool = False, messages: int = DEFAULT_M
     return output
 
 
+def handoff_result(target: str | None, *, copy: bool = False, messages: int = DEFAULT_MESSAGES, message_chars: int = DEFAULT_MESSAGE_CHARS) -> StewardResult:
+    report = collect_handoff_report(resolve_rollout(target), messages=messages, message_chars=message_chars)
+    output = write_handoff(report)
+    prompt = takeover_prompt(output, report)
+    copied = copy_to_clipboard(prompt) if copy else False
+    return StewardResult(
+        status="ok",
+        message="handoff written",
+        handoff_path=str(output),
+        prompt=prompt,
+        copied=copied,
+        trigger="manual",
+        thread_id=report.stats.thread_id,
+        cwd=report.stats.cwd,
+    )
+
+
 def watch_once(*, recent: int = DEFAULT_RECENT, max_age_seconds: int = DEFAULT_MAX_AGE_SECONDS, token_ratio: float = DEFAULT_TOKEN_RATIO, copy: bool = False) -> list[Path]:
     now = time.time()
     outputs: list[Path] = []
@@ -303,3 +390,269 @@ def watch_once(*, recent: int = DEFAULT_RECENT, max_age_seconds: int = DEFAULT_M
         if copy:
             copy_to_clipboard(clipboard_prompt(output))
     return outputs
+
+
+def context_guard_root(root: Path | None = None) -> Path:
+    return (root or codex_home()) / "context-guard"
+
+
+def steward_state_path(root: Path | None = None) -> Path:
+    return context_guard_root(root) / "steward-state.json"
+
+
+def overnight_runs_dir(root: Path | None = None) -> Path:
+    return context_guard_root(root) / "overnight-runs"
+
+
+def now_iso() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def default_steward_state(cwd: str = "", max_handoffs: int = DEFAULT_MAX_HANDOFFS) -> dict[str, Any]:
+    stamp = now_iso()
+    return {
+        "enabled": False,
+        "cwd": cwd,
+        "source_thread_id": "",
+        "handled_thread_ids": [],
+        "handoff_count": 0,
+        "max_handoffs": max_handoffs,
+        "last_handoff_path": "",
+        "last_error": "",
+        "stop_reason": "",
+        "log_path": "",
+        "summary_path": "",
+        "started_at": stamp,
+        "updated_at": stamp,
+    }
+
+
+def load_steward_state(root: Path | None = None) -> dict[str, Any]:
+    path = steward_state_path(root)
+    if not path.exists():
+        return default_steward_state()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return default_steward_state()
+    state = default_steward_state(str(data.get("cwd") or ""), int(data.get("max_handoffs") or DEFAULT_MAX_HANDOFFS))
+    state.update(data)
+    if not isinstance(state.get("handled_thread_ids"), list):
+        state["handled_thread_ids"] = []
+    return state
+
+
+def save_steward_state(state: dict[str, Any], root: Path | None = None) -> Path:
+    state["updated_at"] = now_iso()
+    path = steward_state_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
+
+
+def start_steward(cwd: str, *, max_handoffs: int = DEFAULT_MAX_HANDOFFS, root: Path | None = None) -> dict[str, Any]:
+    state = default_steward_state(cwd, max_handoffs)
+    state["enabled"] = True
+    save_steward_state(state, root)
+    append_steward_log(state, "steward started", root)
+    return state
+
+
+def stop_steward(reason: str, *, root: Path | None = None) -> dict[str, Any]:
+    state = load_steward_state(root)
+    state["enabled"] = False
+    state["stop_reason"] = reason
+    append_steward_log(state, f"steward stopped: {reason}", root)
+    summary = write_steward_summary(state, reason, root)
+    state["summary_path"] = str(summary)
+    save_steward_state(state, root)
+    return state
+
+
+def append_steward_log(state: dict[str, Any], line: str, root: Path | None = None) -> Path:
+    raw_log_path = str(state.get("log_path") or "")
+    if raw_log_path:
+        log_path = Path(raw_log_path)
+    else:
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        log_path = overnight_runs_dir(root) / f"{stamp}-steward.log"
+        state["log_path"] = str(log_path)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(f"[{now_iso()}] {line}\n")
+    save_steward_state(state, root)
+    return log_path
+
+
+def write_steward_summary(state: dict[str, Any], reason: str, root: Path | None = None) -> Path:
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    summary_path = overnight_runs_dir(root) / f"{stamp}-steward-summary.md"
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Codex Context Guard Steward Summary",
+        "",
+        f"- status: `stopped`",
+        f"- reason: `{reason}`",
+        f"- cwd: `{state.get('cwd') or ''}`",
+        f"- source_thread_id: `{state.get('source_thread_id') or ''}`",
+        f"- handoff_count: `{state.get('handoff_count') or 0}`",
+        f"- last_handoff_path: `{state.get('last_handoff_path') or ''}`",
+        f"- last_error: `{state.get('last_error') or ''}`",
+        f"- log_path: `{state.get('log_path') or ''}`",
+        "",
+        "Review the handoff and log before continuing unattended work.",
+        "",
+    ]
+    summary_path.write_text("\n".join(lines), encoding="utf-8")
+    return summary_path
+
+
+def normalize_cwd(value: str | Path) -> str:
+    return str(Path(value).expanduser().resolve())
+
+
+def report_matches_cwd(report: HandoffReport, cwd: str) -> bool:
+    if not cwd:
+        return True
+    if not report.stats.cwd:
+        return False
+    try:
+        return Path(report.stats.cwd).expanduser().resolve() == Path(cwd).expanduser().resolve()
+    except OSError:
+        return report.stats.cwd == cwd
+
+
+def find_recent_report_for_cwd(cwd: str, *, recent: int = DEFAULT_RECENT, root: Path | None = None) -> HandoffReport | None:
+    for path in recent_rollouts(recent, root):
+        report = collect_handoff_report(path)
+        if report_matches_cwd(report, cwd):
+            return report
+    return None
+
+
+def infer_recent_cwd(*, root: Path | None = None) -> str:
+    for path in recent_rollouts(10, root):
+        report = collect_handoff_report(path)
+        if report.stats.cwd:
+            return normalize_cwd(report.stats.cwd)
+    return ""
+
+
+def report_contains_high_risk_action(report: HandoffReport) -> bool:
+    text = "\n".join(message.text for message in report.messages).lower()
+    return any(marker in text for marker in HIGH_RISK_MARKERS)
+
+
+def steward_once(
+    *,
+    cwd: str,
+    max_handoffs: int = DEFAULT_MAX_HANDOFFS,
+    recent: int = DEFAULT_RECENT,
+    copy: bool = True,
+    root: Path | None = None,
+) -> StewardResult:
+    resolved_cwd = normalize_cwd(cwd) if cwd else infer_recent_cwd(root=root)
+    if not resolved_cwd:
+        return StewardResult(status="failed", message="cwd is required and no recent rollout cwd was found")
+    state = load_steward_state(root)
+    if not state.get("enabled"):
+        state = start_steward(resolved_cwd, max_handoffs=max_handoffs, root=root)
+    else:
+        state["cwd"] = resolved_cwd
+        state["max_handoffs"] = max_handoffs
+        save_steward_state(state, root)
+
+    report = find_recent_report_for_cwd(resolved_cwd, recent=recent, root=root)
+    if report is None:
+        append_steward_log(state, f"no rollout found for cwd: {resolved_cwd}", root)
+        return StewardResult(status="idle", message="no rollout found for cwd", log_path=str(state.get("log_path") or ""), cwd=resolved_cwd)
+
+    state["source_thread_id"] = state.get("source_thread_id") or report.stats.thread_id
+    thread_id = report.stats.thread_id or str(report.stats.path)
+    if report_contains_high_risk_action(report):
+        state["last_error"] = "high-risk action detected"
+        stopped = stop_steward("high-risk action detected", root=root)
+        return StewardResult(
+            status="stopped",
+            message="high-risk action detected; steward stopped",
+            stop_reason=str(stopped.get("stop_reason") or ""),
+            log_path=str(stopped.get("log_path") or ""),
+            summary_path=str(stopped.get("summary_path") or ""),
+            thread_id=thread_id,
+            cwd=resolved_cwd,
+        )
+
+    if thread_id in set(str(item) for item in state.get("handled_thread_ids", [])):
+        append_steward_log(state, f"thread already handled: {thread_id}", root)
+        return StewardResult(status="idle", message="thread already handled", log_path=str(state.get("log_path") or ""), thread_id=thread_id, cwd=resolved_cwd)
+
+    if int(state.get("handoff_count") or 0) >= max_handoffs:
+        stopped = stop_steward("max handoffs reached", root=root)
+        return StewardResult(
+            status="stopped",
+            message="max handoffs reached; steward stopped",
+            stop_reason=str(stopped.get("stop_reason") or ""),
+            log_path=str(stopped.get("log_path") or ""),
+            summary_path=str(stopped.get("summary_path") or ""),
+            thread_id=thread_id,
+            cwd=resolved_cwd,
+        )
+
+    if not report.context_error:
+        if token_pressure(report.last_token_count):
+            output = write_handoff(report)
+            state["last_handoff_path"] = str(output)
+            append_steward_log(state, f"token pressure observed; prewrote handoff without takeover: {output}", root)
+            return StewardResult(
+                status="prepared",
+                message="token pressure observed; handoff prepared without takeover",
+                handoff_path=str(output),
+                trigger="token_pressure",
+                log_path=str(state.get("log_path") or ""),
+                thread_id=thread_id,
+                cwd=resolved_cwd,
+            )
+        append_steward_log(state, f"no context error for thread: {thread_id}", root)
+        return StewardResult(status="idle", message="no context error detected", log_path=str(state.get("log_path") or ""), thread_id=thread_id, cwd=resolved_cwd)
+
+    output = write_handoff(report)
+    prompt = takeover_prompt(output, report)
+    copied = copy_to_clipboard(prompt) if copy else False
+    handled = [str(item) for item in state.get("handled_thread_ids", [])]
+    handled.append(thread_id)
+    state["handled_thread_ids"] = handled
+    state["handoff_count"] = int(state.get("handoff_count") or 0) + 1
+    state["last_handoff_path"] = str(output)
+    state["last_error"] = ""
+    append_steward_log(state, f"context error handoff ready: thread={thread_id} path={output}", root)
+    save_steward_state(state, root)
+    return StewardResult(
+        status="handoff_ready",
+        message="context error detected; handoff ready for takeover",
+        handoff_path=str(output),
+        prompt=prompt,
+        copied=copied,
+        trigger="context_error",
+        log_path=str(state.get("log_path") or ""),
+        thread_id=thread_id,
+        cwd=resolved_cwd,
+    )
+
+
+def steward_loop(
+    *,
+    cwd: str,
+    max_handoffs: int = DEFAULT_MAX_HANDOFFS,
+    interval_seconds: float = DEFAULT_STEWARD_INTERVAL_SECONDS,
+    root: Path | None = None,
+) -> int:
+    resolved_cwd = normalize_cwd(cwd) if cwd else infer_recent_cwd(root=root)
+    if not resolved_cwd:
+        raise ValueError("cwd is required and no recent rollout cwd was found")
+    start_steward(resolved_cwd, max_handoffs=max_handoffs, root=root)
+    while load_steward_state(root).get("enabled"):
+        result = steward_once(cwd=resolved_cwd, max_handoffs=max_handoffs, root=root)
+        if result.status == "stopped":
+            return 0
+        time.sleep(interval_seconds)
+    return 0

--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -3,6 +3,7 @@
   const buttonClass = "codex-delete-button";
   const exportButtonClass = "codex-export-button";
   const projectMoveButtonClass = "codex-project-move-button";
+  const contextHandoffButtonClass = "codex-context-handoff-button";
   const projectMoveOverlayClass = "codex-project-move-overlay";
   const actionButtonClass = "codex-session-action-button";
   const actionGroupClass = "codex-session-actions";
@@ -26,7 +27,8 @@
   const codexDeleteVersion = "6";
   const codexExportVersion = "1";
   const codexProjectMoveVersion = "1";
-  const codexActionGroupVersion = "2";
+  const codexContextHandoffVersion = "1";
+  const codexActionGroupVersion = "3";
   const codexArchiveRowActionsVersion = "1";
   const codexArchiveDeleteAllVersion = "2";
   const codexConversationTimelineVersion = "1";
@@ -459,7 +461,7 @@
   }
 
   function defaultCodexPlusSettings() {
-    return { pluginEntryUnlock: true, forcePluginInstall: true, sessionDelete: true, markdownExport: true, projectMove: true, conversationTimeline: true, nativeMenuPlacement: true };
+    return { pluginEntryUnlock: true, forcePluginInstall: true, sessionDelete: true, markdownExport: true, projectMove: true, contextGuard: true, contextGuardSteward: false, conversationTimeline: true, nativeMenuPlacement: true };
   }
 
   function codexPlusSettings() {
@@ -482,6 +484,7 @@
       const key = button.getAttribute("data-codex-plus-setting");
       button.dataset.enabled = String(!!codexPlusSettings()[key]);
     });
+    renderContextGuardStewardToggle();
   }
 
   let codexPlusBackendSettings = { providerSyncEnabled: false };
@@ -648,6 +651,19 @@
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="markdownExport"><span></span></button>
             </div>
             <div class="codex-plus-row">
+              <div><div class="codex-plus-row-title">Context Guard 交接</div><div class="codex-plus-row-description">在上下文爆满时生成轻量 handoff，复制新对话继续提示，不写数据库、不重启 Codex。</div></div>
+              <button type="button" class="codex-plus-toggle" data-codex-plus-setting="contextGuard"><span></span></button>
+            </div>
+            <div class="codex-plus-row">
+              <div><div class="codex-plus-row-title">睡觉托管</div><div class="codex-plus-row-description" data-codex-context-steward-status="true">未运行</div></div>
+              <div class="codex-plus-user-script-actions">
+                <button type="button" class="codex-plus-toggle" data-codex-context-steward-toggle="true"><span></span></button>
+                <button type="button" class="codex-plus-action-button" data-codex-context-steward-start="true">开始托管当前任务</button>
+                <button type="button" class="codex-plus-action-button" data-codex-context-steward-once="true">检查一次</button>
+                <button type="button" class="codex-plus-action-button" data-codex-context-steward-stop="true">停止托管</button>
+              </div>
+            </div>
+            <div class="codex-plus-row">
               <div><div class="codex-plus-row-title">会话项目移动</div><div class="codex-plus-row-description">在会话列表悬停显示移动按钮，可移动到普通对话或其他本地项目。</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="projectMove"><span></span></button>
             </div>
@@ -751,6 +767,22 @@
         loadUserScripts("/user-scripts/reload", {});
         return;
       }
+      if (target?.closest("[data-codex-context-steward-start]")) {
+        startContextGuardSteward();
+        return;
+      }
+      if (target?.closest("[data-codex-context-steward-once]")) {
+        runContextGuardStewardOnce();
+        return;
+      }
+      if (target?.closest("[data-codex-context-steward-stop]")) {
+        stopContextGuardSteward();
+        return;
+      }
+      if (target?.closest("[data-codex-context-steward-toggle]")) {
+        toggleContextGuardSteward();
+        return;
+      }
       const toggle = target?.closest("[data-codex-plus-setting]");
       if (toggle) {
         const key = toggle.getAttribute("data-codex-plus-setting");
@@ -770,6 +802,7 @@
     renderBackendStatus();
     loadBackendSettings();
     loadUserScripts();
+    refreshContextGuardStewardStatus();
   }
 
   function findNativeMenuInsertionPoint() {
@@ -1045,7 +1078,7 @@
     const sessionId = codexThreadId || (idMatch && idMatch[1]) || fallbackId;
     const titleNode = row.querySelector(`${selectors.threadTitle}, .truncate.select-none, .truncate.text-base`);
     const rawTitle = (titleNode?.textContent || (titleNode ? "" : (row.textContent || "Untitled session")));
-    const title = (titleNode ? rawTitle : rawTitle.replace(/\s*(导出|删除|移动|移出项目)(\s*(导出|删除|移动|移出项目))*$/g, "")).trim().slice(0, 160);
+    const title = (titleNode ? rawTitle : rawTitle.replace(/\s*(导出|删除|移动|交接|移出项目)(\s*(导出|删除|移动|交接|移出项目))*$/g, "")).trim().slice(0, 160);
     return { session_id: sessionId, title };
   }
 
@@ -2033,6 +2066,176 @@
     showToast(result.message || "导出失败", null);
   }
 
+  async function createContextHandoff(ref, takeover = false) {
+    const result = await postJson("/context-guard/handoff", { ...ref, copy: true });
+    if (result.status !== "ok" && result.status !== "handoff_ready") {
+      showToast(result.message || "交接失败", null);
+      return result;
+    }
+    if (takeover) {
+      await takeoverContextGuardPrompt(result.prompt || "");
+      showToast("已接管到新对话", null);
+    } else {
+      showToast(result.copied ? "交接提示已复制" : "交接文件已生成", null);
+    }
+    return result;
+  }
+
+  function contextGuardCurrentCwdHint() {
+    return document.querySelector("[data-codex-context-cwd]")?.getAttribute("data-codex-context-cwd")
+      || window.__codexContextGuardCwd
+      || "";
+  }
+
+  function contextGuardStatusLabel(result) {
+    if (!result) return "未运行";
+    if (result.enabled === true) return `运行中 · ${result.cwd || "等待识别工作目录"}`;
+    if (result.stop_reason) return `已停止 · ${result.stop_reason}`;
+    return result.message || "未运行";
+  }
+
+  function renderContextGuardStewardStatus(result) {
+    const label = document.querySelector("[data-codex-context-steward-status]");
+    if (!label) return;
+    const parts = [contextGuardStatusLabel(result)];
+    if (result?.last_handoff_path || result?.handoff_path) parts.push(`最近交接：${result.last_handoff_path || result.handoff_path}`);
+    if (result?.log_path) parts.push(`日志：${result.log_path}`);
+    label.textContent = parts.join("  ");
+    if (typeof result?.enabled === "boolean") {
+      const next = { ...codexPlusSettings(), contextGuardSteward: result.enabled };
+      localStorage.setItem(codexPlusSettingsKey, JSON.stringify(next));
+      renderContextGuardStewardToggle();
+    }
+  }
+
+  function renderContextGuardStewardToggle() {
+    document.querySelectorAll("[data-codex-context-steward-toggle]").forEach((button) => {
+      button.dataset.enabled = String(!!codexPlusSettings().contextGuardSteward);
+    });
+  }
+
+  async function refreshContextGuardStewardStatus() {
+    const result = await postJson("/context-guard/steward/status", {});
+    renderContextGuardStewardStatus(result);
+    return result;
+  }
+
+  function visibleText(value) {
+    return (value || "").replace(/\s+/g, " ").trim();
+  }
+
+  function findContextGuardNewChatControl() {
+    const candidates = Array.from(document.querySelectorAll("a, button")).filter((node) => {
+      const label = visibleText(node.getAttribute("aria-label") || node.getAttribute("title") || node.textContent);
+      return /^(新建对话|新对话|New chat|New conversation)$/i.test(label) || /新建|新对话|new chat|new conversation/i.test(label);
+    });
+    return candidates.find((node) => node.getBoundingClientRect().width > 0 && node.getBoundingClientRect().height > 0) || candidates[0] || null;
+  }
+
+  function findContextGuardComposer() {
+    const candidates = Array.from(document.querySelectorAll("textarea, [contenteditable='true'], [role='textbox']"));
+    return candidates.find((node) => {
+      const rect = node.getBoundingClientRect();
+      return rect.width > 120 && rect.height > 20 && !node.disabled && node.getAttribute("aria-disabled") !== "true";
+    }) || null;
+  }
+
+  function setContextGuardComposerValue(composer, value) {
+    if (!composer) throw new Error("未找到输入框");
+    composer.focus();
+    if (composer instanceof HTMLTextAreaElement || composer instanceof HTMLInputElement) {
+      const setter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(composer), "value")?.set;
+      setter?.call(composer, value);
+      composer.dispatchEvent(new Event("input", { bubbles: true }));
+      composer.dispatchEvent(new Event("change", { bubbles: true }));
+      return;
+    }
+    composer.textContent = value;
+    composer.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: value }));
+  }
+
+  function findContextGuardSendButton() {
+    const candidates = Array.from(document.querySelectorAll("button")).filter((button) => {
+      const label = visibleText(button.getAttribute("aria-label") || button.getAttribute("title") || button.textContent);
+      return /发送|send|submit/i.test(label) || button.type === "submit";
+    });
+    return candidates.find((button) => !button.disabled && button.getAttribute("aria-disabled") !== "true") || null;
+  }
+
+  async function waitForContextGuardElement(factory, timeoutMs = 6000) {
+    const started = Date.now();
+    while (Date.now() - started < timeoutMs) {
+      const value = factory();
+      if (value) return value;
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    }
+    return null;
+  }
+
+  async function takeoverContextGuardPrompt(prompt) {
+    if (!prompt) throw new Error("接管提示为空");
+    const newChat = findContextGuardNewChatControl();
+    if (!newChat) throw new Error("未找到新对话入口，已保留剪贴板提示");
+    newChat.click();
+    const composer = await waitForContextGuardElement(findContextGuardComposer);
+    setContextGuardComposerValue(composer, prompt);
+    const send = await waitForContextGuardElement(findContextGuardSendButton);
+    if (!send) throw new Error("未找到发送按钮，已保留剪贴板提示");
+    send.click();
+  }
+
+  async function runContextGuardStewardOnce() {
+    const result = await postJson("/context-guard/steward/once", { cwd: contextGuardCurrentCwdHint(), copy: true, max_handoffs: 2 });
+    renderContextGuardStewardStatus(result);
+    if (result.status === "handoff_ready" && result.prompt) {
+      try {
+        await takeoverContextGuardPrompt(result.prompt);
+        showToast("睡觉托管已接管到新对话", null);
+      } catch (error) {
+        showToast(`自动接管失败：${error?.message || error}`, null);
+      }
+    }
+    if (result.status === "stopped") stopContextGuardStewardTimer();
+    return result;
+  }
+
+  function startContextGuardStewardTimer() {
+    stopContextGuardStewardTimer();
+    window.__codexContextGuardStewardTimer = setInterval(runContextGuardStewardOnce, 15000);
+  }
+
+  function stopContextGuardStewardTimer() {
+    clearInterval(window.__codexContextGuardStewardTimer);
+    window.__codexContextGuardStewardTimer = null;
+  }
+
+  async function startContextGuardSteward() {
+    const result = await postJson("/context-guard/steward/start", { cwd: contextGuardCurrentCwdHint(), max_handoffs: 2 });
+    renderContextGuardStewardStatus(result);
+    if (result.status === "ok") {
+      startContextGuardStewardTimer();
+      showToast("睡觉托管已开启", null);
+      runContextGuardStewardOnce();
+    } else {
+      showToast(result.message || "睡觉托管启动失败", null);
+    }
+  }
+
+  async function stopContextGuardSteward() {
+    stopContextGuardStewardTimer();
+    const result = await postJson("/context-guard/steward/stop", { reason: "stopped by user" });
+    renderContextGuardStewardStatus(result);
+    showToast("睡觉托管已停止", null);
+  }
+
+  async function toggleContextGuardSteward() {
+    if (codexPlusSettings().contextGuardSteward) {
+      await stopContextGuardSteward();
+    } else {
+      await startContextGuardSteward();
+    }
+  }
+
   function sortStateFromMoveResult(result, ref, row) {
     const trustedSortMs = timestampMsFromPayload(result);
     return { sortMs: trustedSortMs || rowSortMs(row, ref), sortMsTrusted: !!trustedSortMs };
@@ -2178,7 +2381,7 @@
 
   function attachButton(row) {
     const settings = codexPlusSettings();
-    if (!settings.sessionDelete && !settings.markdownExport && !settings.projectMove) {
+    if (!settings.sessionDelete && !settings.markdownExport && !settings.projectMove && !settings.contextGuard) {
       removeActionGroups(row);
       row.dataset.codexDeleteRow = "false";
       row.dataset.codexProjectMoveRow = "false";
@@ -2188,17 +2391,21 @@
     const existingDeleteButton = existingGroup?.querySelector(`.${buttonClass}`);
     const existingExportButton = existingGroup?.querySelector(`.${exportButtonClass}`);
     const existingMoveButton = existingGroup?.querySelector(`.${projectMoveButtonClass}`);
+    const existingContextButton = existingGroup?.querySelector(`.${contextHandoffButtonClass}`);
     const hasUnexpectedDelete = !settings.sessionDelete && !!existingDeleteButton;
     const hasUnexpectedExport = !settings.markdownExport && !!existingExportButton;
     const hasUnexpectedMove = !settings.projectMove && !!existingMoveButton;
+    const hasUnexpectedContext = !settings.contextGuard && !!existingContextButton;
     const missingDelete = settings.sessionDelete && !existingDeleteButton;
     const missingExport = settings.markdownExport && !existingExportButton;
     const missingMove = settings.projectMove && !existingMoveButton;
+    const missingContext = settings.contextGuard && !existingContextButton;
     const deleteReady = !settings.sessionDelete || existingDeleteButton?.dataset.codexDeleteVersion === codexDeleteVersion;
     const exportReady = !settings.markdownExport || existingExportButton?.dataset.codexExportVersion === codexExportVersion;
     const moveReady = !settings.projectMove || existingMoveButton?.dataset.codexProjectMoveVersion === codexProjectMoveVersion;
+    const contextReady = !settings.contextGuard || existingContextButton?.dataset.codexContextHandoffVersion === codexContextHandoffVersion;
     const groupReady = existingGroup?.dataset.codexActionGroupVersion === codexActionGroupVersion;
-    if (groupReady && deleteReady && exportReady && moveReady && !hasUnexpectedDelete && !hasUnexpectedExport && !hasUnexpectedMove && !missingDelete && !missingExport && !missingMove) return;
+    if (groupReady && deleteReady && exportReady && moveReady && contextReady && !hasUnexpectedDelete && !hasUnexpectedExport && !hasUnexpectedMove && !hasUnexpectedContext && !missingDelete && !missingExport && !missingMove && !missingContext) return;
     removeActionGroups(row);
     row.dataset.codexDeleteRow = "false";
     row.dataset.codexProjectMoveRow = "false";
@@ -2209,6 +2416,20 @@
     const group = document.createElement("div");
     group.className = actionGroupClass;
     group.dataset.codexActionGroupVersion = codexActionGroupVersion;
+    if (settings.contextGuard) {
+      const contextButton = document.createElement("button");
+      contextButton.type = "button";
+      contextButton.className = `${actionButtonClass} ${contextHandoffButtonClass}`;
+      contextButton.dataset.codexContextHandoffVersion = codexContextHandoffVersion;
+      contextButton.textContent = "交接";
+      const openContextHandoff = (event) => {
+        stopActionButtonEvent(row, contextButton, event);
+        createContextHandoff(ref, false);
+      };
+      installActionButtonEvents(row, contextButton, openContextHandoff);
+      group.appendChild(contextButton);
+      setTimeout(() => refreshActionButton(contextButton, row, openContextHandoff), 0);
+    }
     if (settings.projectMove) {
       const moveButton = document.createElement("button");
       moveButton.type = "button";

--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -4,6 +4,10 @@
   const exportButtonClass = "codex-export-button";
   const projectMoveButtonClass = "codex-project-move-button";
   const contextHandoffButtonClass = "codex-context-handoff-button";
+  const actionMoreButtonClass = "codex-session-action-more-button";
+  const actionMenuOverlayClass = "codex-session-action-menu-overlay";
+  const actionMenuPanelClass = "codex-session-action-menu-panel";
+  const actionMenuItemClass = "codex-session-action-menu-item";
   const projectMoveOverlayClass = "codex-project-move-overlay";
   const actionButtonClass = "codex-session-action-button";
   const actionGroupClass = "codex-session-actions";
@@ -68,7 +72,7 @@
         opacity: 0;
         display: inline-flex;
         align-items: center;
-        gap: 6px;
+        gap: 0;
       }
       .${actionButtonClass},
       .codex-archive-row-button {
@@ -103,6 +107,54 @@
         border-color: #10a37f;
         background: #d1fae5;
         color: #065f46;
+      }
+      .${actionMoreButtonClass} {
+        min-width: 26px;
+        width: 26px;
+        height: 24px;
+        padding: 0;
+        border-color: #d1d5db;
+        background: #f9fafb;
+        color: #374151;
+        font-size: 17px;
+        line-height: 20px;
+      }
+      .${actionMenuOverlayClass} {
+        position: fixed;
+        inset: 0;
+        z-index: 2147483190;
+        background: transparent;
+      }
+      .${actionMenuPanelClass} {
+        position: fixed;
+        min-width: 112px;
+        padding: 5px;
+        border: 1px solid rgba(15,23,42,.14);
+        border-radius: 8px;
+        background: #ffffff;
+        color: #111827;
+        box-shadow: 0 12px 36px rgba(15,23,42,.2);
+      }
+      .${actionMenuItemClass} {
+        display: block;
+        width: 100%;
+        border: 0;
+        border-radius: 6px;
+        background: transparent;
+        color: #111827;
+        font: 13px system-ui, sans-serif;
+        line-height: 18px;
+        padding: 7px 9px;
+        text-align: left;
+        cursor: pointer;
+      }
+      .${actionMenuItemClass}:hover,
+      .${actionMenuItemClass}:focus-visible {
+        background: #f3f4f6;
+        outline: none;
+      }
+      .${actionMenuItemClass}[data-codex-action-kind="delete"] {
+        color: #991b1b;
       }
       [data-codex-delete-row="true"]:hover .${actionGroupClass} { opacity: 1; }
       [data-codex-delete-row="true"].codex-archive-confirm-visible .${actionGroupClass} { right: 66px; }
@@ -2379,6 +2431,67 @@
     originalButton.replaceWith(replacement);
   }
 
+  function sessionActionSettingsSignature(settings) {
+    return JSON.stringify({
+      contextGuard: !!settings.contextGuard,
+      projectMove: !!settings.projectMove,
+      markdownExport: !!settings.markdownExport,
+      sessionDelete: !!settings.sessionDelete,
+    });
+  }
+
+  function closeSessionActionMenus() {
+    document.querySelectorAll(`.${actionMenuOverlayClass}`).forEach((node) => node.remove());
+  }
+
+  function openSessionActionMenu(row, button, ref, event) {
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation?.();
+    releaseDeleteFocus(row, button);
+    closeSessionActionMenus();
+    const settings = codexPlusSettings();
+    const actions = [];
+    if (settings.contextGuard) actions.push({ kind: "context", label: "交接", run: () => createContextHandoff(ref, false) });
+    if (settings.projectMove) actions.push({ kind: "move", label: "移动", run: (itemEvent, item) => openProjectMoveMenuForRow(row, item, ref, itemEvent) });
+    if (settings.markdownExport) actions.push({ kind: "export", label: "导出", run: () => exportMarkdown(ref) });
+    if (settings.sessionDelete) actions.push({ kind: "delete", label: "删除", run: (itemEvent, item) => openDeleteConfirmForRow(row, item, ref, itemEvent) });
+    if (!actions.length) return;
+    const overlay = document.createElement("div");
+    overlay.className = actionMenuOverlayClass;
+    const panel = document.createElement("div");
+    panel.className = actionMenuPanelClass;
+    const rect = button.getBoundingClientRect();
+    panel.style.top = `${Math.max(8, Math.min(window.innerHeight - 180, rect.bottom + 6))}px`;
+    panel.style.left = `${Math.max(8, Math.min(window.innerWidth - 128, rect.right - 112))}px`;
+    overlay.appendChild(panel);
+    overlay.addEventListener("click", (clickEvent) => {
+      if (clickEvent.target === overlay) closeSessionActionMenus();
+    }, true);
+    overlay.addEventListener("keydown", (keyEvent) => {
+      if (keyEvent.key === "Escape") {
+        keyEvent.preventDefault();
+        closeSessionActionMenus();
+      }
+    }, true);
+    for (const action of actions) {
+      const item = document.createElement("button");
+      item.type = "button";
+      item.className = actionMenuItemClass;
+      item.dataset.codexActionKind = action.kind;
+      item.textContent = action.label;
+      item.addEventListener("click", (itemEvent) => {
+        itemEvent.preventDefault();
+        itemEvent.stopPropagation();
+        action.run(itemEvent, item);
+        closeSessionActionMenus();
+      }, true);
+      panel.appendChild(item);
+    }
+    document.body.appendChild(overlay);
+    panel.querySelector("button")?.focus();
+  }
+
   function attachButton(row) {
     const settings = codexPlusSettings();
     if (!settings.sessionDelete && !settings.markdownExport && !settings.projectMove && !settings.contextGuard) {
@@ -2388,24 +2501,10 @@
       return;
     }
     const existingGroup = actionGroupFromRow(row);
-    const existingDeleteButton = existingGroup?.querySelector(`.${buttonClass}`);
-    const existingExportButton = existingGroup?.querySelector(`.${exportButtonClass}`);
-    const existingMoveButton = existingGroup?.querySelector(`.${projectMoveButtonClass}`);
-    const existingContextButton = existingGroup?.querySelector(`.${contextHandoffButtonClass}`);
-    const hasUnexpectedDelete = !settings.sessionDelete && !!existingDeleteButton;
-    const hasUnexpectedExport = !settings.markdownExport && !!existingExportButton;
-    const hasUnexpectedMove = !settings.projectMove && !!existingMoveButton;
-    const hasUnexpectedContext = !settings.contextGuard && !!existingContextButton;
-    const missingDelete = settings.sessionDelete && !existingDeleteButton;
-    const missingExport = settings.markdownExport && !existingExportButton;
-    const missingMove = settings.projectMove && !existingMoveButton;
-    const missingContext = settings.contextGuard && !existingContextButton;
-    const deleteReady = !settings.sessionDelete || existingDeleteButton?.dataset.codexDeleteVersion === codexDeleteVersion;
-    const exportReady = !settings.markdownExport || existingExportButton?.dataset.codexExportVersion === codexExportVersion;
-    const moveReady = !settings.projectMove || existingMoveButton?.dataset.codexProjectMoveVersion === codexProjectMoveVersion;
-    const contextReady = !settings.contextGuard || existingContextButton?.dataset.codexContextHandoffVersion === codexContextHandoffVersion;
+    const existingMoreButton = existingGroup?.querySelector(`.${actionMoreButtonClass}`);
     const groupReady = existingGroup?.dataset.codexActionGroupVersion === codexActionGroupVersion;
-    if (groupReady && deleteReady && exportReady && moveReady && contextReady && !hasUnexpectedDelete && !hasUnexpectedExport && !hasUnexpectedMove && !hasUnexpectedContext && !missingDelete && !missingExport && !missingMove && !missingContext) return;
+    const settingsReady = existingGroup?.dataset.codexActionSettings === sessionActionSettingsSignature(settings);
+    if (groupReady && settingsReady && existingMoreButton?.dataset.codexContextHandoffVersion === codexContextHandoffVersion) return;
     removeActionGroups(row);
     row.dataset.codexDeleteRow = "false";
     row.dataset.codexProjectMoveRow = "false";
@@ -2416,56 +2515,18 @@
     const group = document.createElement("div");
     group.className = actionGroupClass;
     group.dataset.codexActionGroupVersion = codexActionGroupVersion;
-    if (settings.contextGuard) {
-      const contextButton = document.createElement("button");
-      contextButton.type = "button";
-      contextButton.className = `${actionButtonClass} ${contextHandoffButtonClass}`;
-      contextButton.dataset.codexContextHandoffVersion = codexContextHandoffVersion;
-      contextButton.textContent = "交接";
-      const openContextHandoff = (event) => {
-        stopActionButtonEvent(row, contextButton, event);
-        createContextHandoff(ref, false);
-      };
-      installActionButtonEvents(row, contextButton, openContextHandoff);
-      group.appendChild(contextButton);
-      setTimeout(() => refreshActionButton(contextButton, row, openContextHandoff), 0);
-    }
-    if (settings.projectMove) {
-      const moveButton = document.createElement("button");
-      moveButton.type = "button";
-      moveButton.className = `${actionButtonClass} ${projectMoveButtonClass}`;
-      moveButton.dataset.codexProjectMoveVersion = codexProjectMoveVersion;
-      moveButton.textContent = "移动";
-      const openProjectMove = (event) => openProjectMoveMenuForRow(row, moveButton, ref, event);
-      installActionButtonEvents(row, moveButton, openProjectMove);
-      group.appendChild(moveButton);
-      setTimeout(() => refreshActionButton(moveButton, row, openProjectMove), 0);
-    }
-    if (settings.markdownExport) {
-      const exportButton = document.createElement("button");
-      exportButton.type = "button";
-      exportButton.className = `${actionButtonClass} ${exportButtonClass}`;
-      exportButton.dataset.codexExportVersion = codexExportVersion;
-      exportButton.textContent = "导出";
-      const openExport = (event) => {
-        stopActionButtonEvent(row, exportButton, event);
-        exportMarkdown(ref);
-      };
-      installActionButtonEvents(row, exportButton, openExport);
-      group.appendChild(exportButton);
-      setTimeout(() => refreshActionButton(exportButton, row, openExport), 0);
-    }
-    if (settings.sessionDelete) {
-      const deleteButton = document.createElement("button");
-      deleteButton.type = "button";
-      deleteButton.className = `${actionButtonClass} ${buttonClass}`;
-      deleteButton.dataset.codexDeleteVersion = codexDeleteVersion;
-      deleteButton.textContent = "删除";
-      const openDeleteConfirm = (event) => openDeleteConfirmForRow(row, deleteButton, ref, event);
-      installActionButtonEvents(row, deleteButton, openDeleteConfirm);
-      group.appendChild(deleteButton);
-      setTimeout(() => refreshActionButton(deleteButton, row, openDeleteConfirm), 0);
-    }
+    group.dataset.codexActionSettings = sessionActionSettingsSignature(settings);
+    const moreButton = document.createElement("button");
+    moreButton.type = "button";
+    moreButton.className = `${actionButtonClass} ${actionMoreButtonClass}`;
+    moreButton.dataset.codexContextHandoffVersion = codexContextHandoffVersion;
+    moreButton.textContent = "⋯";
+    moreButton.title = "会话操作";
+    moreButton.setAttribute("aria-label", "会话操作");
+    const openMenu = (event) => openSessionActionMenu(row, moreButton, ref, event);
+    installActionButtonEvents(row, moreButton, openMenu);
+    group.appendChild(moreButton);
+    setTimeout(() => refreshActionButton(moreButton, row, openMenu), 0);
     row.appendChild(group);
   }
 

--- a/codex_session_delete/launcher.py
+++ b/codex_session_delete/launcher.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from codex_session_delete import cdp
+from codex_session_delete import context_guard
 from codex_session_delete.app_paths import resolve_codex_app_dir
 from codex_session_delete.api_adapter import ApiAdapter, UnavailableApiAdapter
 from codex_session_delete.backup_store import BackupStore
@@ -404,6 +405,34 @@ def handle_bridge_request(
         return runtime.backend_status()
     if path == "/backend/repair" and runtime:
         return runtime.repair_backend()
+    if path == "/context-guard/handoff":
+        result = context_guard.handoff_result(
+            str(payload.get("session_id") or payload.get("target") or "") or None,
+            copy=bool(payload.get("copy", True)),
+        )
+        return result.to_dict()
+    if path == "/context-guard/steward/start":
+        cwd = str(payload.get("cwd") or "") or context_guard.infer_recent_cwd()
+        if not cwd:
+            return {"status": "failed", "message": "cwd is required and no recent rollout cwd was found"}
+        max_handoffs = int(payload.get("max_handoffs") or context_guard.DEFAULT_MAX_HANDOFFS)
+        state = context_guard.start_steward(cwd, max_handoffs=max_handoffs)
+        return {"status": "ok", "message": "睡觉托管已开启", **state}
+    if path == "/context-guard/steward/stop":
+        reason = str(payload.get("reason") or "stopped by user")
+        state = context_guard.stop_steward(reason)
+        return {"status": "stopped", "message": "睡觉托管已停止", **state}
+    if path == "/context-guard/steward/status":
+        state = context_guard.load_steward_state()
+        return {"status": "ok", "message": "睡觉托管状态已读取", **state}
+    if path == "/context-guard/steward/once":
+        cwd = str(payload.get("cwd") or "")
+        result = context_guard.steward_once(
+            cwd=cwd,
+            max_handoffs=int(payload.get("max_handoffs") or context_guard.DEFAULT_MAX_HANDOFFS),
+            copy=bool(payload.get("copy", True)),
+        )
+        return result.to_dict()
     if path == "/delete":
         session = SessionRef(session_id=str(payload.get("session_id", "")), title=str(payload.get("title", "")))
         return service.delete(session).to_dict()

--- a/tests/test_context_guard.py
+++ b/tests/test_context_guard.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from codex_session_delete import context_guard
+
+
+def write_rollout(root: Path, *, old: bool = False) -> Path:
+    rollout_dir = root / "sessions" / "2026" / "05" / "13"
+    rollout_dir.mkdir(parents=True, exist_ok=True)
+    path = rollout_dir / "rollout-2026-05-13T00-00-00-019e1f97-6ea9-7181-ba90-59fb48309277.jsonl"
+    records = [
+        {
+            "timestamp": "2026-05-13T00:00:00Z",
+            "type": "session_meta",
+            "payload": {
+                "id": "019e1f97-6ea9-7181-ba90-59fb48309277",
+                "cwd": "C:/tmp/demo",
+            },
+        },
+        {"timestamp": "2026-05-13T00:01:00Z", "type": "turn_context", "payload": {"turn_id": "turn-1"}},
+        {
+            "timestamp": "2026-05-13T00:01:01Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "please continue the task"}],
+            },
+        },
+        {
+            "timestamp": "2026-05-13T00:02:00Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "model_context_window": 1000,
+                    "last_token_usage": {"input_tokens": 900, "total_tokens": 900},
+                    "total_token_usage": {"total_tokens": 1000},
+                },
+            },
+        },
+    ]
+    path.write_text("".join(json.dumps(item) + "\n" for item in records), encoding="utf-8")
+    if old:
+        old_time = time.time() - 7200
+        os.utime(path, (old_time, old_time))
+    return path
+
+
+def test_collect_handoff_report_reads_messages_and_token_pressure(tmp_path):
+    path = write_rollout(tmp_path)
+    report = context_guard.collect_handoff_report(path)
+
+    assert report.stats.thread_id == "019e1f97-6ea9-7181-ba90-59fb48309277"
+    assert report.stats.cwd == "C:/tmp/demo"
+    assert report.messages[-1].text == "please continue the task"
+    assert context_guard.token_pressure(report.last_token_count) is True
+
+
+def test_write_handoff_contains_new_thread_instruction(tmp_path, monkeypatch):
+    path = write_rollout(tmp_path)
+    report = context_guard.collect_handoff_report(path)
+    output = context_guard.write_handoff(report, tmp_path / "handoff.md")
+
+    content = output.read_text(encoding="utf-8")
+    assert "# Codex Thread Handoff" in content
+    assert "Continue from this handoff" in content
+
+
+def test_watch_once_writes_handoff_for_recent_full_context(tmp_path, monkeypatch):
+    write_rollout(tmp_path)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+
+    outputs = context_guard.watch_once(recent=5, max_age_seconds=1800, copy=False)
+
+    assert len(outputs) == 1
+    assert outputs[0].exists()
+
+
+def test_watch_once_skips_old_rollout(tmp_path, monkeypatch):
+    write_rollout(tmp_path, old=True)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+
+    outputs = context_guard.watch_once(recent=5, max_age_seconds=1800, copy=False)
+
+    assert outputs == []
+
+
+def test_clipboard_prompt_mentions_handoff_file():
+    path = Path("C:/tmp/handoff.md")
+    text = context_guard.clipboard_prompt(path)
+
+    assert "Handoff file" in text
+    assert str(path) in text

--- a/tests/test_context_guard.py
+++ b/tests/test_context_guard.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from codex_session_delete import context_guard
 
 
-def write_rollout(root: Path, *, old: bool = False) -> Path:
+def write_rollout(root: Path, *, old: bool = False, context_error: bool = False, user_text: str = "please continue the task") -> Path:
     rollout_dir = root / "sessions" / "2026" / "05" / "13"
     rollout_dir.mkdir(parents=True, exist_ok=True)
     path = rollout_dir / "rollout-2026-05-13T00-00-00-019e1f97-6ea9-7181-ba90-59fb48309277.jsonl"
@@ -28,7 +28,7 @@ def write_rollout(root: Path, *, old: bool = False) -> Path:
             "payload": {
                 "type": "message",
                 "role": "user",
-                "content": [{"type": "input_text", "text": "please continue the task"}],
+                "content": [{"type": "input_text", "text": user_text}],
             },
         },
         {
@@ -44,6 +44,18 @@ def write_rollout(root: Path, *, old: bool = False) -> Path:
             },
         },
     ]
+    if context_error:
+        records.append(
+            {
+                "timestamp": "2026-05-13T00:03:00Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
+                },
+            }
+        )
     path.write_text("".join(json.dumps(item) + "\n" for item in records), encoding="utf-8")
     if old:
         old_time = time.time() - 7200
@@ -96,3 +108,68 @@ def test_clipboard_prompt_mentions_handoff_file():
 
     assert "Handoff file" in text
     assert str(path) in text
+
+
+def test_steward_once_context_error_writes_handoff_and_log(tmp_path, monkeypatch):
+    write_rollout(tmp_path, context_error=True)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    monkeypatch.setattr(context_guard, "copy_to_clipboard", lambda text: True)
+
+    result = context_guard.steward_once(cwd="C:/tmp/demo", root=tmp_path)
+
+    assert result.status == "handoff_ready"
+    assert result.trigger == "context_error"
+    assert result.copied is True
+    assert Path(result.handoff_path).exists()
+    assert Path(result.log_path).exists()
+    assert "Working directory" in result.prompt
+
+
+def test_steward_once_token_pressure_prepares_without_takeover(tmp_path, monkeypatch):
+    write_rollout(tmp_path, context_error=False)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+
+    result = context_guard.steward_once(cwd="C:/tmp/demo", root=tmp_path)
+
+    assert result.status == "prepared"
+    assert result.trigger == "token_pressure"
+    assert result.prompt == ""
+    assert Path(result.handoff_path).exists()
+
+
+def test_steward_once_does_not_repeat_same_thread(tmp_path, monkeypatch):
+    write_rollout(tmp_path, context_error=True)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    monkeypatch.setattr(context_guard, "copy_to_clipboard", lambda text: True)
+
+    first = context_guard.steward_once(cwd="C:/tmp/demo", root=tmp_path)
+    second = context_guard.steward_once(cwd="C:/tmp/demo", root=tmp_path)
+
+    assert first.status == "handoff_ready"
+    assert second.status == "idle"
+    assert second.message == "thread already handled"
+
+
+def test_steward_once_stops_at_max_handoffs(tmp_path, monkeypatch):
+    write_rollout(tmp_path, context_error=True)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    state = context_guard.start_steward("C:/tmp/demo", max_handoffs=1, root=tmp_path)
+    state["handoff_count"] = 1
+    context_guard.save_steward_state(state, tmp_path)
+
+    result = context_guard.steward_once(cwd="C:/tmp/demo", max_handoffs=1, root=tmp_path)
+
+    assert result.status == "stopped"
+    assert result.stop_reason == "max handoffs reached"
+    assert Path(result.summary_path).exists()
+
+
+def test_steward_once_stops_on_high_risk_action(tmp_path, monkeypatch):
+    write_rollout(tmp_path, context_error=True, user_text="please git push and create PR tonight")
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+
+    result = context_guard.steward_once(cwd="C:/tmp/demo", root=tmp_path)
+
+    assert result.status == "stopped"
+    assert result.stop_reason == "high-risk action detected"
+    assert Path(result.summary_path).exists()

--- a/tests/test_launcher_user_scripts.py
+++ b/tests/test_launcher_user_scripts.py
@@ -115,3 +115,35 @@ def test_handle_bridge_request_exports_markdown(tmp_path):
     assert exported["status"] == "exported"
     assert exported["filename"] == "thread.md"
 
+
+def test_handle_bridge_request_runs_context_guard_steward_once(monkeypatch, tmp_path):
+    manager = UserScriptManager(tmp_path / "builtin", tmp_path / "user", tmp_path / "config.json")
+    runtime = FakeRuntime(manager)
+
+    class FakeResult:
+        def to_dict(self):
+            return {"status": "handoff_ready", "prompt": "continue", "handoff_path": "handoff.md"}
+
+    monkeypatch.setattr("codex_session_delete.launcher.context_guard.steward_once", lambda **kwargs: FakeResult())
+
+    result = handle_bridge_request(FakeDeleteService(), FakeExportService(), "/context-guard/steward/once", {"cwd": "C:/tmp/demo"}, runtime)
+
+    assert result["status"] == "handoff_ready"
+    assert result["prompt"] == "continue"
+
+
+def test_handle_bridge_request_starts_and_stops_context_guard_steward(monkeypatch, tmp_path):
+    manager = UserScriptManager(tmp_path / "builtin", tmp_path / "user", tmp_path / "config.json")
+    runtime = FakeRuntime(manager)
+
+    monkeypatch.setattr("codex_session_delete.launcher.context_guard.start_steward", lambda cwd, max_handoffs=2: {"enabled": True, "cwd": cwd})
+    monkeypatch.setattr("codex_session_delete.launcher.context_guard.stop_steward", lambda reason: {"enabled": False, "stop_reason": reason})
+
+    started = handle_bridge_request(FakeDeleteService(), FakeExportService(), "/context-guard/steward/start", {"cwd": "C:/tmp/demo"}, runtime)
+    stopped = handle_bridge_request(FakeDeleteService(), FakeExportService(), "/context-guard/steward/stop", {"reason": "done"}, runtime)
+
+    assert started["status"] == "ok"
+    assert started["enabled"] is True
+    assert stopped["status"] == "stopped"
+    assert stopped["stop_reason"] == "done"
+

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -582,6 +582,36 @@ def test_renderer_script_can_move_sidebar_threads_between_projects():
     assert "__codexProjectMoveChatsSortTimer" in text
     assert "sortMsTrusted" in text
     assert "chatsSortDbRefreshIntervalMs" in text
+
+
+def test_renderer_script_exposes_context_guard_steward_ui():
+    text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
+
+    assert "contextGuard: true" in text
+    assert "contextGuardSteward: false" in text
+    assert "Context Guard 交接" in text
+    assert "睡觉托管" in text
+    assert "data-codex-context-steward-toggle" in text
+    assert "data-codex-context-steward-status" in text
+    assert "data-codex-context-steward-start" in text
+    assert "data-codex-context-steward-stop" in text
+    assert "交接" in text
+    assert "/context-guard/steward/once" in text
+    assert "/context-guard/handoff" in text
+
+
+def test_renderer_script_context_guard_takeover_uses_dom_without_process_control():
+    text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
+    start = text.index("async function takeoverContextGuardPrompt")
+    end = text.index("\n\n  async function runContextGuardStewardOnce", start)
+    takeover_code = text[start:end]
+
+    assert "findContextGuardNewChatControl" in takeover_code
+    assert "setContextGuardComposerValue" in takeover_code
+    assert "findContextGuardSendButton" in takeover_code
+    assert "Stop-Process" not in takeover_code
+    assert "codex_session_delete launch" not in takeover_code
+    assert "state_5.sqlite" not in takeover_code
     assert "data-app-action-sidebar-section-heading=\"Chats\"" in text
     assert "data-app-action-sidebar-project-list-id" in text
     assert "codexProjectMoveSortMs" in text

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -286,7 +286,8 @@ def test_renderer_script_sidebar_delete_opens_on_pointerup_when_click_is_unrelia
     assert "codexSessionDeleteDocumentDeleteHandler" in text
     assert "document.addEventListener(\"pointerup\", handler, true)" in text
     assert "document.addEventListener(\"click\", handler, true)" in text
-    assert "deleteButton.dataset.codexDeleteVersion = codexDeleteVersion" in text
+    assert "openSessionActionMenu" in text
+    assert "data-codex-action-kind=\"delete\"" in text or "item.dataset.codexActionKind = action.kind" in text
 
 
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
@@ -621,5 +622,6 @@ def test_renderer_script_context_guard_takeover_uses_dom_without_process_control
     assert "window.__codexProjectMoveTargets" in text
     assert "projectMoveButtonClass" in text
     assert "openProjectMoveMenuForRow" in text
-    assert "existingMoveButton" in text
+    assert "actionMoreButtonClass" in text
+    assert "sessionActionSettingsSignature" in text
     assert "普通对话" in text


### PR DESCRIPTION
## Summary

Adds a conservative Context Guard handoff command for long Codex threads that hit the model context window.

- Adds python -m codex_session_delete context-guard handoff to write a lightweight Markdown handoff from a rollout/thread id
- Adds python -m codex_session_delete context-guard watch-once to scan recent rollouts and prepare handoffs when context pressure is detected
- Supports optional --copy to place a new-thread prompt on the clipboard
- Documents the workflow in README

This integration intentionally does **not** open or restart Codex Desktop, does **not** modify Codex Desktop SQLite/global state, and does **not** automatically send messages. It only creates local Markdown handoff files and optionally copies a prompt.

The feature is adapted from https://github.com/zjq12333/codex-context-guard.

## Testing

- python -m pytest tests/test_context_guard.py -q
- python -m pytest tests/test_context_guard.py tests/test_readme.py -q
- python -m codex_session_delete context-guard handoff --help
- python -m codex_session_delete context-guard watch-once --max-age-seconds 1
