### PR TITLE
Polish Rust sidebar action icons

### DIFF
--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -6,6 +6,7 @@
   const projectMoveOverlayClass = "codex-project-move-overlay";
   const actionButtonClass = "codex-session-action-button";
   const actionGroupClass = "codex-session-actions";
+  const actionTooltipClass = "codex-session-action-tooltip";
   const timelineClass = "codex-conversation-timeline";
   const timelineTrackClass = "codex-conversation-timeline-track";
   const timelineMarkerClass = "codex-conversation-timeline-marker";
@@ -23,13 +24,13 @@
   const chatsSortRefreshIntervalMs = 1500;
   const chatsSortDbRefreshIntervalMs = 5000;
   const styleId = "codex-delete-style";
-  const codexDeleteStyleVersion = "8";
+  const codexDeleteStyleVersion = "9";
   const codexPlusMenuId = "codex-plus-menu";
   const codexPlusMenuFloatingClass = "codex-plus-menu-floating";
-  const codexDeleteVersion = "6";
+  const codexDeleteVersion = "7";
   const codexExportVersion = "1";
   const codexProjectMoveVersion = "1";
-  const codexActionGroupVersion = "2";
+  const codexActionGroupVersion = "3";
   const codexArchiveRowActionsVersion = "1";
   const codexArchiveDeleteAllVersion = "2";
   const codexConversationTimelineVersion = "2";
@@ -71,44 +72,75 @@
         opacity: 0;
         display: inline-flex;
         align-items: center;
-        gap: 6px;
+        gap: 4px;
+        background: transparent;
       }
-      .${actionButtonClass},
+      .${actionButtonClass} {
+        width: 26px;
+        height: 26px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: 0;
+        border-radius: 7px;
+        background: transparent;
+        color: #d1d5db;
+        font: 14px/1 system-ui, sans-serif;
+        padding: 0;
+        cursor: default;
+        text-align: center;
+      }
+      .${actionButtonClass} svg {
+        display: block;
+        width: 16px;
+        height: 16px;
+      }
+      .${actionButtonClass}:hover,
+      .${actionButtonClass}:focus-visible {
+        background: #363839;
+        color: #f4f4f5;
+        outline: none;
+      }
       .codex-archive-row-button {
         border: 1px solid #ef4444;
-        border-radius: 6px;
+        border-radius: 7px;
         background: #f3f4f6;
         color: #374151;
-        font-size: 12px;
-        line-height: 16px;
-        padding: 1px 6px;
-        cursor: pointer;
-      }
-      .codex-archive-row-button {
-        border-radius: 7px;
         font: 12px system-ui, sans-serif;
         line-height: 16px;
         padding: 3px 8px;
+        cursor: pointer;
       }
-      .${buttonClass},
       .codex-archive-row-button.${buttonClass} {
         border-color: #ef4444;
         background: #fee2e2;
         color: #991b1b;
       }
-      .${exportButtonClass},
       .codex-archive-row-button.${exportButtonClass} {
         border-color: #93c5fd;
         background: #dbeafe;
         color: #1d4ed8;
       }
-      .${projectMoveButtonClass} {
-        border-color: #10a37f;
-        background: #d1fae5;
-        color: #065f46;
-      }
       [data-codex-delete-row="true"]:hover .${actionGroupClass} { opacity: 1; }
+      [data-codex-delete-row="true"]:hover [data-thread-title] {
+        -webkit-mask-image: linear-gradient(90deg, #000 calc(100% - 86px), transparent calc(100% - 80px));
+        mask-image: linear-gradient(90deg, #000 calc(100% - 86px), transparent calc(100% - 80px));
+      }
       [data-codex-delete-row="true"].codex-archive-confirm-visible .${actionGroupClass} { right: 66px; }
+      .${actionTooltipClass} {
+        position: fixed;
+        z-index: 2147483201;
+        max-width: min(220px, calc(100vw - 32px));
+        border: 1px solid rgba(255,255,255,.1);
+        border-radius: 12px;
+        background: #242628;
+        color: #f4f4f5;
+        font: 14px/20px system-ui, sans-serif;
+        padding: 9px 12px;
+        box-shadow: 0 14px 40px rgba(0,0,0,.28);
+        pointer-events: none;
+        white-space: nowrap;
+      }
       .${projectMoveOverlayClass} {
         position: fixed;
         inset: 0;
@@ -2532,8 +2564,42 @@
     ["pointerdown", "mousedown", "mouseup", "touchstart"].forEach((eventName) => {
       button.addEventListener(eventName, (event) => stopActionButtonEvent(row, button, event), true);
     });
+    button.addEventListener("pointerenter", () => showActionButtonTooltip(button));
+    button.addEventListener("pointerleave", hideActionButtonTooltip);
+    button.addEventListener("focus", () => showActionButtonTooltip(button));
+    button.addEventListener("blur", hideActionButtonTooltip);
     button.addEventListener("pointerup", onActivate, true);
-    button.addEventListener("click", onActivate, true);
+    button.addEventListener("click", (event) => {
+      hideActionButtonTooltip();
+      onActivate(event);
+    }, true);
+  }
+
+  function hideActionButtonTooltip() {
+    document.querySelectorAll(`.${actionTooltipClass}`).forEach((node) => node.remove());
+  }
+
+  function showActionButtonTooltip(button) {
+    const label = button.dataset.codexActionLabel || button.getAttribute("aria-label") || "";
+    if (!label) return;
+    hideActionButtonTooltip();
+    const tooltip = document.createElement("div");
+    tooltip.className = actionTooltipClass;
+    tooltip.textContent = label;
+    document.body.appendChild(tooltip);
+    const buttonRect = button.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const gap = 8;
+    const left = Math.min(
+      window.innerWidth - tooltipRect.width - 8,
+      Math.max(8, buttonRect.left + buttonRect.width / 2 - tooltipRect.width / 2),
+    );
+    const top = Math.min(
+      window.innerHeight - tooltipRect.height - 8,
+      buttonRect.bottom + gap,
+    );
+    tooltip.style.left = `${left}px`;
+    tooltip.style.top = `${Math.max(8, top)}px`;
   }
 
   function refreshActionButton(originalButton, row, onActivate) {
@@ -2541,6 +2607,32 @@
     const replacement = originalButton.cloneNode(true);
     installActionButtonEvents(row, replacement, onActivate);
     originalButton.replaceWith(replacement);
+  }
+
+  function configureActionButton(button, label, icon) {
+    button.setAttribute("aria-label", label);
+    button.dataset.codexActionLabel = label;
+    button.removeAttribute("title");
+    button.textContent = icon;
+  }
+
+  function trashIconSvg() {
+    return `
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 6h18"></path>
+        <path d="M8 6V4h8v2"></path>
+        <path d="M19 6l-1 14H6L5 6"></path>
+        <path d="M10 11v5"></path>
+        <path d="M14 11v5"></path>
+      </svg>
+    `;
+  }
+
+  function configureSvgActionButton(button, label, svg) {
+    button.setAttribute("aria-label", label);
+    button.dataset.codexActionLabel = label;
+    button.removeAttribute("title");
+    button.innerHTML = svg;
   }
 
   function attachButton(row) {
@@ -2581,7 +2673,7 @@
       moveButton.type = "button";
       moveButton.className = `${actionButtonClass} ${projectMoveButtonClass}`;
       moveButton.dataset.codexProjectMoveVersion = codexProjectMoveVersion;
-      moveButton.textContent = "移动";
+      configureActionButton(moveButton, "移动", "↗");
       const openProjectMove = (event) => openProjectMoveMenuForRow(row, moveButton, ref, event);
       installActionButtonEvents(row, moveButton, openProjectMove);
       group.appendChild(moveButton);
@@ -2592,7 +2684,7 @@
       exportButton.type = "button";
       exportButton.className = `${actionButtonClass} ${exportButtonClass}`;
       exportButton.dataset.codexExportVersion = codexExportVersion;
-      exportButton.textContent = "导出";
+      configureActionButton(exportButton, "导出", "⇩");
       const openExport = (event) => {
         stopActionButtonEvent(row, exportButton, event);
         exportMarkdown(ref);
@@ -2606,7 +2698,7 @@
       deleteButton.type = "button";
       deleteButton.className = `${actionButtonClass} ${buttonClass}`;
       deleteButton.dataset.codexDeleteVersion = codexDeleteVersion;
-      deleteButton.textContent = "删除";
+      configureSvgActionButton(deleteButton, "删除", trashIconSvg());
       const openDeleteConfirm = (event) => openDeleteConfirmForRow(row, deleteButton, ref, event);
       installActionButtonEvents(row, deleteButton, openDeleteConfirm);
       group.appendChild(deleteButton);

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -45,6 +45,57 @@ def test_renderer_script_positions_delete_button_without_affecting_layout():
     assert "display: inline-flex" in text
 
 
+def test_renderer_script_uses_native_like_sidebar_action_icons_with_tooltips():
+    text = Path("assets/inject/renderer-inject.js").read_text(encoding="utf-8")
+    style_start = text.index("style.textContent = `")
+    style_end = text.index("`;\n    document.documentElement.appendChild(style);", style_start)
+    style_code = text[style_start:style_end]
+    events_start = text.index("function installActionButtonEvents")
+    events_end = text.index("\n\n  function attachButton", events_start)
+    events_code = text[events_start:events_end]
+    attach_start = text.index("function attachButton")
+    attach_end = text.index("\n\n  function tryAttachButton", attach_start)
+    attach_code = text[attach_start:attach_end]
+
+    assert "actionTooltipClass = \"codex-session-action-tooltip\"" in text
+    assert "codexDeleteStyleVersion = \"9\"" in text
+    assert "codexDeleteVersion = \"7\"" in text
+    assert "codexActionGroupVersion = \"3\"" in text
+    assert "background: transparent" in style_code
+    assert "width: 26px" in style_code
+    assert "height: 26px" in style_code
+    assert "display: inline-flex" in style_code
+    assert "align-items: center" in style_code
+    assert "justify-content: center" in style_code
+    assert "color: #d1d5db" in style_code
+    assert "background: #363839" in style_code
+    assert "[data-codex-delete-row=\"true\"]:hover [data-thread-title]" in style_code
+    assert "mask-image: linear-gradient(90deg, #000 calc(100% - 86px), transparent calc(100% - 80px))" in style_code
+    assert ".${actionButtonClass} svg" in style_code
+    assert ".${actionButtonClass}.${buttonClass}:hover" not in style_code
+
+    assert "configureActionButton(moveButton, \"移动\", \"↗\")" in attach_code
+    assert "configureActionButton(exportButton, \"导出\", \"⇩\")" in attach_code
+    assert "configureSvgActionButton(deleteButton, \"删除\", trashIconSvg())" in attach_code
+    assert "function trashIconSvg()" in text
+    assert "<svg viewBox=\"0 0 24 24\"" in text
+    assert "stroke=\"currentColor\"" in text
+    assert "aria-hidden=\"true\"" in text
+    assert "focusable=\"false\"" in text
+    assert "button.setAttribute(\"aria-label\", label)" in text
+    assert "button.dataset.codexActionLabel = label" in text
+    assert "button.removeAttribute(\"title\")" in text
+    assert "button.innerHTML = svg" in text
+    assert "⌫" not in attach_code
+    assert 'moveButton.textContent = "移动"' not in attach_code
+    assert 'exportButton.textContent = "导出"' not in attach_code
+    assert 'deleteButton.textContent = "删除"' not in attach_code
+    assert "showActionButtonTooltip(button)" in events_code
+    assert "hideActionButtonTooltip()" in events_code
+    assert "\"pointerenter\"" in events_code
+    assert "\"focus\"" in events_code
+
+
 
 
 def test_renderer_script_keeps_sponsors_separate_from_author_support():


### PR DESCRIPTION
## 变更说明
- 基于最新 Rust 版本重新提交侧边栏 action button 外观调整。
- 将会话行右侧的移动、导出、删除操作从分块彩色文字按钮改为更接近 Codex 原生风格的透明 icon button。
- 单个 action icon 悬停或聚焦时使用原生风格高亮色，避免整块操作区域显得突兀。
- 会话标题过长时，在 action 区域前做渐隐，避免标题文字遮挡按钮。
- 根据 #110 / #137 的反馈，将删除动作改成垃圾桶 SVG 图标，同时保留 `aria-label="删除"` 和悬停功能提示。

## 交互逻辑
- 用户悬停在侧边栏会话行时，右侧显示移动、导出、删除三个透明 icon button。
- 鼠标悬停到任意 action icon 上时，仅当前 icon 高亮，并展示对应功能提示。
- 删除按钮显示垃圾桶图标，点击后仍进入原有删除确认流程。
- 归档页里的导出/删除文字按钮保持原样，本次只调整普通侧边栏会话行 action buttons。

## 说明
- 本 PR 只迁移侧边栏按钮外观和删除图标改动，不包含批量移动功能。

## 验证
- `.venv/bin/python -m pytest tests/test_renderer_script.py -q`（44 passed）
- `node --check assets/inject/renderer-inject.js`
- `cargo fmt --check`
- `git diff --check`

补充：本地也尝试过 `cargo test`，但当前 main 在 macOS 下已有一个与本次改动无关的失败：`crates/codex-plus-core/tests/cli_wrapper.rs::wrapper_dir_uses_roaming_codex_plus_plus`，原因是测试期望 Windows 反斜杠路径，macOS 下实际 Path 字符串为混合分隔符。
