### PR TITLE
fix(ui)：避免在非 Codex 页面显示插件菜单

### DIFF
--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -890,6 +890,16 @@
     return { parent: menuBar, before: buttons[buttons.length - 1]?.nextSibling || null, nativeButtonClass: buttons[buttons.length - 1]?.className || "" };
   }
 
+  function pageHasCodexAppChrome() {
+    return !!(
+      document.querySelector(selectors.appHeader) ||
+      document.querySelector("header") ||
+      document.querySelector(selectors.sidebarThread) ||
+      document.querySelector('[data-app-action-sidebar-section-heading="Chats"], [data-app-action-sidebar-section-heading="Projects"]') ||
+      document.querySelector(selectors.pluginNavButton)
+    );
+  }
+
   function removeDuplicateCodexPlusMenus(keep) {
     document.querySelectorAll(`#${codexPlusMenuId}, [data-codex-plus-menu="true"]`).forEach((node) => {
       if (node !== keep) node.remove();
@@ -973,6 +983,10 @@
   function installCodexPlusMenu() {
     const existing = document.getElementById(codexPlusMenuId);
     removeDuplicateCodexPlusMenus(existing);
+    if (!pageHasCodexAppChrome()) {
+      existing?.remove();
+      return;
+    }
     let insertionPoint = findNativeMenuInsertionPoint();
     if (existing && existing.dataset.codexPlusMenuVersion !== "6") {
       existing.remove();
@@ -3169,6 +3183,7 @@
     '[class*="user-message"]',
     '[class*="UserMessage"]',
     selectors.appHeader,
+    "header",
     selectors.archiveNav,
     selectors.disabledInstallButton,
   ].join(", ");

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -618,6 +618,10 @@ def test_renderer_script_includes_user_script_manager_ui_contract():
     assert "codexPlusMenuVersion !== \"6\"" in text
     assert "codexPlusTriggerInstalled = \"5\"" in text
     assert ".codex-plus-trigger:hover" not in text
+    assert "function pageHasCodexAppChrome" in text
+    assert "if (!pageHasCodexAppChrome())" in text
+    assert "existing?.remove();" in text[text.index("function installCodexPlusMenu"):text.index("\n\n  function reactFiberFrom", text.index("function installCodexPlusMenu"))]
+    assert 'document.querySelector("header")' in text
     assert "function headerTitleRegion" in text
     assert "function isHeaderToolbarButton" in text
     assert 'button.closest(".ms-auto.flex.shrink-0.items-center")' in text
@@ -625,6 +629,9 @@ def test_renderer_script_includes_user_script_manager_ui_contract():
     assert "if (titleRegion?.contains?.(button)) return false;" in text
     assert ".map((button) => ({ button, rect: button.getBoundingClientRect() }))" in text
     assert ".filter(({ button, rect }) => isHeaderToolbarButton(button, header, rect))" in text
+    relevant_start = text.index("const scanRelevantSelector")
+    relevant_end = text.index("\n\n  function isScanRelevantNode", relevant_start)
+    assert '"header"' in text[relevant_start:relevant_end]
 
 
 def test_renderer_script_has_sponsor_tab():


### PR DESCRIPTION
## 修复内容

修复开启 Codex Desktop 宠物窗口后，Codex++ 版本菜单错误显示在宠物窗口左上角的问题。

原因是 Codex++ 会通过 CDP 注入所有 Codex page target；宠物窗口也会被识别为可注入页面，但它没有 Codex 主界面的 header / sidebar chrome，导致菜单安装逻辑走 fallback，把 `Codex++ 1.0.7` 作为 fixed 浮层渲染出来。

## 变更说明

- 新增 `pageHasCodexAppChrome()` 守卫，只在页面存在 Codex 主界面特征时安装 Codex++ 菜单。
- 如果非主窗口里已经存在旧的 Codex++ 菜单，会主动移除，避免残留。
- 将普通 `header` 加入扫描相关选择器，保证主窗口 header 后加载时仍可触发重新安装菜单。
- 补充 renderer 契约测试，防止以后菜单逻辑再次退回无条件 fallback。

## 验证

已通过：

- `node --check codex_session_delete\inject\renderer-inject.js`
- `python -m pytest tests\test_renderer_script.py -q`
- `python -m pytest tests\test_cdp.py -q`
