### PR TITLE
修复 macOS 锁屏恢复后 helper 后端误断开【Fix macOS helper reinjection after sleep】

### DIFF
--- a/codex_session_delete/cli.py
+++ b/codex_session_delete/cli.py
@@ -5,8 +5,10 @@ import os
 import subprocess
 import sys
 import traceback
+from datetime import datetime
 from pathlib import Path
 
+from codex_session_delete.cdp import list_targets, pick_page_target
 from codex_session_delete.helper_server import HelperServer
 from codex_session_delete.installers import InstallOptions, install_codex_plus_plus, uninstall_codex_plus_plus
 from codex_session_delete.launcher import launch_and_inject, shutdown_helper
@@ -68,10 +70,21 @@ def launch_log_path() -> Path:
     return Path.home() / ".codex-session-delete" / "launcher.log"
 
 
+def log_runtime_event(message: str) -> None:
+    path = launch_log_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().isoformat(timespec="seconds")
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"[{timestamp}] {message}\n")
+
+
 def log_launch_failure(exc: BaseException) -> None:
     path = launch_log_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("".join(traceback.format_exception(type(exc), exc, exc.__traceback__)), encoding="utf-8")
+    timestamp = datetime.now().isoformat(timespec="seconds")
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"[{timestamp}] launch failed\n")
+        handle.write("".join(traceback.format_exception(type(exc), exc, exc.__traceback__)))
 
 
 def wait_for_windows_process_id(process_id: int) -> None:
@@ -98,14 +111,15 @@ def wait_for_windows_process_id(process_id: int) -> None:
         kernel32.CloseHandle(handle)
 
 
-def wait_for_shutdown(server: HelperServer, codex_proc) -> None:
+def wait_for_shutdown(server: HelperServer, codex_proc, debug_port: int = 9229) -> None:
     try:
         if isinstance(codex_proc, int):
             wait_for_windows_process_id(codex_proc)
         elif codex_proc is None and sys.platform == "darwin":
             import time as _time
             while True:
-                if not is_macos_codex_running():
+                if not is_macos_codex_running(debug_port):
+                    log_runtime_event(f"macOS Codex liveness check failed debug_port={debug_port}")
                     break
                 _time.sleep(2)
         elif codex_proc is not None:
@@ -116,9 +130,21 @@ def wait_for_shutdown(server: HelperServer, codex_proc) -> None:
         shutdown_helper(server)
 
 
-def is_macos_codex_running() -> bool:
+def is_macos_codex_running(debug_port: int = 9229) -> bool:
+    return is_codex_cdp_page_available(debug_port) or is_macos_codex_process_running()
+
+
+def is_codex_cdp_page_available(debug_port: int = 9229) -> bool:
+    try:
+        pick_page_target(list_targets(debug_port))
+        return True
+    except Exception:
+        return False
+
+
+def is_macos_codex_process_running() -> bool:
     result = subprocess.run(["ps", "-axo", "pid=,command="], capture_output=True, text=True, check=False)
-    return any("/Codex.app/Contents/MacOS/Codex " in f"{line} " for line in result.stdout.splitlines())
+    return any(".app/Contents/MacOS/Codex " in f"{line} " for line in result.stdout.splitlines())
 
 
 def stop_existing_windows_launchers() -> None:
@@ -156,7 +182,7 @@ def run_launch(args: argparse.Namespace) -> int:
         raise
     print(f"Codex session delete helper running on http://127.0.0.1:{server.port}")
     print("Keep this terminal open while using the delete buttons. Press Ctrl+C to stop.")
-    wait_for_shutdown(server, codex_proc)
+    wait_for_shutdown(server, codex_proc, args.debug_port)
     return 0
 
 

--- a/codex_session_delete/launcher.py
+++ b/codex_session_delete/launcher.py
@@ -12,11 +12,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import requests
+
 from codex_session_delete import cdp
 from codex_session_delete.app_paths import resolve_codex_app_dir
 from codex_session_delete.api_adapter import ApiAdapter, UnavailableApiAdapter
 from codex_session_delete.backup_store import BackupStore
-from codex_session_delete.cdp import evaluate_user_scripts, inject_file, open_devtools
+from codex_session_delete.cdp import evaluate_script, evaluate_user_scripts, inject_file, open_devtools
 from codex_session_delete.helper_server import HelperServer
 from codex_session_delete.helper_server import fetch_ad_list
 from codex_session_delete.markdown_exporter import MarkdownExportService
@@ -67,6 +69,12 @@ class ApiFirstDeleteService:
 
 
 class InjectedHelperServer(HelperServer):
+    bridge_socket: Any = None
+
+
+@dataclass
+class AttachedHelperServer:
+    port: int
     bridge_socket: Any = None
 
 
@@ -297,7 +305,32 @@ def start_helper(service, export_service: MarkdownExportService | None = None, h
     return server
 
 
+def helper_health_ok(port: int, host: str = "127.0.0.1") -> bool:
+    try:
+        session = requests.Session()
+        session.trust_env = False
+        response = session.get(f"http://{host}:{port}/health", timeout=1)
+        response.raise_for_status()
+        return bool(response.json().get("ok"))
+    except Exception:
+        return False
+
+
+def start_or_attach_helper(
+    service,
+    export_service: MarkdownExportService | None = None,
+    host: str = "127.0.0.1",
+    port: int = 57321,
+) -> HelperServer | AttachedHelperServer:
+    if helper_health_ok(port, host):
+        _log_runtime_event(f"attached existing helper host={host} port={port}")
+        return AttachedHelperServer(port)
+    return start_helper(service, export_service, host, port)
+
+
 def shutdown_helper(server: HelperServer) -> None:
+    if isinstance(server, AttachedHelperServer):
+        return
     server.shutdown()
     server.server_close()
 
@@ -323,13 +356,60 @@ def inject_with_retry(
             )
             runtime.websocket_url = injection.websocket_url
             evaluate_user_scripts(injection.websocket_url, runtime.user_scripts.build_enabled_bundle())
+            _log_runtime_event(f"injected renderer bridge debug_port={debug_port} helper_port={helper_port}")
             return injection.bridge_socket or injection.result
         except Exception as exc:
             last_error = exc
+            _log_runtime_event(f"injection attempt failed debug_port={debug_port} helper_port={helper_port}: {exc}")
             time.sleep(delay)
     if last_error is not None:
         raise last_error
     raise RuntimeError("Codex injection failed")
+
+
+def start_bridge_watchdog(
+    debug_port: int,
+    script_path: Path,
+    helper_port: int,
+    service: ApiFirstDeleteService,
+    export_service: MarkdownExportService,
+    runtime: CodexPlusRuntime,
+    interval: float = 5.0,
+) -> threading.Thread:
+    def watch() -> None:
+        while True:
+            time.sleep(interval)
+            check_and_reinject_bridge(debug_port, script_path, helper_port, service, export_service, runtime)
+
+    thread = threading.Thread(target=watch, daemon=True)
+    thread.start()
+    return thread
+
+
+def check_and_reinject_bridge(
+    debug_port: int,
+    script_path: Path,
+    helper_port: int,
+    service: ApiFirstDeleteService,
+    export_service: MarkdownExportService,
+    runtime: CodexPlusRuntime,
+) -> bool:
+    websocket_url = runtime.websocket_url
+    if not websocket_url:
+        return False
+    try:
+        result = evaluate_script(websocket_url, "typeof window.__codexSessionDeleteBridge === 'function'")
+        if result.get("result", {}).get("result", {}).get("value"):
+            return False
+        _log_runtime_event(f"renderer bridge missing; reinjecting debug_port={debug_port} helper_port={helper_port}")
+    except Exception as exc:
+        _log_runtime_event(f"bridge health check failed; reinjecting debug_port={debug_port} helper_port={helper_port}: {exc}")
+    try:
+        inject_with_retry(debug_port, script_path, helper_port, service, export_service, runtime, attempts=3, delay=0.5)
+        return True
+    except Exception as exc:
+        _log_runtime_event(f"bridge reinjection failed debug_port={debug_port} helper_port={helper_port}: {exc}")
+        return False
 
 
 def launch_and_inject(app_dir: Path | None, db_path: Path | None, backup_dir: Path, debug_port: int, helper_port: int) -> tuple[HelperServer, Any]:
@@ -349,11 +429,12 @@ def launch_and_inject(app_dir: Path | None, db_path: Path | None, backup_dir: Pa
         sync_result = run_provider_sync()
         if sync_result.status == ProviderSyncStatus.SKIPPED:
             print(f"Provider sync skipped: {sync_result.message}")
-    server = start_helper(service, export_service, port=helper_port)
+    server = start_or_attach_helper(service, export_service, port=helper_port)
     codex_proc = None
     try:
         codex_proc = launch_codex_app(resolved_app_dir, debug_port)
         server.bridge_socket = inject_with_retry(debug_port, script_path, server.port, service, export_service, runtime)
+        start_bridge_watchdog(debug_port, script_path, server.port, service, export_service, runtime)
         return server, codex_proc
     except Exception:
         shutdown_helper(server)
@@ -379,6 +460,15 @@ def launch_and_inject(app_dir: Path | None, db_path: Path | None, backup_dir: Pa
             except (OSError, subprocess.SubprocessError):
                 pass
         raise
+
+
+def _log_runtime_event(message: str) -> None:
+    try:
+        from codex_session_delete.cli import log_runtime_event
+
+        log_runtime_event(message)
+    except Exception:
+        pass
 
 
 def handle_bridge_request(

--- a/tests/test_launcher_cli.py
+++ b/tests/test_launcher_cli.py
@@ -140,24 +140,24 @@ def test_non_windows_port_selector_keeps_requested_port(monkeypatch):
 def test_cli_keeps_helper_server_alive_after_injection(monkeypatch):
     waited = []
     monkeypatch.setattr(cli, "launch_and_inject", lambda *args: (FakeServer(), None))
-    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc: waited.append(server.port))
+    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc, debug_port=9229: waited.append((server.port, debug_port)))
 
     exit_code = cli.main([])
 
     assert exit_code == 0
-    assert waited == [57321]
+    assert waited == [(57321, 9229)]
 
 
 def test_cli_launch_subcommand_keeps_helper_server_alive_after_injection(monkeypatch):
     waited = []
     calls = []
     monkeypatch.setattr(cli, "launch_and_inject", lambda *args: calls.append(args) or (FakeServer(), None))
-    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc: waited.append(server.port))
+    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc, debug_port=9229: waited.append((server.port, debug_port)))
 
     exit_code = cli.main(["launch"])
 
     assert exit_code == 0
-    assert waited == [57321]
+    assert waited == [(57321, 9229)]
     assert len(calls) == 1
 
 
@@ -207,6 +207,60 @@ def test_launch_retries_injection_until_codex_page_is_ready(monkeypatch, tmp_pat
     assert len(attempts) == 2
 
 
+def test_launch_and_inject_attaches_existing_healthy_helper(monkeypatch, tmp_path):
+    started = []
+    injected = []
+    monkeypatch.setattr(launcher, "resolve_codex_app_dir", lambda app_dir=None: tmp_path)
+    monkeypatch.setattr(launcher, "helper_health_ok", lambda port, host="127.0.0.1": port == 57321)
+    monkeypatch.setattr(launcher, "_log_runtime_event", lambda message: None)
+    monkeypatch.setattr(launcher, "start_helper", lambda *args, **kwargs: started.append((args, kwargs)) or FakeServer())
+    monkeypatch.setattr(launcher, "launch_codex_app", lambda *args: None)
+    monkeypatch.setattr(launcher, "inject_with_retry", lambda *args, **kwargs: injected.append(args) or {"result": {}})
+
+    server, proc = launcher.launch_and_inject(None, None, tmp_path / "backups", 9229, 57321)
+
+    assert isinstance(server, launcher.AttachedHelperServer)
+    assert server.port == 57321
+    assert proc is None
+    assert started == []
+    assert injected[0][2] == 57321
+
+
+def test_helper_health_ok_checks_helper_endpoint(monkeypatch):
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"ok": True}
+
+    class Session:
+        trust_env = True
+
+        def get(self, url, timeout):
+            assert url == "http://127.0.0.1:57321/health"
+            assert timeout == 1
+            assert self.trust_env is False
+            return Response()
+
+    monkeypatch.setattr(launcher.requests, "Session", lambda: Session())
+
+    assert launcher.helper_health_ok(57321) is True
+
+
+def test_check_and_reinject_bridge_reinjects_when_bridge_missing(monkeypatch, tmp_path):
+    events = []
+    runtime = launcher.CodexPlusRuntime("ws://page", type("Scripts", (), {"build_enabled_bundle": lambda self: ""})(), 9229)
+    monkeypatch.setattr(launcher, "evaluate_script", lambda websocket_url, script: {"result": {"result": {"value": False}}})
+    monkeypatch.setattr(launcher, "inject_with_retry", lambda *args, **kwargs: events.append(("inject", args, kwargs)))
+    monkeypatch.setattr(launcher, "_log_runtime_event", lambda message: events.append(("log", message)))
+
+    assert launcher.check_and_reinject_bridge(9229, tmp_path / "renderer.js", 57321, object(), object(), runtime) is True
+
+    assert any(event[0] == "inject" for event in events)
+    assert any(event[0] == "log" and "renderer bridge missing" in event[1] for event in events)
+
+
 def test_launch_and_inject_returns_windows_packaged_process_id(monkeypatch, tmp_path):
     monkeypatch.setattr(launcher, "resolve_codex_app_dir", lambda app_dir=None: tmp_path)
     monkeypatch.setattr(launcher, "start_helper", lambda *args, **kwargs: FakeServer())
@@ -217,6 +271,14 @@ def test_launch_and_inject_returns_windows_packaged_process_id(monkeypatch, tmp_
 
     assert server.port == 57321
     assert proc == 1234
+
+
+def test_shutdown_helper_leaves_attached_helper_running():
+    server = launcher.AttachedHelperServer(57321)
+
+    launcher.shutdown_helper(server)
+
+    assert server.port == 57321
 
 
 def test_launch_and_inject_runs_provider_sync_before_launch_when_enabled(monkeypatch, tmp_path):
@@ -310,7 +372,7 @@ def test_cli_launch_runs_launcher_cleanup_before_injection(monkeypatch):
     events = []
     monkeypatch.setattr(cli, "stop_existing_windows_launchers", lambda: events.append("cleanup"))
     monkeypatch.setattr(cli, "launch_and_inject", lambda *args: events.append("launch") or (FakeServer(), None))
-    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc: events.append("wait"))
+    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc, debug_port=9229: events.append("wait"))
 
     exit_code = cli.main(["launch"])
 
@@ -323,7 +385,7 @@ def test_cli_launch_checks_update_before_injection(monkeypatch):
     monkeypatch.setattr(cli, "stop_existing_windows_launchers", lambda: events.append("cleanup"))
     monkeypatch.setattr(cli, "maybe_print_update_notice", lambda: events.append("check-update"))
     monkeypatch.setattr(cli, "launch_and_inject", lambda *args: events.append("launch") or (FakeServer(), None))
-    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc: events.append("wait"))
+    monkeypatch.setattr(cli, "wait_for_shutdown", lambda server, proc, debug_port=9229: events.append("wait"))
 
     exit_code = cli.main(["launch"])
 
@@ -477,10 +539,14 @@ def test_wait_for_shutdown_waits_for_popen_like_process():
     assert server.server_close_called is True
 
 
-def test_is_macos_codex_running_uses_ps_comm(monkeypatch):
-    class Result:
-        stdout = "123 /Applications/Codex.app/Contents/MacOS/Codex --remote-debugging-port=9229\n456 /usr/bin/other\n"
-
-    monkeypatch.setattr(cli.subprocess, "run", lambda *args, **kwargs: Result())
+def test_is_macos_codex_running_falls_back_to_ps(monkeypatch):
+    monkeypatch.setattr(cli, "is_codex_cdp_page_available", lambda debug_port=9229: False)
+    monkeypatch.setattr(cli, "is_macos_codex_process_running", lambda: True)
 
     assert cli.is_macos_codex_running() is True
+
+
+def test_is_codex_cdp_page_available_returns_true_for_codex_page(monkeypatch):
+    monkeypatch.setattr(cli, "list_targets", lambda debug_port: [{"type": "page", "title": "Codex", "webSocketDebuggerUrl": "ws://page"}])
+
+    assert cli.is_codex_cdp_page_available() is True


### PR DESCRIPTION
## 背景

macOS 下 Codex++ 在锁屏、睡眠或恢复后，顶部状态偶尔会变红，表现为“后端已断开”。

排查发现，这个问题不一定是 helper server 真的退出，而是 renderer 里的注入 bridge 在恢复后丢失或 CDP WebSocket 被重置，导致前端无法继续调用 helper。

## 现场现象

出现红灯时，本地 helper 和 Codex CDP 端口仍然可能正常：

```bash
curl --noproxy '*' http://127.0.0.1:57321/health
# {"ok": true}

curl --noproxy '*' http://127.0.0.1:9229/json
# 可以看到 Codex page target
```

但在 Codex renderer DevTools 中检查：

```js
typeof window.__codexSessionDeleteBridge
// 'undefined'

window.__CODEX_SESSION_DELETE_HELPER__
// undefined
```

这说明 helper 进程和 CDP 还在，但页面里的 bridge 已经不存在了。

## 相关日志

锁屏恢复后，曾观察到 bridge WebSocket 被系统重置，随后重新注入成功：

```text
[2026-05-15T09:09:36] bridge health check failed; reinjecting debug_port=9229 helper_port=57321: [Errno 54] Connection reset by peer
[2026-05-15T09:09:36] injected renderer bridge debug_port=9229 helper_port=57321
```

此前也观察到 macOS 存活判断误判后关闭 helper：

```text
[2026-05-14T23:01:32] macOS Codex liveness check failed debug_port=9229
[2026-05-14T23:01:32] shutting down helper port=57321
[2026-05-14T23:01:33] helper shutdown complete port=57321
```

## 原因分析

macOS 版 launcher 启动 Codex 后拿不到一个可等待的 Codex 子进程句柄，所以原逻辑主要依赖 `ps` 命令行匹配来判断 Codex 是否仍在运行。

这个判断在 macOS/Electron 场景下比较脆弱：

- Codex 由 `open -a` 启动，launcher 不持有真实子进程
- Electron 会派生多个 Helper / Renderer / app-server 进程
- 锁屏、睡眠、恢复后，renderer bridge 可能丢失，但 helper 和 Codex 仍然存活
- 单纯依赖进程命令行无法判断“Codex 页面是否仍可注入”

因此会出现两类问题：

- Codex 仍在运行，但 launcher 误判后关闭 helper
- helper 仍在运行，但 renderer bridge 丢失，前端显示后端断开

## 修改内容

本次改动主要做了三件事：

1. macOS 存活判断优先使用 CDP page target

   先通过当前 debug port 检查是否还能看到 Codex page target；只有 CDP 不可用时，才回退到 `ps` 进程匹配。

2. helper 端口已存在时复用健康实例

   启动前先检查 `127.0.0.1:<helper_port>/health`。如果已有 helper 正常运行，则复用该 helper，避免因为端口已占用直接启动失败。

3. 增加 renderer bridge watchdog

   注入成功后定期检查 renderer 里的 `window.__codexSessionDeleteBridge` 是否还存在。如果 bridge 丢失或 CDP WebSocket 被重置，会尝试重新注入。

同时补充了关键运行日志，后续如果再次出现红灯，可以通过：

```bash
tail -n 120 ~/.codex-session-delete/launcher.log
```

判断是 helper 退出、Codex liveness 误判，还是 bridge 丢失后重注入失败。

## 影响范围

该修复主要影响 macOS launcher 路径：

- macOS 下 `codex_proc is None` 时，会使用新的 CDP 优先存活判断
- Windows 仍然保留原有基于进程 ID 的等待方式
- helper 复用逻辑只在已有 `/health` 正常时生效，不会复用不可用端口
- bridge watchdog 只在注入成功后运行，用于恢复 renderer bridge

## 验证

本地测试通过：

```bash
.venv/bin/python -m pytest tests/test_launcher_cli.py tests/test_cdp.py -q
```

结果：

```text
51 passed
```

本地 macOS 锁屏恢复后观察到 bridge 可自动重注入，红灯状态可以恢复。
