### PR TITLE
修复 rollout 后续 session_meta 未同步导致自定义 Provider 恢复失败

### DIFF
--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -31,9 +31,8 @@ pub struct ProviderSyncResult {
 #[derive(Debug, Clone)]
 struct SessionChange {
     path: PathBuf,
-    original_first_line: String,
-    next_first_line: String,
-    separator: String,
+    original_text: String,
+    next_text: String,
     thread_id: Option<String>,
     cwd: Option<String>,
     has_user_event: bool,
@@ -215,41 +214,49 @@ fn collect_session_changes(
     let mut changes = Vec::new();
     for path in rollout_files(home)? {
         let text = fs::read_to_string(&path)?;
-        let (first_line, separator) = split_first_line(&text);
-        if first_line.trim().is_empty() {
-            continue;
+        let mut thread_id = None;
+        let mut cwd = None;
+        let mut rewrite_needed = false;
+        let mut next_text = String::with_capacity(text.len());
+        for segment in text.split_inclusive('\n') {
+            let line = segment.strip_suffix('\n').unwrap_or(segment);
+            let newline = if segment.ends_with('\n') { "\n" } else { "" };
+            let Ok(mut record) = serde_json::from_str::<Value>(line) else {
+                next_text.push_str(segment);
+                continue;
+            };
+            let is_session_meta = record.get("type").and_then(Value::as_str) == Some("session_meta");
+            let Some(payload) = record.get_mut("payload").and_then(Value::as_object_mut) else {
+                next_text.push_str(segment);
+                continue;
+            };
+            if thread_id.is_none() {
+                thread_id = payload
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string);
+            }
+            if cwd.is_none() {
+                cwd = payload
+                    .get("cwd")
+                    .and_then(Value::as_str)
+                    .and_then(to_desktop_workspace_path);
+            }
+            let provider = payload.get("model_provider").and_then(Value::as_str);
+            if is_session_meta && provider != Some(target_provider) {
+                payload.insert("model_provider".to_string(), json!(target_provider));
+                rewrite_needed = true;
+                next_text.push_str(&serde_json::to_string(&record)?);
+                next_text.push_str(newline);
+            } else {
+                next_text.push_str(segment);
+            }
         }
-        let Ok(mut record) = serde_json::from_str::<Value>(&first_line) else {
-            continue;
-        };
-        let Some(payload) = record.get_mut("payload").and_then(Value::as_object_mut) else {
-            continue;
-        };
-        let thread_id = payload
-            .get("id")
-            .and_then(Value::as_str)
-            .map(ToString::to_string);
-        let cwd = payload
-            .get("cwd")
-            .and_then(Value::as_str)
-            .and_then(to_desktop_workspace_path);
-        let has_user_event =
-            separator.contains("\"user_message\"") || separator.contains("\"user_input\"");
-        let rewrite_needed =
-            payload.get("model_provider").and_then(Value::as_str) != Some(target_provider);
-        if rewrite_needed {
-            payload.insert("model_provider".to_string(), json!(target_provider));
-        }
-        let next_first_line = if rewrite_needed {
-            serde_json::to_string(&record)?
-        } else {
-            first_line.clone()
-        };
+        let has_user_event = text.contains("\"user_message\"") || text.contains("\"user_input\"");
         changes.push(SessionChange {
             path,
-            original_first_line: first_line,
-            next_first_line,
-            separator,
+            original_text: text,
+            next_text,
             thread_id,
             cwd,
             has_user_event,
@@ -285,14 +292,6 @@ fn collect_rollout_files(root: &Path, files: &mut Vec<PathBuf>) -> anyhow::Resul
         }
     }
     Ok(())
-}
-
-fn split_first_line(text: &str) -> (String, String) {
-    if let Some(index) = text.find('\n') {
-        (text[..index].to_string(), text[index..].to_string())
-    } else {
-        (text.to_string(), String::new())
-    }
 }
 
 fn to_desktop_workspace_path(value: &str) -> Option<String> {
@@ -346,8 +345,7 @@ fn create_backup(
         .map(|change| {
             json!({
                 "path": change.path.to_string_lossy(),
-                "originalFirstLine": change.original_first_line,
-                "separator": change.separator,
+                "originalText": change.original_text,
             })
         })
         .collect::<Vec<_>>();
@@ -366,20 +364,14 @@ fn create_backup(
 
 fn apply_session_changes(changes: &[SessionChange]) -> anyhow::Result<()> {
     for change in changes {
-        fs::write(
-            &change.path,
-            format!("{}{}", change.next_first_line, change.separator),
-        )?;
+        fs::write(&change.path, &change.next_text)?;
     }
     Ok(())
 }
 
 fn restore_session_changes(changes: &[SessionChange]) -> anyhow::Result<()> {
     for change in changes {
-        fs::write(
-            &change.path,
-            format!("{}{}", change.original_first_line, change.separator),
-        )?;
+        fs::write(&change.path, &change.original_text)?;
     }
     Ok(())
 }

--- a/crates/codex-plus-data/tests/provider_sync.rs
+++ b/crates/codex-plus-data/tests/provider_sync.rs
@@ -34,6 +34,142 @@ fn create_state_db(path: &Path) {
 }
 
 #[test]
+fn provider_sync_preserves_exact_custom_provider_named_openai() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    fs::create_dir(&home).unwrap();
+    fs::write(
+        home.join("config.toml"),
+        "model_provider = \"Openai\"\n[model_providers.Openai]\n",
+    )
+    .unwrap();
+    let rollout = home.join("sessions/rollout-case-custom.jsonl");
+    write_rollout(&rollout, "apigather", "thread-1", "C:/workspace");
+    create_state_db(&home.join("state_5.sqlite"));
+
+    let result = run_provider_sync(Some(&home));
+
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert_eq!(result.target_provider, "Openai");
+    let first: serde_json::Value = serde_json::from_str(
+        fs::read_to_string(&rollout)
+            .unwrap()
+            .lines()
+            .next()
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(first["payload"]["model_provider"], "Openai");
+    let db = Connection::open(home.join("state_5.sqlite")).unwrap();
+    let provider: String = db
+        .query_row(
+            "SELECT model_provider FROM threads WHERE id = 'thread-1'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(provider, "Openai");
+}
+
+#[test]
+fn provider_sync_rewrites_later_session_meta_provider_entries() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    fs::create_dir(&home).unwrap();
+    fs::write(
+        home.join("config.toml"),
+        "model_provider = \"CodexPlusPlus\"\n[model_providers.CodexPlusPlus]\n",
+    )
+    .unwrap();
+    let rollout = home.join("sessions/rollout-multi-meta.jsonl");
+    fs::create_dir_all(rollout.parent().unwrap()).unwrap();
+    fs::write(
+        &rollout,
+        json!({
+            "type": "session_meta",
+            "payload": {"id": "thread-1", "model_provider": "openai", "cwd": "C:/workspace"}
+        })
+        .to_string()
+            + "\n"
+            + &json!({"type": "event_msg", "payload": {"type": "user_message"}}).to_string()
+            + "\n"
+            + &json!({
+                "type": "event_msg",
+                "payload": {"model_provider": "event-provider"}
+            })
+            .to_string()
+            + "\n"
+            + &json!({
+                "type": "session_meta",
+                "payload": {"id": "thread-1", "model_provider": "Openai", "cwd": "C:/workspace"}
+            })
+            .to_string()
+            + "\n"
+            + &json!({
+                "type": "session_meta",
+                "payload": {"id": "thread-1", "cwd": "C:/workspace"}
+            })
+            .to_string()
+            + "\n",
+    )
+    .unwrap();
+
+    let result = run_provider_sync(Some(&home));
+
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert_eq!(result.changed_session_files, 1);
+    let providers = fs::read_to_string(&rollout)
+        .unwrap()
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter_map(|record| {
+            record
+                .get("payload")?
+                .get("model_provider")?
+                .as_str()
+                .map(ToString::to_string)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        providers,
+        vec![
+            "CodexPlusPlus",
+            "event-provider",
+            "CodexPlusPlus",
+            "CodexPlusPlus"
+        ]
+    );
+}
+
+#[test]
+fn provider_sync_preserves_custom_provider_key_case() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    fs::create_dir(&home).unwrap();
+    fs::write(
+        home.join("config.toml"),
+        "model_provider = \"CodexPlusPlus\"\n",
+    )
+    .unwrap();
+    let rollout = home.join("sessions/rollout-custom.jsonl");
+    write_rollout(&rollout, "openai", "thread-1", "C:/workspace");
+
+    let result = run_provider_sync(Some(&home));
+
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert_eq!(result.target_provider, "CodexPlusPlus");
+    let first: serde_json::Value = serde_json::from_str(
+        fs::read_to_string(&rollout)
+            .unwrap()
+            .lines()
+            .next()
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(first["payload"]["model_provider"], "CodexPlusPlus");
+}
+
+#[test]
 fn provider_sync_updates_rollout_sqlite_visibility_and_creates_backup() {
     let tmp = tempdir().unwrap();
     let home = tmp.path().join(".codex");


### PR DESCRIPTION
## 背景

Provider 同步用于在用户切换 `model_provider` 后，把历史会话的 provider 信息同步到当前 provider，从而避免历史会话因为 provider 不一致而不可见或无法恢复。

这次问题出现在包含多条 `session_meta` 的 rollout 文件里。当前实现只读取并重写 rollout 文件的第一行，如果后续行里还有新的 `session_meta`，其中的 `payload.model_provider` 会保留旧值。

例如用户当前配置已经切到新的 provider，但某个历史 rollout 后续仍保留：

```json
{"type":"session_meta","payload":{"model_provider":"Openai"}}
```

恢复该历史会话时，Codex 可能会读取到这条后续 metadata，并尝试在当前配置中查找 `Openai`。如果当前配置里没有对应的 `[model_providers.Openai]`，就会报错：

```text
Model provider 'Openai' not found
```

这里 `Openai` 也可能是用户自定义 provider 名，不能简单改成官方内置的 `openai`。Provider 同步应当尊重用户当前 `config.toml` 里的 provider key，并把 rollout 内所有会话 metadata 同步到同一个当前 provider。
<img width="553" height="120" alt="image" src="https://github.com/user-attachments/assets/202aa094-2e42-42ad-b4f0-7533c9ad8ac4" />

## Provider 名称兼容性

本修复不把 `Openai` 视为无效 key 或大小写错误。Codex 配置允许用户自定义 provider key，因此 `[model_providers.Openai]` 和官方内置 `openai` 是两个不同的 provider 名称。

同步逻辑应该使用用户当前选择的 provider key 原样写回 session metadata，而不是做大小写归一化或映射。否则会破坏已有自定义 provider 配置。

## 根因

`collect_session_changes` 之前使用 `split_first_line` 只解析 rollout 文件第一行：

- 只更新第一条 `session_meta.payload.model_provider`
- 后续 `session_meta` 中的 `model_provider` 不会被检查或重写
- 备份和失败回滚也只围绕第一行处理

这会导致同一个 rollout 文件里同时存在多个 provider 值，恢复历史会话时可能命中未同步的旧 provider。

## 证据

在本地历史会话样本中，逐行解析 rollout JSONL 后可以确认后续 `session_meta` 并不是假设场景：

- 有 71 个 rollout 文件包含多条 `session_meta`。
- 这些文件的后续 `session_meta` 都带有 `model_provider`。
- 匿名化示例：
  - `~/.codex/sessions/.../rollout-*.jsonl`：共 3 条 `session_meta`，第 86、89 行后续 metadata 的 provider 为 `Openai`。
  - `~/.codex/sessions/.../rollout-*.jsonl`：共 7 条 `session_meta`，第 82、97、107 行等后续 metadata 的 provider 为 `Openai`。
  - `~/.codex/sessions/.../rollout-*.jsonl`：共 28 条 `session_meta`，第 36、172、252 行等后续 metadata 的 provider 为 `CodexPlusPlus`。

## 修改内容

- 将 rollout 同步逻辑改为逐行扫描整个 rollout 文件。
- 对每一行 JSON 记录，只有在满足以下条件时才重写 provider：
  - `type == "session_meta"`
  - `payload` 是对象
  - `payload.model_provider` 缺失或不同于目标 provider
- 保留 provider key 的原始大小写，不把自定义 provider（如 `Openai`）改成 `openai`。
- 普通事件 payload 即使含有 `model_provider` 字段，也不会被同步逻辑误改。
- 对需要重写的 rollout 文件保存完整原文，用于失败时恢复整个文件，而不是只恢复第一行。
- 继续同步 sqlite `threads.model_provider`，保持索引和 rollout metadata 一致。

这里显式限定 `type == "session_meta"` 是为了保留原实现的边界。旧逻辑只解析 rollout 第一行，而第一行按格式应是 `session_meta`；扩展为逐行扫描后，如果不检查事件类型，普通 `event_msg` 或 `response_item` 的 payload 中若碰巧出现 `model_provider` 字段，也会被错误改写。

## 测试覆盖

新增/调整 provider sync 测试覆盖：

- 自定义 provider 名为 `Openai` 时，provider key 按原样同步，不被改成小写。
- rollout 文件后续 `session_meta` 中残留的旧 provider 会被同步到当前 provider。
- `session_meta` 缺失 `model_provider` 时会补齐为当前 provider，兼容旧实现对首条 metadata 的行为。
- 普通 `event_msg.payload.model_provider` 不会被误改。
- 原有 sqlite 同步、路径归一化、备份剪枝、失败回滚等测试继续通过。

## 验证

```bash
cargo test -p codex-plus-data provider_sync
```

结果：8 个 provider sync 测试全部通过。

测试过程中仍有 `codex-plus-core` 里已有的 unused/dead_code warning，与本次改动无关。
