### PR TITLE
Close CDP injection resources

### DIFF
--- a/codex_session_delete/cdp.py
+++ b/codex_session_delete/cdp.py
@@ -50,13 +50,25 @@ class MultiPageInjection:
             first = next(iter(self.injections.values()), None)
         return first.result if first else None
 
+    def close(self) -> None:
+        self.stop_event.set()
+        with self.lock:
+            sockets = [injection.bridge_socket for injection in self.injections.values() if injection.bridge_socket]
+        for socket in sockets:
+            socket.close()
+        if self.watcher_thread:
+            self.watcher_thread.join(timeout=1)
+
 
 def list_targets(port: int) -> list[dict[str, object]]:
     session = requests.Session()
     session.trust_env = False
     response = session.get(f"http://127.0.0.1:{port}/json", timeout=3)
     response.raise_for_status()
-    return response.json()
+    targets = response.json()
+    if hasattr(session, "close"):
+        session.close()
+    return targets
 
 
 def codex_page_targets(targets: list[dict[str, object]]) -> list[dict[str, object]]:
@@ -283,7 +295,10 @@ def _bridge_loop(ws: websocket.WebSocket, handler: BridgeHandler) -> None:
         except Exception as exc:
             request_id = str(locals().get("payload", {}).get("id", ""))
             if request_id:
-                _reject_bridge(ws, request_id, str(exc))
+                try:
+                    _reject_bridge(ws, request_id, str(exc))
+                except Exception:
+                    return
 
 
 def _resolve_bridge(ws: websocket.WebSocket, request_id: str, result: dict[str, object]) -> None:

--- a/codex_session_delete/launcher.py
+++ b/codex_session_delete/launcher.py
@@ -96,12 +96,20 @@ class CodexPlusRuntime:
     user_scripts: UserScriptManager
     debug_port: int | None = None
     websocket_urls: set[str] = field(default_factory=set)
+    injection_manager: Any = None
     lock: threading.Lock = field(default_factory=threading.Lock)
 
     def add_websocket_url(self, websocket_url: str) -> None:
         with self.lock:
             self.websocket_url = websocket_url
             self.websocket_urls.add(websocket_url)
+
+    def replace_injection_manager(self, injection_manager: Any) -> None:
+        with self.lock:
+            old_manager = self.injection_manager
+            self.injection_manager = injection_manager
+        if old_manager is not None and old_manager is not injection_manager:
+            old_manager.close()
 
     def reload_user_scripts(self) -> dict[str, object]:
         script = self.user_scripts.build_enabled_bundle()
@@ -771,6 +779,9 @@ def start_or_attach_helper(
 def shutdown_helper(server: HelperServer) -> None:
     if isinstance(server, AttachedHelperServer):
         return
+    bridge_socket = getattr(server, "bridge_socket", None)
+    if bridge_socket is not None and hasattr(bridge_socket, "close"):
+        bridge_socket.close()
     server.shutdown()
     server.server_close()
 
@@ -802,6 +813,7 @@ def inject_with_retry(
             _log_runtime_event(f"injected renderer bridge debug_port={debug_port} helper_port={helper_port}")
             if injection.websocket_url:
                 runtime.add_websocket_url(injection.websocket_url)
+            runtime.replace_injection_manager(injection)
             return injection
         except Exception as exc:
             last_error = exc


### PR DESCRIPTION
## Summary

Fixes #121.

- close CDP target query sessions after reading `/json`
- add `MultiPageInjection.close()` to stop watcher threads and close bridge sockets
- replace old injection managers during reinjection
- close helper bridge sockets during shutdown
- avoid bridge thread warnings when a websocket closes during response rejection

## Test

```bash
python3 -m pytest tests/test_cdp.py tests/test_launcher_cli.py -q
```

Result:

```text
57 passed
```