### PR TITLE
Respect CODEX_HOME for local storage

### DIFF
--- a/codex_session_delete/cli.py
+++ b/codex_session_delete/cli.py
@@ -14,9 +14,18 @@ from codex_session_delete import updater
 from codex_session_delete import watcher
 
 
+def codex_home() -> Path:
+    configured = os.environ.get("CODEX_HOME")
+    return Path(configured).expanduser() if configured else Path.home() / ".codex"
+
+
+def default_db_path() -> Path:
+    return codex_home() / "state_5.sqlite"
+
+
 def add_launch_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--app-dir", type=Path, default=None)
-    parser.add_argument("--db", type=Path, default=Path.home() / ".codex" / "state_5.sqlite", help="SQLite database path for local deletion fallback")
+    parser.add_argument("--db", type=Path, default=default_db_path(), help="SQLite database path for local deletion fallback")
     parser.add_argument("--backup-dir", type=Path, default=Path.home() / ".codex-session-delete" / "backups")
     parser.add_argument("--debug-port", type=int, default=9229)
     parser.add_argument("--helper-port", type=int, default=57321)

--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -26,7 +26,7 @@
   const codexDeleteStyleVersion = "8";
   const codexPlusMenuId = "codex-plus-menu";
   const codexPlusMenuFloatingClass = "codex-plus-menu-floating";
-  const codexDeleteVersion = "6";
+  const codexDeleteVersion = "7";
   const codexExportVersion = "1";
   const codexProjectMoveVersion = "1";
   const codexActionGroupVersion = "2";
@@ -2113,6 +2113,17 @@
     }
   }
 
+  function isThreadMissingResult(result) {
+    const message = String(result?.message || "");
+    return result?.status === "failed" && message.includes("Thread not found in local storage");
+  }
+
+  async function removeOrphanedProjectedRow(row, button, ref) {
+    await setProjectlessThreadIds(ref, "remove").catch(() => {});
+    await clearThreadWorkspaceHints(ref).catch(() => {});
+    removeDeletedRow(row, button, ref);
+  }
+
   function updateDeleteButtonOffsets() {
     sessionRows().forEach((row) => {
       const hasArchiveConfirm = Array.from(row.querySelectorAll("button")).some((button) => {
@@ -2138,6 +2149,9 @@
       if (result.status === "server_deleted" || result.status === "local_deleted") {
         removeDeletedRow(row, button, ref);
         showToast(result.message || "删除成功", result.undo_token);
+      } else if (isThreadMissingResult(result)) {
+        await removeOrphanedProjectedRow(row, button, ref);
+        showToast("已移除本地列表中的失效会话", null);
       } else {
         showToast(result.message || "删除失败", null);
       }

--- a/tests/test_launcher_cli.py
+++ b/tests/test_launcher_cli.py
@@ -161,6 +161,14 @@ def test_cli_launch_subcommand_keeps_helper_server_alive_after_injection(monkeyp
     assert len(calls) == 1
 
 
+def test_cli_default_db_path_uses_codex_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "profile-home"))
+
+    args = cli.build_parser().parse_args(["launch"])
+
+    assert args.db == tmp_path / "profile-home" / "state_5.sqlite"
+
+
 def test_cli_install_dispatches_to_platform_installer(monkeypatch, tmp_path):
     calls = []
     monkeypatch.setattr(cli, "install_codex_plus_plus", lambda options: calls.append(options))

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -396,7 +396,7 @@ def test_renderer_script_toast_does_not_capture_page_interactions():
 def test_renderer_script_sidebar_delete_opens_on_pointerup_when_click_is_unreliable():
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
     assert "openDeleteConfirm" in text
-    assert "codexDeleteVersion = \"6\"" in text
+    assert "codexDeleteVersion = \"7\"" in text
     assert "actionGroupFromRow" in text
     assert "removeActionGroups(row)" in text
     assert "row.dataset.codexDeleteRow = \"false\"" in text
@@ -405,6 +405,16 @@ def test_renderer_script_sidebar_delete_opens_on_pointerup_when_click_is_unrelia
     assert "document.addEventListener(\"pointerup\", handler, true)" in text
     assert "document.addEventListener(\"click\", handler, true)" in text
     assert "deleteButton.dataset.codexDeleteVersion = codexDeleteVersion" in text
+
+
+def test_renderer_script_removes_orphaned_projected_rows_when_thread_is_missing():
+    text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
+    assert "function isThreadMissingResult" in text
+    assert "Thread not found in local storage" in text
+    assert "function removeOrphanedProjectedRow" in text
+    assert "setProjectlessThreadIds(ref, \"remove\")" in text
+    assert "clearThreadWorkspaceHints(ref)" in text
+    assert "已移除本地列表中的失效会话" in text
 
 
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Resolve the default Codex local database from CODEX_HOME when it is set
- Keep the existing ~/.codex/state_5.sqlite fallback when CODEX_HOME is not configured
- Add a CLI parser test for CODEX_HOME based profile storage

## Why
Tools such as CodexSwitcher launch Codex with an isolated CODEX_HOME per account. Codex++ previously always used the default user ~/.codex/state_5.sqlite path, so sidebar delete actions could fail with "Thread not found in local storage" even though the thread existed in the active profile database.

## Test
- python -m pytest tests/test_launcher_cli.py::test_cli_default_db_path_uses_codex_home tests/test_launcher_cli.py::test_cli_launch_subcommand_keeps_helper_server_alive_after_injection -q