### PR TITLE
Fix baseline tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,19 @@
 
 Codex++ 是面向 Codex App 的外部增强启动器：不修改原始安装文件，通过 Chromium DevTools Protocol 注入增强脚本。
 
+## 目录
+
+- [Windows 使用](#windows-使用)
+- [功能亮点](#功能亮点)
+- [工作方式](#工作方式)
+- [Provider 同步](#provider-同步)
+- [常用命令](#常用命令)
+- [常见问题](#常见问题)
+- [开发](#开发)
+
 ## 快速使用
+
+## Windows 使用
 
 Windows 用户双击项目根目录的 `setup.bat`，选择：
 
@@ -48,6 +60,8 @@ python -m codex_session_delete setup
 欢迎扫码加入 Codex++ 交流群，反馈问题、交流使用体验或提出新功能建议：
 
 <img src="docs/images/discussion-group-qr.jpg" alt="Codex++ 交流群二维码" width="260">
+
+## 赞赏支持
 
 如果 Codex++ 帮到了你，可以请我喝杯咖啡，或者随手赞赏支持一下继续维护。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -113,7 +113,7 @@ This approach does not modify Codex `app.asar` and does not write DLL files into
 
 ## Provider Sync
 
-When `Provider Sync` is enabled, Codex++ synchronizes local session metadata before launch so historical conversations remain visible in Desktop and `/resume` after switching providers.
+When `Provider Sync` is enabled, Codex++ synchronizes local session metadata before launch so you can switch model_provider without losing historical conversations in Desktop and `/resume`.
 
 It aligns rollout files, SQLite thread records, and project path caches. It only fixes visibility metadata and does not rewrite message content. Busy files or SQLite locks are skipped so startup can continue.
 

--- a/tests/test_launcher_cli.py
+++ b/tests/test_launcher_cli.py
@@ -56,6 +56,9 @@ def test_launch_codex_injects_detected_local_proxy(monkeypatch):
     monkeypatch.delenv("HTTP_PROXY", raising=False)
     monkeypatch.delenv("HTTPS_PROXY", raising=False)
     monkeypatch.delenv("ALL_PROXY", raising=False)
+    monkeypatch.delenv("http_proxy", raising=False)
+    monkeypatch.delenv("https_proxy", raising=False)
+    monkeypatch.delenv("all_proxy", raising=False)
     monkeypatch.setattr(launcher, "local_proxy_url", lambda: "http://127.0.0.1:7897")
     monkeypatch.setattr(launcher.subprocess, "Popen", lambda args, **kw: popen_calls.append((args, kw)))
 


### PR DESCRIPTION
## What changed
- Clear lowercase proxy environment variables in the local proxy injection test.
- Restore README sections and Provider Sync wording expected by the existing README tests.

## Verification
- .venv/bin/python -m pytest -q
- 200 passed