### PR TITLE
Fix floating Codex++ menu overlapping long thread titles

### DIFF
--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -815,14 +815,24 @@
     }
   }
 
+  function isHeaderToolbarButton(button, header) {
+    if (!button || button.closest?.(`#${codexPlusMenuId}`)) return false;
+    const rect = button.getBoundingClientRect();
+    if (!(rect.width > 0 && rect.height > 0 && rect.left > window.innerWidth / 2)) return false;
+    const buttonCluster = button.closest(".ms-auto.flex.shrink-0.items-center");
+    if (buttonCluster && header?.contains(buttonCluster)) return true;
+    const titleRegion = header?.children?.[2];
+    if (titleRegion?.contains?.(button)) return false;
+    return !!button.closest?.('[class*="ms-auto"][class*="shrink-0"][class*="items-center"]');
+  }
+
   function updateFloatingCodexPlusMenuPosition(menu) {
     if (!menu?.classList?.contains(codexPlusMenuFloatingClass)) return;
     const header = document.querySelector(selectors.appHeader) || document.querySelector("header");
     if (!header) return;
     const toolbarButtons = Array.from(header.querySelectorAll("button"))
-      .filter((button) => !button.closest(`#${codexPlusMenuId}`))
+      .filter((button) => isHeaderToolbarButton(button, header))
       .map((button) => ({ button, rect: button.getBoundingClientRect() }))
-      .filter(({ rect }) => rect.width > 0 && rect.height > 0 && rect.left > window.innerWidth / 2)
       .sort((left, right) => left.rect.left - right.rect.left);
     const anchor = toolbarButtons[0];
     if (anchor) {

--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -815,13 +815,21 @@
     }
   }
 
-  function isHeaderToolbarButton(button, header) {
+  function headerTitleRegion(header) {
+    const candidates = Array.from(header?.querySelectorAll?.('[data-state], [class*="truncate"], [class*="text-base"]') || []);
+    return candidates.find((node) => {
+      if (!node?.querySelector?.('[data-state], button')) return false;
+      if (!node.textContent?.trim()) return false;
+      return node.closest?.(".draggable") || node.closest?.('[class*="grid-cols-[minmax(0,1fr)]"]');
+    }) || null;
+  }
+
+  function isHeaderToolbarButton(button, header, rect) {
     if (!button || button.closest?.(`#${codexPlusMenuId}`)) return false;
-    const rect = button.getBoundingClientRect();
     if (!(rect.width > 0 && rect.height > 0 && rect.left > window.innerWidth / 2)) return false;
     const buttonCluster = button.closest(".ms-auto.flex.shrink-0.items-center");
     if (buttonCluster && header?.contains(buttonCluster)) return true;
-    const titleRegion = header?.children?.[2];
+    const titleRegion = headerTitleRegion(header);
     if (titleRegion?.contains?.(button)) return false;
     return !!button.closest?.('[class*="ms-auto"][class*="shrink-0"][class*="items-center"]');
   }
@@ -831,8 +839,8 @@
     const header = document.querySelector(selectors.appHeader) || document.querySelector("header");
     if (!header) return;
     const toolbarButtons = Array.from(header.querySelectorAll("button"))
-      .filter((button) => isHeaderToolbarButton(button, header))
       .map((button) => ({ button, rect: button.getBoundingClientRect() }))
+      .filter(({ button, rect }) => isHeaderToolbarButton(button, header, rect))
       .sort((left, right) => left.rect.left - right.rect.left);
     const anchor = toolbarButtons[0];
     if (anchor) {

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -489,10 +489,13 @@ def test_renderer_script_includes_user_script_manager_ui_contract():
     assert "codexPlusMenuVersion !== \"6\"" in text
     assert "codexPlusTriggerInstalled = \"5\"" in text
     assert ".codex-plus-trigger:hover" not in text
+    assert "function headerTitleRegion" in text
     assert "function isHeaderToolbarButton" in text
     assert 'button.closest(".ms-auto.flex.shrink-0.items-center")' in text
-    assert "const titleRegion = header?.children?.[2];" in text
+    assert "const titleRegion = headerTitleRegion(header);" in text
     assert "if (titleRegion?.contains?.(button)) return false;" in text
+    assert ".map((button) => ({ button, rect: button.getBoundingClientRect() }))" in text
+    assert ".filter(({ button, rect }) => isHeaderToolbarButton(button, header, rect))" in text
 
 
 def test_renderer_script_has_sponsor_tab():

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -489,6 +489,10 @@ def test_renderer_script_includes_user_script_manager_ui_contract():
     assert "codexPlusMenuVersion !== \"6\"" in text
     assert "codexPlusTriggerInstalled = \"5\"" in text
     assert ".codex-plus-trigger:hover" not in text
+    assert "function isHeaderToolbarButton" in text
+    assert 'button.closest(".ms-auto.flex.shrink-0.items-center")' in text
+    assert "const titleRegion = header?.children?.[2];" in text
+    assert "if (titleRegion?.contains?.(button)) return false;" in text
 
 
 def test_renderer_script_has_sponsor_tab():


### PR DESCRIPTION
## Summary

This PR fixes a header layout regression where the floating `Codex++` menu can overlap long thread titles in Codex Desktop.



## Problem

When the thread title is short, the floating `Codex++` label appears in the expected position.

When the thread title is long, the floating `Codex++` label can shift left into the title area and visually overlap the thread title text.

This is not a sidebar issue, and it is not a generic text truncation problem in the title itself. It is a regression in the floating menu positioning logic.

This regression was introduced by commit `0e7175a` (`refactor: 标题、操作确认样式优化`).

As shown in the figure:
<img width="2120" height="1432" alt="image" src="https://github.com/user-attachments/assets/06433051-c830-45b4-9676-c679567688d5" />

When `Codex++` cannot be inserted into the native menu area, it falls back to the floating header mode (`codex-plus-menu-floating`) and uses `updateFloatingCodexPlusMenuPosition()` to choose a header button as its positioning anchor.

The anchor selection in that refactor was too broad. It treated any header button on the right half of the window as a possible anchor:

- header button
- not inside `Codex++`
- positioned on the right half of the window

That also includes the thread-title action button (`...`) inside the title region.

In long-title scenarios, the floating `Codex++` menu was therefore anchored against a button inside the title region instead of the real right-side toolbar cluster, which caused the overlap.

I confirmed this by inspecting the live Codex header DOM through CDP:

- the title-region button lives inside the title container
- the real right-side toolbar buttons live inside `.ms-auto.flex.shrink-0.items-center`
- the old logic could incorrectly treat the title-region button as the floating menu anchor

## Fix
- Added `isHeaderToolbarButton(button, header)`
- Explicitly excluded buttons inside the title region (`header.children[2]`)
- Restricted floating-menu anchor candidates to the real right-side toolbar cluster

## Result

- `Codex++` no longer anchors itself to the title-region `...` button
- long thread titles no longer overlap the floating `Codex++` label
- existing native insertion behavior remains unchanged

## Validation

Passed:

- `node --check codex_session_delete/inject/renderer-inject.js`
- `pytest -q tests/test_renderer_script.py tests/test_cdp.py`

Result:

- `37 passed`

## Screenshot
<img width="1060" height="716" alt="image" src="https://github.com/user-attachments/assets/e22fac0a-c444-41cb-9bd1-317b35d49e06" />
