### PR TITLE
修复 macOS 清除中转后写入无效 model_provider = "chatgpt"

### DIFF
--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -182,7 +182,7 @@ pub fn clear_relay_config_to_home(home: &Path) -> anyhow::Result<RelayApplyResul
 
 fn restore_default_model_provider(contents: &str) -> String {
     if cfg!(target_os = "macos") {
-        return remove_root_key(contents, "model_provider");
+        return upsert_root_keys(contents, &[("model_provider", "\"openai\"".to_string())]);
     }
 
     upsert_root_keys(contents, &[("model_provider", "\"chatgpt\"".to_string())])

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -170,10 +170,7 @@ pub fn clear_relay_config_to_home(home: &Path) -> anyhow::Result<RelayApplyResul
         ),
         "OPENAI_API_KEY",
     );
-    let updated = upsert_root_keys(
-        &without_relay,
-        &[("model_provider", "\"chatgpt\"".to_string())],
-    );
+    let updated = restore_default_model_provider(&without_relay);
     std::fs::write(&config_path, updated)?;
     let status = relay_config_status_from_home(home);
     Ok(RelayApplyResult {
@@ -181,6 +178,14 @@ pub fn clear_relay_config_to_home(home: &Path) -> anyhow::Result<RelayApplyResul
         backup_path: backup_path.map(|path| path.to_string_lossy().to_string()),
         configured: status.configured,
     })
+}
+
+fn restore_default_model_provider(contents: &str) -> String {
+    if cfg!(target_os = "macos") {
+        return remove_root_key(contents, "model_provider");
+    }
+
+    upsert_root_keys(contents, &[("model_provider", "\"chatgpt\"".to_string())])
 }
 
 fn auth_json_chatgpt_account_label(path: &Path) -> Option<Option<String>> {

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -198,6 +198,7 @@ base_url = "https://old.example.test/v1"
 }
 
 #[test]
+#[cfg(not(target_os = "macos"))]
 fn clear_relay_config_switches_back_to_chatgpt_and_preserves_other_config() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::write(
@@ -240,6 +241,33 @@ model = "gpt-5-mini"
     assert!(updated.contains("[model_providers.custom1]"));
     assert!(updated.contains(r#"base_url = "https://keep.example.test/v1""#));
     assert!(updated.contains("[profiles.default]"));
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+fn clear_relay_config_does_not_inject_chatgpt_provider_on_macos() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("config.toml"),
+        r#"model = "gpt-5"
+model_provider = "CodexPlusPlus"
+[model_providers.CodexPlusPlus]
+name = "CodexPlusPlus"
+base_url = "https://relay.example.test/v1"
+"#,
+    )
+    .unwrap();
+
+    clear_relay_config_to_home(temp.path()).unwrap();
+    let updated = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+
+    assert!(updated.contains(r#"model = "gpt-5""#));
+    assert!(
+        !updated
+            .lines()
+            .any(|line| line.trim_start().starts_with("model_provider ="))
+    );
+    assert!(!updated.contains("[model_providers.CodexPlusPlus]"));
 }
 
 fn base64_url_no_pad(value: &str) -> String {

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -245,7 +245,7 @@ model = "gpt-5-mini"
 
 #[test]
 #[cfg(target_os = "macos")]
-fn clear_relay_config_does_not_inject_chatgpt_provider_on_macos() {
+fn clear_relay_config_switches_back_to_openai_on_macos() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::write(
         temp.path().join("config.toml"),
@@ -262,11 +262,7 @@ base_url = "https://relay.example.test/v1"
     let updated = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
 
     assert!(updated.contains(r#"model = "gpt-5""#));
-    assert!(
-        !updated
-            .lines()
-            .any(|line| line.trim_start().starts_with("model_provider ="))
-    );
+    assert!(updated.contains(r#"model_provider = "openai""#));
     assert!(!updated.contains("[model_providers.CodexPlusPlus]"));
 }
 


### PR DESCRIPTION
## 背景

重开 #143。原 PR 因 `rust-tauri-migration` 分支删除而关闭，本次改为基于最新 `main`。

macOS 上清除 Codex++ 中转配置后，当前逻辑会回写 `model_provider = "chatgpt"`。但 macOS 官方 Codex 的配置里没有对应的 `chatgpt` provider 表，后续启动可能会继续引用这个无效 provider，导致切回官方模式后恢复失败。
<img width="1167" height="485" alt="image" src="https://github.com/user-attachments/assets/54cb3bc2-da4f-410c-bae5-348ea7b5fe7b" />

## 改动

- macOS 清除中转配置时不再回写 `model_provider = "chatgpt"`
- macOS 清除中转配置时移除 root `model_provider`，避免其继续指向已删除的中转 provider 表
- 非 macOS 仍保持原行为，继续回写 `model_provider = "chatgpt"`
- 补充 relay config 测试覆盖 macOS 清理行为

## 影响范围

仅影响清除 Codex++ 中转配置时的 provider 回退逻辑。不会改变中转配置写入逻辑，也不会影响非 macOS 平台现有行为。

## 验证

已运行：

```bash
cargo test -p codex-plus-core --test relay_config
```
<img width="1164" height="874" alt="image" src="https://github.com/user-attachments/assets/b3604f74-5016-43bf-832f-7bedb6fabb21" />

结果通过，9 个测试全部通过。
