### PR TITLE
fix(macOS): patch Electron fuse to re-enable CDP debug port for Codex.app v26.x

### DIFF
--- a/codex_session_delete/electron_fuses.py
+++ b/codex_session_delete/electron_fuses.py
@@ -1,0 +1,90 @@
+"""Utilities for reading and patching Electron fuses in macOS app bundles.
+
+Electron embeds fuse configuration as a byte sequence in the framework binary.
+Format after sentinel: [version: 1B] [count: 1B] [fuse_0 ... fuse_N: each 0x30=off or 0x31=on]
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_SENTINEL = b"dL7pKGdnNz796PbbjQWNKmHXBZaB9tsX"
+_DISABLED = 0x30
+_ENABLED = 0x31
+
+# Fuse index within the fuse byte array
+_FUSE_CLI_INSPECT_ARGS = 3  # EnableNodeCliInspectArguments
+
+
+def _electron_framework_binary(app_path: Path) -> Path | None:
+    fw = (
+        app_path
+        / "Contents"
+        / "Frameworks"
+        / "Electron Framework.framework"
+        / "Versions"
+        / "A"
+        / "Electron Framework"
+    )
+    return fw if fw.is_file() else None
+
+
+def _fuse_offset(data: bytes, fuse_index: int) -> int | None:
+    pos = data.find(_SENTINEL)
+    if pos == -1:
+        return None
+    # sentinel + version byte (1) + count byte (1) + fuse_index
+    offset = pos + len(_SENTINEL) + 2 + fuse_index
+    if offset >= len(data):
+        return None
+    return offset
+
+
+def is_cli_inspect_enabled(app_path: Path) -> bool:
+    """Return True if EnableNodeCliInspectArguments is already on (or binary not found)."""
+    binary = _electron_framework_binary(app_path)
+    if binary is None:
+        return True
+    data = binary.read_bytes()
+    offset = _fuse_offset(data, _FUSE_CLI_INSPECT_ARGS)
+    if offset is None:
+        return True
+    return data[offset] == _ENABLED
+
+
+def ensure_cli_inspect_enabled(app_path: Path) -> None:
+    """Enable EnableNodeCliInspectArguments and re-sign the app if needed.
+
+    Raises RuntimeError if the fuse cannot be patched.
+    """
+    if is_cli_inspect_enabled(app_path):
+        return
+
+    binary = _electron_framework_binary(app_path)
+    if binary is None:
+        return
+
+    data = bytearray(binary.read_bytes())
+    offset = _fuse_offset(bytes(data), _FUSE_CLI_INSPECT_ARGS)
+    if offset is None:
+        raise RuntimeError("Could not locate Electron fuse table in Codex framework binary.")
+
+    data[offset] = _ENABLED
+    try:
+        binary.write_bytes(bytes(data))
+    except PermissionError as exc:
+        raise RuntimeError(
+            f"Cannot write to {binary} — try running Codex++ with elevated permissions."
+        ) from exc
+
+    try:
+        subprocess.run(
+            ["codesign", "--force", "--deep", "--sign", "-", str(app_path)],
+            check=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"Ad-hoc re-signing of {app_path} failed: {exc.stderr.decode(errors='replace')}"
+        ) from exc

--- a/codex_session_delete/launcher.py
+++ b/codex_session_delete/launcher.py
@@ -349,6 +349,9 @@ def launch_and_inject(app_dir: Path | None, db_path: Path | None, backup_dir: Pa
         sync_result = run_provider_sync()
         if sync_result.status == ProviderSyncStatus.SKIPPED:
             print(f"Provider sync skipped: {sync_result.message}")
+    if sys.platform == "darwin":
+        from codex_session_delete.electron_fuses import ensure_cli_inspect_enabled
+        ensure_cli_inspect_enabled(resolved_app_dir)
     server = start_helper(service, export_service, port=helper_port)
     codex_proc = None
     try:


### PR DESCRIPTION
## 问题根因

Codex.app v26.x 通过 Electron Fuse 在编译时禁用了 `EnableNodeCliInspectArguments`，导致 `--remote-debugging-port` 参数完全失效，Codex++ 的 CDP 注入必然失败并闪退。

可用以下命令复现：
```bash
npx @electron/fuses read --app /Applications/Codex.app
# EnableNodeCliInspectArguments is Disabled  ← 问题所在
```

错误表现：`Connection refused` on `127.0.0.1:9229`

## 修复方案

在 macOS 上 launch 之前，检测该 fuse 是否被禁用。若禁用，则：

1. 在 `Electron Framework` 二进制中定位 fuse sentinel（`dL7pKGdnNz796PbbjQWNKmHXBZaB9tsX`）
2. 将 `EnableNodeCliInspectArguments` 对应字节从 `0x30`（off）翻转为 `0x31`（on）
3. 用 `codesign --force --deep --sign -` 做 ad-hoc 重签名

**为什么 ad-hoc 重签名可行？** Codex.app 本身就是 ad-hoc 签名分发的（`Signature=adhoc, flags=0x2`），无需 Apple Developer 证书，重签名后行为与原版完全一致。

**幂等性**：已 patch 过则直接跳过，不重复操作。

**Codex 更新后**：新版 Codex.app 会覆盖 fuse，下次启动 Codex++ 时自动重新 patch。

## 变更文件

- `codex_session_delete/electron_fuses.py`（新增）：fuse 读取、翻转、重签名工具函数
- `codex_session_delete/launcher.py`：在 macOS launch 前调用 `ensure_cli_inspect_enabled`

## 验证

本地测试通过（macOS 15, Codex.app 26.506.31421, arm64）：
- Codex++ 启动后 `http://127.0.0.1:9229/json` 返回正常 targets
- helper `/health` 返回 `{"ok": true}`
- 注入成功，Codex++ 功能正常运行