### PR TITLE
新增 thread 切换时的浏览位置保留

### DIFF
--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -33,14 +33,35 @@
   const codexArchiveRowActionsVersion = "1";
   const codexArchiveDeleteAllVersion = "2";
   const codexConversationTimelineVersion = "2";
+  const codexThreadScrollVersion = "1";
   const codexPlusVersion = "1.0.7";
+  const codexPlusMenuVersion = `7:${codexPlusVersion}`;
+  const codexPlusTriggerVersion = `6:${codexPlusVersion}`;
   const codexPlusSettingsKey = "codexPlusSettings";
+  const codexThreadScrollKey = "codexThreadScroll";
+  const codexThreadScrollMaxEntries = 120;
+  const codexThreadScrollSaveThrottleMs = 120;
+  const codexThreadScrollRestoreWindowMs = 3200;
+  const codexThreadScrollRestoreDelaysMs = [0, 80, 220, 500, 1000, 1800, 2800];
+  const codexThreadScrollUserIntentWindowMs = 1200;
+  const codexThreadScrollProgrammaticGuardVersion = "dispatcher:2";
+  const codexThreadScrollRouteHooksVersion = "dispatcher:2";
+  const codexThreadScrollListenerVersion = "4";
+  const codexThreadScrollUserIntentVersion = "dispatcher:2";
   window.__codexProjectMoveRuntimeId = (window.__codexProjectMoveRuntimeId || 0) + 1;
   const codexProjectMoveRuntimeId = window.__codexProjectMoveRuntimeId;
   clearTimeout(window.__codexProjectMoveProjectionTimer);
   clearTimeout(window.__codexProjectMoveChatsSortTimer);
   window.__codexProjectMoveProjectionTimer = null;
   window.__codexProjectMoveChatsSortTimer = null;
+  clearTimeout(window.__codexThreadScrollSaveTimer);
+  window.__codexThreadScrollSaveTimer = null;
+  (window.__codexThreadScrollRestoreTimers || []).forEach((timer) => clearTimeout(timer));
+  window.__codexThreadScrollRestoreTimers = [];
+  (window.__codexThreadScrollSyncTimers || []).forEach((timer) => clearTimeout(timer));
+  window.__codexThreadScrollSyncTimers = [];
+  window.__codexThreadScrollRestoreRevision = (window.__codexThreadScrollRestoreRevision || 0) + 1;
+  window.__codexThreadScrollSyncRevision = (window.__codexThreadScrollSyncRevision || 0) + 1;
   window.__codexConversationTimelineNodeCounter = window.__codexConversationTimelineNodeCounter || 0;
   const selectors = {
     sidebarThread: "[data-app-action-sidebar-thread-id]",
@@ -482,7 +503,17 @@
   }
 
   function defaultCodexPlusSettings() {
-    return { pluginEntryUnlock: true, forcePluginInstall: true, sessionDelete: true, markdownExport: true, projectMove: true, conversationTimeline: true, nativeMenuPlacement: true, modelWhitelistUnlock: true };
+    return {
+      pluginEntryUnlock: true,
+      forcePluginInstall: true,
+      sessionDelete: true,
+      markdownExport: true,
+      projectMove: true,
+      conversationTimeline: true,
+      threadScrollRestore: true,
+      nativeMenuPlacement: true,
+      modelWhitelistUnlock: true,
+    };
   }
 
   function codexPlusSettings() {
@@ -496,6 +527,14 @@
   function setCodexPlusSetting(key, value) {
     const next = { ...codexPlusSettings(), [key]: value };
     localStorage.setItem(codexPlusSettingsKey, JSON.stringify(next));
+    if (key === "threadScrollRestore" && !value) {
+      clearThreadScrollRestoreTimers();
+      clearThreadScrollSyncTimers();
+      window.__codexThreadScrollRestoreRevision = (window.__codexThreadScrollRestoreRevision || 0) + 1;
+      window.__codexThreadScrollSyncRevision = (window.__codexThreadScrollSyncRevision || 0) + 1;
+      clearThreadScrollRestoreLock();
+      bindThreadScrollListener(null);
+    }
     renderCodexPlusMenu();
     scan();
   }
@@ -753,6 +792,10 @@
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="conversationTimeline"><span></span></button>
             </div>
             <div class="codex-plus-row">
+              <div><div class="codex-plus-row-title">切换对话保留位置</div><div class="codex-plus-row-description">开启后在不同 thread 之间切换时恢复到上一次浏览位置，不再自动跳到底部。</div></div>
+              <button type="button" class="codex-plus-toggle" data-codex-plus-setting="threadScrollRestore"><span></span></button>
+            </div>
+            <div class="codex-plus-row">
               <div><div class="codex-plus-row-title">Provider 同步</div><div class="codex-plus-row-description">切换供应商（model_provider）时不丢任何历史会话，避免历史对话因为供应商切换而消失。</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-backend-setting="providerSyncEnabled"><span></span></button>
             </div>
@@ -895,17 +938,29 @@
       if (node !== keep) node.remove();
     });
     Array.from(document.querySelectorAll("button")).forEach((button) => {
-      if ((button.textContent || "").trim() === `Codex++ ${codexPlusVersion}` && !button.closest(`#${codexPlusMenuId}`)) {
+      if (/^Codex\+\+ \d+\.\d+\.\d+/.test((button.textContent || "").trim()) && !button.closest(`#${codexPlusMenuId}`)) {
         button.remove();
       }
     });
   }
 
+  function setCodexPlusTriggerLabel(trigger) {
+    if (!trigger) return;
+    const label = `Codex++ ${codexPlusVersion}`;
+    const textNode = Array.from(trigger.childNodes).find((node) => node.nodeType === Node.TEXT_NODE);
+    if (textNode) {
+      textNode.nodeValue = label;
+    } else {
+      trigger.appendChild(document.createTextNode(label));
+    }
+  }
+
   function configureCodexPlusTrigger(menu, trigger, nativeButtonClass) {
     if (!trigger) return;
     if (nativeButtonClass) trigger.className = nativeButtonClass;
-    if (trigger.dataset.codexPlusTriggerInstalled === "5") return;
-    trigger.dataset.codexPlusTriggerInstalled = "5";
+    setCodexPlusTriggerLabel(trigger);
+    if (trigger.dataset.codexPlusTriggerInstalled === codexPlusTriggerVersion) return;
+    trigger.dataset.codexPlusTriggerInstalled = codexPlusTriggerVersion;
     trigger.addEventListener("click", (event) => {
       event.preventDefault();
       event.stopPropagation();
@@ -974,7 +1029,7 @@
     const existing = document.getElementById(codexPlusMenuId);
     removeDuplicateCodexPlusMenus(existing);
     let insertionPoint = findNativeMenuInsertionPoint();
-    if (existing && existing.dataset.codexPlusMenuVersion !== "6") {
+    if (existing && existing.dataset.codexPlusMenuVersion !== codexPlusMenuVersion) {
       existing.remove();
       insertionPoint = findNativeMenuInsertionPoint();
     } else if (existing && insertionPoint && existing.parentElement === insertionPoint.parent) {
@@ -985,7 +1040,7 @@
     const menu = document.createElement("div");
     menu.id = codexPlusMenuId;
     menu.dataset.codexPlusMenu = "true";
-    menu.dataset.codexPlusMenuVersion = "6";
+    menu.dataset.codexPlusMenuVersion = codexPlusMenuVersion;
     const trigger = document.createElement("button");
     trigger.type = "button";
     trigger.textContent = `Codex++ ${codexPlusVersion}`;
@@ -1174,6 +1229,747 @@
     const rawTitle = (titleNode?.textContent || (titleNode ? "" : (row.textContent || "Untitled session")));
     const title = (titleNode ? rawTitle : rawTitle.replace(/\s*(导出|删除|移动|移出项目)(\s*(导出|删除|移动|移出项目))*$/g, "")).trim().slice(0, 160);
     return { session_id: sessionId, title };
+  }
+
+  function locationThreadId() {
+    const source = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    const match = source.match(/(?:session|conversation|thread)(?:\/|=|:|-)([A-Za-z0-9_.-]+)/i)
+      || source.match(/\/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(?:[/?#]|$)/)
+      || source.match(/\/([A-Za-z0-9_-]{24,})(?:[/?#]|$)/);
+    return match ? decodeURIComponent(match[1]) : "";
+  }
+
+  function validThreadScrollSessionKey(sessionId) {
+    const key = projectMoveSessionKey(sessionId);
+    if (!key || key === "__proto__" || key === "prototype" || key === "constructor") return "";
+    return /^[A-Za-z0-9_.-]{8,128}$/.test(key) ? key : "";
+  }
+
+  function currentSessionRef() {
+    const rows = sessionRows();
+    for (const row of rows) {
+      const ref = sessionRefFromRow(row);
+      if (ref.session_id && isCurrentSessionRow(row, ref)) return ref;
+    }
+    return { session_id: locationThreadId(), title: "" };
+  }
+
+  function finiteNonNegativeNumber(value) {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) && numeric >= 0 ? numeric : 0;
+  }
+
+  function finiteScrollNumber(value) {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : 0;
+  }
+
+  function readThreadScrollEntries() {
+    if (window.__codexThreadScrollEntries && typeof window.__codexThreadScrollEntries === "object") {
+      return { ...window.__codexThreadScrollEntries };
+    }
+    try {
+      const parsed = JSON.parse(localStorage.getItem(codexThreadScrollKey) || "{}");
+      const rawEntries = parsed?.version === codexThreadScrollVersion && parsed?.entries && typeof parsed.entries === "object"
+        ? parsed.entries
+        : parsed && typeof parsed === "object"
+          ? parsed
+          : {};
+      const entries = Object.create(null);
+      Object.entries(rawEntries).forEach(([key, value]) => {
+        const safeKey = validThreadScrollSessionKey(key);
+        if (!safeKey || !value || typeof value !== "object") return;
+        entries[safeKey] = {
+          top: finiteScrollNumber(value.top),
+          scrollHeight: finiteNonNegativeNumber(value.scrollHeight),
+          clientHeight: finiteNonNegativeNumber(value.clientHeight),
+          at: finiteNonNegativeNumber(value.at),
+        };
+      });
+      window.__codexThreadScrollEntries = entries;
+      return { ...entries };
+    } catch {
+      window.__codexThreadScrollEntries = Object.create(null);
+      return {};
+    }
+  }
+
+  function writeThreadScrollEntries(entries) {
+    const pruned = Object.create(null);
+    Object.entries(entries || {})
+      .sort((left, right) => finiteNonNegativeNumber(right[1]?.at) - finiteNonNegativeNumber(left[1]?.at))
+      .slice(0, codexThreadScrollMaxEntries)
+      .forEach(([key, value]) => {
+        const safeKey = validThreadScrollSessionKey(key);
+        if (safeKey) pruned[safeKey] = value;
+      });
+    window.__codexThreadScrollEntries = pruned;
+    localStorage.setItem(codexThreadScrollKey, JSON.stringify({ version: codexThreadScrollVersion, entries: pruned }));
+  }
+
+  function currentThreadScroller() {
+    const explicit = document.querySelector(".thread-scroll-container");
+    if (explicit?.isConnected) return explicit;
+    const root = conversationTimelineRoot();
+    if (!root?.isConnected) return document.scrollingElement || document.documentElement;
+    const style = getComputedStyle(root);
+    if (/(auto|scroll)/.test(style.overflowY) && root.scrollHeight > root.clientHeight) return root;
+    return nearestTimelineScroller(root);
+  }
+
+  function threadScrollRuntime() {
+    if (!window.__codexThreadScrollRuntime || typeof window.__codexThreadScrollRuntime !== "object") {
+      window.__codexThreadScrollRuntime = {
+        activeSessionId: "",
+        activeScroller: null,
+        scrollListener: null,
+        scrollListenerUsesWindow: false,
+        lastSavedTop: -1,
+        lastSavedHeight: -1,
+        lastSavedClientHeight: -1,
+        restoreLock: null,
+        applyingRestore: false,
+        pendingNavigation: null,
+        userScrollIntentUntil: 0,
+        userCancelledRestoreSessionId: "",
+      };
+    }
+    return window.__codexThreadScrollRuntime;
+  }
+
+  function clearThreadScrollRestoreTimers() {
+    (window.__codexThreadScrollRestoreTimers || []).forEach((timer) => clearTimeout(timer));
+    window.__codexThreadScrollRestoreTimers = [];
+  }
+
+  function clearThreadScrollSyncTimers() {
+    (window.__codexThreadScrollSyncTimers || []).forEach((timer) => clearTimeout(timer));
+    window.__codexThreadScrollSyncTimers = [];
+  }
+
+  function clearThreadScrollRestoreLock() {
+    const runtime = threadScrollRuntime();
+    runtime.restoreLock = null;
+  }
+
+  function cancelThreadScrollRestoreForUserIntent() {
+    const runtime = threadScrollRuntime();
+    const cancelledSessionId = validThreadScrollSessionKey(runtime.restoreLock?.sessionId)
+      || validThreadScrollSessionKey(currentSessionRef().session_id)
+      || validThreadScrollSessionKey(runtime.activeSessionId);
+    runtime.userScrollIntentUntil = Date.now() + codexThreadScrollUserIntentWindowMs;
+    runtime.userCancelledRestoreSessionId = cancelledSessionId;
+    window.__codexThreadScrollRestoreRevision = (window.__codexThreadScrollRestoreRevision || 0) + 1;
+    window.__codexThreadScrollSyncRevision = (window.__codexThreadScrollSyncRevision || 0) + 1;
+    clearThreadScrollRestoreTimers();
+    clearThreadScrollSyncTimers();
+    clearThreadScrollRestoreLock();
+  }
+
+  function userScrollIntentActive() {
+    return finiteNonNegativeNumber(threadScrollRuntime().userScrollIntentUntil) > Date.now();
+  }
+
+  function threadScrollRestoreCancelledForSession(sessionId = threadScrollRuntime().activeSessionId) {
+    const key = validThreadScrollSessionKey(sessionId);
+    return !!key && threadScrollRuntime().userCancelledRestoreSessionId === key;
+  }
+
+  function activeThreadScrollRestoreLock(sessionId = threadScrollRuntime().activeSessionId) {
+    const runtime = threadScrollRuntime();
+    const key = validThreadScrollSessionKey(sessionId);
+    const lock = runtime.restoreLock;
+    if (!lock || !key || lock.sessionId !== key) return null;
+    if (lock.expiresAt <= Date.now()) {
+      clearThreadScrollRestoreLock();
+      return null;
+    }
+    return lock;
+  }
+
+  function currentThreadScrollRestoreLock() {
+    const sessionId = threadScrollRuntime().restoreLock?.sessionId;
+    return sessionId ? activeThreadScrollRestoreLock(sessionId) : null;
+  }
+
+  function threadScrollIsReversed(scroller) {
+    return getComputedStyle(scroller).flexDirection === "column-reverse";
+  }
+
+  function threadScrollRange(scroller) {
+    const extent = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+    return threadScrollIsReversed(scroller)
+      ? { min: -extent, max: 0, bottom: 0 }
+      : { min: 0, max: extent, bottom: extent };
+  }
+
+  function startThreadScrollRestoreLock(sessionId, entry) {
+    const key = validThreadScrollSessionKey(sessionId);
+    if (!key || !entry) {
+      clearThreadScrollRestoreLock();
+      return null;
+    }
+    const runtime = threadScrollRuntime();
+    runtime.restoreLock = {
+      sessionId: key,
+      targetTop: finiteScrollNumber(entry.top),
+      expiresAt: Date.now() + codexThreadScrollRestoreWindowMs,
+    };
+    return runtime.restoreLock;
+  }
+
+  function prepareThreadScrollRestoreLock(sessionId) {
+    const key = validThreadScrollSessionKey(sessionId);
+    const entry = key ? readThreadScrollEntries()[key] : null;
+    if (entry) startThreadScrollRestoreLock(key, entry);
+  }
+
+  function threadScrollTargetTop(scroller, targetTop) {
+    const range = threadScrollRange(scroller);
+    return Math.max(range.min, Math.min(range.max, finiteScrollNumber(targetTop)));
+  }
+
+  function threadScrollNearBottom(scroller, top) {
+    const range = threadScrollRange(scroller);
+    return Math.abs(range.bottom - finiteScrollNumber(top)) <= Math.max(24, scroller.clientHeight * 0.15);
+  }
+
+  function threadScrollGuardScroller(scroller) {
+    if (!scroller) return null;
+    const runtime = threadScrollRuntime();
+    const rootScroller = document.scrollingElement || document.documentElement || document.body;
+    const normalizedScroller = scroller === document.body || scroller === document.documentElement ? rootScroller : scroller;
+    if (normalizedScroller === runtime.activeScroller) return normalizedScroller;
+    const currentScroller = currentThreadScroller();
+    if (normalizedScroller === currentScroller) return normalizedScroller;
+    return null;
+  }
+
+  function shouldBlockThreadScrollAutobottom(scroller, top) {
+    const runtime = threadScrollRuntime();
+    const lock = currentThreadScrollRestoreLock();
+    if (!lock || !codexPlusSettings().threadScrollRestore) return false;
+    const guardScroller = threadScrollGuardScroller(scroller);
+    if (runtime.applyingRestore || !guardScroller) return false;
+    const targetTop = threadScrollTargetTop(guardScroller, lock.targetTop);
+    return Math.abs(finiteScrollNumber(top) - targetTop) > 8 && threadScrollNearBottom(guardScroller, top);
+  }
+
+  function scrollToRequestedTop(args, scroller) {
+    if (!args.length) return null;
+    const first = args[0];
+    if (typeof first === "object" && first !== null) {
+      return first.top == null ? null : finiteScrollNumber(first.top);
+    }
+    if (args.length >= 2) return finiteScrollNumber(args[1]);
+    return scroller?.scrollTop ?? null;
+  }
+
+  function scrollByRequestedTop(args, scroller) {
+    if (!args.length || !scroller) return null;
+    const first = args[0];
+    let delta = null;
+    if (typeof first === "object" && first !== null) {
+      delta = first.top == null ? null : Number(first.top);
+    } else if (args.length >= 2) {
+      delta = Number(args[1]);
+    }
+    return Number.isFinite(delta) ? finiteScrollNumber(scroller.scrollTop + delta) : null;
+  }
+
+  function shouldBlockThreadScrollIntoView(element) {
+    const runtime = threadScrollRuntime();
+    const lock = currentThreadScrollRestoreLock();
+    if (runtime.applyingRestore || !lock || !element) return false;
+    const activeScroller = threadScrollGuardScroller(runtime.activeScroller) || threadScrollGuardScroller(currentThreadScroller());
+    if (!activeScroller || element === activeScroller || !activeScroller.contains?.(element)) return false;
+    if (threadScrollIsReversed(activeScroller) && shouldBlockThreadScrollAutobottom(activeScroller, 0)) return true;
+    const elementRect = element.getBoundingClientRect?.();
+    if (!elementRect) return false;
+    const elementBottomTop = activeScroller.scrollTop + elementRect.bottom - timelineScrollerViewportTop(activeScroller) - activeScroller.clientHeight;
+    return shouldBlockThreadScrollAutobottom(activeScroller, elementBottomTop);
+  }
+
+  function findScrollTopDescriptor() {
+    const htmlElementPrototype = typeof HTMLElement === "undefined" ? null : HTMLElement.prototype;
+    for (const prototype of [Element.prototype, htmlElementPrototype].filter(Boolean)) {
+      const descriptor = Object.getOwnPropertyDescriptor(prototype, "scrollTop");
+      if (descriptor?.get && descriptor?.set) return { prototype, descriptor };
+    }
+    return null;
+  }
+
+  function threadScrollNativePrototypeSnapshot() {
+    if (window.__codexThreadScrollNativePrototypeSnapshot) return window.__codexThreadScrollNativePrototypeSnapshot;
+    const snapshot = {};
+    let frame = null;
+    try {
+      frame = document.createElement("iframe");
+      frame.style.display = "none";
+      frame.tabIndex = -1;
+      frame.setAttribute("aria-hidden", "true");
+      (document.documentElement || document.body)?.appendChild(frame);
+      const frameWindow = frame.contentWindow;
+      if (frameWindow?.Element?.prototype) {
+        snapshot.elementScrollTo = frameWindow.Element.prototype.scrollTo;
+        snapshot.elementScroll = frameWindow.Element.prototype.scroll;
+        snapshot.elementScrollBy = frameWindow.Element.prototype.scrollBy;
+        snapshot.scrollIntoView = frameWindow.Element.prototype.scrollIntoView;
+      }
+      if (frameWindow?.Window?.prototype) {
+        snapshot.windowScrollTo = frameWindow.Window.prototype.scrollTo;
+        snapshot.windowScroll = frameWindow.Window.prototype.scroll;
+        snapshot.windowScrollBy = frameWindow.Window.prototype.scrollBy;
+      }
+      const frameHtmlElementPrototype = frameWindow?.HTMLElement?.prototype;
+      const candidates = [
+        { framePrototype: frameWindow?.Element?.prototype, prototype: Element.prototype },
+        { framePrototype: frameHtmlElementPrototype, prototype: typeof HTMLElement === "undefined" ? null : HTMLElement.prototype },
+      ];
+      for (const candidate of candidates) {
+        const descriptor = candidate.framePrototype ? Object.getOwnPropertyDescriptor(candidate.framePrototype, "scrollTop") : null;
+        if (descriptor?.get && descriptor?.set && candidate.prototype) {
+          snapshot.scrollTop = { prototype: candidate.prototype, descriptor };
+          break;
+        }
+      }
+    } catch {
+      snapshot.unavailable = true;
+    } finally {
+      frame?.remove?.();
+    }
+    window.__codexThreadScrollNativePrototypeSnapshot = snapshot;
+    return snapshot;
+  }
+
+  function threadScrollFunctionLooksGuarded(fn) {
+    return typeof fn === "function" && (fn.name || "").startsWith("codexThreadScrollGuarded");
+  }
+
+  function threadScrollDescriptorLooksGuarded(descriptor) {
+    try {
+      return String(descriptor?.set || "").includes("__codexThreadScrollHandlers")
+        || String(descriptor?.set || "").includes("shouldBlockThreadScrollAutobottom");
+    } catch {
+      return false;
+    }
+  }
+
+  function threadScrollOriginalFunction(originals, key, current, nativeFunction) {
+    if (typeof originals[key] === "function" && !threadScrollFunctionLooksGuarded(originals[key])) return originals[key];
+    if (threadScrollFunctionLooksGuarded(current) && typeof nativeFunction === "function") return nativeFunction;
+    return typeof originals[key] === "function" ? originals[key] : current;
+  }
+
+  function threadScrollOriginalScrollTopDescriptor(originals) {
+    const current = findScrollTopDescriptor();
+    const nativeScrollTop = threadScrollNativePrototypeSnapshot().scrollTop;
+    if (originals.scrollTop && !threadScrollDescriptorLooksGuarded(originals.scrollTop.descriptor)) return originals.scrollTop;
+    if (current && threadScrollDescriptorLooksGuarded(current.descriptor) && nativeScrollTop) return nativeScrollTop;
+    return originals.scrollTop || current;
+  }
+
+  function installThreadScrollProgrammaticScrollGuard() {
+    if (window.__codexThreadScrollProgrammaticGuardInstalled === codexThreadScrollProgrammaticGuardVersion) return;
+    window.__codexThreadScrollProgrammaticGuardInstalled = codexThreadScrollProgrammaticGuardVersion;
+    window.__codexThreadScrollOriginals = window.__codexThreadScrollOriginals || {};
+    const originals = window.__codexThreadScrollOriginals;
+    const nativeSnapshot = threadScrollNativePrototypeSnapshot();
+    const originalElementScrollTo = threadScrollOriginalFunction(originals, "elementScrollTo", Element.prototype.scrollTo, nativeSnapshot.elementScrollTo);
+    originals.elementScrollTo = originalElementScrollTo;
+    if (typeof originalElementScrollTo === "function") {
+      Element.prototype.scrollTo = function codexThreadScrollGuardedScrollTo(...args) {
+        const top = scrollToRequestedTop(args, this);
+        if (top != null && window.__codexThreadScrollHandlers?.shouldBlockAutobottom?.(this, top)) return;
+        return originalElementScrollTo.apply(this, args);
+      };
+    }
+    const originalElementScroll = threadScrollOriginalFunction(originals, "elementScroll", Element.prototype.scroll, nativeSnapshot.elementScroll);
+    originals.elementScroll = originalElementScroll;
+    if (typeof originalElementScroll === "function") {
+      Element.prototype.scroll = function codexThreadScrollGuardedScroll(...args) {
+        const top = scrollToRequestedTop(args, this);
+        if (top != null && window.__codexThreadScrollHandlers?.shouldBlockAutobottom?.(this, top)) return;
+        return originalElementScroll.apply(this, args);
+      };
+    }
+    const originalElementScrollBy = threadScrollOriginalFunction(originals, "elementScrollBy", Element.prototype.scrollBy, nativeSnapshot.elementScrollBy);
+    originals.elementScrollBy = originalElementScrollBy;
+    if (typeof originalElementScrollBy === "function") {
+      Element.prototype.scrollBy = function codexThreadScrollGuardedScrollBy(...args) {
+        const top = scrollByRequestedTop(args, this);
+        if (top != null && window.__codexThreadScrollHandlers?.shouldBlockAutobottom?.(this, top)) return;
+        return originalElementScrollBy.apply(this, args);
+      };
+    }
+    const originalScrollIntoView = threadScrollOriginalFunction(originals, "scrollIntoView", Element.prototype.scrollIntoView, nativeSnapshot.scrollIntoView);
+    originals.scrollIntoView = originalScrollIntoView;
+    if (typeof originalScrollIntoView === "function") {
+      Element.prototype.scrollIntoView = function codexThreadScrollGuardedScrollIntoView(...args) {
+        if (window.__codexThreadScrollHandlers?.shouldBlockIntoView?.(this)) return;
+        return originalScrollIntoView.apply(this, args);
+      };
+    }
+    const originalWindowScrollTo = threadScrollOriginalFunction(originals, "windowScrollTo", window.scrollTo, nativeSnapshot.windowScrollTo);
+    originals.windowScrollTo = originalWindowScrollTo;
+    if (typeof originalWindowScrollTo === "function") {
+      window.scrollTo = function codexThreadScrollGuardedWindowScrollTo(...args) {
+        const scroller = document.scrollingElement || document.documentElement || document.body;
+        const top = scrollToRequestedTop(args, scroller);
+        if (top != null && window.__codexThreadScrollHandlers?.shouldBlockAutobottom?.(scroller, top)) return;
+        return originalWindowScrollTo.apply(this, args);
+      };
+    }
+    const originalWindowScroll = threadScrollOriginalFunction(originals, "windowScroll", window.scroll, nativeSnapshot.windowScroll);
+    originals.windowScroll = originalWindowScroll;
+    if (typeof originalWindowScroll === "function") {
+      window.scroll = function codexThreadScrollGuardedWindowScroll(...args) {
+        const scroller = document.scrollingElement || document.documentElement || document.body;
+        const top = scrollToRequestedTop(args, scroller);
+        if (top != null && window.__codexThreadScrollHandlers?.shouldBlockAutobottom?.(scroller, top)) return;
+        return originalWindowScroll.apply(this, args);
+      };
+    }
+    const originalWindowScrollBy = threadScrollOriginalFunction(originals, "windowScrollBy", window.scrollBy, nativeSnapshot.windowScrollBy);
+    originals.windowScrollBy = originalWindowScrollBy;
+    if (typeof originalWindowScrollBy === "function") {
+      window.scrollBy = function codexThreadScrollGuardedWindowScrollBy(...args) {
+        const scroller = document.scrollingElement || document.documentElement || document.body;
+        const top = scrollByRequestedTop(args, scroller);
+        if (top != null && window.__codexThreadScrollHandlers?.shouldBlockAutobottom?.(scroller, top)) return;
+        return originalWindowScrollBy.apply(this, args);
+      };
+    }
+    const scrollTop = threadScrollOriginalScrollTopDescriptor(originals);
+    originals.scrollTop = scrollTop;
+    if (scrollTop?.descriptor?.configurable !== false) {
+      try {
+        Object.defineProperty(scrollTop.prototype, "scrollTop", {
+          configurable: true,
+          enumerable: scrollTop.descriptor.enumerable,
+          get() {
+            return scrollTop.descriptor.get.call(this);
+          },
+          set(value) {
+            if (window.__codexThreadScrollHandlers?.shouldBlockAutobottom?.(this, value)) return;
+            return scrollTop.descriptor.set.call(this, value);
+          },
+        });
+      } catch {
+        window.__codexThreadScrollTopGuardUnavailable = true;
+      }
+    }
+  }
+
+  function bindThreadScrollListener(scroller) {
+    const runtime = threadScrollRuntime();
+    const currentUsesWindow = !runtime.activeScroller || runtime.activeScroller === document.scrollingElement || runtime.activeScroller === document.documentElement || runtime.activeScroller === document.body;
+    const nextUsesWindow = !scroller || scroller === document.scrollingElement || scroller === document.documentElement || scroller === document.body;
+    let listenerReplaced = false;
+    if (runtime.scrollListener && runtime.scrollListenerVersion !== codexThreadScrollListenerVersion) {
+      const currentTarget = currentUsesWindow ? window : runtime.activeScroller;
+      currentTarget?.removeEventListener?.("scroll", runtime.scrollListener, true);
+      runtime.scrollListener = null;
+      runtime.scrollListenerVersion = "";
+      listenerReplaced = true;
+    }
+    runtime.scrollListener = runtime.scrollListener || (() => scheduleThreadScrollSave());
+    runtime.scrollListenerVersion = codexThreadScrollListenerVersion;
+    if (!listenerReplaced && runtime.activeScroller === scroller && runtime.scrollListenerUsesWindow === nextUsesWindow) return;
+    if (runtime.activeScroller) {
+      const target = currentUsesWindow ? window : runtime.activeScroller;
+      target.removeEventListener("scroll", runtime.scrollListener, true);
+    }
+    runtime.activeScroller = scroller;
+    runtime.scrollListenerUsesWindow = nextUsesWindow;
+    if (!scroller || !codexPlusSettings().threadScrollRestore) return;
+    const target = nextUsesWindow ? window : scroller;
+    target.addEventListener("scroll", runtime.scrollListener, true);
+  }
+
+  function saveThreadScrollPositionNow(sessionId = threadScrollRuntime().activeSessionId, scroller = threadScrollRuntime().activeScroller) {
+    if (!codexPlusSettings().threadScrollRestore) return;
+    const runtime = threadScrollRuntime();
+    const key = validThreadScrollSessionKey(sessionId);
+    if (!key || !scroller) return;
+    if (activeThreadScrollRestoreLock(key)) return;
+    const snapshot = {
+      top: finiteScrollNumber(scroller.scrollTop),
+      scrollHeight: finiteNonNegativeNumber(scroller.scrollHeight),
+      clientHeight: finiteNonNegativeNumber(scroller.clientHeight),
+      at: Date.now(),
+    };
+    if (
+      Math.abs(runtime.lastSavedTop - snapshot.top) < 2 &&
+      runtime.lastSavedHeight === snapshot.scrollHeight &&
+      runtime.lastSavedClientHeight === snapshot.clientHeight
+    ) {
+      return;
+    }
+    const entries = readThreadScrollEntries();
+    entries[key] = snapshot;
+    writeThreadScrollEntries(entries);
+    runtime.lastSavedTop = snapshot.top;
+    runtime.lastSavedHeight = snapshot.scrollHeight;
+    runtime.lastSavedClientHeight = snapshot.clientHeight;
+  }
+
+  function scheduleThreadScrollSave() {
+    if (!codexPlusSettings().threadScrollRestore || window.__codexThreadScrollSaveTimer) return;
+    window.__codexThreadScrollSaveTimer = setTimeout(() => {
+      window.__codexThreadScrollSaveTimer = null;
+      saveThreadScrollPositionNow();
+    }, codexThreadScrollSaveThrottleMs);
+  }
+
+  function restoreThreadScrollPosition(sessionId) {
+    const runtime = threadScrollRuntime();
+    const key = validThreadScrollSessionKey(sessionId);
+    if (!codexPlusSettings().threadScrollRestore || !key || runtime.activeSessionId !== key || userScrollIntentActive() || threadScrollRestoreCancelledForSession(key)) return;
+    const lock = activeThreadScrollRestoreLock(key);
+    const entry = lock || readThreadScrollEntries()[key];
+    if (!entry) return;
+    const scroller = currentThreadScroller();
+    if (!scroller) return;
+    bindThreadScrollListener(scroller);
+    const targetTop = threadScrollTargetTop(scroller, lock ? lock.targetTop : entry.top);
+    if (Math.abs(scroller.scrollTop - targetTop) <= 1) return;
+    runtime.applyingRestore = true;
+    try {
+      if (typeof scroller.scrollTo === "function") {
+        scroller.scrollTo({ top: targetTop, behavior: "auto" });
+      } else {
+        scroller.scrollTop = targetTop;
+      }
+    } finally {
+      runtime.applyingRestore = false;
+    }
+    runtime.lastSavedTop = targetTop;
+    runtime.lastSavedHeight = finiteNonNegativeNumber(scroller.scrollHeight);
+    runtime.lastSavedClientHeight = finiteNonNegativeNumber(scroller.clientHeight);
+  }
+
+  function scheduleThreadScrollRestore(sessionId) {
+    clearThreadScrollRestoreTimers();
+    const key = validThreadScrollSessionKey(sessionId);
+    if (!codexPlusSettings().threadScrollRestore || !key || userScrollIntentActive() || threadScrollRestoreCancelledForSession(key)) return;
+    const entry = readThreadScrollEntries()[key];
+    if (!entry) {
+      clearThreadScrollRestoreLock();
+      return;
+    }
+    startThreadScrollRestoreLock(key, entry);
+    const restoreRevision = (window.__codexThreadScrollRestoreRevision || 0) + 1;
+    window.__codexThreadScrollRestoreRevision = restoreRevision;
+    window.__codexThreadScrollRestoreTimers = codexThreadScrollRestoreDelaysMs.map((delay) => {
+      return setTimeout(() => {
+        if (window.__codexThreadScrollRestoreRevision !== restoreRevision) return;
+        restoreThreadScrollPosition(key);
+      }, delay);
+    });
+  }
+
+  function syncThreadScrollState(forceRestore = false) {
+    const runtime = threadScrollRuntime();
+    const currentRef = currentSessionRef();
+    const nextSessionId = validThreadScrollSessionKey(currentRef.session_id);
+    if (!nextSessionId) return;
+    if (!codexPlusSettings().threadScrollRestore) {
+      bindThreadScrollListener(null);
+      clearThreadScrollRestoreTimers();
+      clearThreadScrollRestoreLock();
+      runtime.activeSessionId = nextSessionId;
+      return;
+    }
+    if (runtime.activeSessionId !== nextSessionId) prepareThreadScrollRestoreLock(nextSessionId);
+    const nextScroller = currentThreadScroller();
+    bindThreadScrollListener(nextScroller);
+    if (runtime.activeSessionId !== nextSessionId) {
+      runtime.lastSavedTop = -1;
+      runtime.lastSavedHeight = -1;
+      runtime.lastSavedClientHeight = -1;
+      clearThreadScrollRestoreLock();
+      runtime.activeSessionId = nextSessionId;
+      runtime.pendingNavigation = null;
+      runtime.userScrollIntentUntil = 0;
+      if (runtime.userCancelledRestoreSessionId !== nextSessionId) runtime.userCancelledRestoreSessionId = "";
+      scheduleThreadScrollRestore(nextSessionId);
+      return;
+    }
+    runtime.activeSessionId = nextSessionId;
+    if (forceRestore && !userScrollIntentActive() && !threadScrollRestoreCancelledForSession(nextSessionId)) scheduleThreadScrollRestore(nextSessionId);
+  }
+
+  function scheduleThreadScrollSyncAttempts(forceRestore = true) {
+    const currentKey = validThreadScrollSessionKey(currentSessionRef().session_id) || validThreadScrollSessionKey(threadScrollRuntime().activeSessionId);
+    if (userScrollIntentActive() || threadScrollRestoreCancelledForSession(currentKey)) return;
+    clearThreadScrollSyncTimers();
+    const syncRevision = (window.__codexThreadScrollSyncRevision || 0) + 1;
+    window.__codexThreadScrollSyncRevision = syncRevision;
+    window.__codexThreadScrollSyncTimers = codexThreadScrollRestoreDelaysMs.map((delay) => {
+      return setTimeout(() => {
+        if (window.__codexThreadScrollSyncRevision !== syncRevision) return;
+        scheduleThreadScrollSync(forceRestore);
+      }, delay);
+    });
+  }
+
+  function captureThreadScrollNavigation(targetSessionId) {
+    if (!codexPlusSettings().threadScrollRestore) return;
+    const runtime = threadScrollRuntime();
+    const targetKey = validThreadScrollSessionKey(targetSessionId);
+    const sessionChanged = !!targetKey && targetKey !== runtime.activeSessionId;
+    if (sessionChanged) {
+      runtime.userScrollIntentUntil = 0;
+      runtime.userCancelledRestoreSessionId = "";
+    }
+    const pending = runtime.pendingNavigation;
+    const duplicatePendingTarget = !!targetKey && pending?.targetSessionId === targetKey && Date.now() - finiteNonNegativeNumber(pending.at) < 5000;
+    if (!duplicatePendingTarget) saveThreadScrollPositionNow();
+    if (targetKey) {
+      runtime.pendingNavigation = { fromSessionId: runtime.activeSessionId, targetSessionId: targetKey, at: Date.now() };
+      prepareThreadScrollRestoreLock(targetKey);
+    }
+    scheduleThreadScrollSyncAttempts(true);
+  }
+
+  function editableThreadScrollTarget(element) {
+    return !!element?.closest?.("input, textarea, select, [contenteditable='true'], [contenteditable='']");
+  }
+
+  function eventTargetsActiveThreadScroller(event) {
+    const runtime = threadScrollRuntime();
+    const scroller = threadScrollGuardScroller(runtime.activeScroller) || threadScrollGuardScroller(currentThreadScroller());
+    if (!scroller) return false;
+    const target = event?.target;
+    if (!target || target === document || target === window) return true;
+    return target === scroller || scroller.contains?.(target) || scroller.contains?.(document.activeElement);
+  }
+
+  function markThreadScrollUserIntent(event) {
+    if (!codexPlusSettings().threadScrollRestore || !eventTargetsActiveThreadScroller(event)) return;
+    cancelThreadScrollRestoreForUserIntent();
+  }
+
+  function markThreadScrollKeyboardIntent(event) {
+    if (editableThreadScrollTarget(event.target)) return;
+    if (!["ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End", " ", "Spacebar"].includes(event.key)) return;
+    markThreadScrollUserIntent(event);
+  }
+
+  function markThreadScrollPointerIntent(event) {
+    const scroller = threadScrollGuardScroller(threadScrollRuntime().activeScroller) || threadScrollGuardScroller(currentThreadScroller());
+    if (event.target === scroller) markThreadScrollUserIntent(event);
+  }
+
+  function updateThreadScrollHandlers() {
+    window.__codexThreadScrollHandlers = {
+      shouldBlockAutobottom: shouldBlockThreadScrollAutobottom,
+      shouldBlockIntoView: shouldBlockThreadScrollIntoView,
+      markUserIntent: markThreadScrollUserIntent,
+      markKeyboardIntent: markThreadScrollKeyboardIntent,
+      markPointerIntent: markThreadScrollPointerIntent,
+      captureNavigation: captureThreadScrollNavigation,
+      saveNow: saveThreadScrollPositionNow,
+      prepareRestoreLock: prepareThreadScrollRestoreLock,
+      scheduleSyncAttempts: scheduleThreadScrollSyncAttempts,
+    };
+  }
+
+  function installThreadScrollUserIntentCapture() {
+    if (window.__codexThreadScrollUserIntentInstalled === codexThreadScrollUserIntentVersion) return;
+    document.removeEventListener("wheel", window.__codexThreadScrollWheelIntentHandler, true);
+    document.removeEventListener("touchmove", window.__codexThreadScrollTouchIntentHandler, true);
+    document.removeEventListener("keydown", window.__codexThreadScrollKeyIntentHandler, true);
+    document.removeEventListener("pointerdown", window.__codexThreadScrollPointerIntentHandler, true);
+    window.__codexThreadScrollWheelIntentHandler = (event) => window.__codexThreadScrollHandlers?.markUserIntent?.(event);
+    window.__codexThreadScrollTouchIntentHandler = (event) => window.__codexThreadScrollHandlers?.markUserIntent?.(event);
+    window.__codexThreadScrollKeyIntentHandler = (event) => window.__codexThreadScrollHandlers?.markKeyboardIntent?.(event);
+    window.__codexThreadScrollPointerIntentHandler = (event) => window.__codexThreadScrollHandlers?.markPointerIntent?.(event);
+    document.addEventListener("wheel", window.__codexThreadScrollWheelIntentHandler, { capture: true, passive: true });
+    document.addEventListener("touchmove", window.__codexThreadScrollTouchIntentHandler, { capture: true, passive: true });
+    document.addEventListener("keydown", window.__codexThreadScrollKeyIntentHandler, true);
+    document.addEventListener("pointerdown", window.__codexThreadScrollPointerIntentHandler, true);
+    window.__codexThreadScrollUserIntentInstalled = codexThreadScrollUserIntentVersion;
+  }
+
+  function installThreadScrollNavigationCapture() {
+    document.removeEventListener("pointerdown", window.__codexThreadScrollNavigationHandler, true);
+    document.removeEventListener("click", window.__codexThreadScrollClickNavigationHandler, true);
+    document.removeEventListener("keydown", window.__codexThreadScrollKeyboardHandler, true);
+    const navigationHandler = (event) => {
+      if (!codexPlusSettings().threadScrollRestore) return;
+      const row = event.target?.closest?.(selectors.sidebarThread);
+      if (!row) return;
+      window.__codexThreadScrollHandlers?.captureNavigation?.(sessionRefFromRow(row).session_id);
+    };
+    const clickHandler = (event) => {
+      if (!codexPlusSettings().threadScrollRestore) return;
+      const row = event.target?.closest?.(selectors.sidebarThread);
+      if (!row) return;
+      window.__codexThreadScrollHandlers?.captureNavigation?.(sessionRefFromRow(row).session_id);
+    };
+    const keyboardHandler = (event) => {
+      if (!codexPlusSettings().threadScrollRestore) return;
+      if (event.key !== "Enter" && event.key !== " ") return;
+      const row = event.target?.closest?.(selectors.sidebarThread);
+      if (!row) return;
+      window.__codexThreadScrollHandlers?.captureNavigation?.(sessionRefFromRow(row).session_id);
+    };
+    window.__codexThreadScrollNavigationHandler = navigationHandler;
+    window.__codexThreadScrollClickNavigationHandler = clickHandler;
+    window.__codexThreadScrollKeyboardHandler = keyboardHandler;
+    document.addEventListener("pointerdown", navigationHandler, true);
+    document.addEventListener("click", clickHandler, true);
+    document.addEventListener("keydown", keyboardHandler, true);
+  }
+
+  function scheduleThreadScrollSync(forceRestore = false) {
+    if (window.__codexThreadScrollSyncPending) return;
+    window.__codexThreadScrollSyncPending = true;
+    setTimeout(() => {
+      window.__codexThreadScrollSyncPending = false;
+      syncThreadScrollState(forceRestore);
+    }, 0);
+  }
+
+  function installThreadScrollRouteHooks() {
+    if (window.__codexThreadScrollRouteHooksInstalled === codexThreadScrollRouteHooksVersion) return;
+    window.__codexThreadScrollRouteHooksInstalled = codexThreadScrollRouteHooksVersion;
+    window.__codexThreadScrollOriginals = window.__codexThreadScrollOriginals || {};
+    const originals = window.__codexThreadScrollOriginals;
+    ["pushState", "replaceState"].forEach((method) => {
+      const prototypeMethod = typeof History !== "undefined" ? History.prototype?.[method] : null;
+      const currentMethod = history[method];
+      const storedMethod = originals[`history_${method}`];
+      const original = (storedMethod?.name === "codexThreadScrollPatchedHistory" && typeof prototypeMethod === "function" ? prototypeMethod : storedMethod)
+        || (currentMethod?.name === "codexThreadScrollPatchedHistory" && typeof prototypeMethod === "function" ? prototypeMethod : currentMethod);
+      originals[`history_${method}`] = original;
+      if (typeof original !== "function") return;
+      history[method] = function codexThreadScrollPatchedHistory(...args) {
+        window.__codexThreadScrollHandlers?.saveNow?.();
+        const result = original.apply(this, args);
+        window.__codexThreadScrollHandlers?.captureNavigation?.(locationThreadId());
+        return result;
+      };
+    });
+    window.removeEventListener("popstate", window.__codexThreadScrollPopStateHandler, true);
+    window.removeEventListener("hashchange", window.__codexThreadScrollHashChangeHandler, true);
+    document.removeEventListener("visibilitychange", window.__codexThreadScrollVisibilityHandler, true);
+    window.__codexThreadScrollPopStateHandler = () => {
+      window.__codexThreadScrollHandlers?.saveNow?.();
+      window.__codexThreadScrollHandlers?.captureNavigation?.(locationThreadId());
+    };
+    window.__codexThreadScrollHashChangeHandler = () => {
+      window.__codexThreadScrollHandlers?.saveNow?.();
+      window.__codexThreadScrollHandlers?.captureNavigation?.(locationThreadId());
+    };
+    window.__codexThreadScrollVisibilityHandler = () => {
+      if (document.visibilityState === "hidden") window.__codexThreadScrollHandlers?.saveNow?.();
+    };
+    window.addEventListener("popstate", window.__codexThreadScrollPopStateHandler, true);
+    window.addEventListener("hashchange", window.__codexThreadScrollHashChangeHandler, true);
+    document.addEventListener("visibilitychange", window.__codexThreadScrollVisibilityHandler, true);
   }
 
   async function postJson(path, payload) {
@@ -3124,6 +3920,12 @@
     scheduleBackendHeartbeat();
     patchCodexModelWhitelist();
     installDeleteButtonEventDelegation();
+    updateThreadScrollHandlers();
+    installThreadScrollProgrammaticScrollGuard();
+    installThreadScrollNavigationCapture();
+    installThreadScrollUserIntentCapture();
+    installThreadScrollRouteHooks();
+    scheduleThreadScrollSync(true);
   }
 
   function scanDeferred() {
@@ -3137,6 +3939,7 @@
     archivedPageRows().forEach(attachArchivedPageDeleteButton);
     installArchivedDeleteAllButton();
     refreshConversationTimeline();
+    scheduleThreadScrollSync(true);
   }
 
   function runScanStep(step) {
@@ -3217,6 +4020,9 @@
   }
 
   function scheduleScan(mutations) {
+    if (mutations?.some((mutation) => mutation.type === "attributes" && mutation.attributeName === "aria-current" && mutation.target?.matches?.(selectors.sidebarThread))) {
+      scheduleThreadScrollSyncAttempts(true);
+    }
     if (!shouldScheduleScan(mutations)) return;
     if (window.__codexSessionDeleteScanPending) return;
     window.__codexSessionDeleteScanPending = true;
@@ -3240,5 +4046,5 @@
   window.addEventListener("resize", window.__codexPlusResizeHandler);
   window.__codexSessionDeleteObserver?.disconnect();
   window.__codexSessionDeleteObserver = new MutationObserver(scheduleScan);
-  window.__codexSessionDeleteObserver.observe(document.body || document.documentElement, { childList: true, subtree: true });
+  window.__codexSessionDeleteObserver.observe(document.body || document.documentElement, { childList: true, subtree: true, attributes: true, attributeFilter: ["aria-current"] });
 })();

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -592,7 +592,9 @@ def test_renderer_script_includes_user_script_manager_ui_contract():
     assert "sessionDelete" in text
     assert "markdownExport" in text
     assert "projectMove" in text
+    assert "threadScrollRestore" in text
     assert "会话项目移动" in text
+    assert "切换对话保留位置" in text
     assert "移动按钮" in text
     assert "codex-plus-modal-overlay" in text
     assert "codex-plus-modal-content" in text
@@ -614,9 +616,12 @@ def test_renderer_script_includes_user_script_manager_ui_contract():
     assert "nativeButtonClass" in text
     assert "removeDuplicateCodexPlusMenus" in text
     assert "data-codex-plus-menu" in text
-    assert "textContent || \"\").trim() === `Codex++ ${codexPlusVersion}`" in text
-    assert "codexPlusMenuVersion !== \"6\"" in text
-    assert "codexPlusTriggerInstalled = \"5\"" in text
+    assert "/^Codex\\+\\+ \\d+\\.\\d+\\.\\d+/.test((button.textContent || \"\").trim())" in text
+    assert "codexPlusMenuVersion = `7:${codexPlusVersion}`" in text
+    assert "codexPlusTriggerVersion = `6:${codexPlusVersion}`" in text
+    assert "existing.dataset.codexPlusMenuVersion !== codexPlusMenuVersion" in text
+    assert "trigger.dataset.codexPlusTriggerInstalled = codexPlusTriggerVersion" in text
+    assert "function setCodexPlusTriggerLabel" in text
     assert ".codex-plus-trigger:hover" not in text
     assert "function headerTitleRegion" in text
     assert "function isHeaderToolbarButton" in text
@@ -737,3 +742,183 @@ def test_renderer_script_can_move_sidebar_threads_between_projects():
     assert "openProjectMoveMenuForRow" in text
     assert "existingMoveButton" in text
     assert "普通对话" in text
+
+
+def test_renderer_script_has_thread_scroll_restore_toggle():
+    text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
+
+    assert "threadScrollRestore: true" in text
+    assert "切换对话保留位置" in text
+    assert "恢复到上一次浏览位置" in text
+    assert 'data-codex-plus-setting="threadScrollRestore"' in text
+    assert "codexThreadScrollKey" in text
+    assert "codexThreadScrollVersion" in text
+
+
+def test_renderer_script_persists_and_restores_thread_scroll_positions():
+    text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
+
+    assert "function readThreadScrollEntries" in text
+    assert "function writeThreadScrollEntries" in text
+    assert "function saveThreadScrollPositionNow" in text
+    assert "function restoreThreadScrollPosition" in text
+    assert "function scheduleThreadScrollRestore" in text
+    assert "function syncThreadScrollState" in text
+    assert "function currentThreadScroller" in text
+    assert "function currentSessionRef" in text
+    assert "function locationThreadId" in text
+    assert "codexThreadScrollRestoreWindowMs = 3200" in text
+    assert 'localStorage.getItem(codexThreadScrollKey)' in text
+    assert 'localStorage.setItem(codexThreadScrollKey' in text
+    assert "scrollTo({ top: targetTop, behavior: \"auto\" })" in text
+    assert "codexThreadScrollRestoreDelaysMs" in text
+    assert "codexThreadScrollMaxEntries = 120" in text
+
+
+def test_renderer_script_tracks_thread_switches_for_scroll_restore():
+    text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
+
+    assert "function installThreadScrollNavigationCapture" in text
+    assert "function installThreadScrollRouteHooks" in text
+    assert "document.addEventListener(\"pointerdown\", navigationHandler, true)" in text
+    assert "document.addEventListener(\"click\", clickHandler, true)" in text
+    assert "document.addEventListener(\"keydown\", keyboardHandler, true)" in text
+    assert "history[method] = function codexThreadScrollPatchedHistory" in text
+    assert "window.__codexThreadScrollHandlers?.captureNavigation?.(sessionRefFromRow(row).session_id)" in text
+    assert "function scheduleThreadScrollSyncAttempts" in text
+    assert "function captureThreadScrollNavigation" in text
+    assert "const sessionChanged = !!targetKey && targetKey !== runtime.activeSessionId" in text
+    assert "runtime.pendingNavigation = { fromSessionId: runtime.activeSessionId, targetSessionId: targetKey, at: Date.now() }" in text
+    assert "duplicatePendingTarget" in text
+    assert "if (!duplicatePendingTarget) saveThreadScrollPositionNow();" in text
+    assert "scheduleThreadScrollSyncAttempts(true)" in text
+    assert "window.__codexThreadScrollHandlers?.captureNavigation?.(locationThreadId())" in text
+    assert 'window.removeEventListener("popstate", window.__codexThreadScrollPopStateHandler, true)' in text
+    assert 'window.removeEventListener("hashchange", window.__codexThreadScrollHashChangeHandler, true)' in text
+    assert 'window.addEventListener("popstate", window.__codexThreadScrollPopStateHandler, true)' in text
+    assert 'window.addEventListener("hashchange", window.__codexThreadScrollHashChangeHandler, true)' in text
+    assert "document.addEventListener(\"visibilitychange\"" in text
+    assert "codexThreadScrollRouteHooksVersion = \"dispatcher:2\"" in text
+    assert "const prototypeMethod = typeof History !== \"undefined\" ? History.prototype?.[method] : null" in text
+    assert "storedMethod?.name === \"codexThreadScrollPatchedHistory\"" in text
+    assert "currentMethod?.name === \"codexThreadScrollPatchedHistory\"" in text
+    assert 'mutation.type === "attributes" && mutation.attributeName === "aria-current"' in text
+    assert 'attributes: true, attributeFilter: ["aria-current"]' in text
+    assert "setTimeout(() => {" in text[text.index("function scheduleThreadScrollSync"):text.index("\n\n  function installThreadScrollRouteHooks")]
+    assert "updateThreadScrollHandlers();" in text[text.index("function scanLightweight"):text.index("\n\n  function scanDeferred")]
+    assert "scheduleThreadScrollSync(true);" in text[text.index("function scanLightweight"):text.index("\n\n  function scanDeferred")]
+    assert "scheduleThreadScrollSync(true);" in text[text.index("function scanDeferred"):text.index("\n\n  function runScanStep")]
+    sync_code = text[text.index("function syncThreadScrollState"):text.index("\n\n  function scheduleThreadScrollSyncAttempts")]
+    assert "if (!nextSessionId) return;" in sync_code
+    assert "saveThreadScrollPositionNow(runtime.activeSessionId, runtime.activeScroller)" not in sync_code
+
+
+def test_renderer_script_prevents_native_autoscroll_from_overwriting_restored_position():
+    text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
+
+    assert "function clearThreadScrollRestoreLock" in text
+    assert "function activeThreadScrollRestoreLock" in text
+    assert "function startThreadScrollRestoreLock" in text
+    assert "function prepareThreadScrollRestoreLock" in text
+    assert "function currentThreadScrollRestoreLock" in text
+    assert "function shouldBlockThreadScrollAutobottom" in text
+    assert "function finiteScrollNumber" in text
+    assert "top: finiteScrollNumber(value.top)" in text
+    assert "top: finiteScrollNumber(scroller.scrollTop)" in text
+    assert "function threadScrollIsReversed" in text
+    assert 'flexDirection === "column-reverse"' in text
+    assert "function threadScrollRange" in text
+    assert "? { min: -extent, max: 0, bottom: 0 }" in text
+    assert "codexThreadScrollListenerVersion = \"4\"" in text
+    assert "let listenerReplaced = false" in text
+    assert "listenerReplaced = true" in text
+    assert "if (!listenerReplaced && runtime.activeScroller === scroller" in text
+    assert "runtime.scrollListenerVersion !== codexThreadScrollListenerVersion" in text
+    assert "runtime.scrollListenerVersion = codexThreadScrollListenerVersion" in text
+    assert "threadScrollTargetTop(scroller, targetTop)" in text
+    assert "return Math.max(range.min, Math.min(range.max, finiteScrollNumber(targetTop)))" in text
+    assert "return Math.abs(range.bottom - finiteScrollNumber(top))" in text
+    assert "function installThreadScrollProgrammaticScrollGuard" in text
+    assert "codexThreadScrollProgrammaticGuardVersion = \"dispatcher:2\"" in text
+    assert "window.__codexThreadScrollOriginals = window.__codexThreadScrollOriginals || {}" in text
+    assert "window.__codexThreadScrollHandlers?.shouldBlockAutobottom" in text
+    assert "function threadScrollNativePrototypeSnapshot" in text
+    assert "document.createElement(\"iframe\")" in text
+    assert "function threadScrollFunctionLooksGuarded" in text
+    assert "function threadScrollOriginalFunction" in text
+    assert "threadScrollFunctionLooksGuarded(current)" in text
+    assert "nativeSnapshot.elementScrollTo" in text
+    assert "Element.prototype.scrollTo = function codexThreadScrollGuardedScrollTo" in text
+    assert "Element.prototype.scroll = function codexThreadScrollGuardedScroll" in text
+    assert "Element.prototype.scrollBy = function codexThreadScrollGuardedScrollBy" in text
+    assert "Element.prototype.scrollIntoView = function codexThreadScrollGuardedScrollIntoView" in text
+    assert "window.scrollTo = function codexThreadScrollGuardedWindowScrollTo" in text
+    assert "window.scroll = function codexThreadScrollGuardedWindowScroll" in text
+    assert "window.scrollBy = function codexThreadScrollGuardedWindowScrollBy" in text
+    assert 'Object.defineProperty(scrollTop.prototype, "scrollTop"' in text
+    assert "runtime.applyingRestore = true" in text
+    guard_code = text[text.index("function shouldBlockThreadScrollAutobottom"):text.index("\n\n  function scrollToRequestedTop")]
+    assert "const lock = currentThreadScrollRestoreLock();" in guard_code
+    assert "if (!lock || !codexPlusSettings().threadScrollRestore) return false;" in guard_code
+    assert "if (runtime.applyingRestore || !guardScroller) return false;" in guard_code
+    assert "if (activeThreadScrollRestoreLock(key)) return;" in text
+    assert "installThreadScrollProgrammaticScrollGuard();" in text[text.index("function scanLightweight"):text.index("\n\n  function scanDeferred")]
+    assert "shouldEnforceThreadScrollRestore" not in text
+    assert "scheduleThreadScrollRestoreEnforcement" not in text
+    assert "restoreEnforceRafId" not in text
+
+
+def test_renderer_script_cancels_thread_scroll_restore_on_user_scroll_intent():
+    text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
+
+    assert "codexThreadScrollUserIntentWindowMs = 1200" in text
+    assert "codexThreadScrollUserIntentVersion = \"dispatcher:2\"" in text
+    assert "function cancelThreadScrollRestoreForUserIntent" in text
+    assert "function userScrollIntentActive" in text
+    assert "function markThreadScrollUserIntent" in text
+    assert "function markThreadScrollKeyboardIntent" in text
+    assert "function markThreadScrollPointerIntent" in text
+    assert "function installThreadScrollUserIntentCapture" in text
+    assert "function clearThreadScrollSyncTimers" in text
+    assert "runtime.userCancelledRestoreSessionId = cancelledSessionId" in text
+    assert "runtime.userScrollIntentUntil = Date.now() + codexThreadScrollUserIntentWindowMs" in text
+    assert "window.__codexThreadScrollRestoreRevision = (window.__codexThreadScrollRestoreRevision || 0) + 1" in text
+    assert "window.__codexThreadScrollSyncRevision = (window.__codexThreadScrollSyncRevision || 0) + 1" in text
+    assert "clearThreadScrollRestoreTimers();" in text
+    assert "clearThreadScrollSyncTimers();" in text
+    assert "clearThreadScrollRestoreLock();" in text
+    assert "function threadScrollRestoreCancelledForSession" in text
+    assert "if (userScrollIntentActive() || threadScrollRestoreCancelledForSession(currentKey)) return;" in text
+    assert 'document.addEventListener("wheel", window.__codexThreadScrollWheelIntentHandler' in text
+    assert 'document.addEventListener("touchmove", window.__codexThreadScrollTouchIntentHandler' in text
+    assert 'document.addEventListener("keydown", window.__codexThreadScrollKeyIntentHandler, true)' in text
+    assert "installThreadScrollUserIntentCapture();" in text[text.index("function scanLightweight"):text.index("\n\n  function scanDeferred")]
+
+
+def test_renderer_script_hardens_thread_scroll_storage_keys():
+    text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
+
+    assert "function validThreadScrollSessionKey" in text
+    assert 'key === "__proto__"' in text
+    assert 'key === "prototype"' in text
+    assert 'key === "constructor"' in text
+    assert "/^[A-Za-z0-9_.-]{8,128}$/.test(key)" in text
+    assert "const entries = Object.create(null)" in text
+    assert "const pruned = Object.create(null)" in text
+    assert "window.__codexThreadScrollEntries = Object.create(null)" in text
+
+
+def test_renderer_script_installs_thread_scroll_dispatcher_handlers():
+    text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
+
+    assert "function updateThreadScrollHandlers" in text
+    assert "window.__codexThreadScrollHandlers = {" in text
+    assert "shouldBlockAutobottom: shouldBlockThreadScrollAutobottom" in text
+    assert "shouldBlockIntoView: shouldBlockThreadScrollIntoView" in text
+    assert "markUserIntent: markThreadScrollUserIntent" in text
+    assert "markKeyboardIntent: markThreadScrollKeyboardIntent" in text
+    assert "markPointerIntent: markThreadScrollPointerIntent" in text
+    assert "captureNavigation: captureThreadScrollNavigation" in text
+    assert "saveNow: saveThreadScrollPositionNow" in text
+    assert "prepareRestoreLock: prepareThreadScrollRestoreLock" in text
+    assert "scheduleSyncAttempts: scheduleThreadScrollSyncAttempts" in text


### PR DESCRIPTION
## 变更说明

这个 PR 为 Codex++ 增加默认开启的 thread 切换浏览位置保留能力：在多个 thread 之间切换时，会记录每个 thread 的滚动位置，并在回到该 thread 时恢复到上一次浏览的位置。

实现重点：

- 使用真实对话滚动容器 `.thread-scroll-container`，兼容 `flex-direction: column-reverse`，其中底部为 `scrollTop = 0`，向上浏览为负 `scrollTop`。
- 保存每个 thread 的 `scrollTop`、`scrollHeight`、`clientHeight` 和时间戳，并限制最多 120 条记录。
- 在 sidebar click、keyboard navigation、history route、hash/popstate 和 `aria-current` 变化时同步 thread 状态。
- 增加 programmatic scroll guard，避免 Codex 原生自动滚到底部覆盖已经恢复的位置。
- 用户主动 wheel/touch/key/pointer 滚动后，立即取消当前 thread 的 restore lock、restore timers 和 sync retry timers，避免恢复后再次被强制拉回。
- 热注入时使用 dispatcher handler 和原始方法缓存，减少重复注入造成的旧闭包/wrapper 堆叠风险。
- 对持久化 key 做基本 hardening，过滤 `__proto__`、`prototype`、`constructor` 和异常 session id。

## 验证

- `node --check codex_session_delete\inject\renderer-inject.js`
- `python -m pytest tests\test_renderer_script.py -q --basetemp H:\tmp\codexpp-pytest-renderer-pr -p no:cacheprovider`
- `git diff --check --cached`

## 备注

本 PR 不修改项目版本号，只提交新增功能和对应 renderer 测试。