### PR TITLE
支持批量导出选中会话为 ZIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ python -m codex_session_delete setup
 - 插件入口解锁：API Key 模式下显示并启用插件入口。
 - 特殊插件强制安装：解除 App unavailable / 应用不可用导致的前端安装禁用。
 - 会话删除：悬停显示删除按钮，删除前确认并支持撤销。
-- Markdown 导出：按本地 rollout 导出带时间戳的会话 Markdown。
+- Markdown 导出：按本地 rollout 导出带时间戳的会话 Markdown，并支持多选会话批量导出为 ZIP。
 - 会话项目移动：把会话移动到普通对话或其他本地项目。
 - 对话 Timeline：右侧显示用户提问时间线，悬停摘要，点击跳转。
 - Provider 同步：切换 model_provider 或供应商时不丢历史会话。

--- a/README_EN.md
+++ b/README_EN.md
@@ -73,7 +73,7 @@ If Codex++ has helped you, you can buy me a coffee or send a small tip to suppor
 - Plugin entry unlock for API Key mode.
 - Forced plugin install when the frontend blocks App unavailable states.
 - Session delete with confirmation and undo.
-- Markdown export from local rollout files.
+- Markdown export from local rollout files, including multi-select ZIP export.
 - Project move for normal conversations and local projects.
 - Conversation Timeline with question markers, hover summaries, and quick jump.
 - Provider Sync so historical conversations remain visible after switching `model_provider`.

--- a/codex_session_delete/helper_server.py
+++ b/codex_session_delete/helper_server.py
@@ -7,7 +7,7 @@ from urllib.parse import unquote
 from urllib.request import Request, urlopen
 from typing import Protocol
 
-from codex_session_delete.models import DeleteResult, DeleteStatus, ExportResult, ExportStatus, SessionRef
+from codex_session_delete.models import BulkExportResult, DeleteResult, DeleteStatus, ExportResult, ExportStatus, SessionRef
 
 DEFAULT_AD_LIST_URLS = [
     "https://raw.githubusercontent.com/BigPizzaV3/Ad-List/main/ads.json",
@@ -38,6 +38,7 @@ class DeleteService(Protocol):
 
 class ExportService(Protocol):
     def export(self, session: SessionRef) -> ExportResult: ...
+    def export_zip(self, sessions: list[SessionRef]) -> BulkExportResult: ...
 
 
 class HelperServer(ThreadingHTTPServer):
@@ -86,7 +87,7 @@ class _Handler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:
         try:
             payload = self._read_json()
-            if self.path in {"/delete", "/undo", "/archived-thread", "/export-markdown"} and not self._is_mutation_authorized():
+            if self.path in {"/delete", "/undo", "/archived-thread", "/export-markdown", "/export-markdown-zip"} and not self._is_mutation_authorized():
                 self._send_json({"error": "forbidden"}, status=403)
                 return
             if self.path == "/delete":
@@ -106,6 +107,21 @@ class _Handler(BaseHTTPRequestHandler):
                     return
                 session = SessionRef(session_id=str(payload.get("session_id", "")), title=str(payload.get("title", "")))
                 self._send_json(self.server.export_service.export(session).to_dict())
+                return
+            if self.path == "/export-markdown-zip":
+                if self.server.export_service is None:
+                    self._send_json(
+                        BulkExportResult(ExportStatus.FAILED, "Markdown 批量导出不可用").to_dict(),
+                        status=400,
+                    )
+                    return
+                raw_sessions = payload.get("sessions", [])
+                sessions = [
+                    SessionRef(session_id=str(item.get("session_id", "")), title=str(item.get("title", "")))
+                    for item in raw_sessions
+                    if isinstance(item, dict) and item.get("session_id")
+                ] if isinstance(raw_sessions, list) else []
+                self._send_json(self.server.export_service.export_zip(sessions).to_dict())
                 return
             if self.path == "/archived-thread":
                 session = self.server.service.find_archived_thread_by_title(str(payload.get("title", "")))
@@ -131,7 +147,7 @@ class _Handler(BaseHTTPRequestHandler):
             self._send_json({"error": "not found"}, status=404)
         except Exception as exc:
             session_id = str(payload.get("session_id", "")) if "payload" in locals() else ""
-            if self.path == "/export-markdown":
+            if self.path in {"/export-markdown", "/export-markdown-zip"}:
                 result = ExportResult(ExportStatus.FAILED, session_id, str(exc))
                 self._send_json(result.to_dict(), status=400)
                 return

--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -2185,10 +2185,9 @@
     checkbox.setAttribute("aria-label", `选择导出：${ref.title || ref.session_id}`);
     checkbox.checked = codexBulkExportSelection.has(ref.session_id);
     checkbox.addEventListener("click", (event) => {
-      event.preventDefault();
       event.stopPropagation();
       event.stopImmediatePropagation?.();
-      updateBulkExportRowSelection(row, ref, !codexBulkExportSelection.has(ref.session_id));
+      updateBulkExportRowSelection(row, ref, checkbox.checked);
     }, true);
     if (!existing) row.appendChild(checkbox);
   }

--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -2,6 +2,8 @@
   const helperBase = window.__CODEX_SESSION_DELETE_HELPER__ || "http://127.0.0.1:57321";
   const buttonClass = "codex-delete-button";
   const exportButtonClass = "codex-export-button";
+  const bulkExportCheckboxClass = "codex-bulk-export-checkbox";
+  const bulkExportBarClass = "codex-bulk-export-bar";
   const projectMoveButtonClass = "codex-project-move-button";
   const projectMoveOverlayClass = "codex-project-move-overlay";
   const actionButtonClass = "codex-session-action-button";
@@ -100,6 +102,56 @@
         border-color: #93c5fd;
         background: #dbeafe;
         color: #1d4ed8;
+      }
+      .${bulkExportCheckboxClass} {
+        position: absolute;
+        left: 8px;
+        top: 50%;
+        transform: translateY(-50%);
+        z-index: 21;
+        width: 16px;
+        height: 16px;
+        margin: 0;
+        accent-color: #10a37f;
+      }
+      [data-codex-bulk-export-mode="true"] {
+        padding-left: 30px !important;
+      }
+      [data-codex-bulk-export-selected="true"] {
+        background: rgba(16,163,127,.12) !important;
+      }
+      .${bulkExportBarClass} {
+        position: fixed;
+        left: 50%;
+        bottom: 18px;
+        z-index: 2147483001;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        transform: translateX(-50%);
+        border: 1px solid rgba(255,255,255,.12);
+        border-radius: 12px;
+        background: rgba(24,24,27,.96);
+        color: #f4f4f5;
+        padding: 10px 12px;
+        font: 13px system-ui, sans-serif;
+        box-shadow: 0 16px 48px rgba(0,0,0,.28);
+      }
+      .${bulkExportBarClass} button {
+        border: 0;
+        border-radius: 8px;
+        background: rgba(255,255,255,.12);
+        color: #f4f4f5;
+        padding: 6px 10px;
+        cursor: pointer;
+      }
+      .${bulkExportBarClass} button[data-codex-bulk-export-submit] {
+        background: #10a37f;
+        color: #fff;
+      }
+      .${bulkExportBarClass} button:disabled {
+        cursor: not-allowed;
+        opacity: .55;
       }
       .${projectMoveButtonClass} {
         border-color: #10a37f;
@@ -258,6 +310,28 @@
         cursor: pointer;
         pointer-events: auto;
         -webkit-app-region: no-drag;
+      }
+      .codex-bulk-export-trigger {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: 0;
+        border-radius: 7px;
+        background: transparent;
+        color: inherit;
+        font: inherit;
+        height: 100%;
+        line-height: 1;
+        margin-left: 4px;
+        padding: 0 8px;
+        cursor: pointer;
+        pointer-events: auto;
+        -webkit-app-region: no-drag;
+      }
+      .codex-bulk-export-trigger:hover,
+      .codex-bulk-export-trigger:focus-visible {
+        background: rgba(255,255,255,.1);
+        outline: none;
       }
       .codex-plus-modal-overlay {
         position: fixed;
@@ -481,7 +555,7 @@
   }
 
   function defaultCodexPlusSettings() {
-    return { pluginEntryUnlock: true, forcePluginInstall: true, sessionDelete: true, markdownExport: true, projectMove: true, conversationTimeline: true, nativeMenuPlacement: true };
+    return { pluginEntryUnlock: true, forcePluginInstall: true, sessionDelete: true, markdownExport: true, bulkExport: true, projectMove: true, conversationTimeline: true, nativeMenuPlacement: true };
   }
 
   function codexPlusSettings() {
@@ -743,6 +817,10 @@
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="markdownExport"><span></span></button>
             </div>
             <div class="codex-plus-row">
+              <div><div class="codex-plus-row-title">批量导出 ZIP</div><div class="codex-plus-row-description">在会话列表选择多个会话，一次导出为 ZIP。</div></div>
+              <button type="button" class="codex-plus-toggle" data-codex-plus-setting="bulkExport"><span></span></button>
+            </div>
+            <div class="codex-plus-row">
               <div><div class="codex-plus-row-title">会话项目移动</div><div class="codex-plus-row-description">在会话列表悬停显示移动按钮，可移动到普通对话或其他本地项目。</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="projectMove"><span></span></button>
             </div>
@@ -968,7 +1046,7 @@
     const existing = document.getElementById(codexPlusMenuId);
     removeDuplicateCodexPlusMenus(existing);
     let insertionPoint = findNativeMenuInsertionPoint();
-    if (existing && existing.dataset.codexPlusMenuVersion !== "6") {
+    if (existing && existing.dataset.codexPlusMenuVersion !== "7") {
       existing.remove();
       insertionPoint = findNativeMenuInsertionPoint();
     } else if (existing && insertionPoint && existing.parentElement === insertionPoint.parent) {
@@ -979,7 +1057,7 @@
     const menu = document.createElement("div");
     menu.id = codexPlusMenuId;
     menu.dataset.codexPlusMenu = "true";
-    menu.dataset.codexPlusMenuVersion = "6";
+    menu.dataset.codexPlusMenuVersion = "7";
     const trigger = document.createElement("button");
     trigger.type = "button";
     trigger.textContent = `Codex++ ${codexPlusVersion}`;
@@ -991,6 +1069,18 @@
     const nativeButtonClass = insertionPoint?.nativeButtonClass || "codex-plus-trigger";
     configureCodexPlusTrigger(menu, trigger, nativeButtonClass);
     menu.appendChild(trigger);
+    const bulkExportButton = document.createElement("button");
+    bulkExportButton.type = "button";
+    bulkExportButton.textContent = "批量导出";
+    bulkExportButton.className = "codex-bulk-export-trigger";
+    bulkExportButton.dataset.codexBulkExportToggle = "true";
+    bulkExportButton.hidden = !codexPlusSettings().bulkExport;
+    bulkExportButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      toggleBulkExportMode();
+    }, true);
+    menu.appendChild(bulkExportButton);
     if (insertionPoint) {
       menu.className = "";
       const safeBefore = insertionPoint.before?.parentElement === insertionPoint.parent ? insertionPoint.before : null;
@@ -1182,6 +1272,22 @@
       throw new Error("导出结果不完整");
     }
     const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+
+  function downloadZip(filename, zipBase64) {
+    if (!filename || typeof zipBase64 !== "string") {
+      throw new Error("批量导出结果不完整");
+    }
+    const bytes = Uint8Array.from(atob(zipBase64), (char) => char.charCodeAt(0));
+    const blob = new Blob([bytes], { type: "application/zip" });
     const url = URL.createObjectURL(blob);
     const anchor = document.createElement("a");
     anchor.href = url;
@@ -2031,6 +2137,104 @@
     setTimeout(() => toast.remove(), 10000);
   }
 
+  const codexBulkExportSelection = new Map();
+  let codexBulkExportMode = false;
+
+  function selectedBulkExportSessions() {
+    return Array.from(codexBulkExportSelection.values());
+  }
+
+  function setBulkExportMode(enabled) {
+    codexBulkExportMode = !!enabled && !!codexPlusSettings().bulkExport;
+    if (!codexBulkExportMode) codexBulkExportSelection.clear();
+    sessionRows(true).forEach((row) => installBulkExportSelectionControl(row));
+    renderBulkExportBar();
+  }
+
+  function toggleBulkExportMode() {
+    setBulkExportMode(!codexBulkExportMode);
+  }
+
+  function updateBulkExportRowSelection(row, ref, selected) {
+    if (selected) {
+      codexBulkExportSelection.set(ref.session_id, ref);
+    } else {
+      codexBulkExportSelection.delete(ref.session_id);
+    }
+    row.dataset.codexBulkExportSelected = String(!!selected);
+    const checkbox = row.querySelector(`.${bulkExportCheckboxClass}`);
+    if (checkbox) checkbox.checked = !!selected;
+    renderBulkExportBar();
+  }
+
+  function installBulkExportSelectionControl(row) {
+    const existing = row.querySelector(`.${bulkExportCheckboxClass}`);
+    if (!codexBulkExportMode || !codexPlusSettings().bulkExport) {
+      existing?.remove();
+      row.dataset.codexBulkExportMode = "false";
+      row.dataset.codexBulkExportSelected = "false";
+      return;
+    }
+    const ref = sessionRefFromRow(row);
+    if (!ref.session_id) return;
+    row.dataset.codexBulkExportMode = "true";
+    row.dataset.codexBulkExportSelected = String(codexBulkExportSelection.has(ref.session_id));
+    const checkbox = existing || document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.className = bulkExportCheckboxClass;
+    checkbox.setAttribute("aria-label", `选择导出：${ref.title || ref.session_id}`);
+    checkbox.checked = codexBulkExportSelection.has(ref.session_id);
+    checkbox.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation?.();
+      updateBulkExportRowSelection(row, ref, !codexBulkExportSelection.has(ref.session_id));
+    }, true);
+    if (!existing) row.appendChild(checkbox);
+  }
+
+  function renderBulkExportBar() {
+    document.querySelectorAll(`.${bulkExportBarClass}`).forEach((node) => node.remove());
+    if (!codexBulkExportMode) return;
+    const selectedCount = selectedBulkExportSessions().length;
+    const bar = document.createElement("div");
+    bar.className = bulkExportBarClass;
+    bar.innerHTML = `
+      <span>已选择 ${selectedCount} 个会话</span>
+      <button type="button" data-codex-bulk-export-submit ${selectedCount ? "" : "disabled"}>导出 ZIP</button>
+      <button type="button" data-codex-bulk-export-cancel>取消</button>
+    `;
+    bar.addEventListener("click", (event) => {
+      const target = event.target instanceof Element ? event.target : event.target?.parentElement;
+      event.preventDefault();
+      event.stopPropagation();
+      if (target?.closest("[data-codex-bulk-export-cancel]")) {
+        setBulkExportMode(false);
+        return;
+      }
+      if (target?.closest("[data-codex-bulk-export-submit]")) {
+        exportSelectedSessionsZip();
+      }
+    }, true);
+    document.body.appendChild(bar);
+  }
+
+  async function exportSelectedSessionsZip() {
+    const sessions = selectedBulkExportSessions();
+    if (!sessions.length) {
+      showToast("请选择要导出的会话", null);
+      return;
+    }
+    const result = await postJson("/export-markdown-zip", { sessions });
+    if (result.status === "exported" && result.filename && result.zip_base64) {
+      downloadZip(result.filename, result.zip_base64);
+      showToast(result.message || "批量导出成功", null);
+      setBulkExportMode(false);
+      return;
+    }
+    showToast(result.message || "批量导出失败", null);
+  }
+
   function escapeHtml(value) {
     return String(value)
       .replaceAll("&", "&amp;")
@@ -2802,6 +3006,7 @@
     enablePluginEntry();
     unblockPluginInstallButtons();
     sessionRows().forEach(tryAttachButton);
+    sessionRows().forEach((row) => installBulkExportSelectionControl(row));
     updateDeleteButtonOffsets();
     scheduleProjectMoveProjection();
     scheduleChatsSortCorrection();
@@ -2825,7 +3030,7 @@
   }
 
   function isExtensionUiNode(node) {
-    return !!node?.closest?.(`.codex-delete-toast, .codex-delete-confirm-overlay, .codex-plus-modal-overlay, .${projectMoveOverlayClass}, .${timelineClass}, .codex-conversation-timeline, #codex-plus-menu`);
+    return !!node?.closest?.(`.codex-delete-toast, .codex-delete-confirm-overlay, .codex-plus-modal-overlay, .${projectMoveOverlayClass}, .${timelineClass}, .codex-conversation-timeline, .${bulkExportBarClass}, .${bulkExportCheckboxClass}, #codex-plus-menu`);
   }
 
   const scanRelevantSelector = [

--- a/codex_session_delete/launcher.py
+++ b/codex_session_delete/launcher.py
@@ -418,6 +418,14 @@ def handle_bridge_request(
     if path == "/export-markdown":
         session = SessionRef(session_id=str(payload.get("session_id", "")), title=str(payload.get("title", "")))
         return export_service.export(session).to_dict()
+    if path == "/export-markdown-zip":
+        raw_sessions = payload.get("sessions", [])
+        sessions = [
+            SessionRef(session_id=str(item.get("session_id", "")), title=str(item.get("title", "")))
+            for item in raw_sessions
+            if isinstance(item, dict) and item.get("session_id")
+        ] if isinstance(raw_sessions, list) else []
+        return export_service.export_zip(sessions).to_dict()
     if path == "/archived-thread":
         session = service.find_archived_thread_by_title(str(payload.get("title", "")))
         return {"session_id": session.session_id, "title": session.title} if session else {"session_id": "", "title": ""}

--- a/codex_session_delete/markdown_exporter.py
+++ b/codex_session_delete/markdown_exporter.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import base64
 import json
 import re
 import sqlite3
+import zipfile
+from io import BytesIO
 from datetime import datetime
 from pathlib import Path
 
-from codex_session_delete.models import ExportResult, ExportStatus, SessionRef
+from codex_session_delete.models import BulkExportResult, ExportResult, ExportStatus, SessionRef
 
 
 _WINDOWS_FILENAME_CHARS_RE = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
@@ -60,6 +63,61 @@ class MarkdownExportService:
             message=f"已导出为 Markdown：{filename}",
             filename=filename,
             markdown=markdown,
+        )
+
+    def export_zip(self, sessions: list[SessionRef]) -> BulkExportResult:
+        if not sessions:
+            return BulkExportResult(
+                status=ExportStatus.FAILED,
+                message="未选择可导出的会话",
+                failures=[],
+            )
+
+        failures: list[dict[str, str]] = []
+        exported: list[ExportResult] = []
+        for session in sessions:
+            result = self.export(session)
+            if result.status == ExportStatus.EXPORTED and result.filename and result.markdown is not None:
+                exported.append(result)
+            else:
+                failures.append({
+                    "session_id": session.session_id,
+                    "title": session.title,
+                    "message": result.message,
+                })
+
+        if not exported:
+            return BulkExportResult(
+                status=ExportStatus.FAILED,
+                message=f"导出失败：{len(failures)} 个会话未导出",
+                exported_count=0,
+                failed_count=len(failures),
+                failures=failures,
+            )
+
+        buffer = BytesIO()
+        used_names: set[str] = set()
+        with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            for result in exported:
+                archive.writestr(self._unique_zip_name(result.filename or "Untitled session.md", used_names), result.markdown or "")
+            if failures:
+                archive.writestr("export-failures.md", self._render_failure_summary(failures))
+
+        total = len(sessions)
+        exported_count = len(exported)
+        failed_count = len(failures)
+        filename = f"codex-sessions-{exported_count}-of-{total}.zip"
+        message = f"已导出 {exported_count}/{total} 个会话为 ZIP"
+        if failed_count:
+            message += f"，{failed_count} 个失败"
+        return BulkExportResult(
+            status=ExportStatus.EXPORTED,
+            message=message,
+            filename=filename,
+            zip_base64=base64.b64encode(buffer.getvalue()).decode("ascii"),
+            exported_count=exported_count,
+            failed_count=failed_count,
+            failures=failures,
         )
 
     def _supports_codex_threads(self, db: sqlite3.Connection) -> bool:
@@ -144,6 +202,30 @@ class MarkdownExportService:
             lines.append(body.rstrip())
             lines.append("")
         return "\n".join(lines).rstrip() + "\n"
+
+    def _render_failure_summary(self, failures: list[dict[str, str]]) -> str:
+        lines = ["# Export failures", ""]
+        for failure in failures:
+            title = failure.get("title") or "Untitled session"
+            session_id = failure.get("session_id") or ""
+            message = failure.get("message") or "导出失败"
+            lines.append(f"- {title} ({session_id}): {message}")
+        return "\n".join(lines).rstrip() + "\n"
+
+    def _unique_zip_name(self, filename: str, used_names: set[str]) -> str:
+        if filename not in used_names:
+            used_names.add(filename)
+            return filename
+        stem, dot, suffix = filename.rpartition(".")
+        base = stem if dot else filename
+        extension = f".{suffix}" if dot else ""
+        index = 2
+        while True:
+            candidate = f"{base}-{index}{extension}"
+            if candidate not in used_names:
+                used_names.add(candidate)
+                return candidate
+            index += 1
 
     def _normalize_session_id(self, session_id: str) -> str:
         return session_id.removeprefix("local:")

--- a/codex_session_delete/models.py
+++ b/codex_session_delete/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 from dataclasses import dataclass
 from enum import Enum
 
@@ -60,4 +61,29 @@ class ExportResult:
             "message": self.message,
             "filename": self.filename,
             "markdown": self.markdown,
+        }
+
+
+@dataclass(frozen=True)
+class BulkExportResult:
+    status: ExportStatus
+    message: str
+    filename: str | None = None
+    zip_base64: str | None = None
+    exported_count: int = 0
+    failed_count: int = 0
+    failures: list[dict[str, str]] | None = None
+
+    def zip_bytes(self) -> bytes:
+        return base64.b64decode(self.zip_base64 or "")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "status": self.status.value,
+            "message": self.message,
+            "filename": self.filename,
+            "zip_base64": self.zip_base64,
+            "exported_count": self.exported_count,
+            "failed_count": self.failed_count,
+            "failures": self.failures or [],
         }

--- a/tests/test_helper_server.py
+++ b/tests/test_helper_server.py
@@ -6,7 +6,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from importlib import resources
 
 from codex_session_delete.helper_server import HelperServer
-from codex_session_delete.models import DeleteResult, DeleteStatus, ExportResult, ExportStatus, SessionRef
+from codex_session_delete.models import BulkExportResult, DeleteResult, DeleteStatus, ExportResult, ExportStatus, SessionRef
 
 
 class FakeDeleteService:
@@ -40,10 +40,23 @@ class FakeDeleteService:
 class FakeExportService:
     def __init__(self):
         self.exported = []
+        self.zip_exported = []
 
     def export(self, session: SessionRef):
         self.exported.append(session)
         return ExportResult(ExportStatus.EXPORTED, session.session_id, "Exported", filename="thread.md", markdown="# Thread\n")
+
+    def export_zip(self, sessions: list[SessionRef]):
+        self.zip_exported.extend(sessions)
+        return BulkExportResult(
+            ExportStatus.EXPORTED,
+            f"Exported {len(sessions)} sessions",
+            filename="codex-sessions.zip",
+            zip_base64="UEsDBAo=",
+            exported_count=len(sessions),
+            failed_count=0,
+            failures=[],
+        )
 
 
 def post_json(url, payload, headers=None):
@@ -190,6 +203,25 @@ def test_helper_server_exports_markdown_when_authorized():
     assert export_service.exported[0].session_id == "s1"
 
 
+def test_helper_server_exports_selected_sessions_as_zip_when_authorized():
+    delete_service = FakeDeleteService()
+    export_service = FakeExportService()
+    server = HelperServer("127.0.0.1", 0, delete_service, export_service, allow_http_mutation=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        base = f"http://127.0.0.1:{server.port}"
+        exported = post_json(base + "/export-markdown-zip", {"sessions": [{"session_id": "s1", "title": "First"}, {"session_id": "s2", "title": "Second"}]})
+    finally:
+        server.shutdown()
+        thread.join(timeout=3)
+
+    assert exported["status"] == "exported"
+    assert exported["filename"] == "codex-sessions.zip"
+    assert exported["exported_count"] == 2
+    assert [session.session_id for session in export_service.zip_exported] == ["s1", "s2"]
+
+
 def test_helper_server_rejects_http_mutation_by_default():
     service = FakeDeleteService()
     server = HelperServer("127.0.0.1", 0, service)
@@ -204,6 +236,11 @@ def test_helper_server_rejects_http_mutation_by_default():
             assert exc.code == 403
         try:
             post_json(base + "/export-markdown", {"session_id": "s1", "title": "First"})
+            assert False, "expected forbidden response"
+        except urllib.error.HTTPError as exc:
+            assert exc.code == 403
+        try:
+            post_json(base + "/export-markdown-zip", {"sessions": [{"session_id": "s1", "title": "First"}]})
             assert False, "expected forbidden response"
         except urllib.error.HTTPError as exc:
             assert exc.code == 403

--- a/tests/test_launcher_user_scripts.py
+++ b/tests/test_launcher_user_scripts.py
@@ -1,5 +1,5 @@
 from codex_session_delete.launcher import handle_bridge_request
-from codex_session_delete.models import ExportResult, ExportStatus
+from codex_session_delete.models import BulkExportResult, ExportResult, ExportStatus
 from codex_session_delete.settings_store import SettingsStore
 from codex_session_delete.user_scripts import UserScriptManager
 
@@ -18,6 +18,17 @@ class FakeDeleteService:
 class FakeExportService:
     def export(self, session):
         return ExportResult(ExportStatus.EXPORTED, session.session_id, "Exported", filename="thread.md", markdown="# Thread\n")
+
+    def export_zip(self, sessions):
+        return BulkExportResult(
+            ExportStatus.EXPORTED,
+            f"Exported {len(sessions)} sessions",
+            filename="codex-sessions.zip",
+            zip_base64="UEsDBAo=",
+            exported_count=len(sessions),
+            failed_count=0,
+            failures=[],
+        )
 
 
 class FakeRuntime:
@@ -129,3 +140,19 @@ def test_handle_bridge_request_exports_markdown(tmp_path):
     assert exported["status"] == "exported"
     assert exported["filename"] == "thread.md"
 
+
+def test_handle_bridge_request_exports_selected_sessions_as_zip(tmp_path):
+    manager = UserScriptManager(tmp_path / "builtin", tmp_path / "user", tmp_path / "config.json")
+    runtime = FakeRuntime(manager)
+
+    exported = handle_bridge_request(
+        FakeDeleteService(),
+        FakeExportService(),
+        "/export-markdown-zip",
+        {"sessions": [{"session_id": "s1", "title": "First"}, {"session_id": "s2", "title": "Second"}]},
+        runtime,
+    )
+
+    assert exported["status"] == "exported"
+    assert exported["filename"] == "codex-sessions.zip"
+    assert exported["exported_count"] == 2

--- a/tests/test_markdown_exporter.py
+++ b/tests/test_markdown_exporter.py
@@ -1,4 +1,6 @@
 import sqlite3
+import zipfile
+from io import BytesIO
 from datetime import datetime
 
 from codex_session_delete.markdown_exporter import MarkdownExportService
@@ -7,7 +9,7 @@ from codex_session_delete.models import ExportStatus, SessionRef
 
 def create_codex_thread_db(path, rollout_path, *, thread_id="t1", title="Codex Thread"):
     with sqlite3.connect(path) as db:
-        db.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT, title TEXT, archived INTEGER, archived_at INTEGER)")
+        db.execute("CREATE TABLE IF NOT EXISTS threads (id TEXT PRIMARY KEY, rollout_path TEXT, title TEXT, archived INTEGER, archived_at INTEGER)")
         db.execute(
             "INSERT INTO threads (id, rollout_path, title, archived, archived_at) VALUES (?, ?, ?, 0, NULL)",
             (thread_id, str(rollout_path), title),
@@ -180,3 +182,40 @@ def test_markdown_exporter_fails_when_thread_missing_rollout_missing_or_no_messa
     assert missing_thread.status == ExportStatus.FAILED
     assert missing_rollout.status == ExportStatus.FAILED
     assert no_messages.status == ExportStatus.FAILED
+
+
+def test_markdown_exporter_exports_multiple_sessions_as_zip_with_failure_summary(tmp_path):
+    db_path = tmp_path / "state_5.sqlite"
+    first_rollout = tmp_path / "first.jsonl"
+    second_rollout = tmp_path / "second.jsonl"
+    first_rollout.write_text(
+        '{"type":"response_item","timestamp":"2026-05-10T13:12:06Z","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"First body"}]}}\n',
+        encoding="utf-8",
+    )
+    second_rollout.write_text(
+        '{"type":"response_item","timestamp":"2026-05-10T13:12:07Z","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Second body"}]}}\n',
+        encoding="utf-8",
+    )
+    create_codex_thread_db(db_path, first_rollout, thread_id="t1", title="First Thread")
+    create_codex_thread_db(db_path, second_rollout, thread_id="t2", title="First Thread")
+
+    result = MarkdownExportService(db_path).export_zip([
+        SessionRef(session_id="t1", title="First"),
+        SessionRef(session_id="missing", title="Missing Thread"),
+        SessionRef(session_id="t2", title="Second"),
+    ])
+
+    assert result.status == ExportStatus.EXPORTED
+    assert result.filename == "codex-sessions-2-of-3.zip"
+    assert result.exported_count == 2
+    assert result.failed_count == 1
+    assert result.failures == [{"session_id": "missing", "title": "Missing Thread", "message": "未找到对应会话"}]
+    assert result.zip_base64 is not None
+    with zipfile.ZipFile(BytesIO(result.zip_bytes())) as archive:
+        names = set(archive.namelist())
+        assert "First Thread-t1.md" in names
+        assert "First Thread-t2.md" in names
+        assert "export-failures.md" in names
+        assert "First body" in archive.read("First Thread-t1.md").decode("utf-8")
+        assert "Second body" in archive.read("First Thread-t2.md").decode("utf-8")
+        assert "Missing Thread" in archive.read("export-failures.md").decode("utf-8")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,4 @@
-from codex_session_delete.models import DeleteResult, DeleteStatus, ExportResult, ExportStatus, SessionRef
+from codex_session_delete.models import BulkExportResult, DeleteResult, DeleteStatus, ExportResult, ExportStatus, SessionRef
 
 
 def test_session_ref_requires_session_id():
@@ -43,4 +43,26 @@ def test_export_result_serializes_to_json_dict():
         "message": "Exported",
         "filename": "example.md",
         "markdown": "# Example\n",
+    }
+
+
+def test_bulk_export_result_serializes_to_json_dict():
+    result = BulkExportResult(
+        status=ExportStatus.EXPORTED,
+        message="Exported 2 sessions",
+        filename="codex-sessions.zip",
+        zip_base64="UEsDBAo=",
+        exported_count=2,
+        failed_count=1,
+        failures=[{"session_id": "missing", "title": "Missing", "message": "未找到对应会话"}],
+    )
+
+    assert result.to_dict() == {
+        "status": "exported",
+        "message": "Exported 2 sessions",
+        "filename": "codex-sessions.zip",
+        "zip_base64": "UEsDBAo=",
+        "exported_count": 2,
+        "failed_count": 1,
+        "failures": [{"session_id": "missing", "title": "Missing", "message": "未找到对应会话"}],
     }

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -63,6 +63,17 @@ def test_renderer_script_can_bulk_export_selected_sidebar_sessions_as_zip():
     assert "sessionRows().forEach((row) => installBulkExportSelectionControl(row))" in text
 
 
+def test_renderer_script_allows_bulk_export_checkbox_native_checked_state():
+    text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
+    start = text.index("function installBulkExportSelectionControl")
+    end = text.index("\n\n  function renderBulkExportBar", start)
+    checkbox_code = text[start:end]
+
+    assert "checkbox.addEventListener(\"click\"" in checkbox_code
+    assert "event.preventDefault()" not in checkbox_code
+    assert "updateBulkExportRowSelection(row, ref, checkbox.checked)" in checkbox_code
+
+
 
 
 def test_renderer_script_keeps_sponsors_separate_from_author_support():

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -46,6 +46,24 @@ def test_renderer_script_positions_delete_button_without_affecting_layout():
 
 
 
+def test_renderer_script_can_bulk_export_selected_sidebar_sessions_as_zip():
+    text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
+
+    assert "bulkExport: true" in text
+    assert 'data-codex-plus-setting="bulkExport"' in text
+    assert "codex-bulk-export-checkbox" in text
+    assert "codex-bulk-export-bar" in text
+    assert "codexBulkExportSelection" in text
+    assert "toggleBulkExportMode()" in text
+    assert "installBulkExportSelectionControl(row)" in text
+    assert "exportSelectedSessionsZip()" in text
+    assert 'postJson("/export-markdown-zip"' in text
+    assert "downloadZip(result.filename, result.zip_base64)" in text
+    assert "Uint8Array.from(atob(zipBase64)" in text
+    assert "sessionRows().forEach((row) => installBulkExportSelectionControl(row))" in text
+
+
+
 
 def test_renderer_script_keeps_sponsors_separate_from_author_support():
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
@@ -605,7 +623,7 @@ def test_renderer_script_includes_user_script_manager_ui_contract():
     assert "removeDuplicateCodexPlusMenus" in text
     assert "data-codex-plus-menu" in text
     assert "textContent || \"\").trim() === `Codex++ ${codexPlusVersion}`" in text
-    assert "codexPlusMenuVersion !== \"6\"" in text
+    assert "codexPlusMenuVersion !== \"7\"" in text
     assert "codexPlusTriggerInstalled = \"5\"" in text
     assert ".codex-plus-trigger:hover" not in text
     assert "function headerTitleRegion" in text


### PR DESCRIPTION
## 变更说明

- 新增批量导出入口：在顶部 `Codex++` 按钮旁增加 `批量导出` 按钮，方便从会话列表直接进入批量选择模式。
- 进入批量导出模式后，会话列表左侧显示复选框；用户可以选择多个会话，底部浮动操作栏会显示已选择数量。
- 点击底部操作栏的 `导出 ZIP` 后，会将选中的会话按 Markdown 导出结果打包为 ZIP 下载；点击 `取消` 会退出批量选择模式并清空选择。
- 如果部分会话导出失败，ZIP 中会附带失败说明文件，避免一次失败影响其他会话导出。
- 修正复选框点击交互，保留浏览器原生 checked 状态，避免勾选状态和内部选择状态不同步。

## 交互逻辑

1. 用户点击顶部 `Codex++` 旁边的 `批量导出` 按钮。
2. 会话列表进入批量选择模式，每个可识别会话左侧出现复选框。
3. 用户勾选一个或多个会话后，底部浮动栏显示当前选择数量。
4. 点击 `导出 ZIP` 触发 `/export-markdown-zip`，下载包含多个 Markdown 文件的 ZIP。
5. 点击 `取消` 或导出成功后退出批量选择模式。

## 验证

- `node --check codex_session_delete/inject/renderer-inject.js`
- `.venv/bin/python -m pytest tests/test_renderer_script.py -q`（37 passed）
- `.venv/bin/python -m pytest tests/test_models.py tests/test_markdown_exporter.py tests/test_helper_server.py tests/test_launcher_user_scripts.py tests/test_renderer_script.py -q`（72 passed）
- `git diff --check`
