### PR TITLE
修复切回官方模式后残留无效 provider

### DIFF
--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -170,10 +170,7 @@ pub fn clear_relay_config_to_home(home: &Path) -> anyhow::Result<RelayApplyResul
         ),
         "OPENAI_API_KEY",
     );
-    let updated = upsert_root_keys(
-        &without_relay,
-        &[("model_provider", "\"chatgpt\"".to_string())],
-    );
+    let updated = clear_relay_model_provider(&without_relay);
     std::fs::write(&config_path, updated)?;
     let status = relay_config_status_from_home(home);
     Ok(RelayApplyResult {
@@ -181,6 +178,19 @@ pub fn clear_relay_config_to_home(home: &Path) -> anyhow::Result<RelayApplyResul
         backup_path: backup_path.map(|path| path.to_string_lossy().to_string()),
         configured: status.configured,
     })
+}
+
+fn clear_relay_model_provider(contents: &str) -> String {
+    if cfg!(target_os = "macos") {
+        return match root_key_string(contents, "model_provider").as_deref() {
+            Some(RELAY_PROVIDER) | Some(LEGACY_RELAY_PROVIDER) | Some("chatgpt") => {
+                remove_root_key(contents, "model_provider")
+            }
+            _ => contents.to_string(),
+        };
+    }
+
+    upsert_root_keys(contents, &[("model_provider", "\"chatgpt\"".to_string())])
 }
 
 fn auth_json_chatgpt_account_label(path: &Path) -> Option<Option<String>> {

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -198,7 +198,58 @@ base_url = "https://old.example.test/v1"
 }
 
 #[test]
-fn clear_relay_config_switches_back_to_chatgpt_and_preserves_other_config() {
+#[cfg(target_os = "macos")]
+fn clear_relay_config_removes_relay_provider_on_macos_and_preserves_other_config() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("config.toml"),
+        r#"model = "gpt-5"
+model_provider = "CodexPlusPlus"
+[model_providers.CodexPlusPlus]
+name = "CodexPlusPlus"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example.test/v1"
+experimental_bearer_token = "sk-test-redacted"
+
+[model_providers.CodexPP]
+name = "CodexPP"
+base_url = "https://old.example.test/v1"
+
+[model_providers.custom1]
+name = "custom1"
+wire_api = "responses"
+base_url = "https://keep.example.test/v1"
+
+[profiles.default]
+model = "gpt-5-mini"
+"#,
+    )
+    .unwrap();
+
+    let result = clear_relay_config_to_home(temp.path()).unwrap();
+    let updated = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+
+    assert!(!result.configured);
+    assert!(result.backup_path.is_some());
+    assert!(updated.contains(r#"model = "gpt-5""#));
+    assert!(
+        !updated
+            .lines()
+            .any(|line| line.trim_start().starts_with("model_provider ="))
+    );
+    assert!(!updated.contains("OPENAI_API_KEY"));
+    assert!(!updated.contains("[model_providers.CodexPlusPlus]"));
+    assert!(!updated.contains("[model_providers.CodexPP]"));
+    assert!(!updated.contains("experimental_bearer_token"));
+    assert!(updated.contains("[model_providers.custom1]"));
+    assert!(updated.contains(r#"base_url = "https://keep.example.test/v1""#));
+    assert!(updated.contains("[profiles.default]"));
+}
+
+#[test]
+#[cfg(not(target_os = "macos"))]
+fn clear_relay_config_switches_back_to_chatgpt_on_non_macos_and_preserves_other_config() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::write(
         temp.path().join("config.toml"),
@@ -240,6 +291,28 @@ model = "gpt-5-mini"
     assert!(updated.contains("[model_providers.custom1]"));
     assert!(updated.contains(r#"base_url = "https://keep.example.test/v1""#));
     assert!(updated.contains("[profiles.default]"));
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+fn clear_relay_config_preserves_non_relay_model_provider() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("config.toml"),
+        r#"model = "gpt-5"
+model_provider = "openai"
+[model_providers.CodexPlusPlus]
+name = "CodexPlusPlus"
+base_url = "https://relay.example.test/v1"
+"#,
+    )
+    .unwrap();
+
+    clear_relay_config_to_home(temp.path()).unwrap();
+    let updated = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+
+    assert!(updated.contains(r#"model_provider = "openai""#));
+    assert!(!updated.contains("[model_providers.CodexPlusPlus]"));
 }
 
 fn base64_url_no_pad(value: &str) -> String {


### PR DESCRIPTION
## 背景

在 macOS 上，通过中转页面点击「切回官方登录模式」后，`~/.codex/config.toml` 可能会残留：

```toml
model_provider = "chatgpt"
```

原版 Codex 重新加载插件配置时，如果当前版本没有注册 `chatgpt` 这个 provider，会出现：

```text
failed to reload config: Model provider `chatgpt` not found
```

## 复现截图

<img width="1167" height="485" alt="image" src="https://github.com/user-attachments/assets/edb7e237-a0a5-4cc9-8be9-d23d0eea0e3d" />

## 原因

`clear_relay_config_to_home` 清理 Codex++ 中转配置时，会删除 `CodexPlusPlus` provider 表，但随后又主动写入：

```toml
model_provider = "chatgpt"
```

这里把「切回官方登录模式」实现成了「强制切到 chatgpt provider」。但 `chatgpt` 在 macOS 原版 Codex 中不是稳定可用的 provider 名，导致配置读取失败。

## 修改

- macOS 下清理中转配置时，不再写入 `model_provider = "chatgpt"`。
- macOS 下当根配置里的 `model_provider` 是 `CodexPlusPlus`、旧名 `CodexPP` 或历史残留的无效 `chatgpt` 时，移除该根配置项，避免原版 Codex 重新加载配置失败。
- 非 macOS 平台保持原有行为，继续在切回时写入 `model_provider = "chatgpt"`，避免影响 Windows 既有路径。
- 如果 macOS 用户原本配置的是 `openai` 或其他自定义 provider，则保留不动。
- 更新 relay config 测试，分别覆盖 macOS 清理路径和非 macOS 原行为保留路径。

## 验证

```bash
cargo test -p codex-plus-core --test relay_config
cargo fmt --check
cargo build --release
```
<img width="1164" height="874" alt="image" src="https://github.com/user-attachments/assets/10e28262-13b1-4c0c-a422-2aa9a4e4facf" />

本机 macOS 也做了安装验证：重新构建 release 二进制，安装到 `/Applications/Codex++.app` 和 `/Applications/Codex++ 管理工具.app`，确认 macOS 下切回官方模式后不再残留无效的 `chatgpt` provider。
