### PR TITLE
Polish sidebar action buttons

### DIFF
--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -6,6 +6,7 @@
   const projectMoveOverlayClass = "codex-project-move-overlay";
   const actionButtonClass = "codex-session-action-button";
   const actionGroupClass = "codex-session-actions";
+  const actionTooltipClass = "codex-session-action-tooltip";
   const timelineClass = "codex-conversation-timeline";
   const timelineTrackClass = "codex-conversation-timeline-track";
   const timelineMarkerClass = "codex-conversation-timeline-marker";
@@ -23,13 +24,13 @@
   const chatsSortRefreshIntervalMs = 1500;
   const chatsSortDbRefreshIntervalMs = 5000;
   const styleId = "codex-delete-style";
-  const codexDeleteStyleVersion = "8";
+  const codexDeleteStyleVersion = "10";
   const codexPlusMenuId = "codex-plus-menu";
   const codexPlusMenuFloatingClass = "codex-plus-menu-floating";
   const codexDeleteVersion = "6";
   const codexExportVersion = "1";
   const codexProjectMoveVersion = "1";
-  const codexActionGroupVersion = "2";
+  const codexActionGroupVersion = "3";
   const codexArchiveRowActionsVersion = "1";
   const codexArchiveDeleteAllVersion = "2";
   const codexConversationTimelineVersion = "2";
@@ -70,44 +71,67 @@
         opacity: 0;
         display: inline-flex;
         align-items: center;
-        gap: 6px;
+        gap: 4px;
+        background: transparent;
       }
-      .${actionButtonClass},
+      .${actionButtonClass} {
+        width: 26px;
+        height: 26px;
+        border: 0;
+        border-radius: 7px;
+        background: transparent;
+        color: #d1d5db;
+        font: 14px/26px system-ui, sans-serif;
+        padding: 0;
+        cursor: default;
+        text-align: center;
+      }
+      .${actionButtonClass}:hover,
+      .${actionButtonClass}:focus-visible {
+        background: #363839;
+        color: #f4f4f5;
+        outline: none;
+      }
       .codex-archive-row-button {
         border: 1px solid #ef4444;
-        border-radius: 6px;
+        border-radius: 7px;
         background: #f3f4f6;
         color: #374151;
-        font-size: 12px;
-        line-height: 16px;
-        padding: 1px 6px;
-        cursor: pointer;
-      }
-      .codex-archive-row-button {
-        border-radius: 7px;
         font: 12px system-ui, sans-serif;
         line-height: 16px;
         padding: 3px 8px;
+        cursor: pointer;
       }
-      .${buttonClass},
       .codex-archive-row-button.${buttonClass} {
         border-color: #ef4444;
         background: #fee2e2;
         color: #991b1b;
       }
-      .${exportButtonClass},
       .codex-archive-row-button.${exportButtonClass} {
         border-color: #93c5fd;
         background: #dbeafe;
         color: #1d4ed8;
       }
-      .${projectMoveButtonClass} {
-        border-color: #10a37f;
-        background: #d1fae5;
-        color: #065f46;
-      }
       [data-codex-delete-row="true"]:hover .${actionGroupClass} { opacity: 1; }
+      [data-codex-delete-row="true"]:hover [data-thread-title] {
+        -webkit-mask-image: linear-gradient(90deg, #000 calc(100% - 86px), transparent calc(100% - 80px));
+        mask-image: linear-gradient(90deg, #000 calc(100% - 86px), transparent calc(100% - 80px));
+      }
       [data-codex-delete-row="true"].codex-archive-confirm-visible .${actionGroupClass} { right: 66px; }
+      .${actionTooltipClass} {
+        position: fixed;
+        z-index: 2147483201;
+        max-width: min(220px, calc(100vw - 32px));
+        border: 1px solid rgba(255,255,255,.1);
+        border-radius: 12px;
+        background: #242628;
+        color: #f4f4f5;
+        font: 14px/20px system-ui, sans-serif;
+        padding: 9px 12px;
+        box-shadow: 0 14px 40px rgba(0,0,0,.28);
+        pointer-events: none;
+        white-space: nowrap;
+      }
       .${projectMoveOverlayClass} {
         position: fixed;
         inset: 0;
@@ -2286,8 +2310,42 @@
     ["pointerdown", "mousedown", "mouseup", "touchstart"].forEach((eventName) => {
       button.addEventListener(eventName, (event) => stopActionButtonEvent(row, button, event), true);
     });
+    button.addEventListener("pointerenter", () => showActionButtonTooltip(button));
+    button.addEventListener("pointerleave", hideActionButtonTooltip);
+    button.addEventListener("focus", () => showActionButtonTooltip(button));
+    button.addEventListener("blur", hideActionButtonTooltip);
     button.addEventListener("pointerup", onActivate, true);
-    button.addEventListener("click", onActivate, true);
+    button.addEventListener("click", (event) => {
+      hideActionButtonTooltip();
+      onActivate(event);
+    }, true);
+  }
+
+  function hideActionButtonTooltip() {
+    document.querySelectorAll(`.${actionTooltipClass}`).forEach((node) => node.remove());
+  }
+
+  function showActionButtonTooltip(button) {
+    const label = button.dataset.codexActionLabel || button.getAttribute("aria-label") || "";
+    if (!label) return;
+    hideActionButtonTooltip();
+    const tooltip = document.createElement("div");
+    tooltip.className = actionTooltipClass;
+    tooltip.textContent = label;
+    document.body.appendChild(tooltip);
+    const buttonRect = button.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const gap = 8;
+    const left = Math.min(
+      window.innerWidth - tooltipRect.width - 8,
+      Math.max(8, buttonRect.left + buttonRect.width / 2 - tooltipRect.width / 2),
+    );
+    const top = Math.min(
+      window.innerHeight - tooltipRect.height - 8,
+      buttonRect.bottom + gap,
+    );
+    tooltip.style.left = `${left}px`;
+    tooltip.style.top = `${Math.max(8, top)}px`;
   }
 
   function refreshActionButton(originalButton, row, onActivate) {
@@ -2295,6 +2353,13 @@
     const replacement = originalButton.cloneNode(true);
     installActionButtonEvents(row, replacement, onActivate);
     originalButton.replaceWith(replacement);
+  }
+
+  function configureActionButton(button, label, icon) {
+    button.setAttribute("aria-label", label);
+    button.dataset.codexActionLabel = label;
+    button.removeAttribute("title");
+    button.textContent = icon;
   }
 
   function attachButton(row) {
@@ -2335,7 +2400,7 @@
       moveButton.type = "button";
       moveButton.className = `${actionButtonClass} ${projectMoveButtonClass}`;
       moveButton.dataset.codexProjectMoveVersion = codexProjectMoveVersion;
-      moveButton.textContent = "移动";
+      configureActionButton(moveButton, "移动", "↗");
       const openProjectMove = (event) => openProjectMoveMenuForRow(row, moveButton, ref, event);
       installActionButtonEvents(row, moveButton, openProjectMove);
       group.appendChild(moveButton);
@@ -2346,7 +2411,7 @@
       exportButton.type = "button";
       exportButton.className = `${actionButtonClass} ${exportButtonClass}`;
       exportButton.dataset.codexExportVersion = codexExportVersion;
-      exportButton.textContent = "导出";
+      configureActionButton(exportButton, "导出", "⇩");
       const openExport = (event) => {
         stopActionButtonEvent(row, exportButton, event);
         exportMarkdown(ref);
@@ -2360,7 +2425,7 @@
       deleteButton.type = "button";
       deleteButton.className = `${actionButtonClass} ${buttonClass}`;
       deleteButton.dataset.codexDeleteVersion = codexDeleteVersion;
-      deleteButton.textContent = "删除";
+      configureActionButton(deleteButton, "删除", "⌫");
       const openDeleteConfirm = (event) => openDeleteConfirmForRow(row, deleteButton, ref, event);
       installActionButtonEvents(row, deleteButton, openDeleteConfirm);
       group.appendChild(deleteButton);

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -47,6 +47,59 @@ def test_renderer_script_positions_delete_button_without_affecting_layout():
 
 
 
+def test_renderer_script_uses_native_like_sidebar_action_icons_with_tooltips():
+    text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
+    style_start = text.index("style.textContent = `")
+    style_end = text.index("`;\n    document.documentElement.appendChild(style);", style_start)
+    style_code = text[style_start:style_end]
+    events_start = text.index("function installActionButtonEvents")
+    events_end = text.index("\n\n  function refreshActionButton", events_start)
+    events_code = text[events_start:events_end]
+    attach_start = text.index("function attachButton")
+    attach_end = text.index("\n\n  function tryAttachButton", attach_start)
+    attach_code = text[attach_start:attach_end]
+
+    assert "actionTooltipClass = \"codex-session-action-tooltip\"" in text
+    assert "codexDeleteStyleVersion = \"10\"" in text
+    assert "codexActionGroupVersion = \"3\"" in text
+    assert "padding-left: 38px" not in style_code
+    assert "--codex-action-row-bg" not in style_code
+    assert "background: linear-gradient(90deg" not in style_code
+    assert "[data-codex-delete-row=\"true\"]:hover [data-thread-title]" in style_code
+    assert "mask-image: linear-gradient(90deg, #000 calc(100% - 86px), transparent calc(100% - 80px))" in style_code
+    assert "border: 0" in style_code
+    assert "background: transparent" in style_code
+    assert "width: 26px" in style_code
+    assert "height: 26px" in style_code
+    assert "color: #d1d5db" in style_code
+    assert "background: #363839" in style_code
+    assert ".${actionButtonClass}.${buttonClass}:hover" not in style_code
+    assert ".${actionTooltipClass}" in style_code
+    assert "position: fixed" in style_code
+    assert "pointer-events: none" in style_code
+
+    assert "configureActionButton(moveButton, \"移动\", \"↗\")" in attach_code
+    assert "configureActionButton(exportButton, \"导出\", \"⇩\")" in attach_code
+    assert "configureActionButton(deleteButton, \"删除\", \"⌫\")" in attach_code
+    assert "button.setAttribute(\"aria-label\", label)" in text
+    assert "button.dataset.codexActionLabel = label" in text
+    assert "button.removeAttribute(\"title\")" in text
+    assert "button.textContent = icon" in text
+    assert "syncActionGroupBackground(row, group)" not in attach_code
+    assert "function syncActionGroupBackground(row, group)" not in text
+    assert "transparentColorForBackground(background)" not in text
+    assert "showActionButtonTooltip(button)" in events_code
+    assert "hideActionButtonTooltip()" in events_code
+    assert "\"pointerenter\"" in events_code
+    assert "\"focus\"" in events_code
+    assert 'moveButton.textContent = "移动"' not in attach_code
+    assert 'exportButton.textContent = "导出"' not in attach_code
+    assert 'deleteButton.textContent = "删除"' not in attach_code
+    assert "移动" in text
+    assert "导出" in text
+    assert "删除" in text
+
+
 def test_renderer_script_keeps_sponsors_separate_from_author_support():
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
     sponsor_start = text.index('<div class="codex-plus-panel" data-codex-plus-panel="sponsor"')
@@ -409,7 +462,7 @@ def test_renderer_script_sidebar_delete_opens_on_pointerup_when_click_is_unrelia
 
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
     assert "updateDeleteButtonOffsets" in text
-    assert "codexDeleteStyleVersion = \"8\"" in text
+    assert "codexDeleteStyleVersion = \"10\"" in text
     assert "right: 66px" in text
     assert "确认" in text
     assert "归档对话" in text


### PR DESCRIPTION
## Summary
- Replace the sidebar action button block background with native-like transparent icon buttons.
- Use the native-style hover highlight color for individual action icons.
- Fade long thread titles before the action area so labels do not overlap the buttons.

## Test Plan
- .venv/bin/python -m pytest tests/test_renderer_script.py -q
- node --check codex_session_delete/inject/renderer-inject.js
- git diff --check