### PR TITLE
修复 macOS 下 helper 自行退出

### DIFF
--- a/codex_session_delete/cli.py
+++ b/codex_session_delete/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import requests
 import subprocess
 import sys
 import traceback
@@ -98,14 +99,14 @@ def wait_for_windows_process_id(process_id: int) -> None:
         kernel32.CloseHandle(handle)
 
 
-def wait_for_shutdown(server: HelperServer, codex_proc) -> None:
+def wait_for_shutdown(server: HelperServer, codex_proc, debug_port: int = 9229) -> None:
     try:
         if isinstance(codex_proc, int):
             wait_for_windows_process_id(codex_proc)
         elif codex_proc is None and sys.platform == "darwin":
             import time as _time
             while True:
-                if not is_macos_codex_running():
+                if not is_macos_codex_running(debug_port):
                     break
                 _time.sleep(2)
         elif codex_proc is not None:
@@ -116,9 +117,23 @@ def wait_for_shutdown(server: HelperServer, codex_proc) -> None:
         shutdown_helper(server)
 
 
-def is_macos_codex_running() -> bool:
+def is_macos_codex_running(debug_port: int = 9229) -> bool:
+    try:
+        session = requests.Session()
+        session.trust_env = False
+        response = session.get(f"http://127.0.0.1:{debug_port}/json", timeout=1)
+        response.raise_for_status()
+        targets = response.json()
+        if any(
+            target.get("type") == "page"
+            and "codex" in f"{target.get('title', '')} {target.get('url', '')}".lower()
+            for target in targets
+        ):
+            return True
+    except Exception:
+        pass
     result = subprocess.run(["ps", "-axo", "pid=,command="], capture_output=True, text=True, check=False)
-    return any("/Codex.app/Contents/MacOS/Codex " in f"{line} " for line in result.stdout.splitlines())
+    return any(".app/Contents/MacOS/Codex " in f"{line} " for line in result.stdout.splitlines())
 
 
 def stop_existing_windows_launchers() -> None:
@@ -156,7 +171,7 @@ def run_launch(args: argparse.Namespace) -> int:
         raise
     print(f"Codex session delete helper running on http://127.0.0.1:{server.port}")
     print("Keep this terminal open while using the delete buttons. Press Ctrl+C to stop.")
-    wait_for_shutdown(server, codex_proc)
+    wait_for_shutdown(server, codex_proc, args.debug_port)
     return 0
 
 

--- a/tests/test_launcher_cli.py
+++ b/tests/test_launcher_cli.py
@@ -140,24 +140,24 @@ def test_non_windows_port_selector_keeps_requested_port(monkeypatch):
 def test_cli_keeps_helper_server_alive_after_injection(monkeypatch):
     waited = []
     monkeypatch.setattr(cli, "launch_and_inject", lambda *args: (FakeServer(), None))
-    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc: waited.append(server.port))
+    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc, debug_port=9229: waited.append((server.port, debug_port)))
 
     exit_code = cli.main([])
 
     assert exit_code == 0
-    assert waited == [57321]
+    assert waited == [(57321, 9229)]
 
 
 def test_cli_launch_subcommand_keeps_helper_server_alive_after_injection(monkeypatch):
     waited = []
     calls = []
     monkeypatch.setattr(cli, "launch_and_inject", lambda *args: calls.append(args) or (FakeServer(), None))
-    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc: waited.append(server.port))
+    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc, debug_port=9229: waited.append((server.port, debug_port)))
 
     exit_code = cli.main(["launch"])
 
     assert exit_code == 0
-    assert waited == [57321]
+    assert waited == [(57321, 9229)]
     assert len(calls) == 1
 
 
@@ -310,7 +310,7 @@ def test_cli_launch_runs_launcher_cleanup_before_injection(monkeypatch):
     events = []
     monkeypatch.setattr(cli, "stop_existing_windows_launchers", lambda: events.append("cleanup"))
     monkeypatch.setattr(cli, "launch_and_inject", lambda *args: events.append("launch") or (FakeServer(), None))
-    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc: events.append("wait"))
+    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc, debug_port=9229: events.append("wait"))
 
     exit_code = cli.main(["launch"])
 
@@ -323,7 +323,7 @@ def test_cli_launch_checks_update_before_injection(monkeypatch):
     monkeypatch.setattr(cli, "stop_existing_windows_launchers", lambda: events.append("cleanup"))
     monkeypatch.setattr(cli, "maybe_print_update_notice", lambda: events.append("check-update"))
     monkeypatch.setattr(cli, "launch_and_inject", lambda *args: events.append("launch") or (FakeServer(), None))
-    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc: events.append("wait"))
+    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc, debug_port=9229: events.append("wait"))
 
     exit_code = cli.main(["launch"])
 
@@ -478,9 +478,61 @@ def test_wait_for_shutdown_waits_for_popen_like_process():
 
 
 def test_is_macos_codex_running_uses_ps_comm(monkeypatch):
+    class Session:
+        trust_env = True
+
+        def get(self, *args, **kwargs):
+            raise RuntimeError("cdp unavailable")
+
     class Result:
         stdout = "123 /Applications/Codex.app/Contents/MacOS/Codex --remote-debugging-port=9229\n456 /usr/bin/other\n"
 
+    monkeypatch.setattr(cli.requests, "Session", lambda: Session())
     monkeypatch.setattr(cli.subprocess, "run", lambda *args, **kwargs: Result())
 
     assert cli.is_macos_codex_running() is True
+
+
+def test_is_macos_codex_running_prefers_cdp_page(monkeypatch):
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return [{"type": "page", "title": "Codex", "url": "app://-/index.html?hostId=local"}]
+
+    class Session:
+        trust_env = True
+
+        def get(self, url, timeout):
+            assert url == "http://127.0.0.1:9229/json"
+            assert timeout == 1
+            assert self.trust_env is False
+            return Response()
+
+    monkeypatch.setattr(cli.requests, "Session", lambda: Session())
+    monkeypatch.setattr(cli.subprocess, "run", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("ps fallback should not run")))
+
+    assert cli.is_macos_codex_running() is True
+
+
+def test_is_macos_codex_running_uses_custom_debug_port(monkeypatch):
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return [{"type": "page", "title": "Codex", "url": "app://-/index.html?hostId=local"}]
+
+    class Session:
+        trust_env = True
+
+        def get(self, url, timeout):
+            assert url == "http://127.0.0.1:9333/json"
+            assert timeout == 1
+            assert self.trust_env is False
+            return Response()
+
+    monkeypatch.setattr(cli.requests, "Session", lambda: Session())
+
+    assert cli.is_macos_codex_running(9333) is True


### PR DESCRIPTION
本次修复 macOS 环境下 Codex++ 使用一段时间后顶部状态显示“后端已断开”的问题。

排查现场：

Codex CDP 端口 127.0.0.1:9229 仍然正常监听
访问 http://127.0.0.1:9229/json 可以看到 Codex page
Codex++ helper 端口 127.0.0.1:57321 已经没有进程监听
launcher.log 没有新的启动失败日志
这说明 Codex App 本身和 CDP 仍然正常，但 Codex++ 的 helper server 被关闭了。

原因：

macOS 版 launcher 在启动 Codex 后，会通过 is_macos_codex_running() 判断 Codex 是否仍在运行。

原逻辑主要依赖 ps 进程命令行匹配。这个判断比较脆弱，一旦轮询时误判 Codex 不存在，就会进入 shutdown 流程并关闭 helper server，导致 57321 后端断开。

修改：

优先访问当前 debug port 的 /json
如果 CDP target 列表里仍然存在 Codex page，则认为 Codex 仍在运行
CDP 不可用时，再回退到 ps 进程检查
将 --debug-port 传递到 shutdown 等待链路，避免自定义端口时仍然写死检查 9229
放宽 ps fallback 的路径匹配，兼容不同 .app 名称
影响范围：

该改动只作用于 macOS 分支：sys.platform == "darwin" 且 codex_proc is None。

Windows 仍然使用原有的进程 ID 等待方式，不会走新的 CDP 存活检查。

验证：

.venv/bin/python -m pytest tests/test_launcher_cli.py -q
38 passed in 0.14s
