### PR TITLE
[codex] Improve conversation timeline

### DIFF
--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -12,6 +12,9 @@
   const timelineTooltipClass = "codex-conversation-timeline-tooltip";
   const timelineTargetClass = "codex-conversation-timeline-target";
   const timelineQuestionLimit = 40;
+  const timelineMinTopPercent = 2;
+  const timelineMaxTopPercent = 98;
+  const timelineMaxMarkerGapPercent = 3.5;
   const projectMoveProjectionKey = "codexProjectMoveProjection";
   const legacyProjectMoveOverridesKey = "codexProjectMoveOverrides";
   const projectMoveProjectionTtlMs = 24 * 60 * 60 * 1000;
@@ -20,7 +23,7 @@
   const chatsSortRefreshIntervalMs = 1500;
   const chatsSortDbRefreshIntervalMs = 5000;
   const styleId = "codex-delete-style";
-  const codexDeleteStyleVersion = "7";
+  const codexDeleteStyleVersion = "8";
   const codexPlusMenuId = "codex-plus-menu";
   const codexPlusMenuFloatingClass = "codex-plus-menu-floating";
   const codexDeleteVersion = "6";
@@ -29,7 +32,7 @@
   const codexActionGroupVersion = "2";
   const codexArchiveRowActionsVersion = "1";
   const codexArchiveDeleteAllVersion = "2";
-  const codexConversationTimelineVersion = "1";
+  const codexConversationTimelineVersion = "2";
   const codexPlusVersion = "1.0.6";
   const codexPlusSettingsKey = "codexPlusSettings";
   window.__codexProjectMoveRuntimeId = (window.__codexProjectMoveRuntimeId || 0) + 1;
@@ -38,6 +41,7 @@
   clearTimeout(window.__codexProjectMoveChatsSortTimer);
   window.__codexProjectMoveProjectionTimer = null;
   window.__codexProjectMoveChatsSortTimer = null;
+  window.__codexConversationTimelineNodeCounter = window.__codexConversationTimelineNodeCounter || 0;
   const selectors = {
     sidebarThread: "[data-app-action-sidebar-thread-id]",
     threadTitle: "[data-thread-title]",
@@ -428,7 +432,10 @@
         position: absolute;
         right: 20px;
         top: 50%;
-        max-width: 260px;
+        display: block;
+        box-sizing: border-box;
+        width: max-content;
+        max-width: min(320px, calc(100vw - 72px));
         transform: translateY(-50%);
         border-radius: 8px;
         background: rgba(80, 80, 80, .92);
@@ -437,6 +444,8 @@
         line-height: 18px;
         padding: 10px 12px;
         white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
         box-shadow: 0 8px 24px rgba(0, 0, 0, .18);
         opacity: 0;
         visibility: hidden;
@@ -2470,12 +2479,42 @@
 
   function truncateTimelineQuestion(text) {
     const normalized = String(text || "").replace(/\s+/g, " ").trim();
-    if (normalized.length <= timelineQuestionLimit) return normalized;
-    return `${normalized.slice(0, timelineQuestionLimit)}…`;
+    const chars = Array.from(normalized);
+    if (chars.length <= timelineQuestionLimit) return normalized;
+    return `${chars.slice(0, timelineQuestionLimit).join("")}…`;
   }
 
   function conversationTimelineRoot() {
     return document.querySelector(".thread-scroll-container") || document.querySelector("main") || document.querySelector('[role="main"]');
+  }
+
+  function timelineQuestionSelector() {
+    return [
+      '[data-message-author-role="user"]',
+      '[data-testid="conversation-turn"][data-message-author-role="user"]',
+      '[data-testid="conversation-turn"] [data-message-author-role="user"]',
+      '[class*="user-message"]',
+      '[class*="UserMessage"]',
+    ].join(", ");
+  }
+
+  function nodeOrAncestorLooksLikeCodexUserBubble(node) {
+    if (node.nodeType !== 1) return false;
+    const className = String(node.className || "");
+    if (className.includes("bg-token-foreground/5") && node.parentElement?.classList?.contains("items-end")) return true;
+    const bubble = node.closest?.("[class*='bg-token-foreground/5']");
+    return !!bubble?.parentElement?.classList?.contains("items-end");
+  }
+
+  function nodeLooksLikeCodexUserBubble(node) {
+    if (nodeOrAncestorLooksLikeCodexUserBubble(node)) return true;
+    return !!node.querySelector?.(".group.flex.w-full.flex-col.items-end.justify-end.gap-1 > [class*='bg-token-foreground/5']");
+  }
+
+  function nodeLooksLikeTimelineQuestion(node) {
+    if (node.nodeType !== 1 || isExtensionUiNode(node)) return false;
+    const questionSelector = timelineQuestionSelector();
+    return !!node.matches?.(questionSelector) || !!node.closest?.(questionSelector) || !!node.querySelector?.(questionSelector) || nodeLooksLikeCodexUserBubble(node);
   }
 
   function conversationTimelineQuestionCandidates(root) {
@@ -2498,6 +2537,22 @@
     return clone.textContent.replace(/\s+/g, " ").trim();
   }
 
+  function timelineNodeId(node) {
+    if (!node.__codexConversationTimelineNodeId) {
+      window.__codexConversationTimelineNodeCounter += 1;
+      node.__codexConversationTimelineNodeId = String(window.__codexConversationTimelineNodeCounter);
+    }
+    return node.__codexConversationTimelineNodeId;
+  }
+
+  function visibleTimelineNode(node) {
+    if (!node.isConnected) return false;
+    const style = getComputedStyle(node);
+    if (style.display === "none" || style.visibility === "hidden") return false;
+    const rect = node.getBoundingClientRect();
+    return rect.width > 0 || rect.height > 0 || !!node.textContent?.trim();
+  }
+
   function conversationTimelineQuestions() {
     const root = conversationTimelineRoot();
     if (!root?.matches?.('.thread-scroll-container, main, [role="main"]')) return [];
@@ -2508,16 +2563,40 @@
       const target = node.closest('[data-testid="conversation-turn"]') || node;
       if (seen.has(target)) return [];
       seen.add(target);
+      if (!visibleTimelineNode(target)) return [];
       const text = extractTimelineQuestionText(node);
       if (!text) return [];
-      return [{ node: target, text }];
+      return [{ node: target, text, nodeId: timelineNodeId(target) }];
     });
   }
 
-  function timelineMarkerTop(question, questions) {
-    if (questions.length <= 1) return 50;
-    const index = questions.indexOf(question);
-    return Math.max(2, Math.min(98, (index / (questions.length - 1)) * 100));
+  function timelineScrollerViewportTop(scroller) {
+    if (scroller === document.scrollingElement || scroller === document.documentElement || scroller === document.body) return 0;
+    return scroller.getBoundingClientRect().top;
+  }
+
+  function timelineScrollableHeight(scroller) {
+    return Math.max(1, scroller.scrollHeight - scroller.clientHeight);
+  }
+
+  function timelineRawMarkerTop(question, scroller) {
+    const scrollOffset = scroller.scrollTop + question.node.getBoundingClientRect().top - timelineScrollerViewportTop(scroller);
+    const percent = (scrollOffset / timelineScrollableHeight(scroller)) * 100;
+    return Math.max(timelineMinTopPercent, Math.min(timelineMaxTopPercent, percent));
+  }
+
+  function timelineMarkerTops(questions, scroller) {
+    if (questions.length <= 1) return [50];
+    const minGap = Math.min(timelineMaxMarkerGapPercent, (timelineMaxTopPercent - timelineMinTopPercent) / Math.max(questions.length - 1, 1));
+    const tops = questions.map((question) => timelineRawMarkerTop(question, scroller));
+    for (let index = 1; index < tops.length; index += 1) {
+      tops[index] = Math.max(tops[index], tops[index - 1] + minGap);
+    }
+    for (let index = tops.length - 1; index >= 0; index -= 1) {
+      const maxForIndex = timelineMaxTopPercent - ((tops.length - 1 - index) * minGap);
+      tops[index] = Math.min(tops[index], maxForIndex);
+    }
+    return tops.map((top) => Math.max(timelineMinTopPercent, Math.min(timelineMaxTopPercent, top)));
   }
 
   function removeConversationTimeline() {
@@ -2534,9 +2613,8 @@
 
   function scrollTimelineTarget(node) {
     const scroller = nearestTimelineScroller(node);
-    const scrollerRect = scroller.getBoundingClientRect();
     const nodeRect = node.getBoundingClientRect();
-    const nextTop = scroller.scrollTop + nodeRect.top - scrollerRect.top - (scroller.clientHeight / 2) + (nodeRect.height / 2);
+    const nextTop = scroller.scrollTop + nodeRect.top - timelineScrollerViewportTop(scroller) - (scroller.clientHeight / 2) + (nodeRect.height / 2);
     scroller.scrollTo({ top: nextTop, behavior: "smooth" });
   }
 
@@ -2550,15 +2628,18 @@
     }, 1300);
   }
 
-  function createConversationTimelineMarker(question, questions) {
+  function createConversationTimelineMarker(question) {
     const marker = document.createElement("button");
     marker.type = "button";
     marker.className = timelineMarkerClass;
-    marker.style.top = `${timelineMarkerTop(question, questions)}%`;
-    marker.setAttribute("aria-label", truncateTimelineQuestion(question.text));
+    marker.style.top = `${question.markerTop}%`;
+    marker.setAttribute("aria-label", `跳转到：${truncateTimelineQuestion(question.text)}`);
     const tooltip = document.createElement("span");
     tooltip.className = timelineTooltipClass;
+    tooltip.id = `codex-conversation-timeline-tooltip-${question.nodeId}`;
+    tooltip.setAttribute("role", "tooltip");
     tooltip.textContent = truncateTimelineQuestion(question.text);
+    marker.setAttribute("aria-describedby", tooltip.id);
     marker.appendChild(tooltip);
     const activateMarker = (event) => {
       event.preventDefault();
@@ -2572,22 +2653,51 @@
       highlightTimelineTarget(question.node);
     };
     marker.addEventListener("pointerup", activateMarker, true);
+    marker.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") activateMarker(event);
+    }, true);
     return marker;
   }
 
+  function prepareTimelineQuestions(questions) {
+    if (questions.length === 0) return [];
+    const scroller = nearestTimelineScroller(questions[0].node);
+    const tops = timelineMarkerTops(questions, scroller);
+    return questions.map((question, index) => ({ ...question, markerTop: Number(tops[index].toFixed(3)) }));
+  }
+
+  function timelineSignature(questions) {
+    return questions.map((question) => `${question.nodeId}:${Math.round(question.markerTop * 10)}:${truncateTimelineQuestion(question.text)}`).join("|");
+  }
+
   function refreshConversationTimeline() {
+    if (!codexPlusSettings().conversationTimeline) {
+      removeConversationTimeline();
+      return;
+    }
+    const questions = prepareTimelineQuestions(conversationTimelineQuestions());
+    if (questions.length === 0) {
+      removeConversationTimeline();
+      return;
+    }
+    const signature = timelineSignature(questions);
+    const existing = document.querySelector(`.${timelineClass}`);
+    if (
+      existing?.dataset.codexConversationTimelineVersion === codexConversationTimelineVersion &&
+      existing?.dataset.codexConversationTimelineSignature === signature
+    ) {
+      return;
+    }
     removeConversationTimeline();
-    if (!codexPlusSettings().conversationTimeline) return;
-    const questions = conversationTimelineQuestions();
-    if (questions.length === 0) return;
     const container = document.createElement("div");
     container.className = timelineClass;
     container.dataset.codexConversationTimelineVersion = codexConversationTimelineVersion;
+    container.dataset.codexConversationTimelineSignature = signature;
     const track = document.createElement("div");
     track.className = timelineTrackClass;
     container.appendChild(track);
     questions.forEach((question) => {
-      container.appendChild(createConversationTimelineMarker(question, questions));
+      container.appendChild(createConversationTimelineMarker(question));
     });
     document.body.appendChild(container);
   }
@@ -2638,24 +2748,35 @@
     "[data-codex-archive-delete-all]",
     '[data-message-author-role]',
     '[data-testid="conversation-turn"]',
-    'main .prose',
+    '[class*="user-message"]',
+    '[class*="UserMessage"]',
     selectors.appHeader,
     selectors.archiveNav,
     selectors.disabledInstallButton,
   ].join(", ");
 
+  function nodeSelfOrAncestorMatchesScanRelevance(node) {
+    if (node.nodeType !== 1) return false;
+    if (isExtensionUiNode(node)) return false;
+    const questionSelector = timelineQuestionSelector();
+    return !!node.matches?.(scanRelevantSelector) ||
+      !!node.closest?.(scanRelevantSelector) ||
+      !!node.matches?.(questionSelector) ||
+      !!node.closest?.(questionSelector) ||
+      nodeOrAncestorLooksLikeCodexUserBubble(node);
+  }
+
   function isScanRelevantNode(node) {
     if (node.nodeType !== 1) return false;
     if (isExtensionUiNode(node)) return false;
-    return !!node.matches?.(scanRelevantSelector) || !!node.closest?.(scanRelevantSelector) || !!node.querySelector?.(scanRelevantSelector);
+    return nodeSelfOrAncestorMatchesScanRelevance(node) || !!node.querySelector?.(scanRelevantSelector) || nodeLooksLikeTimelineQuestion(node);
   }
 
   function isChatContentMutation(mutation) {
     const target = mutation.target;
-    if (target?.closest?.('[data-message-author-role], [data-testid="conversation-turn"], main .prose')) {
-      return false;
-    }
-    return false;
+    if (!target?.closest?.('[data-message-author-role], [data-testid="conversation-turn"], main .prose')) return false;
+    return !Array.from(mutation.addedNodes).some((node) => node.nodeType === 1 && isScanRelevantNode(node)) &&
+      !Array.from(mutation.removedNodes).some((node) => node.nodeType === 1 && isScanRelevantNode(node));
   }
 
   function shouldScheduleScan(mutations) {
@@ -2664,7 +2785,9 @@
       if (isChatContentMutation(mutation)) return false;
       const target = mutation.target;
       if (isExtensionUiNode(target)) return false;
-      return Array.from(mutation.addedNodes).some((node) => node.nodeType === 1 && !isExtensionUiNode(node)) || Array.from(mutation.removedNodes).some((node) => node.nodeType === 1);
+      if (target?.nodeType === 1 && nodeSelfOrAncestorMatchesScanRelevance(target)) return true;
+      const changedNodes = [...Array.from(mutation.addedNodes), ...Array.from(mutation.removedNodes)];
+      return changedNodes.some((node) => node.nodeType === 1 && isScanRelevantNode(node));
     });
   }
 
@@ -2691,9 +2814,10 @@
   let codexPlusResizeRafId = 0;
   window.__codexPlusResizeHandler = () => {
     cancelAnimationFrame(codexPlusResizeRafId);
-    codexPlusResizeRafId = requestAnimationFrame(() =>
-      updateFloatingCodexPlusMenuPosition(document.getElementById(codexPlusMenuId))
-    );
+    codexPlusResizeRafId = requestAnimationFrame(() => {
+      updateFloatingCodexPlusMenuPosition(document.getElementById(codexPlusMenuId));
+      runScanStep(refreshConversationTimeline);
+    });
   };
   window.addEventListener("resize", window.__codexPlusResizeHandler);
   window.__codexSessionDeleteObserver?.disconnect();

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -58,6 +58,8 @@ def test_renderer_script_contains_conversation_timeline_contract():
     assert "refreshConversationTimeline" in text
     assert "truncateTimelineQuestion" in text
     assert "timelineQuestionLimit = 40" in text
+    assert "timelineMinTopPercent" in text
+    assert "timelineMaxTopPercent" in text
 
 
 
@@ -74,6 +76,8 @@ def test_renderer_script_detects_user_questions_for_timeline_without_sidebar_sca
     assert "thread-scroll-container" in text
     assert "bg-token-foreground/5" in text
     assert "items-end" in text
+    assert "visibleTimelineNode" in timeline_detection_code
+    assert "timelineNodeId" in timeline_detection_code
     assert "main" in timeline_detection_code
     assert "selectors.sidebarThread" not in timeline_detection_code
     assert "document.body.textContent" not in timeline_detection_code
@@ -100,7 +104,9 @@ def test_renderer_script_refreshes_conversation_timeline_from_scan_loop():
     assert ".codex-conversation-timeline" in extension_code
     assert "[data-message-author-role]" in relevant_code
     assert "[data-testid=\"conversation-turn\"]" in relevant_code
-    assert "main .prose" in relevant_code
+    assert "[class*=\"user-message\"]" in relevant_code
+    assert "nodeLooksLikeTimelineQuestion(node)" in text
+    assert "main .prose" in chat_code
     assert "return false" in chat_code
 
 
@@ -109,27 +115,37 @@ def test_renderer_script_timeline_uses_stable_hover_and_scroll_behavior():
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
     assert "top: calc(72px + 12px)" in text
     assert "bottom: calc(28px + 12px)" in text
+    assert "width: max-content" in text
+    assert "max-width: min(320px, calc(100vw - 72px))" in text
+    assert "overflow: hidden" in text
+    assert "text-overflow: ellipsis" in text
     assert "z-index: 2147482501" in text
     assert "pointer-events: none" in text
     assert "scrollTimelineTarget" in text
     assert "nearestTimelineScroller" in text
+    assert "timelineScrollerViewportTop(scroller)" in text
     assert "scrollTo({" in text
     assert "behavior: \"smooth\"" in text
+    assert "aria-describedby" in text
+    assert "role\", \"tooltip\"" in text
+    assert "keydown" in text[text.index("function createConversationTimelineMarker"):text.index("\n\n  function prepareTimelineQuestions")]
     assert "click" not in text[text.index("function createConversationTimelineMarker"):text.index("\n\n  function refreshConversationTimeline")]
     assert "pointerup" in text[text.index("function createConversationTimelineMarker"):text.index("\n\n  function refreshConversationTimeline")]
 
 
 
-def test_renderer_script_timeline_positions_all_questions_by_document_order():
+def test_renderer_script_timeline_positions_questions_by_scroll_location():
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
-    start = text.index("function timelineMarkerTop")
+    start = text.index("function timelineScrollerViewportTop")
     end = text.index("\n\n  function removeConversationTimeline", start)
     marker_top_code = text[start:end]
 
-    assert "questions.indexOf(question)" in marker_top_code
-    assert "questions.length - 1" in marker_top_code
-    assert "relativeTop" not in marker_top_code
-    assert "getBoundingClientRect" not in marker_top_code
+    assert "timelineRawMarkerTop" in marker_top_code
+    assert "timelineMarkerTops" in marker_top_code
+    assert "getBoundingClientRect" in marker_top_code
+    assert "timelineScrollableHeight(scroller)" in marker_top_code
+    assert "timelineMaxMarkerGapPercent" in marker_top_code
+    assert "questions.indexOf(question)" not in marker_top_code
 
 
 
@@ -223,8 +239,10 @@ def test_renderer_script_ignores_chat_content_mutations_before_scheduling_scan()
     should_start = text.index("function shouldScheduleScan")
     should_end = text.index("\n\n  function runScheduledScan", should_start)
     should_schedule_only = text[should_start:should_end]
-    assert "node.nodeType === 1 && !isExtensionUiNode(node)" in should_schedule_only
-    assert "Array.from(mutation.addedNodes).some(isScanRelevantNode)" not in should_schedule_only
+    assert "nodeSelfOrAncestorMatchesScanRelevance(target)" in should_schedule_only
+    assert "const changedNodes = [...Array.from(mutation.addedNodes), ...Array.from(mutation.removedNodes)]" in should_schedule_only
+    assert "changedNodes.some((node) => node.nodeType === 1 && isScanRelevantNode(node))" in should_schedule_only
+    assert "Array.from(mutation.addedNodes).some((node) => node.nodeType === 1 && isScanRelevantNode(node))" in should_schedule_code
     assert "selectors.sidebarThread" in should_schedule_code
     assert "selectors.appHeader" in should_schedule_code
 
@@ -236,6 +254,7 @@ def test_renderer_script_chat_filter_keeps_relevant_node_escape_hatch():
     relevant_code = text[start:end]
     assert "node.matches?.(scanRelevantSelector)" in relevant_code
     assert "node.querySelector?.(scanRelevantSelector)" in relevant_code
+    assert "nodeLooksLikeTimelineQuestion(node)" in relevant_code
     assert "selectors.archiveNav" in relevant_code
     assert "selectors.disabledInstallButton" in relevant_code
     assert "button[aria-label=\"已归档对话\"]" in text
@@ -291,7 +310,7 @@ def test_renderer_script_sidebar_delete_opens_on_pointerup_when_click_is_unrelia
 
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
     assert "updateDeleteButtonOffsets" in text
-    assert "codexDeleteStyleVersion = \"7\"" in text
+    assert "codexDeleteStyleVersion = \"8\"" in text
     assert "right: 66px" in text
     assert "确认" in text
     assert "归档对话" in text

--- a/tests/test_windows_installer.py
+++ b/tests/test_windows_installer.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 from codex_session_delete.installers import InstallOptions
@@ -45,7 +46,9 @@ def test_default_windows_launcher_uses_current_python_executable(tmp_path):
     assert "$Python = " not in script
     assert "Get-Command python" not in script
     assert "-m codex_session_delete launch" in script
-    assert "pythonw.exe" in script or "python.exe" in script
+    pythonw = Path(sys.executable).with_name("pythonw.exe")
+    expected_python = pythonw if pythonw.exists() else Path(sys.executable)
+    assert str(expected_python) in script
 
 
 def test_build_uninstall_shortcut_script_removes_codex_plus_shortcuts(tmp_path):


### PR DESCRIPTION
## Summary

- Position conversation timeline markers from the actual scroll location of each user prompt instead of distributing them only by question order.
- Harden timeline tooltip rendering so long prompts stay inside the bubble and truncate cleanly.
- Reduce unnecessary timeline rebuilds by using relevant mutation filtering and timeline signatures, while refreshing marker positions on resize.
- Add keyboard activation and tooltip ARIA wiring for timeline markers.
- Make the Windows installer test assert the actual configured Python executable so it passes outside Windows-specific Python paths.

## Root Cause

The timeline tooltip had a max width but no overflow clipping, so long prompt summaries could draw outside the visible bubble. Marker placement also ignored real scroll positions, and the mutation scheduler was broad enough to rebuild the timeline for many unrelated DOM changes.

## Validation

- `node --check codex_session_delete/inject/renderer-inject.js`
- `uv run --extra test python -m pytest -q`
