### PR TITLE
修复插件入口解锁对模型选择器的影响

### DIFF
--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -1042,6 +1042,9 @@
   function spoofChatGPTAuthMethod(element) {
     const auth = authContextValueFrom(element);
     if (!auth || auth.authMethod === "chatgpt") return false;
+    // Injection workaround: the plugin gate reads authMethod synchronously from
+    // the current React fiber context before state propagation completes.
+    auth.authMethod = "chatgpt";
     auth.setAuthMethod("chatgpt");
     return true;
   }
@@ -1051,6 +1054,17 @@
     if (byIcon) return byIcon;
     return Array.from(document.querySelectorAll(selectors.pluginNavButton))
       .find((button) => /^(插件|Plugins)(\s+-\s+.*)?$/i.test((button.textContent || "").trim())) || null;
+  }
+
+  function isPluginEntryButtonElement(button) {
+    return !!button?.matches?.(selectors.pluginNavButton) &&
+      (!!button.querySelector?.(selectors.pluginSvgPath) || /^(插件|Plugins)(\s+-\s+.*)?$/i.test((button.textContent || "").trim()));
+  }
+
+  function pluginEntryButtonFromNode(node) {
+    if (node.nodeType !== 1) return null;
+    const button = node.matches?.(selectors.pluginNavButton) ? node : node.closest?.(selectors.pluginNavButton);
+    return isPluginEntryButtonElement(button) ? button : null;
   }
 
   function labelUnlockedPluginEntry(button) {
@@ -1066,23 +1080,83 @@
     if (!codexPlusSettings().pluginEntryUnlock) return;
     const pluginButton = pluginEntryButton();
     if (!pluginButton) return;
-    spoofChatGPTAuthMethod(pluginButton);
-    pluginButton.disabled = false;
-    pluginButton.removeAttribute("disabled");
+    unblockButtonElement(pluginButton);
     pluginButton.style.display = "";
     pluginButton.querySelectorAll("*").forEach((node) => {
+      const looksDisabled = node.style.display === "none" ||
+        node.hasAttribute("aria-disabled") ||
+        node.classList?.contains("disabled") ||
+        node.classList?.contains("opacity-50") ||
+        node.classList?.contains("cursor-not-allowed") ||
+        node.classList?.contains("pointer-events-none");
+      if (!looksDisabled) return;
       node.style.display = "";
+      node.removeAttribute("aria-disabled");
+      node.classList?.remove("disabled", "opacity-50", "cursor-not-allowed", "pointer-events-none");
+      node.style.removeProperty("pointer-events");
+      node.style.removeProperty("opacity");
     });
     labelUnlockedPluginEntry(pluginButton);
-    const reactPropsKey = Object.keys(pluginButton).find((key) => key.startsWith("__reactProps"));
-    if (reactPropsKey) {
-      pluginButton[reactPropsKey].disabled = false;
-    }
-    if (pluginButton.dataset.codexPluginEnabled === "true") return;
+    const pluginEntryHandlerVersion = "activation-v2";
+    if (pluginButton.dataset.codexPluginEnabledVersion === pluginEntryHandlerVersion) return;
     pluginButton.dataset.codexPluginEnabled = "true";
+    pluginButton.dataset.codexPluginEnabledVersion = pluginEntryHandlerVersion;
+    // Capture phase runs before Codex's own activation handler reads authMethod.
+    ["pointerdown", "mousedown", "touchstart"].forEach((eventName) => {
+      pluginButton.addEventListener(eventName, () => {
+        spoofChatGPTAuthMethod(pluginButton);
+      }, true);
+    });
     pluginButton.addEventListener("click", () => {
       spoofChatGPTAuthMethod(pluginButton);
     }, true);
+    pluginButton.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") spoofChatGPTAuthMethod(pluginButton);
+    }, true);
+  }
+
+  function nodeContainsPluginEntryCandidate(node) {
+    if (node.nodeType !== 1) return false;
+    return !!node.matches?.(selectors.pluginNavButton) ||
+      !!node.querySelector?.(selectors.pluginNavButton) ||
+      !!node.matches?.(selectors.pluginSvgPath) ||
+      !!node.querySelector?.(selectors.pluginSvgPath);
+  }
+
+  function schedulePluginEntryUnlockRetries() {
+    if (!codexPlusSettings().pluginEntryUnlock) return;
+    (window.__codexPlusPluginEntryUnlockTimers || []).forEach(clearTimeout);
+    window.__codexPlusPluginEntryUnlockTimers = [100, 300, 700, 1500, 3000].map((delay) => {
+      return setTimeout(() => {
+        if (document.visibilityState !== "hidden") runScanStep(enablePluginEntry);
+      }, delay);
+    });
+  }
+
+  function schedulePluginEntryUnlockFrame() {
+    if (!codexPlusSettings().pluginEntryUnlock || window.__codexPlusPluginEntryUnlockRaf) return;
+    window.__codexPlusPluginEntryUnlockRaf = requestAnimationFrame(() => {
+      window.__codexPlusPluginEntryUnlockRaf = 0;
+      runScanStep(enablePluginEntry);
+    });
+  }
+
+  function nodeLooksPluginEntryLocked(node) {
+    return node.disabled === true ||
+      node.hasAttribute?.("disabled") ||
+      node.getAttribute?.("aria-disabled") === "true" ||
+      node.classList?.contains("disabled") ||
+      node.classList?.contains("opacity-50") ||
+      node.classList?.contains("cursor-not-allowed") ||
+      node.classList?.contains("pointer-events-none") ||
+      node.style?.pointerEvents === "none" ||
+      node.style?.opacity === "0.5";
+  }
+
+  function shouldRefreshPluginEntryUnlock(mutation) {
+    if (mutation.type !== "attributes" || !["disabled", "aria-disabled", "class", "style"].includes(mutation.attributeName)) return false;
+    const button = pluginEntryButtonFromNode(mutation.target);
+    return !!button && (nodeLooksPluginEntryLocked(button) || nodeLooksPluginEntryLocked(mutation.target));
   }
 
   function pluginInstallCandidates() {
@@ -3218,6 +3292,7 @@
       if (isChatContentMutation(mutation)) return false;
       const target = mutation.target;
       if (isExtensionUiNode(target)) return false;
+      if (Array.from(mutation.addedNodes).some(nodeContainsPluginEntryCandidate)) return true;
       if (target?.nodeType === 1 && nodeSelfOrAncestorMatchesScanRelevance(target)) return true;
       const changedNodes = [...Array.from(mutation.addedNodes), ...Array.from(mutation.removedNodes)];
       return changedNodes.some((node) => node.nodeType === 1 && isScanRelevantNode(node));
@@ -3232,6 +3307,9 @@
   }
 
   function scheduleScan(mutations) {
+    if (mutations?.some(shouldRefreshPluginEntryUnlock)) {
+      schedulePluginEntryUnlockFrame();
+    }
     if (!shouldScheduleScan(mutations)) return;
     if (window.__codexSessionDeleteScanPending) return;
     window.__codexSessionDeleteScanPending = true;
@@ -3239,6 +3317,7 @@
   }
 
   scan();
+  schedulePluginEntryUnlockRetries();
   window.__codexProjectMoveApplyProjection = applyProjectMoveProjection;
   window.__codexProjectMoveReadProjection = readProjectMoveProjection;
   window.__codexProjectMoveTargets = projectMoveTargets;
@@ -3255,5 +3334,10 @@
   window.addEventListener("resize", window.__codexPlusResizeHandler);
   window.__codexSessionDeleteObserver?.disconnect();
   window.__codexSessionDeleteObserver = new MutationObserver(scheduleScan);
-  window.__codexSessionDeleteObserver.observe(document.body || document.documentElement, { childList: true, subtree: true });
+  window.__codexSessionDeleteObserver.observe(document.body || document.documentElement, {
+    attributeFilter: ["disabled", "aria-disabled", "class", "style"],
+    attributes: true,
+    childList: true,
+    subtree: true,
+  });
 })();

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -270,10 +270,62 @@ def test_renderer_script_enables_plugin_entry_for_api_key_users():
     assert "svg path[d^=\"M7.94562 14.0277\"]" in text
     assert "selectors.pluginNavButton" in plugin_entry_code
     assert "selectors.pluginSvgPath" in plugin_entry_code
+    scan_relevant_code = text[text.index("const scanRelevantSelector") : text.index("function nodeSelfOrAncestorMatchesScanRelevance")]
+    assert "selectors.pluginNavButton" not in scan_relevant_code
+    assert "function runForegroundResumeScans" not in text
+    assert "__codexPlusForegroundResumeScanTimers" not in text
+    assert 'window.addEventListener("visibilitychange", window.__codexPlusVisibilityResumeHandler)' not in text
+    assert 'window.addEventListener("focus", window.__codexPlusFocusResumeHandler)' not in text
+    assert "function nodeContainsPluginEntryCandidate" in plugin_entry_code
+    assert "node.querySelector?.(selectors.pluginNavButton)" in plugin_entry_code
+    assert "function schedulePluginEntryUnlockRetries" in plugin_entry_code
+    assert "__codexPlusPluginEntryUnlockTimers" in plugin_entry_code
+    assert "[100, 300, 700, 1500, 3000].map" in plugin_entry_code
+    assert "runScanStep(enablePluginEntry)" in plugin_entry_code
+    assert "function schedulePluginEntryUnlockFrame" in plugin_entry_code
+    assert "__codexPlusPluginEntryUnlockRaf" in plugin_entry_code
+    assert "function nodeLooksPluginEntryLocked" in plugin_entry_code
+    assert "function shouldRefreshPluginEntryUnlock" in plugin_entry_code
+    assert '["disabled", "aria-disabled", "class", "style"].includes(mutation.attributeName)' in plugin_entry_code
+    assert "nodeLooksPluginEntryLocked(button) || nodeLooksPluginEntryLocked(mutation.target)" in plugin_entry_code
+    assert "Array.from(mutation.addedNodes).some(nodeContainsPluginEntryCandidate)" in text
+    assert "mutations?.some(shouldRefreshPluginEntryUnlock)" in text
+    assert "schedulePluginEntryUnlockFrame();" in text
+    assert "schedulePluginEntryUnlockRetries();" in text
+    assert 'attributeFilter: ["disabled", "aria-disabled", "class", "style"]' in text
+    assert "attributes: true" in text
     assert "document.querySelectorAll(\"button\")" not in plugin_entry_code
-    assert "disabled = false" in plugin_entry_code
-    assert "removeAttribute(\"disabled\")" in plugin_entry_code
+    assert "unblockButtonElement(pluginButton)" in plugin_entry_code
+    assert "const looksDisabled = node.style.display === \"none\"" in plugin_entry_code
+    assert "if (!looksDisabled) return;" in plugin_entry_code
+    assert "node.style.display = \"\"" in plugin_entry_code
+    assert "node.removeAttribute(\"aria-disabled\")" in plugin_entry_code
+    assert "node.classList?.remove(\"disabled\", \"opacity-50\", \"cursor-not-allowed\", \"pointer-events-none\")" in plugin_entry_code
+    assert "node.style.removeProperty(\"pointer-events\")" in plugin_entry_code
+    assert "node.style.removeProperty(\"opacity\")" in plugin_entry_code
     assert "setAuthMethod(\"chatgpt\")" in text
+    assert "Injection workaround: the plugin gate reads authMethod synchronously" in text
+    assert "Capture phase runs before Codex's own activation handler reads authMethod" in text
+    assert "auth.authMethod = \"chatgpt\"" in text
+    assert 'const pluginEntryHandlerVersion = "activation-v2"' in plugin_entry_code
+    assert "pluginButton.dataset.codexPluginEnabledVersion === pluginEntryHandlerVersion" in plugin_entry_code
+    assert "pluginButton.dataset.codexPluginEnabledVersion = pluginEntryHandlerVersion" in plugin_entry_code
+    assert 'pluginButton.dataset.codexPluginEnabled === "true"' not in plugin_entry_code
+    assert "[\"pointerdown\", \"mousedown\", \"touchstart\"].forEach((eventName) => {" in plugin_entry_code
+    assert 'pluginButton.addEventListener("keydown", (event) => {' in plugin_entry_code
+    assert 'event.key === "Enter" || event.key === " "' in plugin_entry_code
+    assert 'event.key === "Spacebar"' in plugin_entry_code
+    assert "pointerenter" not in plugin_entry_code
+    assert "mouseover" not in plugin_entry_code
+    assert "focusin" not in plugin_entry_code
+    assert "if (!pluginButton) return;\n    spoofChatGPTAuthMethod(pluginButton);" not in plugin_entry_code
+    assert "data-codex-restore-model-selector" not in text
+    assert "data-codex-apply-plugin-entry-unlock" not in text
+    assert "恢复模型选择" not in text
+    assert "重新应用插件" not in text
+    assert "restoreModelSelectorAuthMethod" not in text
+    assert "applyPluginEntryUnlock" not in text
+    assert "__codexPlusModelSelectorDiagnostic" not in text
     assert "插件 - 已解锁" in plugin_entry_code
     assert "Plugins - Unlocked" in plugin_entry_code
     assert "labelUnlockedPluginEntry" in plugin_entry_code


### PR DESCRIPTION
## 背景

Codex++ 的插件选项解锁会在扫描到插件入口时立即把 authMethod spoof 成 chatgpt。这个副作用会影响发送按钮左侧的模型选择组件，导致选择对话后模型选择框偶发消失。

同时，恢复/重注入场景下如果页面已经带有旧的 data-codex-plugin-enabled 标记，新版本的激活事件监听可能被跳过，导致修复不能稳定应用到已打开窗口。

## 修改内容

- 移除扫描阶段的立即 auth spoof，避免未操作插件入口时污染模型选择器状态。
- 仅在真正激活插件入口前 spoof auth：pointerdown、mousedown、touchstart、capture click，以及 Enter/Space 键盘激活。
- 同步修改当前 React fiber context value，再调用 setAuthMethod，保证 Codex 自身插件入口读取 authMethod 时序正确。
- 复用 unblockButtonElement 并清理插件按钮内部禁用态，减少启动时按钮灰显。
- 使用版本化 listener marker，确保热重注入到旧页面时也会补齐新的激活 handler。
- 不把插件按钮加入全局扫描 relevance，也不增加 focus/visibility 多次扫描，避免插件入口状态被反复刷新造成闪烁。
- 增加插件入口专项轻量重试，并在插件入口被新增或被 React 重新打回 disabled/class/style 灰态时，下一帧只重跑插件入口解锁，避免按钮晚渲染或后续 render 后一直灰着。
- 移除手动恢复/重新应用类 UI，保持行为自动完成。

## 验证

- node --check codex_session_delete/inject/renderer-inject.js
- pytest tests/test_renderer_script.py -q
- python -m codex_session_delete setup

## 关联 Issue

Closes #107