### PR TITLE
Fix provider sync ghost workspace roots

### DIFF
--- a/codex_session_delete/provider_sync.py
+++ b/codex_session_delete/provider_sync.py
@@ -310,57 +310,55 @@ def count_array_changes(previous: list[str], next_values: list[str]) -> int:
     return sum(1 for index in range(compared) if (previous[index] if index < len(previous) else None) != (next_values[index] if index < len(next_values) else None))
 
 
-def normalized_global_state(state: dict[str, object]) -> tuple[list[str], list[str], object, object]:
-    saved_roots = path_array(state.get("electron-saved-workspace-roots"))
-    project_order = path_array(state.get("project-order"))
-    active_roots = path_array(state.get("active-workspace-roots"))
-    next_saved_roots = dedupe_paths(
-        [*project_order, *saved_roots, *active_roots] if project_order else [*saved_roots, *active_roots]
-    )
-    next_project_order = dedupe_paths([*project_order, *saved_roots] if project_order else next_saved_roots)
-    next_active_roots = dedupe_paths(active_roots)
-    original_active_value = state.get("active-workspace-roots")
-    next_active_value: object
-    if isinstance(original_active_value, list):
-        next_active_value = next_active_roots
-    else:
-        next_active_value = next_active_roots[0] if next_active_roots else original_active_value
-    next_labels = resolve_global_state_keyed_paths(state.get("electron-workspace-root-labels"))
-    return next_saved_roots, next_project_order, next_active_value, next_labels
+def normalize_active_workspace_roots(value: object) -> object:
+    if isinstance(value, list):
+        return dedupe_paths(value)
+    normalized = dedupe_paths(path_array(value))
+    return normalized[0] if normalized else value
+
+
+def normalized_global_state(state: dict[str, object]) -> dict[str, object]:
+    next_state: dict[str, object] = {}
+    if "electron-saved-workspace-roots" in state:
+        next_state["electron-saved-workspace-roots"] = dedupe_paths(path_array(state.get("electron-saved-workspace-roots")))
+    if "project-order" in state:
+        next_state["project-order"] = dedupe_paths(path_array(state.get("project-order")))
+    if "active-workspace-roots" in state:
+        next_state["active-workspace-roots"] = normalize_active_workspace_roots(state.get("active-workspace-roots"))
+    if "electron-workspace-root-labels" in state:
+        next_state["electron-workspace-root-labels"] = resolve_global_state_keyed_paths(state.get("electron-workspace-root-labels"))
+    return next_state
+
+
+def count_global_state_changes(state: dict[str, object], next_state: dict[str, object]) -> int:
+    total = 0
+    for key in ("electron-saved-workspace-roots", "project-order"):
+        if key in next_state:
+            total += count_array_changes(path_array(state.get(key)), next_state[key] if isinstance(next_state[key], list) else path_array(next_state[key]))
+    if "active-workspace-roots" in next_state:
+        original_active_value = state.get("active-workspace-roots")
+        next_active_value = next_state["active-workspace-roots"]
+        if isinstance(original_active_value, list):
+            total += count_array_changes(path_array(original_active_value), next_active_value if isinstance(next_active_value, list) else path_array(next_active_value))
+        elif original_active_value != next_active_value:
+            total += 1
+    if "electron-workspace-root-labels" in next_state:
+        total += 1 if next_state["electron-workspace-root-labels"] != state.get("electron-workspace-root-labels") else 0
+    return total
 
 
 def count_global_state_updates(global_state_path: Path) -> int:
     state = load_global_state(global_state_path)
-    next_saved_roots, next_project_order, next_active_value, next_labels = normalized_global_state(state)
-    total = count_array_changes(path_array(state.get("electron-saved-workspace-roots")), next_saved_roots)
-    total += count_array_changes(path_array(state.get("project-order")), next_project_order)
-    original_active_value = state.get("active-workspace-roots")
-    if isinstance(original_active_value, list):
-        total += count_array_changes(path_array(original_active_value), next_active_value if isinstance(next_active_value, list) else [])
-    elif original_active_value != next_active_value:
-        total += 1
-    if "electron-workspace-root-labels" in state:
-        total += 1 if next_labels != state.get("electron-workspace-root-labels") else 0
-    return total
+    next_state = normalized_global_state(state)
+    return count_global_state_changes(state, next_state)
 
 
 def apply_global_state_update(global_state_path: Path) -> int:
     state = load_global_state(global_state_path)
-    next_saved_roots, next_project_order, next_active_value, next_labels = normalized_global_state(state)
-    total = count_array_changes(path_array(state.get("electron-saved-workspace-roots")), next_saved_roots)
-    total += count_array_changes(path_array(state.get("project-order")), next_project_order)
-    original_active_value = state.get("active-workspace-roots")
-    if isinstance(original_active_value, list):
-        total += count_array_changes(path_array(original_active_value), next_active_value if isinstance(next_active_value, list) else [])
-    elif original_active_value != next_active_value:
-        total += 1
-    state["electron-saved-workspace-roots"] = next_saved_roots
-    state["project-order"] = next_project_order
-    state["active-workspace-roots"] = next_active_value
-    if "electron-workspace-root-labels" in state:
-        if next_labels != state.get("electron-workspace-root-labels"):
-            state["electron-workspace-root-labels"] = next_labels
-            total += 1
+    next_state = normalized_global_state(state)
+    total = count_global_state_changes(state, next_state)
+    for key, value in next_state.items():
+        state[key] = value
     if total:
         global_state_path.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
     return total

--- a/codex_session_delete/provider_sync.py
+++ b/codex_session_delete/provider_sync.py
@@ -62,14 +62,14 @@ def run_provider_sync(codex_home: Path | None = None) -> ProviderSyncResult:
         thread_ids_with_user_events = {change.thread_id for change in changes if change.thread_id and change.has_user_event}
         cwd_by_thread_id = {change.thread_id: change.cwd for change in changes if change.thread_id and change.cwd}
         sqlite_update_count = count_sqlite_updates(home / "state_5.sqlite", target_provider, thread_ids_with_user_events, cwd_by_thread_id)
-        global_state_update_count = count_global_state_updates(home / ".codex-global-state.json", cwd_by_thread_id)
+        global_state_update_count = count_global_state_updates(home / ".codex-global-state.json")
         if not rewrite_changes and sqlite_update_count == 0 and global_state_update_count == 0:
             return ProviderSyncResult(ProviderSyncStatus.SYNCED, "Provider sync already up to date", target_provider)
         backup_dir = create_backup(home, target_provider, rewrite_changes)
         try:
             apply_session_changes(rewrite_changes)
             sqlite_rows_updated = apply_sqlite_update(home / "state_5.sqlite", target_provider, thread_ids_with_user_events, cwd_by_thread_id)
-            apply_global_state_update(home / ".codex-global-state.json", cwd_by_thread_id)
+            apply_global_state_update(home / ".codex-global-state.json")
             prune_backups(home)
         except Exception:
             restore_session_changes(rewrite_changes)
@@ -287,10 +287,6 @@ def dedupe_paths(paths: list[str]) -> list[str]:
     return result
 
 
-def normalized_workspace_roots(cwd_by_thread_id: dict[str | None, str]) -> list[str]:
-    return dedupe_paths([cwd for cwd in cwd_by_thread_id.values() if cwd])
-
-
 def path_array(value: object) -> list[str]:
     if isinstance(value, list):
         return [item for item in value if isinstance(item, str) and item.strip()]
@@ -309,43 +305,59 @@ def resolve_global_state_keyed_paths(value: object) -> object:
     return result
 
 
-def append_missing_values(values: object, additions: list[str]) -> tuple[list[str], int]:
-    current = path_array(values)
-    next_values = dedupe_paths([*current, *additions])
-    return next_values, count_array_changes(current, next_values)
-
-
 def count_array_changes(previous: list[str], next_values: list[str]) -> int:
     compared = max(len(previous), len(next_values))
     return sum(1 for index in range(compared) if (previous[index] if index < len(previous) else None) != (next_values[index] if index < len(next_values) else None))
 
 
-def count_global_state_updates(global_state_path: Path, cwd_by_thread_id: dict[str | None, str]) -> int:
-    roots = normalized_workspace_roots(cwd_by_thread_id)
-    if not roots:
-        return 0
+def normalized_global_state(state: dict[str, object]) -> tuple[list[str], list[str], object, object]:
+    saved_roots = path_array(state.get("electron-saved-workspace-roots"))
+    project_order = path_array(state.get("project-order"))
+    active_roots = path_array(state.get("active-workspace-roots"))
+    next_saved_roots = dedupe_paths(
+        [*project_order, *saved_roots, *active_roots] if project_order else [*saved_roots, *active_roots]
+    )
+    next_project_order = dedupe_paths([*project_order, *saved_roots] if project_order else next_saved_roots)
+    next_active_roots = dedupe_paths(active_roots)
+    original_active_value = state.get("active-workspace-roots")
+    next_active_value: object
+    if isinstance(original_active_value, list):
+        next_active_value = next_active_roots
+    else:
+        next_active_value = next_active_roots[0] if next_active_roots else original_active_value
+    next_labels = resolve_global_state_keyed_paths(state.get("electron-workspace-root-labels"))
+    return next_saved_roots, next_project_order, next_active_value, next_labels
+
+
+def count_global_state_updates(global_state_path: Path) -> int:
     state = load_global_state(global_state_path)
-    total = 0
-    for key in ("electron-saved-workspace-roots", "project-order", "active-workspace-roots"):
-        _, changed = append_missing_values(state.get(key), roots)
-        total += changed
+    next_saved_roots, next_project_order, next_active_value, next_labels = normalized_global_state(state)
+    total = count_array_changes(path_array(state.get("electron-saved-workspace-roots")), next_saved_roots)
+    total += count_array_changes(path_array(state.get("project-order")), next_project_order)
+    original_active_value = state.get("active-workspace-roots")
+    if isinstance(original_active_value, list):
+        total += count_array_changes(path_array(original_active_value), next_active_value if isinstance(next_active_value, list) else [])
+    elif original_active_value != next_active_value:
+        total += 1
     if "electron-workspace-root-labels" in state:
-        next_labels = resolve_global_state_keyed_paths(state.get("electron-workspace-root-labels"))
         total += 1 if next_labels != state.get("electron-workspace-root-labels") else 0
     return total
 
 
-def apply_global_state_update(global_state_path: Path, cwd_by_thread_id: dict[str | None, str]) -> int:
-    roots = normalized_workspace_roots(cwd_by_thread_id)
-    if not roots:
-        return 0
+def apply_global_state_update(global_state_path: Path) -> int:
     state = load_global_state(global_state_path)
-    total = 0
-    for key in ("electron-saved-workspace-roots", "project-order", "active-workspace-roots"):
-        state[key], changed = append_missing_values(state.get(key), roots)
-        total += changed
+    next_saved_roots, next_project_order, next_active_value, next_labels = normalized_global_state(state)
+    total = count_array_changes(path_array(state.get("electron-saved-workspace-roots")), next_saved_roots)
+    total += count_array_changes(path_array(state.get("project-order")), next_project_order)
+    original_active_value = state.get("active-workspace-roots")
+    if isinstance(original_active_value, list):
+        total += count_array_changes(path_array(original_active_value), next_active_value if isinstance(next_active_value, list) else [])
+    elif original_active_value != next_active_value:
+        total += 1
+    state["electron-saved-workspace-roots"] = next_saved_roots
+    state["project-order"] = next_project_order
+    state["active-workspace-roots"] = next_active_value
     if "electron-workspace-root-labels" in state:
-        next_labels = resolve_global_state_keyed_paths(state.get("electron-workspace-root-labels"))
         if next_labels != state.get("electron-workspace-root-labels"):
             state["electron-workspace-root-labels"] = next_labels
             total += 1

--- a/tests/test_provider_sync.py
+++ b/tests/test_provider_sync.py
@@ -141,6 +141,54 @@ def test_provider_sync_does_not_create_workspace_roots_from_historical_thread_cw
     assert state["active-workspace-roots"] == []
 
 
+def test_provider_sync_does_not_reintroduce_removed_roots_from_other_lists(tmp_path):
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    (codex_home / "config.toml").write_text('model_provider = "apigather"\n', encoding="utf-8")
+    (codex_home / ".codex-global-state.json").write_text(
+        json.dumps(
+            {
+                "electron-saved-workspace-roots": [],
+                "project-order": ["\\\\?\\C:\\ghost-plugin"],
+                "active-workspace-roots": ["\\\\?\\C:\\ghost-plugin"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    write_rollout(codex_home / "sessions" / "rollout-current.jsonl", provider="apigather", thread_id="thread-1", cwd="C:/workspace")
+    create_state_db(codex_home / "state_5.sqlite")
+
+    result = run_provider_sync(codex_home)
+
+    assert result.status == ProviderSyncStatus.SYNCED
+    state = json.loads((codex_home / ".codex-global-state.json").read_text(encoding="utf-8"))
+    assert state["electron-saved-workspace-roots"] == []
+    assert state["project-order"] == ["C:/ghost-plugin"]
+    assert state["active-workspace-roots"] == ["C:/ghost-plugin"]
+
+
+def test_provider_sync_normalizes_scalar_active_workspace_root(tmp_path):
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    (codex_home / "config.toml").write_text('model_provider = "apigather"\n', encoding="utf-8")
+    (codex_home / ".codex-global-state.json").write_text(
+        json.dumps(
+            {
+                "active-workspace-roots": "\\\\?\\C:\\workspace",
+            }
+        ),
+        encoding="utf-8",
+    )
+    write_rollout(codex_home / "sessions" / "rollout-current.jsonl", provider="apigather", thread_id="thread-1", cwd="C:/workspace")
+    create_state_db(codex_home / "state_5.sqlite")
+
+    result = run_provider_sync(codex_home)
+
+    assert result.status == ProviderSyncStatus.SYNCED
+    state = json.loads((codex_home / ".codex-global-state.json").read_text(encoding="utf-8"))
+    assert state["active-workspace-roots"] == "C:/workspace"
+
+
 def test_provider_sync_skips_when_lock_exists(tmp_path):
     codex_home = tmp_path / ".codex"
     codex_home.mkdir()

--- a/tests/test_provider_sync.py
+++ b/tests/test_provider_sync.py
@@ -82,7 +82,7 @@ def test_provider_sync_normalizes_sqlite_cwd_to_desktop_path(tmp_path):
     assert row == ("C:/workspace",)
 
 
-def test_provider_sync_resolves_global_state_roots_from_sqlite_cwd_stats(tmp_path):
+def test_provider_sync_normalizes_existing_global_state_roots(tmp_path):
     codex_home = tmp_path / ".codex"
     codex_home.mkdir()
     (codex_home / "config.toml").write_text('model_provider = "apigather"\n', encoding="utf-8")
@@ -108,6 +108,37 @@ def test_provider_sync_resolves_global_state_roots_from_sqlite_cwd_stats(tmp_pat
     assert state["project-order"] == ["C:/workspace"]
     assert state["active-workspace-roots"] == ["C:/workspace"]
     assert state["electron-workspace-root-labels"] == {"C:/workspace": "Workspace"}
+
+
+def test_provider_sync_does_not_create_workspace_roots_from_historical_thread_cwds(tmp_path):
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    (codex_home / "config.toml").write_text('model_provider = "apigather"\n', encoding="utf-8")
+    (codex_home / ".codex-global-state.json").write_text(
+        json.dumps(
+            {
+                "electron-saved-workspace-roots": [],
+                "project-order": [],
+                "active-workspace-roots": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    write_rollout(
+        codex_home / "sessions" / "rollout-current.jsonl",
+        provider="apigather",
+        thread_id="thread-1",
+        cwd="C:/Users/shallfun/.codex/plugins/example-plugin",
+    )
+    create_state_db(codex_home / "state_5.sqlite")
+
+    result = run_provider_sync(codex_home)
+
+    assert result.status == ProviderSyncStatus.SYNCED
+    state = json.loads((codex_home / ".codex-global-state.json").read_text(encoding="utf-8"))
+    assert state["electron-saved-workspace-roots"] == []
+    assert state["project-order"] == []
+    assert state["active-workspace-roots"] == []
 
 
 def test_provider_sync_skips_when_lock_exists(tmp_path):


### PR DESCRIPTION
## Summary

Fix a Provider Sync regression where historical thread `cwd` values were being promoted into sidebar workspace roots, causing ghost directories to appear in the chat/project list.

This issue was reported by @15290391025 in [#85](https://github.com/BigPizzaV3/CodexPlusPlus/issues/85).

This fix prevents new ghost directories from being created. Existing ghost directories that were already written into `.codex-global-state.json` are intentionally **not** auto-removed; for safety, users should clean them up manually.

## Problem

When Provider Sync is enabled, Codex++ synchronizes historical session metadata on launch so older conversations remain visible after switching `model_provider`.

However, the current implementation was doing more than rollout and SQLite synchronization. It also appended historical thread `cwd` values into these workspace-root caches inside `.codex-global-state.json`:

- `electron-saved-workspace-roots`
- `project-order`
- `active-workspace-roots`

That incorrectly treated “directories used by historical threads” as “real sidebar projects”.

As a result:

- non-project directories could appear in the chat list
- plugin directories, internal directories, and temporary paths could be promoted into projects
- Provider Sync fixed history visibility while also polluting the project list

## Root Cause

The issue is in the Provider Sync global-state update strategy, not in rollout or SQLite synchronization itself.

The previous logic did this:

1. collect all thread `cwd` values from historical rollouts
2. deduplicate them into `roots`
3. append them into the global workspace-root lists

That means it treated historical thread context paths as a source of project roots.

This step was too aggressive and is the direct cause of ghost directories.

## Fix

This change is intentionally conservative. It does not alter the main Provider Sync behavior. It only narrows the workspace-root synchronization strategy.

### What changed

- Stop generating new workspace roots from historical thread `cwd` values
- Only normalize and reconcile existing global-state roots:
  - `electron-saved-workspace-roots`
  - `project-order`
  - `active-workspace-roots`
  - `electron-workspace-root-labels`
- Keep the existing rollout and SQLite synchronization behavior:
  - rollout `model_provider`
  - SQLite `model_provider`
  - `has_user_event`
  - `cwd`

### Result

- Provider Sync still preserves historical conversation visibility
- but it no longer auto-promotes historical thread paths into sidebar projects
- plugin-like paths will no longer be newly injected into the workspace/project list
- previously created ghost directories are left untouched and should be cleaned up manually by the user if needed

## Validation

Passed:

- `pytest -q tests/test_provider_sync.py`

Result:

- `7 passed`

## Tests

Added or updated focused coverage for:

- existing global-state roots are still normalized correctly
- historical thread `cwd` values no longer create new workspace roots

## Scope

Changed files:

- `codex_session_delete/provider_sync.py`
- `tests/test_provider_sync.py`

## Recommendations

This is a lightweight fix. If users are particularly concerned about provider synchronization, they should be advised to use other independent synchronization solutions on GitHub. Completely porting other synchronization solutions, including backup, inspection, and diagnostic features, to this project would incur significant maintenance costs.