### PR TITLE
Inject Codex++ into new Codex windows

### DIFF
--- a/codex_session_delete/cdp.py
+++ b/codex_session_delete/cdp.py
@@ -4,7 +4,7 @@ import base64
 import json
 import threading
 import webbrowser
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from importlib import resources
 from pathlib import Path
 from typing import Callable
@@ -14,6 +14,7 @@ import websocket
 
 
 BridgeHandler = Callable[[str, dict[str, object]], dict[str, object]]
+InjectionCallback = Callable[["InjectionResult"], None]
 BRIDGE_BINDING_NAME = "codexSessionDeleteV2"
 
 
@@ -24,6 +25,32 @@ class InjectionResult:
     result: dict[str, object] | None
 
 
+@dataclass
+class MultiPageInjection:
+    injections: dict[str, InjectionResult] = field(default_factory=dict)
+    stop_event: threading.Event = field(default_factory=threading.Event)
+    watcher_thread: threading.Thread | None = None
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    @property
+    def websocket_url(self) -> str | None:
+        with self.lock:
+            first = next(iter(self.injections.values()), None)
+        return first.websocket_url if first else None
+
+    @property
+    def bridge_socket(self) -> websocket.WebSocket | None:
+        with self.lock:
+            first = next((injection.bridge_socket for injection in self.injections.values() if injection.bridge_socket), None)
+        return first
+
+    @property
+    def result(self) -> dict[str, object] | None:
+        with self.lock:
+            first = next(iter(self.injections.values()), None)
+        return first.result if first else None
+
+
 def list_targets(port: int) -> list[dict[str, object]]:
     session = requests.Session()
     session.trust_env = False
@@ -32,13 +59,20 @@ def list_targets(port: int) -> list[dict[str, object]]:
     return response.json()
 
 
-def pick_page_target(targets: list[dict[str, object]]) -> dict[str, object]:
+def codex_page_targets(targets: list[dict[str, object]]) -> list[dict[str, object]]:
     pages = [target for target in targets if target.get("type") == "page" and target.get("webSocketDebuggerUrl")]
+    codex_pages = []
     for target in pages:
         title = str(target.get("title", ""))
         url = str(target.get("url", ""))
-        if "codex" in (title + " " + url).lower():
-            return target
+        haystack = (title + " " + url).lower()
+        if "codex" in haystack or url.startswith("app://"):
+            codex_pages.append(target)
+    return codex_pages or pages
+
+
+def pick_page_target(targets: list[dict[str, object]]) -> dict[str, object]:
+    pages = codex_page_targets(targets)
     if pages:
         return pages[0]
     raise RuntimeError("No injectable Codex page target found")
@@ -150,21 +184,84 @@ def sponsor_image_data_uris() -> dict[str, str]:
     }
 
 
-def inject_file(port: int, script_path: Path, helper_port: int, handler: BridgeHandler | None = None) -> InjectionResult:
-    targets = list_targets(port)
-    target = pick_page_target(targets)
-    websocket_url = str(target["webSocketDebuggerUrl"])
+def target_key(target: dict[str, object]) -> str:
+    return str(target.get("id") or target.get("webSocketDebuggerUrl") or "")
+
+
+def build_full_injection_script(script_path: Path, helper_port: int) -> str:
     script = script_path.read_text(encoding="utf-8")
     prefix = (
         f"window.__CODEX_SESSION_DELETE_HELPER__ = 'http://127.0.0.1:{helper_port}';\n"
         f"window.__CODEX_PLUS_SPONSOR_IMAGES__ = {json.dumps(sponsor_image_data_uris())};\n"
     )
-    full_script = prefix + script
+    return prefix + script
+
+
+def inject_target(target: dict[str, object], full_script: str, handler: BridgeHandler | None = None) -> InjectionResult:
+    websocket_url = str(target["webSocketDebuggerUrl"])
     bridge_socket = install_bridge(websocket_url, BRIDGE_BINDING_NAME, handler, [full_script]) if handler else None
     if not bridge_socket:
         add_script_to_new_documents(websocket_url, full_script)
     result = evaluate_script(websocket_url, full_script)
     return InjectionResult(websocket_url=websocket_url, bridge_socket=bridge_socket, result=result)
+
+
+def inject_file(port: int, script_path: Path, helper_port: int, handler: BridgeHandler | None = None) -> InjectionResult:
+    target = pick_page_target(list_targets(port))
+    return inject_target(target, build_full_injection_script(script_path, helper_port), handler)
+
+
+def inject_file_into_all_pages(
+    port: int,
+    script_path: Path,
+    helper_port: int,
+    handler: BridgeHandler | None = None,
+    on_injection: InjectionCallback | None = None,
+    poll_interval: float = 0.75,
+) -> MultiPageInjection:
+    manager = MultiPageInjection()
+    full_script = build_full_injection_script(script_path, helper_port)
+
+    def inject_available_pages() -> int:
+        injected = 0
+        last_error: Exception | None = None
+        for target in codex_page_targets(list_targets(port)):
+            key = target_key(target)
+            with manager.lock:
+                already_injected = key in manager.injections
+            if not key or already_injected:
+                continue
+            try:
+                injection = inject_target(target, full_script, handler)
+                with manager.lock:
+                    manager.injections[key] = injection
+                if on_injection:
+                    on_injection(injection)
+                injected += 1
+            except Exception as exc:
+                last_error = exc
+        with manager.lock:
+            has_injections = bool(manager.injections)
+        if not has_injections and last_error is not None:
+            raise last_error
+        return injected
+
+    inject_available_pages()
+    with manager.lock:
+        has_injections = bool(manager.injections)
+    if not has_injections:
+        raise RuntimeError("No injectable Codex page target found")
+
+    def watch_pages() -> None:
+        while not manager.stop_event.wait(poll_interval):
+            try:
+                inject_available_pages()
+            except Exception:
+                continue
+
+    manager.watcher_thread = threading.Thread(target=watch_pages, daemon=True)
+    manager.watcher_thread.start()
+    return manager
 
 
 def _bridge_loop(ws: websocket.WebSocket, handler: BridgeHandler) -> None:

--- a/codex_session_delete/launcher.py
+++ b/codex_session_delete/launcher.py
@@ -8,7 +8,7 @@ import sys
 import threading
 import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -16,7 +16,8 @@ from codex_session_delete import cdp
 from codex_session_delete.app_paths import resolve_codex_app_dir
 from codex_session_delete.api_adapter import ApiAdapter, UnavailableApiAdapter
 from codex_session_delete.backup_store import BackupStore
-from codex_session_delete.cdp import evaluate_user_scripts, inject_file, open_devtools
+from codex_session_delete.cdp import evaluate_user_scripts, open_devtools
+from codex_session_delete.cdp import inject_file_into_all_pages
 from codex_session_delete.helper_server import HelperServer
 from codex_session_delete.helper_server import fetch_ad_list
 from codex_session_delete.markdown_exporter import MarkdownExportService
@@ -75,11 +76,32 @@ class CodexPlusRuntime:
     websocket_url: str | None
     user_scripts: UserScriptManager
     debug_port: int | None = None
+    websocket_urls: set[str] = field(default_factory=set)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def add_websocket_url(self, websocket_url: str) -> None:
+        with self.lock:
+            self.websocket_url = websocket_url
+            self.websocket_urls.add(websocket_url)
 
     def reload_user_scripts(self) -> dict[str, object]:
-        if self.websocket_url:
-            evaluate_user_scripts(self.websocket_url, self.user_scripts.build_enabled_bundle())
-        return self.user_scripts.inventory()
+        script = self.user_scripts.build_enabled_bundle()
+        with self.lock:
+            websocket_urls = list(self.websocket_urls or ({self.websocket_url} if self.websocket_url else set()))
+        failed_urls = []
+        for websocket_url in websocket_urls:
+            try:
+                evaluate_user_scripts(websocket_url, script)
+            except Exception:
+                failed_urls.append(websocket_url)
+        if failed_urls:
+            with self.lock:
+                self.websocket_urls.difference_update(failed_urls)
+                if self.websocket_url in failed_urls:
+                    self.websocket_url = next(iter(self.websocket_urls), None)
+        inventory = self.user_scripts.inventory()
+        inventory["target_count"] = len(websocket_urls) - len(failed_urls)
+        return inventory
 
     def open_devtools(self) -> dict[str, object]:
         if self.debug_port is None:
@@ -315,15 +337,20 @@ def inject_with_retry(
     last_error: Exception | None = None
     for _ in range(attempts):
         try:
-            injection = inject_file(
+            def on_injection(injection):
+                runtime.add_websocket_url(injection.websocket_url)
+                evaluate_user_scripts(injection.websocket_url, runtime.user_scripts.build_enabled_bundle())
+
+            injection = inject_file_into_all_pages(
                 debug_port,
                 script_path,
                 helper_port,
                 lambda path, payload: handle_bridge_request(service, export_service, path, payload, runtime),
+                on_injection=on_injection,
             )
-            runtime.websocket_url = injection.websocket_url
-            evaluate_user_scripts(injection.websocket_url, runtime.user_scripts.build_enabled_bundle())
-            return injection.bridge_socket or injection.result
+            if injection.websocket_url:
+                runtime.add_websocket_url(injection.websocket_url)
+            return injection
         except Exception as exc:
             last_error = exc
             time.sleep(delay)

--- a/tests/test_cdp.py
+++ b/tests/test_cdp.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import codex_session_delete.cdp as cdp
 import websocket
 
-from codex_session_delete.cdp import BRIDGE_BINDING_NAME, _bridge_loop, add_script_to_new_documents, build_bridge_script, evaluate_user_scripts, install_bridge, list_targets, open_devtools, pick_page_target
+from codex_session_delete.cdp import BRIDGE_BINDING_NAME, _bridge_loop, add_script_to_new_documents, build_bridge_script, codex_page_targets, evaluate_user_scripts, install_bridge, list_targets, open_devtools, pick_page_target
 
 
 class TimeoutThenMessageSocket:
@@ -57,6 +57,15 @@ class BridgeInstallSocket:
         return json.dumps(response)
 
 
+class FakeThread:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.started = False
+
+    def start(self):
+        self.started = True
+
+
 def test_pick_page_target_prefers_codex_title():
     targets = [
         {"type": "background_page", "title": "bg", "webSocketDebuggerUrl": "ws://bg"},
@@ -64,6 +73,17 @@ def test_pick_page_target_prefers_codex_title():
     ]
 
     assert pick_page_target(targets)["webSocketDebuggerUrl"] == "ws://page"
+
+
+def test_codex_page_targets_keeps_all_codex_windows():
+    targets = [
+        {"id": "devtools", "type": "page", "title": "DevTools", "url": "devtools://devtools", "webSocketDebuggerUrl": "ws://devtools"},
+        {"id": "main", "type": "page", "title": "Codex", "url": "app://-/index.html", "webSocketDebuggerUrl": "ws://main"},
+        {"id": "child", "type": "page", "title": "Codex", "url": "app://-/index.html?initialRoute=%2Flocal%2F1", "webSocketDebuggerUrl": "ws://child"},
+        {"id": "worker", "type": "worker", "title": "", "url": "", "webSocketDebuggerUrl": "ws://worker"},
+    ]
+
+    assert [target["id"] for target in codex_page_targets(targets)] == ["main", "child"]
 
 
 def test_list_targets_bypasses_proxy_environment(monkeypatch):
@@ -159,6 +179,58 @@ def test_inject_file_exposes_packaged_sponsor_images_as_data_uris(monkeypatch, t
     assert '"alipay": "data:image/jpeg;base64,' in captured["evaluated"]
     assert '"wechat": "data:image/jpeg;base64,' in captured["evaluated"]
     assert captured["new_document"] == captured["evaluated"]
+
+
+def test_inject_file_into_all_pages_injects_existing_codex_windows(monkeypatch, tmp_path):
+    script_path = tmp_path / "renderer.js"
+    script_path.write_text("window.__rendererLoaded = true;", encoding="utf-8")
+    thread = FakeThread()
+    targets = [
+        {"id": "main", "type": "page", "title": "Codex", "url": "app://-/index.html", "webSocketDebuggerUrl": "ws://main"},
+        {"id": "child", "type": "page", "title": "Codex", "url": "app://-/index.html?initialRoute=%2Flocal%2F1", "webSocketDebuggerUrl": "ws://child"},
+        {"id": "worker", "type": "worker", "title": "", "url": "", "webSocketDebuggerUrl": "ws://worker"},
+    ]
+    injected = []
+    callbacks = []
+
+    def fake_inject_target(target, full_script, handler):
+        injected.append((target["id"], full_script))
+        return cdp.InjectionResult(websocket_url=target["webSocketDebuggerUrl"], bridge_socket=None, result={"status": target["id"]})
+
+    monkeypatch.setattr(cdp, "list_targets", lambda port: targets)
+    monkeypatch.setattr(cdp, "inject_target", fake_inject_target)
+    monkeypatch.setattr(cdp.threading, "Thread", lambda **kwargs: thread)
+
+    manager = cdp.inject_file_into_all_pages(9229, script_path, 57321, lambda path, payload: {}, on_injection=callbacks.append)
+
+    assert [item[0] for item in injected] == ["main", "child"]
+    assert "window.__CODEX_SESSION_DELETE_HELPER__ = 'http://127.0.0.1:57321';" in injected[0][1]
+    assert sorted(manager.injections) == ["child", "main"]
+    assert [callback.websocket_url for callback in callbacks] == ["ws://main", "ws://child"]
+    assert manager.websocket_url == "ws://main"
+    assert thread.started is True
+
+
+def test_inject_file_into_all_pages_keeps_successful_targets_when_one_fails(monkeypatch, tmp_path):
+    script_path = tmp_path / "renderer.js"
+    script_path.write_text("window.__rendererLoaded = true;", encoding="utf-8")
+    targets = [
+        {"id": "main", "type": "page", "title": "Codex", "url": "app://-/index.html", "webSocketDebuggerUrl": "ws://main"},
+        {"id": "child", "type": "page", "title": "Codex", "url": "app://-/index.html?initialRoute=%2Flocal%2F1", "webSocketDebuggerUrl": "ws://child"},
+    ]
+
+    def fake_inject_target(target, full_script, handler):
+        if target["id"] == "child":
+            raise RuntimeError("page still loading")
+        return cdp.InjectionResult(websocket_url=target["webSocketDebuggerUrl"], bridge_socket=None, result={"status": target["id"]})
+
+    monkeypatch.setattr(cdp, "list_targets", lambda port: targets)
+    monkeypatch.setattr(cdp, "inject_target", fake_inject_target)
+    monkeypatch.setattr(cdp.threading, "Thread", lambda **kwargs: FakeThread())
+
+    manager = cdp.inject_file_into_all_pages(9229, script_path, 57321)
+
+    assert sorted(manager.injections) == ["main"]
 
 
 def test_open_devtools_opens_chrome_devtools_frontend(monkeypatch):

--- a/tests/test_launcher_cli.py
+++ b/tests/test_launcher_cli.py
@@ -56,6 +56,9 @@ def test_launch_codex_injects_detected_local_proxy(monkeypatch):
     monkeypatch.delenv("HTTP_PROXY", raising=False)
     monkeypatch.delenv("HTTPS_PROXY", raising=False)
     monkeypatch.delenv("ALL_PROXY", raising=False)
+    monkeypatch.delenv("http_proxy", raising=False)
+    monkeypatch.delenv("https_proxy", raising=False)
+    monkeypatch.delenv("all_proxy", raising=False)
     monkeypatch.setattr(launcher, "local_proxy_url", lambda: "http://127.0.0.1:7897")
     monkeypatch.setattr(launcher.subprocess, "Popen", lambda args, **kw: popen_calls.append((args, kw)))
 
@@ -191,13 +194,13 @@ def test_launch_retries_injection_until_codex_page_is_ready(monkeypatch, tmp_pat
     monkeypatch.setattr(launcher, "start_helper", lambda *args, **kwargs: FakeServer())
     monkeypatch.setattr(launcher, "launch_codex_app", lambda *args: None)
 
-    def inject_after_retry(*args):
+    def inject_after_retry(*args, **kwargs):
         attempts.append(args)
         if len(attempts) == 1:
             raise RuntimeError("CDP page not ready")
         return launcher.cdp.InjectionResult(websocket_url="ws://page", bridge_socket=None, result={"result": {}})
 
-    monkeypatch.setattr(launcher, "inject_file", inject_after_retry)
+    monkeypatch.setattr(launcher, "inject_file_into_all_pages", inject_after_retry)
     monkeypatch.setattr(launcher, "evaluate_user_scripts", lambda websocket_url, script: None)
     monkeypatch.setattr(launcher.time, "sleep", lambda seconds: None)
 
@@ -205,6 +208,67 @@ def test_launch_retries_injection_until_codex_page_is_ready(monkeypatch, tmp_pat
 
     assert server.port == 57321
     assert len(attempts) == 2
+
+
+def test_inject_with_retry_tracks_all_injected_page_targets(monkeypatch, tmp_path):
+    evaluations = []
+    runtime = launcher.CodexPlusRuntime(
+        None,
+        type("Scripts", (), {"build_enabled_bundle": lambda self: "window.__userScript = true;"})(),
+        9229,
+    )
+    injections = {
+        "main": launcher.cdp.InjectionResult(websocket_url="ws://main", bridge_socket=None, result={"result": "main"}),
+        "child": launcher.cdp.InjectionResult(websocket_url="ws://child", bridge_socket=None, result={"result": "child"}),
+    }
+
+    def inject_pages(*args, **kwargs):
+        for injection in injections.values():
+            kwargs["on_injection"](injection)
+        return launcher.cdp.MultiPageInjection(injections=injections)
+
+    monkeypatch.setattr(launcher, "inject_file_into_all_pages", inject_pages)
+    monkeypatch.setattr(launcher, "evaluate_user_scripts", lambda websocket_url, script: evaluations.append((websocket_url, script)))
+
+    result = launcher.inject_with_retry(9229, tmp_path / "renderer.js", 57321, object(), object(), runtime)
+
+    assert result.websocket_url == "ws://main"
+    assert runtime.websocket_urls == {"ws://main", "ws://child"}
+    assert evaluations == [
+        ("ws://main", "window.__userScript = true;"),
+        ("ws://child", "window.__userScript = true;"),
+    ]
+
+
+def test_reload_user_scripts_drops_closed_page_targets(monkeypatch):
+    evaluations = []
+    runtime = launcher.CodexPlusRuntime(
+        "ws://closed",
+        type(
+            "Scripts",
+            (),
+            {
+                "build_enabled_bundle": lambda self: "window.__userScript = true;",
+                "inventory": lambda self: {"global_enabled": True},
+            },
+        )(),
+        9229,
+    )
+    runtime.websocket_urls.update({"ws://closed", "ws://open"})
+
+    def evaluate(websocket_url, script):
+        evaluations.append((websocket_url, script))
+        if websocket_url == "ws://closed":
+            raise RuntimeError("target closed")
+
+    monkeypatch.setattr(launcher, "evaluate_user_scripts", evaluate)
+
+    result = runtime.reload_user_scripts()
+
+    assert result["target_count"] == 1
+    assert runtime.websocket_urls == {"ws://open"}
+    assert runtime.websocket_url == "ws://open"
+    assert ("ws://open", "window.__userScript = true;") in evaluations
 
 
 def test_launch_and_inject_returns_windows_packaged_process_id(monkeypatch, tmp_path):


### PR DESCRIPTION
## What changed
- Inject Codex++ into every existing Codex CDP page target at startup.
- Keep watching CDP targets so windows opened later through `Open in new window` receive the same Codex++ wrapper.
- Track all injected websocket targets so user-script reload covers every Codex window.
- Drop closed websocket targets during reload so closed child windows do not break reload for remaining windows.

## Verification
- Confirmed locally that Codex exposes multiple page targets for main, local chat, and hotkey/new windows.
- Confirmed after relaunch that `Open in new window` shows the Codex++ menu in the child window.
- `.venv/bin/python -m pytest tests/test_cdp.py tests/test_launcher_cli.py -q` -> 51 passed
- `.venv/bin/python -m py_compile codex_session_delete/cdp.py codex_session_delete/launcher.py` -> passed

## Notes
This PR intentionally keeps the diff focused on multi-window injection and related tests.