### PR TITLE
修复 macOS 上 Codex 版本健康检查显示异常

### DIFF
--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -749,8 +749,8 @@ function OverviewScreen({
         <CardHead title="健康检查" detail="概览只展示关键问题，具体配置在对应页面处理" />
         <CardContent>
           <div className="health-grid">
-            <div className="health-item ok">
-              <CheckCircle2 className="h-4 w-4" />
+            <div className={`health-item ${overview?.codex_version ? "ok" : "needs-fix"}`}>
+              {overview?.codex_version ? <CheckCircle2 className="h-4 w-4" /> : <Bell className="h-4 w-4" />}
               <div>
                 <strong>Codex 版本</strong>
                 <span>{overview?.codex_version ?? "未检测到 Codex 应用版本。"}</span>

--- a/crates/codex-plus-core/src/app_paths.rs
+++ b/crates/codex-plus-core/src/app_paths.rs
@@ -113,6 +113,9 @@ pub fn build_codex_executable(app_dir: &Path) -> PathBuf {
 }
 
 pub fn codex_app_version(app_dir: &Path) -> Option<String> {
+    if app_dir.extension() == Some(OsStr::new("app")) {
+        return macos_app_version(app_dir);
+    }
     let package_dir = if app_dir
         .file_name()
         .and_then(OsStr::to_str)
@@ -148,13 +151,35 @@ pub fn packaged_app_user_model_id(app_dir: &Path) -> Option<String> {
 }
 
 fn codex_package_version(package_dir: &Path) -> Option<String> {
-    let name = package_dir.file_name()?.to_str()?;
+    let path = package_dir.to_string_lossy().replace('\\', "/");
+    let name = path
+        .split('/')
+        .rev()
+        .find(|part| part.starts_with("OpenAI.Codex_"))?;
     let rest = name.strip_prefix("OpenAI.Codex_")?;
     let version = rest.split_once('_')?.0;
     if version.is_empty() {
         None
     } else {
         Some(version.to_string())
+    }
+}
+
+fn macos_app_version(app_dir: &Path) -> Option<String> {
+    let plist = std::fs::read_to_string(app_dir.join("Contents").join("Info.plist")).ok()?;
+    plist_string_value(&plist, "CFBundleShortVersionString")
+        .or_else(|| plist_string_value(&plist, "CFBundleVersion"))
+}
+
+fn plist_string_value(plist: &str, key: &str) -> Option<String> {
+    let (_, after_key) = plist.split_once(&format!("<key>{key}</key>"))?;
+    let (_, after_string_open) = after_key.split_once("<string>")?;
+    let (value, _) = after_string_open.split_once("</string>")?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
     }
 }
 

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -68,6 +68,30 @@ fn app_paths_extracts_codex_version_from_windows_package_app_dir() {
 }
 
 #[test]
+fn app_paths_extracts_codex_version_from_macos_bundle_plist() {
+    let temp = tempfile::tempdir().unwrap();
+    let app = temp.path().join("OpenAI Codex.app");
+    let contents = app.join("Contents");
+    std::fs::create_dir_all(&contents).unwrap();
+    std::fs::write(
+        contents.join("Info.plist"),
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleVersion</key>
+  <string>26.500.0</string>
+  <key>CFBundleShortVersionString</key>
+  <string>26.513.3673</string>
+</dict>
+</plist>
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(codex_app_version(&app).as_deref(), Some("26.513.3673"));
+}
+
+#[test]
 fn app_paths_user_data_candidates_include_local_and_roaming_variants() {
     let local = PathBuf::from(r"C:\Users\me\AppData\Local");
     let roaming = PathBuf::from(r"C:\Users\me\AppData\Roaming");


### PR DESCRIPTION
## 背景
在 macOS 上，健康检查概览能找到 Codex 应用，但 Codex 版本仍显示为未检测到。与此同时，概览里的“Codex 版本”这一行即使没有检测到版本，也会显示绿色对勾，容易让用户误以为检查已经正常通过。

## 现场现象
- Codex 应用路径可以被发现。
- Codex 版本显示“未检测到 Codex 应用版本。”
- 该健康检查项仍然展示为成功状态。
<img width="794" height="229" alt="image" src="https://github.com/user-attachments/assets/f40da687-3c0f-40a9-8d5f-e6512308a247" />

## 原因分析
Windows 版 Codex 的版本号包含在安装包目录名里，原有逻辑可以从类似 OpenAI.Codex_版本号_x64__... 的路径中解析版本。

macOS 版 Codex 是 app bundle，目录名本身不包含版本号，版本信息在 Contents/Info.plist 中。原逻辑没有读取 macOS bundle 的 Info.plist，因此在 macOS 上会返回空版本。

## 修改内容
- macOS app bundle 版本读取改为解析 Contents/Info.plist。
- 优先读取 CFBundleShortVersionString，缺失时回退到 CFBundleVersion。
- 保留 Windows 包名解析逻辑，并兼容测试里的 Windows 风格路径。
- 健康检查概览中，Codex 版本为空时不再显示绿色成功状态，而是显示为需要处理。
- 新增 macOS bundle 版本解析回归测试。

## 影响范围
- 影响 macOS 上 Codex 版本检测和健康检查概览展示。
- Windows 包名版本解析逻辑保持不变，并由现有测试覆盖。
- 不改变 Codex 应用查找路径、启动逻辑或安装逻辑。

## 验证
已通过：

- cargo test -p codex-plus-core app_paths_extracts_codex_version
- npm run build

其中 npm run build 已成功完成 Tauri release 构建，产物位于 target/release/codex-plus-plus-manager。
<img width="787" height="222" alt="image" src="https://github.com/user-attachments/assets/9807dbea-d7cc-45b0-854e-5e1aec1e9898" />
<img width="320" height="227" alt="image" src="https://github.com/user-attachments/assets/bfcc2828-a83e-49db-9a44-b842af20c62e" />

## 备注
构建过程中仍有已有的 unused import / dead code warning，本次改动未处理这些无关 warning。
