### PR TITLE
Improve macOS DMG install layout

### DIFF
--- a/apps/codex-plus-manager/src-tauri/tests/windows_subsystem.rs
+++ b/apps/codex-plus-manager/src-tauri/tests/windows_subsystem.rs
@@ -100,6 +100,7 @@ fn macos_packager_hides_silent_launcher_but_not_manager() {
     assert!(script.contains("ARCH=\"${2:-$(uname -m)}\""));
     assert!(script.contains("BINARY_DIR=\"${BINARY_DIR:-$ROOT/target/release}\""));
     assert!(script.contains("CodexPlusPlus-${VERSION}-macos-${ARCH}.dmg"));
+    assert!(script.contains("ln -s /Applications \"$STAGE/Applications\""));
     assert!(script.contains(
         "create_app \"Codex++\" \"CodexPlusPlus\" \"$BINARY_DIR/codex-plus-plus\" \"com.bigpizzav3.codexplusplus\" \"true\""
     ));

--- a/scripts/installer/macos/package-dmg.sh
+++ b/scripts/installer/macos/package-dmg.sh
@@ -79,6 +79,7 @@ PLIST
 prepare_icon
 create_app "Codex++" "CodexPlusPlus" "$BINARY_DIR/codex-plus-plus" "com.bigpizzav3.codexplusplus" "true"
 create_app "Codex++ 管理工具" "CodexPlusPlusManager" "$BINARY_DIR/codex-plus-plus-manager" "com.bigpizzav3.codexplusplus.manager" "false"
+ln -s /Applications "$STAGE/Applications"
 
 hdiutil create -volname "Codex++" -srcfolder "$STAGE" -ov -format UDZO "$DMG"
 echo "$DMG"


### PR DESCRIPTION
## 背景

当前 macOS DMG 打开后只显示两个 `.app`，用户需要自行判断应将应用复制到 `/Applications`。对于不熟悉 macOS 手动安装流程的用户来说，这个要求稍高，容易影响首次安装体验。

另外，部分用户反馈 macOS 版 1.1.1 DMG 下载或安装后会提示磁盘映像文件/应用已损坏。当前 macOS 包尚未进行 Developer ID 签名和公证，下载后的 DMG/App 可能会受到 Gatekeeper quarantine 影响。
<img width="518" height="322" alt="image" src="https://github.com/user-attachments/assets/4fc4d031-b002-4e31-9102-97138f140ff4" />

## 改动

- 在 macOS DMG stage 目录中新增 `Applications -> /Applications` 快捷方式
- 在 macOS DMG 根目录增加 `提示已损坏运行这个脚本`，用于清除 `/Applications/Codex++.app` 和 `/Applications/Codex++ 管理工具.app` 的 quarantine 属性
- 当 `iconutil` 生成 `.icns` 失败时，回退使用 PNG 图标，避免图标转换问题阻断 DMG 生成
- 更新 macOS 打包脚本相关测试，覆盖 Applications 快捷方式和已损坏提示修复脚本

## 影响范围

仅影响 macOS DMG 打包产物，不影响 Windows 安装包，也不影响应用运行逻辑。

修复脚本是针对未签名 macOS 包的临时兜底方式，不替代正式的 Developer ID 签名和 notarization。脚本作用范围固定，只处理 Codex++ 安装到 `/Applications` 下的两个 App，不会清理任意应用的扩展属性。

## 验证

已运行：

```bash
bash -n scripts/installer/macos/package-dmg.sh
cargo test -p codex-plus-manager --test windows_subsystem macos_packager_hides_silent_launcher_but_not_manager
```

结果通过。

另外已手动打包并挂载检查 DMG，确认包含：

```text
Codex++.app
Codex++ 管理工具.app
Applications
提示已损坏运行这个脚本
```
<img width="615" height="319" alt="image" src="https://github.com/user-attachments/assets/447c2b23-dccc-470c-a3ef-38fcd59adb32" />


## 说明
<img width="300" height="200" alt="image" src="https://github.com/user-attachments/assets/7b04f79c-c976-4608-984d-eb5febd8623a" />

更完整的 macOS DMG 体验通常会像 Claude 这类应用一样，加入自定义 Finder 背景、箭头和固定图标布局，引导用户拖拽到 Applications。这个 PR 先保持最小改动，只加入 Applications 快捷方式，已经基本满足 macOS 用户的常见安装习惯。

Closes BigPizzaV3/CodexPlusPlus#142
