### PR TITLE
Add mobile provider routing

### DIFF
--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -377,6 +377,16 @@
       .codex-plus-backend-repair { border: 1px solid rgba(255,255,255,.18); border-radius: 7px; background: #3f3f46; color: #f3f4f6; font: 12px system-ui, sans-serif; padding: 6px 8px; }
       .codex-plus-backend-repair[hidden] { display: none; }
       .codex-plus-model-compat-warning { margin-top: 6px; color: #fbbf24; font-size: 12px; line-height: 1.45; }
+      .codex-plus-provider-form { display: grid; gap: 8px; min-width: 240px; }
+      .codex-plus-provider-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+      .codex-plus-provider-field { display: grid; gap: 4px; color: #d1d5db; font-size: 11px; }
+      .codex-plus-provider-field[data-wide="true"] { grid-column: 1 / -1; }
+      .codex-plus-provider-field input { min-width: 0; border: 1px solid rgba(255,255,255,.14); border-radius: 7px; background: #18181b; color: #f3f4f6; font: 12px system-ui, sans-serif; padding: 6px 8px; }
+      .codex-plus-provider-actions { display: flex; align-items: center; justify-content: flex-end; gap: 8px; }
+      .codex-plus-provider-status { color: #a1a1aa; font-size: 12px; line-height: 1.4; text-align: right; }
+      .codex-plus-provider-status[data-status="ok"] { color: #34d399; }
+      .codex-plus-provider-status[data-status="failed"],
+      .codex-plus-provider-status[data-status="needs_attention"] { color: #fbbf24; }
       .codex-plus-user-script-warning { margin-top: 4px; color: #fbbf24; font-size: 12px; }
       .codex-plus-user-script-dirs { margin-top: 6px; color: #a1a1aa; font-size: 11px; line-height: 1.4; word-break: break-all; }
       .codex-plus-user-script-list { margin-top: 8px; display: grid; gap: 6px; }
@@ -509,6 +519,7 @@
   }
 
   let codexPlusBackendSettings = { providerSyncEnabled: false };
+  let codexMobileProviderStatus = { status: "checking", auth: {}, provider: {} };
 
   async function loadBackendSettings() {
     try {
@@ -536,6 +547,77 @@
       const key = button.getAttribute("data-codex-backend-setting");
       button.dataset.enabled = String(!!codexPlusBackendSettings[key]);
     });
+  }
+
+  function mobileProviderStatusText() {
+    const auth = codexMobileProviderStatus.auth || {};
+    const provider = codexMobileProviderStatus.provider || {};
+    if (codexMobileProviderStatus.status === "ok") {
+      return `ChatGPT 身份已保留，当前 Provider：${provider.provider_name || provider.model_provider || "未命名"}`;
+    }
+    if (auth.status && auth.status !== "ok") return auth.message || "ChatGPT 身份需要修复";
+    if (provider.status && provider.status !== "ok") return provider.message || "Provider 配置不完整";
+    return codexMobileProviderStatus.message || "正在读取 Mobile Provider 状态";
+  }
+
+  function setMobileProviderField(name, value) {
+    const input = document.querySelector(`[data-mobile-provider-field="${name}"]`);
+    if (!input || input.dataset.initialized === "true" || input.value) return;
+    input.value = value || "";
+    input.dataset.initialized = "true";
+  }
+
+  function renderMobileProviderStatus() {
+    const provider = codexMobileProviderStatus.provider || {};
+    setMobileProviderField("provider_id", provider.model_provider);
+    setMobileProviderField("display_name", provider.provider_name);
+    setMobileProviderField("base_url", provider.base_url);
+    setMobileProviderField("model", provider.model);
+    const label = document.querySelector("[data-mobile-provider-status]");
+    if (!label) return;
+    label.dataset.status = codexMobileProviderStatus.status || "failed";
+    label.textContent = mobileProviderStatusText();
+  }
+
+  async function loadMobileProviderStatus() {
+    try {
+      const status = await postJson("/mobile-provider/status", {});
+      codexMobileProviderStatus = status && typeof status === "object" ? status : { status: "failed", message: "Mobile Provider 状态不可用", auth: {}, provider: {} };
+    } catch (error) {
+      codexMobileProviderStatus = { status: "failed", message: String(error?.message || error), auth: {}, provider: {} };
+    }
+    renderMobileProviderStatus();
+  }
+
+  function mobileProviderPayload() {
+    const value = (name) => document.querySelector(`[data-mobile-provider-field="${name}"]`)?.value?.trim?.() || "";
+    return {
+      provider_id: value("provider_id"),
+      display_name: value("display_name"),
+      base_url: value("base_url"),
+      bearer_token: value("bearer_token"),
+      model: value("model"),
+      requires_openai_auth: true,
+    };
+  }
+
+  async function applyMobileProvider() {
+    const label = document.querySelector("[data-mobile-provider-status]");
+    if (label) {
+      label.dataset.status = "checking";
+      label.textContent = "正在写入 provider，并守住 ChatGPT 身份…";
+    }
+    const result = await postJson("/mobile-provider/apply", mobileProviderPayload());
+    codexMobileProviderStatus = result && typeof result === "object" ? result : { status: "failed", message: "Mobile Provider 写入失败", auth: {}, provider: {} };
+    renderMobileProviderStatus();
+    if (codexMobileProviderStatus.status === "ok") {
+      const tokenInput = document.querySelector('[data-mobile-provider-field="bearer_token"]');
+      if (tokenInput) tokenInput.value = "";
+      await loadCodexModelCatalog(true);
+      showToast("Mobile Provider 已启用；重启 Codex++ 后新会话会使用该 Provider", null);
+    } else {
+      showToast(codexMobileProviderStatus.message || mobileProviderStatusText(), null);
+    }
   }
 
   let codexPlusUserScripts = { enabled: true, builtin_dir: "", user_dir: "", scripts: [] };
@@ -757,6 +839,25 @@
               <button type="button" class="codex-plus-toggle" data-codex-backend-setting="providerSyncEnabled"><span></span></button>
             </div>
             <div class="codex-plus-row">
+              <div>
+                <div class="codex-plus-row-title">ChatGPT Mobile + 第三方 Provider</div>
+                <div class="codex-plus-row-description">保留 ChatGPT 登录用于 Mobile 发现，把对话模型路由写到 config.toml 的第三方 provider。</div>
+              </div>
+              <div class="codex-plus-provider-form">
+                <div class="codex-plus-provider-grid">
+                  <label class="codex-plus-provider-field">Provider ID<input data-mobile-provider-field="provider_id" autocomplete="off" placeholder="apiname"></label>
+                  <label class="codex-plus-provider-field">显示名<input data-mobile-provider-field="display_name" autocomplete="off" placeholder="apiname"></label>
+                  <label class="codex-plus-provider-field" data-wide="true">Base URL<input data-mobile-provider-field="base_url" autocomplete="off" placeholder="https://example.com/v1"></label>
+                  <label class="codex-plus-provider-field" data-wide="true">Bearer Token<input data-mobile-provider-field="bearer_token" autocomplete="off" type="password" placeholder="只写入，不回显"></label>
+                  <label class="codex-plus-provider-field" data-wide="true">默认模型<input data-mobile-provider-field="model" autocomplete="off" placeholder="gpt-5.5"></label>
+                </div>
+                <div class="codex-plus-provider-actions">
+                  <div class="codex-plus-provider-status" data-mobile-provider-status="true" data-status="checking">正在读取状态…</div>
+                  <button type="button" class="codex-plus-action-button" data-mobile-provider-apply="true">启用</button>
+                </div>
+              </div>
+            </div>
+            <div class="codex-plus-row">
               <div><div class="codex-plus-row-title">原生菜单栏位置</div><div class="codex-plus-row-description">把 Codex++ 菜单插入顶部原生菜单栏；默认关闭以避免页面重渲染冲突。</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="nativeMenuPlacement"><span></span></button>
             </div>
@@ -838,6 +939,10 @@
         repairBackend();
         return;
       }
+      if (target?.closest("[data-mobile-provider-apply]")) {
+        applyMobileProvider();
+        return;
+      }
       const issueButton = target?.closest("[data-codex-plus-issue]");
       if (issueButton) {
         const issueUrl = "https://github.com/BigPizzaV3/CodexPlusPlus/issues";
@@ -878,6 +983,7 @@
     refreshCodexPlusBackendToggles();
     renderBackendStatus();
     loadBackendSettings();
+    loadMobileProviderStatus();
     loadUserScripts();
   }
 

--- a/codex_session_delete/launcher.py
+++ b/codex_session_delete/launcher.py
@@ -25,6 +25,7 @@ from codex_session_delete.cdp import evaluate_script, evaluate_user_scripts, inj
 from codex_session_delete.helper_server import HelperServer
 from codex_session_delete.helper_server import fetch_ad_list
 from codex_session_delete.markdown_exporter import MarkdownExportService
+from codex_session_delete.mobile_provider_guard import apply_mobile_provider_guard, mobile_provider_status
 from codex_session_delete.models import DeleteResult, DeleteStatus, SessionRef
 from codex_session_delete.provider_sync import ProviderSyncStatus, run_provider_sync
 from codex_session_delete.settings_store import BackendSettings, SettingsStore
@@ -141,6 +142,12 @@ class CodexPlusRuntime:
 
     def codex_model_catalog(self) -> dict[str, object]:
         return read_codex_model_catalog()
+
+    def mobile_provider_status(self) -> dict[str, object]:
+        return mobile_provider_status(codex_home_path())
+
+    def apply_mobile_provider(self, payload: dict[str, object]) -> dict[str, object]:
+        return apply_mobile_provider_guard(payload, codex_home_path())
 
 
 def codex_home_path() -> Path:
@@ -949,6 +956,10 @@ def handle_bridge_request(
         return runtime.codex_model_catalog()
     if path == "/codex-config-model" and runtime:
         return runtime.codex_model_catalog()
+    if path == "/mobile-provider/status" and runtime:
+        return runtime.mobile_provider_status()
+    if path == "/mobile-provider/apply" and runtime:
+        return runtime.apply_mobile_provider(payload)
     if path == "/delete":
         session = SessionRef(session_id=str(payload.get("session_id", "")), title=str(payload.get("title", "")))
         return service.delete(session).to_dict()

--- a/codex_session_delete/mobile_provider_guard.py
+++ b/codex_session_delete/mobile_provider_guard.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import time
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+PROVIDER_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+@dataclass(frozen=True)
+class AuthSnapshot:
+    path: Path
+    status: str
+    auth_mode: str
+    has_chatgpt_tokens: bool
+    has_openai_api_key: bool
+    message: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "path": str(self.path),
+            "auth_mode": self.auth_mode,
+            "has_chatgpt_tokens": self.has_chatgpt_tokens,
+            "has_openai_api_key": self.has_openai_api_key,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class ProviderSummary:
+    path: Path
+    status: str
+    model: str
+    model_provider: str
+    provider_name: str
+    base_url: str
+    has_bearer_token: bool
+    requires_openai_auth: bool
+    message: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "path": str(self.path),
+            "model": self.model,
+            "model_provider": self.model_provider,
+            "provider_name": self.provider_name,
+            "base_url": self.base_url,
+            "has_bearer_token": self.has_bearer_token,
+            "requires_openai_auth": self.requires_openai_auth,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    provider_id: str
+    base_url: str
+    bearer_token: str
+    model: str = ""
+    display_name: str = ""
+
+
+def default_codex_home() -> Path:
+    return Path.home() / ".codex"
+
+
+def _string(value: object) -> str:
+    return str(value).strip() if isinstance(value, str) else ""
+
+
+def _auth_path(home: Path) -> Path:
+    return home / "auth.json"
+
+
+def _config_path(home: Path) -> Path:
+    return home / "config.toml"
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} is not a JSON object")
+    return data
+
+
+def _has_tokens(value: object) -> bool:
+    return isinstance(value, dict) and bool(value)
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f"{path.name}.tmp")
+    temp_path.write_text(text, encoding="utf-8")
+    os.replace(temp_path, path)
+
+
+def inspect_auth(path: Path) -> AuthSnapshot:
+    try:
+        payload = _load_json(path)
+    except Exception as exc:
+        return AuthSnapshot(path, "failed", "", False, False, str(exc))
+    auth_mode = _string(payload.get("auth_mode"))
+    has_tokens = _has_tokens(payload.get("tokens"))
+    has_key = bool(_string(payload.get("OPENAI_API_KEY")))
+    if has_tokens and auth_mode == "chatgpt" and not has_key:
+        return AuthSnapshot(path, "ok", auth_mode, True, False, "ChatGPT identity is preserved")
+    if has_tokens:
+        return AuthSnapshot(path, "repairable", auth_mode, True, has_key, "ChatGPT tokens exist but auth mode needs normalization")
+    return AuthSnapshot(path, "not_chatgpt", auth_mode, False, has_key, "Run codex login before enabling Mobile provider guard")
+
+
+def normalize_chatgpt_auth(path: Path) -> AuthSnapshot:
+    payload = _load_json(path)
+    if not _has_tokens(payload.get("tokens")):
+        raise ValueError("ChatGPT tokens are missing; run codex login first")
+    payload["auth_mode"] = "chatgpt"
+    payload["OPENAI_API_KEY"] = None
+    _atomic_write(path, json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
+    return inspect_auth(path)
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def _effective_config(config: dict[str, Any]) -> dict[str, Any]:
+    effective = dict(config)
+    profile = _string(config.get("profile"))
+    profiles = config.get("profiles")
+    if profile and isinstance(profiles, dict) and isinstance(profiles.get(profile), dict):
+        effective.update(profiles[profile])
+    return effective
+
+
+def _provider_config(config: dict[str, Any], provider_id: str) -> tuple[str, dict[str, Any] | None]:
+    providers = config.get("model_providers")
+    if not isinstance(providers, dict):
+        return provider_id, None
+    if provider_id and isinstance(providers.get(provider_id), dict):
+        return provider_id, providers[provider_id]
+    provider_items = [(name, provider) for name, provider in providers.items() if isinstance(name, str) and isinstance(provider, dict)]
+    if not provider_id and len(provider_items) == 1:
+        return provider_items[0]
+    return provider_id, None
+
+
+def _provider_token(provider: dict[str, Any]) -> str:
+    for key in ("experimental_bearer_token", "api_key", "apikey", "bearer_token", "token"):
+        value = _string(provider.get(key))
+        if value:
+            return value
+    return ""
+
+
+def read_provider_summary(path: Path) -> ProviderSummary:
+    try:
+        config = _load_toml(path)
+    except Exception as exc:
+        return ProviderSummary(path, "failed", "", "", "", "", False, False, str(exc))
+    effective = _effective_config(config)
+    model = _string(effective.get("model"))
+    configured_provider = _string(effective.get("model_provider"))
+    provider_id, provider = _provider_config(config, configured_provider)
+    if not isinstance(provider, dict):
+        return ProviderSummary(path, "not_configured", model, provider_id, "", "", False, False, "Active provider is not configured")
+    provider_name = _string(provider.get("name")) or provider_id
+    base_url = _string(provider.get("base_url"))
+    has_token = bool(_provider_token(provider))
+    requires_openai_auth = bool(provider.get("requires_openai_auth", False))
+    status = "ok" if base_url and has_token and requires_openai_auth else "incomplete"
+    return ProviderSummary(path, status, model, provider_id, provider_name, base_url, has_token, requires_openai_auth)
+
+
+def _provider_spec(payload: dict[str, object]) -> ProviderSpec:
+    provider_id = _string(payload.get("provider_id") or payload.get("provider") or payload.get("name"))
+    base_url = _string(payload.get("base_url")).rstrip("/")
+    bearer_token = _string(payload.get("bearer_token") or payload.get("experimental_bearer_token") or payload.get("token"))
+    if not provider_id or not PROVIDER_ID_RE.match(provider_id):
+        raise ValueError("Provider id must contain only letters, numbers, underscores, or hyphens")
+    if not base_url.startswith(("http://", "https://")):
+        raise ValueError("Provider base_url must start with http:// or https://")
+    if not bearer_token:
+        raise ValueError("Provider bearer token is required")
+    return ProviderSpec(provider_id, base_url, bearer_token, _string(payload.get("model")), _string(payload.get("display_name") or payload.get("provider_name")))
+
+
+def _set_top_level_string(text: str, key: str, value: str) -> str:
+    lines = text.splitlines()
+    pattern = re.compile(rf"^(\s*{re.escape(key)}\s*=\s*).*$")
+    for index, line in enumerate(lines):
+        if line.lstrip().startswith("["):
+            break
+        if pattern.match(line):
+            lines[index] = f'{key} = {json.dumps(value)}'
+            return "\n".join(lines).rstrip() + "\n"
+    lines.insert(0, f'{key} = {json.dumps(value)}')
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _remove_provider_table(text: str, provider_id: str) -> str:
+    pattern = re.compile(rf"(?ms)^\[model_providers\.{re.escape(provider_id)}\]\n.*?(?=^\[|\Z)")
+    return pattern.sub("", text).rstrip() + "\n"
+
+
+def write_provider_config(path: Path, spec: ProviderSpec) -> ProviderSummary:
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
+    text = _set_top_level_string(text, "model_provider", spec.provider_id)
+    if spec.model:
+        text = _set_top_level_string(text, "model", spec.model)
+    text = _remove_provider_table(text, spec.provider_id)
+    table = "\n".join(
+        [
+            "",
+            f"[model_providers.{spec.provider_id}]",
+            f"name = {json.dumps(spec.display_name or spec.provider_id)}",
+            f"base_url = {json.dumps(spec.base_url)}",
+            f"experimental_bearer_token = {json.dumps(spec.bearer_token)}",
+            "requires_openai_auth = true",
+            "",
+        ]
+    )
+    _atomic_write(path, text.rstrip() + "\n" + table)
+    return read_provider_summary(path)
+
+
+def _backup_dir(home: Path) -> Path:
+    root = home / "backups_state" / "mobile-provider-guard"
+    backup = root / time.strftime("%Y%m%d%H%M%S")
+    suffix = 0
+    while backup.exists():
+        suffix += 1
+        backup = root / f"{time.strftime('%Y%m%d%H%M%S')}-{suffix}"
+    backup.mkdir(parents=True)
+    return backup
+
+
+def _backup_files(home: Path) -> Path:
+    backup = _backup_dir(home)
+    for name in ("auth.json", "config.toml"):
+        source = home / name
+        if source.exists():
+            shutil.copy2(source, backup / name)
+    return backup
+
+
+def _restore_backup(home: Path, backup: Path) -> None:
+    for name in ("auth.json", "config.toml"):
+        source = backup / name
+        if source.exists():
+            shutil.copy2(source, home / name)
+
+
+def mobile_provider_status(codex_home: Path | None = None) -> dict[str, object]:
+    home = codex_home or default_codex_home()
+    auth = inspect_auth(_auth_path(home))
+    provider = read_provider_summary(_config_path(home))
+    status = "ok" if auth.status == "ok" and provider.status == "ok" else "needs_attention"
+    return {"status": status, "codex_home": str(home), "auth": auth.to_dict(), "provider": provider.to_dict()}
+
+
+def apply_mobile_provider_guard(payload: dict[str, object], codex_home: Path | None = None) -> dict[str, object]:
+    home = codex_home or default_codex_home()
+    try:
+        spec = _provider_spec(payload)
+        auth = inspect_auth(_auth_path(home))
+        if not auth.has_chatgpt_tokens:
+            return {"status": "failed", "message": auth.message, "auth": auth.to_dict()}
+        backup = _backup_files(home)
+        try:
+            next_auth = normalize_chatgpt_auth(_auth_path(home))
+            provider = write_provider_config(_config_path(home), spec)
+        except Exception:
+            _restore_backup(home, backup)
+            raise
+        return {
+            "status": "ok",
+            "message": "ChatGPT identity preserved; third-party provider activated",
+            "backup_dir": str(backup),
+            "auth": next_auth.to_dict(),
+            "provider": provider.to_dict(),
+        }
+    except Exception as exc:
+        status = mobile_provider_status(home)
+        status["status"] = "failed"
+        status["message"] = str(exc)
+        return status

--- a/tests/test_launcher_user_scripts.py
+++ b/tests/test_launcher_user_scripts.py
@@ -61,6 +61,16 @@ class FakeRuntime:
             "sources": [{"type": "config", "status": "ok", "models": 2}],
         }
 
+    def mobile_provider_status(self):
+        return {
+            "status": "ok",
+            "auth": {"status": "ok", "has_chatgpt_tokens": True, "has_openai_api_key": False},
+            "provider": {"status": "ok", "model_provider": "dashscope", "provider_name": "DashScope"},
+        }
+
+    def apply_mobile_provider(self, payload):
+        return {"status": "ok", "provider": {"model_provider": payload["provider_id"]}}
+
 
 def test_handle_bridge_request_lists_user_scripts(tmp_path):
     builtin = tmp_path / "builtin"
@@ -118,6 +128,18 @@ def test_handle_bridge_request_keeps_legacy_codex_config_model_route(tmp_path):
 
     assert result["status"] == "ok"
     assert result["models"] == ["qwen3-coder", "deepseek-coder"]
+
+
+def test_handle_bridge_request_handles_mobile_provider_guard(tmp_path):
+    manager = UserScriptManager(tmp_path / "builtin", tmp_path / "user", tmp_path / "config.json")
+    runtime = FakeRuntime(manager)
+
+    status = handle_bridge_request(FakeDeleteService(), FakeExportService(), "/mobile-provider/status", {}, runtime)
+    applied = handle_bridge_request(FakeDeleteService(), FakeExportService(), "/mobile-provider/apply", {"provider_id": "apiname"}, runtime)
+
+    assert status["status"] == "ok"
+    assert status["auth"]["has_chatgpt_tokens"] is True
+    assert applied == {"status": "ok", "provider": {"model_provider": "apiname"}}
 
 
 def test_read_codex_config_model_uses_active_profile(tmp_path):
@@ -451,4 +473,3 @@ def test_handle_bridge_request_exports_markdown(tmp_path):
 
     assert exported["status"] == "exported"
     assert exported["filename"] == "thread.md"
-

--- a/tests/test_mobile_provider_guard.py
+++ b/tests/test_mobile_provider_guard.py
@@ -1,0 +1,125 @@
+import json
+
+from codex_session_delete.mobile_provider_guard import (
+    apply_mobile_provider_guard,
+    inspect_auth,
+    mobile_provider_status,
+    normalize_chatgpt_auth,
+    read_provider_summary,
+)
+
+
+def write_chatgpt_auth(path, *, mode="apikey", openai_key="sk-old"):
+    path.write_text(
+        json.dumps(
+            {
+                "auth_mode": mode,
+                "OPENAI_API_KEY": openai_key,
+                "tokens": {"access_token": "chatgpt-token", "refresh_token": "refresh-token"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_normalize_chatgpt_auth_preserves_tokens_and_clears_api_key(tmp_path):
+    auth = tmp_path / "auth.json"
+    write_chatgpt_auth(auth)
+
+    snapshot = normalize_chatgpt_auth(auth)
+    payload = json.loads(auth.read_text(encoding="utf-8"))
+
+    assert snapshot.status == "ok"
+    assert payload["auth_mode"] == "chatgpt"
+    assert payload["OPENAI_API_KEY"] is None
+    assert payload["tokens"]["access_token"] == "chatgpt-token"
+
+
+def test_inspect_codex_auth_rejects_plain_api_key_identity(tmp_path):
+    auth = tmp_path / "auth.json"
+    auth.write_text(json.dumps({"auth_mode": "apikey", "OPENAI_API_KEY": "sk-only"}), encoding="utf-8")
+
+    snapshot = inspect_auth(auth)
+
+    assert snapshot.status == "not_chatgpt"
+    assert snapshot.has_openai_api_key is True
+    assert snapshot.has_chatgpt_tokens is False
+
+
+def test_apply_mobile_provider_guard_keeps_chatgpt_identity_and_writes_provider(tmp_path):
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    write_chatgpt_auth(codex_home / "auth.json")
+    (codex_home / "config.toml").write_text('model = "gpt-5.5"\nmodel_provider = "openai"\n', encoding="utf-8")
+
+    result = apply_mobile_provider_guard(
+        {
+            "provider_id": "apiname",
+            "display_name": "API Name",
+            "base_url": "https://relay.example.com/v1",
+            "bearer_token": "relay-token",
+            "model": "gpt-5.5",
+        },
+        codex_home,
+    )
+
+    assert result["status"] == "ok"
+    payload = json.loads((codex_home / "auth.json").read_text(encoding="utf-8"))
+    assert payload["auth_mode"] == "chatgpt"
+    assert payload["OPENAI_API_KEY"] is None
+    assert payload["tokens"]["access_token"] == "chatgpt-token"
+    text = (codex_home / "config.toml").read_text(encoding="utf-8")
+    assert 'model_provider = "apiname"' in text
+    assert 'experimental_bearer_token = "relay-token"' in text
+    assert "requires_openai_auth = true" in text
+    assert result["provider"]["has_bearer_token"] is True
+    assert result["provider"]["requires_openai_auth"] is True
+    assert (codex_home / "backups_state" / "mobile-provider-guard").exists()
+
+
+def test_apply_mobile_provider_guard_refuses_when_chatgpt_tokens_missing(tmp_path):
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text(json.dumps({"auth_mode": "apikey", "OPENAI_API_KEY": "sk-only"}), encoding="utf-8")
+    (codex_home / "config.toml").write_text("", encoding="utf-8")
+
+    result = apply_mobile_provider_guard(
+        {
+            "provider_id": "apiname",
+            "base_url": "https://relay.example.com/v1",
+            "bearer_token": "relay-token",
+        },
+        codex_home,
+    )
+
+    assert result["status"] == "failed"
+    assert result["auth"]["has_chatgpt_tokens"] is False
+    assert "codex login" in result["message"]
+    assert not (codex_home / "backups_state").exists()
+
+
+def test_mobile_provider_status_reports_active_provider_without_leaking_token(tmp_path):
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    write_chatgpt_auth(codex_home / "auth.json", mode="chatgpt", openai_key=None)
+    (codex_home / "config.toml").write_text(
+        """
+model = "gpt-5.5"
+model_provider = "local"
+
+[model_providers.local]
+name = "local"
+base_url = "http://127.0.0.1:8317/v1"
+experimental_bearer_token = "local-secret"
+requires_openai_auth = true
+""".strip(),
+        encoding="utf-8",
+    )
+
+    status = mobile_provider_status(codex_home)
+
+    assert status["status"] == "ok"
+    assert status["provider"]["model_provider"] == "local"
+    assert status["provider"]["has_bearer_token"] is True
+    assert "local-secret" not in json.dumps(status)
+    assert read_provider_summary(codex_home / "config.toml").status == "ok"

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -661,6 +661,18 @@ def test_renderer_script_has_backend_provider_sync_toggle():
     assert "setBackendSetting" in text
 
 
+def test_renderer_script_has_mobile_provider_guard_panel():
+    text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
+
+    assert "ChatGPT Mobile + 第三方 Provider" in text
+    assert "/mobile-provider/status" in text
+    assert "/mobile-provider/apply" in text
+    assert "data-mobile-provider-field=\"provider_id\"" in text
+    assert "data-mobile-provider-field=\"base_url\"" in text
+    assert "data-mobile-provider-field=\"bearer_token\"" in text
+    assert "data-mobile-provider-apply=\"true\"" in text
+
+
 def test_renderer_script_can_move_sidebar_threads_between_projects():
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 概要
- 新增 Mobile Provider Guard：保留 ChatGPT 登录 tokens，同时启用第三方模型 provider。
- 在 Codex++ 里增加状态查询和应用配置的 bridge 路由，并加入一个小型设置面板。
- 增加测试覆盖 auth 规范化、provider 写入、bridge 路由和 renderer 注入锚点。

## 验证
- `.venv/bin/python -m pytest -q tests/test_mobile_provider_guard.py tests/test_launcher_user_scripts.py tests/test_renderer_script.py tests/test_provider_sync.py`
- `.venv/bin/python -m py_compile codex_session_delete/mobile_provider_guard.py codex_session_delete/launcher.py`

## 说明
- 保持 ChatGPT 登录用于 Codex Mobile 发现/授权，模型请求通过 `config.toml` 中的第三方 provider 路由。
