### PR TITLE
fix(zed): fall back to selected remote workspace

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -413,6 +413,12 @@ impl BridgeRuntimeService for LauncherRuntimeService {
         ))
     }
 
+    async fn fallback_zed_remote_request(&self, payload: Value) -> anyhow::Result<Value> {
+        Ok(codex_plus_core::zed_remote::fallback_open_request_response(
+            &payload,
+        ))
+    }
+
     async fn open_zed_remote(&self, payload: Value) -> anyhow::Result<Value> {
         Ok(codex_plus_core::zed_remote::open_zed_remote(&payload))
     }

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -72,7 +72,7 @@
     sidebarThread: "[data-app-action-sidebar-thread-id]",
     threadTitle: "[data-thread-title]",
     appHeader: ".app-header-tint",
-    nativeMenuBar: ".flex.items-center.gap-0\\.5, [class*=\"flex items-center gap-0.5\"]",
+    nativeMenuBar: "[class*=\"ms-auto\"][class*=\"flex\"][class*=\"items-center\"]",
     archiveNav: 'button[aria-label="已归档对话"], button[aria-label="Archived conversations"]',
     disabledInstallButton: 'button:disabled.w-full.justify-center, [role="button"][aria-disabled="true"].cursor-not-allowed',
     pluginNavButton: 'nav[role="navigation"] button.h-token-nav-row.w-full',
@@ -727,7 +727,7 @@
   }
 
   function scheduleBackendHeartbeat() {
-    clearInterval(window.__codexPlusBackendHeartbeat);
+    if (window.__codexPlusBackendHeartbeat) return;
     window.__codexPlusBackendHeartbeat = setInterval(checkBackendStatus, 5000);
     checkBackendStatus();
   }
@@ -4175,6 +4175,11 @@
     return result?.status === "ok" && result.ssh ? result.ssh : null;
   }
 
+  async function resolveZedRemoteFallbackRequest() {
+    const result = await postJson("/zed-remote/fallback-request", {});
+    return result?.status === "ok" && result.request ? result.request : null;
+  }
+
   function zedRemoteString(value) {
     return typeof value === "string" || typeof value === "number" ? String(value).trim() : "";
   }
@@ -4247,7 +4252,7 @@
       const context = zedRemoteContextFromElement(node);
       if (context) return context;
     }
-    return zedRemoteContext();
+    return null;
   }
 
   function zedRemoteHostIdFromText(text) {
@@ -4315,42 +4320,71 @@
     };
   }
 
-  function zedRemoteContext() {
-    const settings = codexPlusSettings();
-    if (!settings.zedRemoteOpen) return null;
-    const explicitNodes = document.querySelectorAll("[data-host-config], [data-ssh-host], [data-remote-host], [data-remote-workspace-root], [data-supports-ssh]");
-    for (const node of explicitNodes) {
-      if (!(node instanceof HTMLElement)) continue;
-      const data = node.dataset;
-      const context = zedRemoteContextFromObject({
-        hostConfig: data.hostConfig ? { host: data.hostConfig, supportsSsh: true } : {},
-        supportsSsh: data.supportsSsh || data.supportsSshRemote,
-        sshHost: data.sshHost,
-        remoteHost: data.remoteHost,
-        host: data.host,
-        sshUser: data.sshUser,
-        remoteUser: data.remoteUser,
-        user: data.user,
-        sshPort: data.sshPort,
-        remotePort: data.remotePort,
-        port: data.port,
-        remoteWorkspaceRoot: data.remoteWorkspaceRoot,
-        workspaceRoot: data.workspaceRoot,
-      });
+  const zedRemoteContextCacheTtlMs = 1200;
+  let zedRemoteContextCache = { scope: null, at: 0, value: null };
+
+  function zedRemoteScopedElements(scope, selector) {
+    const root = scope?.querySelectorAll ? scope : document;
+    const nodes = [];
+    if (scope instanceof HTMLElement && scope.matches?.(selector)) nodes.push(scope);
+    root.querySelectorAll?.(selector).forEach((node) => nodes.push(node));
+    return Array.from(new Set(nodes));
+  }
+
+  function zedRemoteContextFromDataset(node) {
+    if (!(node instanceof HTMLElement)) return null;
+    const data = node.dataset;
+    return zedRemoteContextFromObject({
+      hostConfig: data.hostConfig ? { host: data.hostConfig, supportsSsh: true } : {},
+      supportsSsh: data.supportsSsh || data.supportsSshRemote,
+      sshHost: data.sshHost,
+      remoteHost: data.remoteHost,
+      host: data.host,
+      sshUser: data.sshUser,
+      remoteUser: data.remoteUser,
+      user: data.user,
+      sshPort: data.sshPort,
+      remotePort: data.remotePort,
+      port: data.port,
+      remoteWorkspaceRoot: data.remoteWorkspaceRoot,
+      workspaceRoot: data.workspaceRoot,
+    });
+  }
+
+  function zedRemoteContextUncached(scope = document) {
+    const explicitSelector = "[data-host-config], [data-ssh-host], [data-remote-host], [data-remote-workspace-root], [data-supports-ssh]";
+    for (const node of zedRemoteScopedElements(scope, explicitSelector)) {
+      if (isExtensionUiNode(node)) continue;
+      const context = zedRemoteContextFromDataset(node);
       if (context) return context;
     }
-    const reactNodes = [document.body, ...document.querySelectorAll("[data-remote-path], [data-file-path], [data-path], [data-open-in-targets], [data-open-file], span.inline-markdown, code, [class*='inlineMarkdown'], a, button, [role='button'], [role='menuitem'], [role='treeitem']")].filter(Boolean);
-    for (const node of reactNodes.slice(0, 260)) {
+    const reactSelector = "[data-remote-path], [data-file-path], [data-path], [data-open-in-targets], [data-open-file], [data-codex-open-file], [role='menuitem']";
+    const reactNodes = zedRemoteScopedElements(scope, reactSelector);
+    if (scope instanceof HTMLElement && !isExtensionUiNode(scope)) reactNodes.unshift(scope);
+    for (const node of Array.from(new Set(reactNodes)).slice(0, 60)) {
       if (!(node instanceof HTMLElement) || isExtensionUiNode(node)) continue;
       const context = zedRemoteContextFromElement(node);
       if (context) return context;
     }
+    if (scope !== document) return null;
     const scripts = Array.from(document.querySelectorAll("script[type='application/json'], script[data-state], script#__NEXT_DATA__, script:not([src])"));
-    for (const script of scripts.slice(0, 40)) {
+    for (const script of scripts.slice(0, 20)) {
       const context = zedRemoteContextFromSerializedState(script.textContent || "");
       if (context) return context;
     }
     return null;
+  }
+
+  function zedRemoteContext(scope = document) {
+    const settings = codexPlusSettings();
+    if (!settings.zedRemoteOpen) return null;
+    const now = Date.now();
+    if (zedRemoteContextCache.scope === scope && now - zedRemoteContextCache.at < zedRemoteContextCacheTtlMs) {
+      return zedRemoteContextCache.value;
+    }
+    const value = zedRemoteContextUncached(scope);
+    zedRemoteContextCache = { scope, at: now, value };
+    return value;
   }
 
   function zedRemoteAbsolutePath(value, workspaceRoot) {
@@ -4395,7 +4429,7 @@
     return /open[-_\s]?file|open-in-targets|remote/i.test(label) && !!zedRemotePathFromElementMetadata(anchor);
   }
 
-  function zedRemoteFileCandidates(context) {
+  function zedRemoteFileCandidates(context, scope = document) {
     const candidates = [];
     const seen = new Set();
     const addCandidate = (node, candidateContext, rawPath) => {
@@ -4406,23 +4440,25 @@
       candidates.push({ node, request: { ssh: candidateContext.ssh, hostId: candidateContext.hostId || "", path } });
     };
     const selectors = "[data-remote-path], [data-file-path], [data-path], [data-open-in-targets], [data-open-file], [data-codex-open-file], a[data-remote-path], a[data-file-path], a[data-path]";
-    document.querySelectorAll(selectors).forEach((node) => {
+    zedRemoteScopedElements(scope, selectors).forEach((node) => {
       if (!(node instanceof HTMLElement) || isExtensionUiNode(node)) return;
       if (node instanceof HTMLAnchorElement && !zedRemoteAnchorHasOpenFileMetadata(node)) return;
       addCandidate(node, zedRemoteContextForElement(node) || context, zedRemotePathFromElementMetadata(node));
     });
-    document.querySelectorAll("span.inline-markdown, code, [class*='inlineMarkdown']").forEach((node) => {
-      if (!(node instanceof HTMLElement) || isExtensionUiNode(node)) return;
-      const candidateContext = zedRemoteContextForElement(node) || context || zedRemoteFallbackContextForElement(node);
-      if (!candidateContext?.hostId && !candidateContext?.ssh?.host) return;
-      const path = zedRemoteInlinePathFromElement(node, candidateContext);
-      if (path) addCandidate(node, candidateContext, path);
-    });
+    if (scope !== document) {
+      zedRemoteScopedElements(scope, "span.inline-markdown, code, [class*='inlineMarkdown']").forEach((node) => {
+        if (!(node instanceof HTMLElement) || isExtensionUiNode(node)) return;
+        const candidateContext = zedRemoteContextForElement(node) || context || zedRemoteFallbackContextForElement(node);
+        if (!candidateContext?.hostId && !candidateContext?.ssh?.host) return;
+        const path = zedRemoteInlinePathFromElement(node, candidateContext);
+        if (path) addCandidate(node, candidateContext, path);
+      });
+    }
     return candidates;
   }
 
-  function zedRemoteBestOpenRequest(context = zedRemoteContext() || {}) {
-    const candidates = zedRemoteFileCandidates(context);
+  function zedRemoteBestOpenRequest(scope = document, context = zedRemoteContext(scope) || zedRemoteContext(document) || {}) {
+    const candidates = zedRemoteFileCandidates(context, scope);
     if (candidates.length) return candidates[0].request;
     const workspaceRoot = zedRemoteAbsolutePath(context.workspaceRoot || "", "");
     if (!workspaceRoot || (!context?.ssh?.host && !context?.hostId)) return null;
@@ -4451,10 +4487,10 @@
     }
   }
 
-  function openBestZedRemoteTarget() {
-    const request = zedRemoteBestOpenRequest();
+  async function openBestZedRemoteTarget() {
+    const request = zedRemoteBestOpenRequest(document) || await resolveZedRemoteFallbackRequest();
     if (!request) {
-      showZedRemoteToast("Cannot find a remote workspace or file for Zed Remote");
+      showZedRemoteToast("Cannot find a remote workspace or file for Zed");
       return;
     }
     openZedRemote(request);
@@ -4511,15 +4547,19 @@
     return false;
   }
 
-  function activateZedRemoteOpenInMenuItem(event) {
+  async function activateZedRemoteOpenInMenuItem(event) {
     if (!codexPlusSettings().zedRemoteOpen) return;
     if (event?.type === "keydown" && !["Enter", " "].includes(event.key)) return;
-    const request = zedRemoteBestOpenRequest();
-    if (!request) return;
+    const scope = event?.currentTarget?.closest?.('[role="menu"], [data-radix-popper-content-wrapper]') || event?.currentTarget || document;
     event.preventDefault();
     event.stopPropagation();
     event.stopImmediatePropagation?.();
     if (zedRemoteOpenInMenuActivationIsDuplicate(event?.currentTarget)) return;
+    const request = zedRemoteBestOpenRequest(scope) || await resolveZedRemoteFallbackRequest();
+    if (!request) {
+      showZedRemoteToast("Cannot find a remote workspace or file for Zed");
+      return;
+    }
     openZedRemote(request);
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", code: "Escape", bubbles: true }));
   }
@@ -4534,16 +4574,23 @@
     item.addEventListener("keydown", activateZedRemoteOpenInMenuItem, true);
   }
 
-  function removeZedRemoteOpenInMenuItems() {
-    document.querySelectorAll(`.${zedRemoteOpenInMenuItemClass}, [data-codex-zed-open-in-menu="injected"]`).forEach((node) => node.remove());
+  function removeZedRemoteOpenInMenuItems(scope = document) {
+    const root = scope?.querySelectorAll ? scope : document;
+    root.querySelectorAll(`.${zedRemoteOpenInMenuItemClass}, [data-codex-zed-open-in-menu="injected"]`).forEach((node) => node.remove());
   }
 
-  function refreshZedRemoteOpenInMenus(context) {
-    removeZedRemoteOpenInMenuItems();
+  function zedRemoteOpenInMenuScopes(scope = document) {
+    const root = scope?.querySelectorAll ? scope : document;
+    const menus = [];
+    if (scope instanceof HTMLElement && scope.matches?.('[role="menu"]')) menus.push(scope);
+    root.querySelectorAll?.('[role="menu"]').forEach((menu) => menus.push(menu));
+    return Array.from(new Set(menus));
+  }
+
+  function refreshZedRemoteOpenInMenus(scope = document) {
+    removeZedRemoteOpenInMenuItems(scope);
     if (!codexPlusSettings().zedRemoteOpen) return;
-    const request = zedRemoteBestOpenRequest(context || zedRemoteContext() || {});
-    if (!request) return;
-    document.querySelectorAll('[role="menu"]').forEach((menu) => {
+    zedRemoteOpenInMenuScopes(scope).forEach((menu) => {
       if (!(menu instanceof HTMLElement) || isExtensionUiNode(menu)) return;
       const items = Array.from(menu.querySelectorAll('[role="menuitem"]')).filter((item) => !isExtensionUiNode(item));
       const menuText = items.map((item) => (item.textContent || "").trim()).join(" ");
@@ -4559,13 +4606,12 @@
     });
   }
 
-  async function refreshZedRemoteOpenControls() {
+  async function refreshZedRemoteOpenControls(scope = document) {
     if (!codexPlusSettings().zedRemoteOpen) {
       removeZedRemoteButtons();
       removeZedRemoteOpenInMenuItems();
       return;
     }
-    const context = zedRemoteContext() || {};
     try {
       const status = await loadZedRemoteStatus();
       if (!status?.platformSupported || (!status.zedAppFound && !status.zedCliFound)) {
@@ -4578,10 +4624,37 @@
       removeZedRemoteOpenInMenuItems();
       return;
     }
-    removeZedRemoteButtons();
-    const candidates = zedRemoteFileCandidates(context);
-    candidates.forEach(attachZedRemoteButton);
-    refreshZedRemoteOpenInMenus(context);
+    refreshZedRemoteOpenInMenus(scope);
+  }
+
+  function runScheduledZedRemoteMenuRefresh() {
+    window.__codexZedRemoteMenuRefreshPending = false;
+    clearTimeout(window.__codexZedRemoteMenuRefreshTimer);
+    window.__codexZedRemoteMenuRefreshTimer = null;
+    refreshZedRemoteOpenControls().catch(() => {
+      removeZedRemoteOpenInMenuItems();
+    });
+  }
+
+  function shouldRefreshZedRemoteMenus(mutations) {
+    if (!codexPlusSettings().zedRemoteOpen) return false;
+    if (!mutations) return true;
+    return mutations.some((mutation) => {
+      const target = mutation.target;
+      if (isExtensionUiNode(target)) return false;
+      if (target?.nodeType === 1 && target.matches?.('[role="menu"], [data-radix-popper-content-wrapper]')) return true;
+      return [...Array.from(mutation.addedNodes), ...Array.from(mutation.removedNodes)].some((node) => node.nodeType === 1 && (
+        node.matches?.('[role="menu"], [data-radix-popper-content-wrapper]') ||
+        node.querySelector?.('[role="menu"], [data-radix-popper-content-wrapper]')
+      ));
+    });
+  }
+
+  function scheduleZedRemoteMenuRefresh(mutations) {
+    if (!shouldRefreshZedRemoteMenus(mutations)) return;
+    if (window.__codexZedRemoteMenuRefreshPending) return;
+    window.__codexZedRemoteMenuRefreshPending = true;
+    window.__codexZedRemoteMenuRefreshTimer = setTimeout(runScheduledZedRemoteMenuRefresh, 50);
   }
 
   function scanDeferred() {
@@ -4599,7 +4672,6 @@
     installArchivedDeleteAllButton();
     refreshConversationTimeline();
     scheduleThreadScrollSync();
-    refreshZedRemoteOpenControls();
     patchCodexModelWhitelist();
   }
 
@@ -4633,9 +4705,6 @@
       '[data-testid="conversation-turn"]',
       '[class*="user-message"]',
       '[class*="UserMessage"]',
-      "span.inline-markdown",
-      "[class*='inlineMarkdown']",
-      "code",
       selectors.appHeader,
       selectors.archiveNav,
       ...(pluginPatchDisabledInRelayMode() ? [] : [selectors.disabledInstallButton]),
@@ -4673,13 +4742,8 @@
       if (isChatContentMutation(mutation)) return false;
       const target = mutation.target;
       if (isExtensionUiNode(target)) return false;
-      if (target?.nodeType === 1 && target.matches?.('[role="menu"], [data-radix-popper-content-wrapper]')) return true;
       if (target?.nodeType === 1 && nodeSelfOrAncestorMatchesScanRelevance(target)) return true;
       const changedNodes = [...Array.from(mutation.addedNodes), ...Array.from(mutation.removedNodes)];
-      if (changedNodes.some((node) => node.nodeType === 1 && (
-        node.matches?.('[role="menu"], [data-radix-popper-content-wrapper]') ||
-        node.querySelector?.('[role="menu"], [data-radix-popper-content-wrapper]')
-      ))) return true;
       return changedNodes.some((node) => node.nodeType === 1 && isScanRelevantNode(node));
     });
   }
@@ -4692,6 +4756,7 @@
   }
 
   function scheduleScan(mutations) {
+    scheduleZedRemoteMenuRefresh(mutations);
     if (!shouldScheduleScan(mutations)) return;
     if (window.__codexSessionDeleteScanPending) return;
     window.__codexSessionDeleteScanPending = true;

--- a/codex_session_delete/inject/renderer-inject.js
+++ b/codex_session_delete/inject/renderer-inject.js
@@ -73,7 +73,7 @@
     sidebarThread: "[data-app-action-sidebar-thread-id]",
     threadTitle: "[data-thread-title]",
     appHeader: ".app-header-tint",
-    nativeMenuBar: ".flex.items-center.gap-0\\.5, [class*=\"flex items-center gap-0.5\"]",
+    nativeMenuBar: "[class*=\"ms-auto\"][class*=\"flex\"][class*=\"items-center\"]",
     archiveNav: 'button[aria-label="已归档对话"], button[aria-label="Archived conversations"]',
     disabledInstallButton: 'button:disabled.w-full.justify-center, [role="button"][aria-disabled="true"].cursor-not-allowed',
     pluginNavButton: 'nav[role="navigation"] button.h-token-nav-row.w-full',
@@ -668,7 +668,7 @@
   }
 
   function scheduleBackendHeartbeat() {
-    clearInterval(window.__codexPlusBackendHeartbeat);
+    if (window.__codexPlusBackendHeartbeat) return;
     window.__codexPlusBackendHeartbeat = setInterval(checkBackendStatus, 5000);
     checkBackendStatus();
   }
@@ -4017,6 +4017,11 @@
     return result?.status === "ok" && result.ssh ? result.ssh : null;
   }
 
+  async function resolveZedRemoteFallbackRequest() {
+    const result = await postJson("/zed-remote/fallback-request", {});
+    return result?.status === "ok" && result.request ? result.request : null;
+  }
+
   function zedRemoteString(value) {
     return typeof value === "string" || typeof value === "number" ? String(value).trim() : "";
   }
@@ -4089,7 +4094,7 @@
       const context = zedRemoteContextFromElement(node);
       if (context) return context;
     }
-    return zedRemoteContext();
+    return null;
   }
 
   function zedRemoteHostIdFromText(text) {
@@ -4157,42 +4162,71 @@
     };
   }
 
-  function zedRemoteContext() {
-    const settings = codexPlusSettings();
-    if (!settings.zedRemoteOpen) return null;
-    const explicitNodes = document.querySelectorAll("[data-host-config], [data-ssh-host], [data-remote-host], [data-remote-workspace-root], [data-supports-ssh]");
-    for (const node of explicitNodes) {
-      if (!(node instanceof HTMLElement)) continue;
-      const data = node.dataset;
-      const context = zedRemoteContextFromObject({
-        hostConfig: data.hostConfig ? { host: data.hostConfig, supportsSsh: true } : {},
-        supportsSsh: data.supportsSsh || data.supportsSshRemote,
-        sshHost: data.sshHost,
-        remoteHost: data.remoteHost,
-        host: data.host,
-        sshUser: data.sshUser,
-        remoteUser: data.remoteUser,
-        user: data.user,
-        sshPort: data.sshPort,
-        remotePort: data.remotePort,
-        port: data.port,
-        remoteWorkspaceRoot: data.remoteWorkspaceRoot,
-        workspaceRoot: data.workspaceRoot,
-      });
+  const zedRemoteContextCacheTtlMs = 1200;
+  let zedRemoteContextCache = { scope: null, at: 0, value: null };
+
+  function zedRemoteScopedElements(scope, selector) {
+    const root = scope?.querySelectorAll ? scope : document;
+    const nodes = [];
+    if (scope instanceof HTMLElement && scope.matches?.(selector)) nodes.push(scope);
+    root.querySelectorAll?.(selector).forEach((node) => nodes.push(node));
+    return Array.from(new Set(nodes));
+  }
+
+  function zedRemoteContextFromDataset(node) {
+    if (!(node instanceof HTMLElement)) return null;
+    const data = node.dataset;
+    return zedRemoteContextFromObject({
+      hostConfig: data.hostConfig ? { host: data.hostConfig, supportsSsh: true } : {},
+      supportsSsh: data.supportsSsh || data.supportsSshRemote,
+      sshHost: data.sshHost,
+      remoteHost: data.remoteHost,
+      host: data.host,
+      sshUser: data.sshUser,
+      remoteUser: data.remoteUser,
+      user: data.user,
+      sshPort: data.sshPort,
+      remotePort: data.remotePort,
+      port: data.port,
+      remoteWorkspaceRoot: data.remoteWorkspaceRoot,
+      workspaceRoot: data.workspaceRoot,
+    });
+  }
+
+  function zedRemoteContextUncached(scope = document) {
+    const explicitSelector = "[data-host-config], [data-ssh-host], [data-remote-host], [data-remote-workspace-root], [data-supports-ssh]";
+    for (const node of zedRemoteScopedElements(scope, explicitSelector)) {
+      if (isExtensionUiNode(node)) continue;
+      const context = zedRemoteContextFromDataset(node);
       if (context) return context;
     }
-    const reactNodes = [document.body, ...document.querySelectorAll("[data-remote-path], [data-file-path], [data-path], [data-open-in-targets], [data-open-file], span.inline-markdown, code, [class*='inlineMarkdown'], a, button, [role='button'], [role='menuitem'], [role='treeitem']")].filter(Boolean);
-    for (const node of reactNodes.slice(0, 260)) {
+    const reactSelector = "[data-remote-path], [data-file-path], [data-path], [data-open-in-targets], [data-open-file], [data-codex-open-file], [role='menuitem']";
+    const reactNodes = zedRemoteScopedElements(scope, reactSelector);
+    if (scope instanceof HTMLElement && !isExtensionUiNode(scope)) reactNodes.unshift(scope);
+    for (const node of Array.from(new Set(reactNodes)).slice(0, 60)) {
       if (!(node instanceof HTMLElement) || isExtensionUiNode(node)) continue;
       const context = zedRemoteContextFromElement(node);
       if (context) return context;
     }
+    if (scope !== document) return null;
     const scripts = Array.from(document.querySelectorAll("script[type='application/json'], script[data-state], script#__NEXT_DATA__, script:not([src])"));
-    for (const script of scripts.slice(0, 40)) {
+    for (const script of scripts.slice(0, 20)) {
       const context = zedRemoteContextFromSerializedState(script.textContent || "");
       if (context) return context;
     }
     return null;
+  }
+
+  function zedRemoteContext(scope = document) {
+    const settings = codexPlusSettings();
+    if (!settings.zedRemoteOpen) return null;
+    const now = Date.now();
+    if (zedRemoteContextCache.scope === scope && now - zedRemoteContextCache.at < zedRemoteContextCacheTtlMs) {
+      return zedRemoteContextCache.value;
+    }
+    const value = zedRemoteContextUncached(scope);
+    zedRemoteContextCache = { scope, at: now, value };
+    return value;
   }
 
   function zedRemoteAbsolutePath(value, workspaceRoot) {
@@ -4237,7 +4271,7 @@
     return /open[-_\s]?file|open-in-targets|remote/i.test(label) && !!zedRemotePathFromElementMetadata(anchor);
   }
 
-  function zedRemoteFileCandidates(context) {
+  function zedRemoteFileCandidates(context, scope = document) {
     const candidates = [];
     const seen = new Set();
     const addCandidate = (node, candidateContext, rawPath) => {
@@ -4248,23 +4282,25 @@
       candidates.push({ node, request: { ssh: candidateContext.ssh, hostId: candidateContext.hostId || "", path } });
     };
     const selectors = "[data-remote-path], [data-file-path], [data-path], [data-open-in-targets], [data-open-file], [data-codex-open-file], a[data-remote-path], a[data-file-path], a[data-path]";
-    document.querySelectorAll(selectors).forEach((node) => {
+    zedRemoteScopedElements(scope, selectors).forEach((node) => {
       if (!(node instanceof HTMLElement) || isExtensionUiNode(node)) return;
       if (node instanceof HTMLAnchorElement && !zedRemoteAnchorHasOpenFileMetadata(node)) return;
       addCandidate(node, zedRemoteContextForElement(node) || context, zedRemotePathFromElementMetadata(node));
     });
-    document.querySelectorAll("span.inline-markdown, code, [class*='inlineMarkdown']").forEach((node) => {
-      if (!(node instanceof HTMLElement) || isExtensionUiNode(node)) return;
-      const candidateContext = zedRemoteContextForElement(node) || context || zedRemoteFallbackContextForElement(node);
-      if (!candidateContext?.hostId && !candidateContext?.ssh?.host) return;
-      const path = zedRemoteInlinePathFromElement(node, candidateContext);
-      if (path) addCandidate(node, candidateContext, path);
-    });
+    if (scope !== document) {
+      zedRemoteScopedElements(scope, "span.inline-markdown, code, [class*='inlineMarkdown']").forEach((node) => {
+        if (!(node instanceof HTMLElement) || isExtensionUiNode(node)) return;
+        const candidateContext = zedRemoteContextForElement(node) || context || zedRemoteFallbackContextForElement(node);
+        if (!candidateContext?.hostId && !candidateContext?.ssh?.host) return;
+        const path = zedRemoteInlinePathFromElement(node, candidateContext);
+        if (path) addCandidate(node, candidateContext, path);
+      });
+    }
     return candidates;
   }
 
-  function zedRemoteBestOpenRequest(context = zedRemoteContext() || {}) {
-    const candidates = zedRemoteFileCandidates(context);
+  function zedRemoteBestOpenRequest(scope = document, context = zedRemoteContext(scope) || zedRemoteContext(document) || {}) {
+    const candidates = zedRemoteFileCandidates(context, scope);
     if (candidates.length) return candidates[0].request;
     const workspaceRoot = zedRemoteAbsolutePath(context.workspaceRoot || "", "");
     if (!workspaceRoot || (!context?.ssh?.host && !context?.hostId)) return null;
@@ -4293,10 +4329,10 @@
     }
   }
 
-  function openBestZedRemoteTarget() {
-    const request = zedRemoteBestOpenRequest();
+  async function openBestZedRemoteTarget() {
+    const request = zedRemoteBestOpenRequest(document) || await resolveZedRemoteFallbackRequest();
     if (!request) {
-      showZedRemoteToast("Cannot find a remote workspace or file for Zed Remote");
+      showZedRemoteToast("Cannot find a remote workspace or file for Zed");
       return;
     }
     openZedRemote(request);
@@ -4353,15 +4389,19 @@
     return false;
   }
 
-  function activateZedRemoteOpenInMenuItem(event) {
+  async function activateZedRemoteOpenInMenuItem(event) {
     if (!codexPlusSettings().zedRemoteOpen) return;
     if (event?.type === "keydown" && !["Enter", " "].includes(event.key)) return;
-    const request = zedRemoteBestOpenRequest();
-    if (!request) return;
+    const scope = event?.currentTarget?.closest?.('[role="menu"], [data-radix-popper-content-wrapper]') || event?.currentTarget || document;
     event.preventDefault();
     event.stopPropagation();
     event.stopImmediatePropagation?.();
     if (zedRemoteOpenInMenuActivationIsDuplicate(event?.currentTarget)) return;
+    const request = zedRemoteBestOpenRequest(scope) || await resolveZedRemoteFallbackRequest();
+    if (!request) {
+      showZedRemoteToast("Cannot find a remote workspace or file for Zed");
+      return;
+    }
     openZedRemote(request);
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", code: "Escape", bubbles: true }));
   }
@@ -4376,16 +4416,23 @@
     item.addEventListener("keydown", activateZedRemoteOpenInMenuItem, true);
   }
 
-  function removeZedRemoteOpenInMenuItems() {
-    document.querySelectorAll(`.${zedRemoteOpenInMenuItemClass}, [data-codex-zed-open-in-menu="injected"]`).forEach((node) => node.remove());
+  function removeZedRemoteOpenInMenuItems(scope = document) {
+    const root = scope?.querySelectorAll ? scope : document;
+    root.querySelectorAll(`.${zedRemoteOpenInMenuItemClass}, [data-codex-zed-open-in-menu="injected"]`).forEach((node) => node.remove());
   }
 
-  function refreshZedRemoteOpenInMenus(context) {
-    removeZedRemoteOpenInMenuItems();
+  function zedRemoteOpenInMenuScopes(scope = document) {
+    const root = scope?.querySelectorAll ? scope : document;
+    const menus = [];
+    if (scope instanceof HTMLElement && scope.matches?.('[role="menu"]')) menus.push(scope);
+    root.querySelectorAll?.('[role="menu"]').forEach((menu) => menus.push(menu));
+    return Array.from(new Set(menus));
+  }
+
+  function refreshZedRemoteOpenInMenus(scope = document) {
+    removeZedRemoteOpenInMenuItems(scope);
     if (!codexPlusSettings().zedRemoteOpen) return;
-    const request = zedRemoteBestOpenRequest(context || zedRemoteContext() || {});
-    if (!request) return;
-    document.querySelectorAll('[role="menu"]').forEach((menu) => {
+    zedRemoteOpenInMenuScopes(scope).forEach((menu) => {
       if (!(menu instanceof HTMLElement) || isExtensionUiNode(menu)) return;
       const items = Array.from(menu.querySelectorAll('[role="menuitem"]')).filter((item) => !isExtensionUiNode(item));
       const menuText = items.map((item) => (item.textContent || "").trim()).join(" ");
@@ -4401,13 +4448,12 @@
     });
   }
 
-  async function refreshZedRemoteOpenControls() {
+  async function refreshZedRemoteOpenControls(scope = document) {
     if (!codexPlusSettings().zedRemoteOpen) {
       removeZedRemoteButtons();
       removeZedRemoteOpenInMenuItems();
       return;
     }
-    const context = zedRemoteContext() || {};
     try {
       const status = await loadZedRemoteStatus();
       if (!status?.platformSupported || (!status.zedAppFound && !status.zedCliFound)) {
@@ -4420,10 +4466,37 @@
       removeZedRemoteOpenInMenuItems();
       return;
     }
-    removeZedRemoteButtons();
-    const candidates = zedRemoteFileCandidates(context);
-    candidates.forEach(attachZedRemoteButton);
-    refreshZedRemoteOpenInMenus(context);
+    refreshZedRemoteOpenInMenus(scope);
+  }
+
+  function runScheduledZedRemoteMenuRefresh() {
+    window.__codexZedRemoteMenuRefreshPending = false;
+    clearTimeout(window.__codexZedRemoteMenuRefreshTimer);
+    window.__codexZedRemoteMenuRefreshTimer = null;
+    refreshZedRemoteOpenControls().catch(() => {
+      removeZedRemoteOpenInMenuItems();
+    });
+  }
+
+  function shouldRefreshZedRemoteMenus(mutations) {
+    if (!codexPlusSettings().zedRemoteOpen) return false;
+    if (!mutations) return true;
+    return mutations.some((mutation) => {
+      const target = mutation.target;
+      if (isExtensionUiNode(target)) return false;
+      if (target?.nodeType === 1 && target.matches?.('[role="menu"], [data-radix-popper-content-wrapper]')) return true;
+      return [...Array.from(mutation.addedNodes), ...Array.from(mutation.removedNodes)].some((node) => node.nodeType === 1 && (
+        node.matches?.('[role="menu"], [data-radix-popper-content-wrapper]') ||
+        node.querySelector?.('[role="menu"], [data-radix-popper-content-wrapper]')
+      ));
+    });
+  }
+
+  function scheduleZedRemoteMenuRefresh(mutations) {
+    if (!shouldRefreshZedRemoteMenus(mutations)) return;
+    if (window.__codexZedRemoteMenuRefreshPending) return;
+    window.__codexZedRemoteMenuRefreshPending = true;
+    window.__codexZedRemoteMenuRefreshTimer = setTimeout(runScheduledZedRemoteMenuRefresh, 50);
   }
 
   function scanDeferred() {
@@ -4437,7 +4510,6 @@
     archivedPageRows().forEach(attachArchivedPageDeleteButton);
     installArchivedDeleteAllButton();
     refreshConversationTimeline();
-    refreshZedRemoteOpenControls();
     scheduleThreadScrollSync(true);
   }
 
@@ -4480,9 +4552,6 @@
     '[data-testid="conversation-turn"]',
     '[class*="user-message"]',
     '[class*="UserMessage"]',
-    "span.inline-markdown",
-    "[class*='inlineMarkdown']",
-    "code",
     selectors.appHeader,
     "header",
     selectors.archiveNav,
@@ -4519,13 +4588,8 @@
       if (isChatContentMutation(mutation)) return false;
       const target = mutation.target;
       if (isExtensionUiNode(target)) return false;
-      if (target?.nodeType === 1 && target.matches?.('[role="menu"], [data-radix-popper-content-wrapper]')) return true;
       if (target?.nodeType === 1 && nodeSelfOrAncestorMatchesScanRelevance(target)) return true;
       const changedNodes = [...Array.from(mutation.addedNodes), ...Array.from(mutation.removedNodes)];
-      if (changedNodes.some((node) => node.nodeType === 1 && (
-        node.matches?.('[role="menu"], [data-radix-popper-content-wrapper]') ||
-        node.querySelector?.('[role="menu"], [data-radix-popper-content-wrapper]')
-      ))) return true;
       return changedNodes.some((node) => node.nodeType === 1 && isScanRelevantNode(node));
     });
   }
@@ -4541,6 +4605,7 @@
     if (mutations?.some((mutation) => mutation.type === "attributes" && mutation.attributeName === "aria-current" && mutation.target?.matches?.(selectors.sidebarThread))) {
       scheduleThreadScrollSyncAttempts(true);
     }
+    scheduleZedRemoteMenuRefresh(mutations);
     if (!shouldScheduleScan(mutations)) return;
     if (window.__codexSessionDeleteScanPending) return;
     window.__codexSessionDeleteScanPending = true;

--- a/codex_session_delete/launcher.py
+++ b/codex_session_delete/launcher.py
@@ -947,6 +947,8 @@ def handle_bridge_request(
         return zed_remote.zed_remote_status()
     if path == "/zed-remote/resolve-host" and runtime:
         return zed_remote.resolve_ssh_target_response(payload)
+    if path == "/zed-remote/fallback-request" and runtime:
+        return zed_remote.fallback_open_request_response(payload)
     if path == "/zed-remote/open" and runtime:
         return zed_remote.open_zed_remote(payload)
     if path == "/ads" and runtime:

--- a/codex_session_delete/zed_remote.py
+++ b/codex_session_delete/zed_remote.py
@@ -210,6 +210,63 @@ def resolve_ssh_target_for_host_id(host_id: str, state_path: Path | None = None)
     return resolve_ssh_target_from_global_state(data, host_id)
 
 
+def ordered_remote_projects_from_global_state(state: dict[str, object]) -> list[dict[str, object]]:
+    """Return saved remote projects in Codex's most recent project order first."""
+    raw_projects = state.get("remote-projects")
+    projects = [project for project in raw_projects if isinstance(project, dict)] if isinstance(raw_projects, list) else []
+    raw_order = state.get("project-order")
+    project_order = [string_value(item) for item in raw_order] if isinstance(raw_order, list) else []
+    by_id = {string_value(project.get("id")): project for project in projects if string_value(project.get("id"))}
+    ordered = [by_id[project_id] for project_id in project_order if project_id in by_id]
+    ordered_ids = {string_value(project.get("id")) for project in ordered}
+    ordered.extend(project for project in projects if string_value(project.get("id")) not in ordered_ids)
+    return ordered
+
+
+def fallback_open_request_from_global_state(state: dict[str, object], host_id: str = "") -> dict[str, object]:
+    """Build a Zed open request from Codex's selected remote workspace metadata."""
+    selected_host_id = string_value(host_id) or string_value(state.get("selected-remote-host-id"))
+    projects = ordered_remote_projects_from_global_state(state)
+    selected_project = None
+    for project in projects:
+        project_host_id = string_value(project.get("hostId"))
+        if selected_host_id and project_host_id != selected_host_id:
+            continue
+        remote_path = string_value(project.get("remotePath"))
+        if not remote_path.startswith("/"):
+            continue
+        selected_project = project
+        break
+    if selected_project is None:
+        raise ZedRemoteError("Cannot determine remote workspace or file for Zed")
+    resolved_host_id = selected_host_id or string_value(selected_project.get("hostId"))
+    if not resolved_host_id:
+        raise ZedRemoteError("Remote host id is required")
+    target = resolve_ssh_target_from_global_state(state, resolved_host_id)
+    return {
+        "hostId": resolved_host_id,
+        "ssh": {"user": target.user, "host": target.host, "port": target.port},
+        "path": string_value(selected_project.get("remotePath")),
+    }
+
+
+def fallback_open_request_response(payload: dict[str, object]) -> dict[str, object]:
+    """Return a bridge response for opening the current selected remote workspace."""
+    try:
+        state = json.loads(codex_global_state_path().read_text(encoding="utf-8"))
+    except OSError as exc:
+        return {"status": "failed", "message": "Cannot read Codex remote connection state"}
+    except json.JSONDecodeError as exc:
+        return {"status": "failed", "message": "Cannot parse Codex remote connection state"}
+    if not isinstance(state, dict):
+        return {"status": "failed", "message": "Cannot parse Codex remote connection state"}
+    try:
+        request = fallback_open_request_from_global_state(state, string_value(payload.get("hostId")))
+        return {"status": "ok", "request": request}
+    except ZedRemoteError as exc:
+        return {"status": "failed", "message": str(exc)}
+
+
 def resolve_ssh_target_response(payload: dict[str, object]) -> dict[str, object]:
     """Return serialized SSH metadata for a remote host id bridge request."""
     try:

--- a/crates/codex-plus-core/src/routes.rs
+++ b/crates/codex-plus-core/src/routes.rs
@@ -65,6 +65,7 @@ pub trait BridgeRuntimeService: Send + Sync {
     async fn ads(&self) -> anyhow::Result<Value>;
     async fn zed_remote_status(&self) -> anyhow::Result<Value>;
     async fn resolve_zed_remote_host(&self, payload: Value) -> anyhow::Result<Value>;
+    async fn fallback_zed_remote_request(&self, payload: Value) -> anyhow::Result<Value>;
     async fn open_zed_remote(&self, payload: Value) -> anyhow::Result<Value>;
 }
 
@@ -135,6 +136,11 @@ pub async fn handle_bridge_request(
         "/ads" => ctx.runtime.ads().await,
         "/zed-remote/status" => ctx.runtime.zed_remote_status().await,
         "/zed-remote/resolve-host" => ctx.runtime.resolve_zed_remote_host(payload.clone()).await,
+        "/zed-remote/fallback-request" => {
+            ctx.runtime
+                .fallback_zed_remote_request(payload.clone())
+                .await
+        }
         "/zed-remote/open" => ctx.runtime.open_zed_remote(payload.clone()).await,
         "/delete" => result_value(ctx.data.delete(session_from_payload(&payload)).await),
         "/undo" => {
@@ -376,6 +382,10 @@ impl BridgeRuntimeService for CoreRuntimeService {
 
     async fn resolve_zed_remote_host(&self, payload: Value) -> anyhow::Result<Value> {
         Ok(crate::zed_remote::resolve_ssh_target_response(&payload))
+    }
+
+    async fn fallback_zed_remote_request(&self, payload: Value) -> anyhow::Result<Value> {
+        Ok(crate::zed_remote::fallback_open_request_response(&payload))
     }
 
     async fn open_zed_remote(&self, payload: Value) -> anyhow::Result<Value> {

--- a/crates/codex-plus-core/src/zed_remote.rs
+++ b/crates/codex-plus-core/src/zed_remote.rs
@@ -373,6 +373,84 @@ pub fn resolve_ssh_target_for_host_id(
     resolve_ssh_target_from_global_state(&state, host_id)
 }
 
+pub fn ordered_remote_projects_from_global_state(state: &Value) -> Vec<Value> {
+    let projects = state
+        .get("remote-projects")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|project| project.as_object().is_some())
+        .collect::<Vec<_>>();
+    let project_order = state
+        .get("project-order")
+        .and_then(Value::as_array)
+        .map(|order| {
+            order
+                .iter()
+                .map(|item| string_value(Some(item)))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let mut ordered = Vec::new();
+    for project_id in project_order {
+        if let Some(project) = projects
+            .iter()
+            .find(|project| string_value(project.get("id")) == project_id)
+        {
+            ordered.push(project.clone());
+        }
+    }
+    let ordered_ids = ordered
+        .iter()
+        .map(|project| string_value(project.get("id")))
+        .collect::<std::collections::HashSet<_>>();
+    ordered.extend(
+        projects
+            .into_iter()
+            .filter(|project| !ordered_ids.contains(&string_value(project.get("id")))),
+    );
+    ordered
+}
+
+pub fn fallback_open_request_from_global_state(state: &Value) -> Result<Value, ZedRemoteError> {
+    let selected_host_id = string_value(state.get("selected-remote-host-id"));
+    let selected_project = ordered_remote_projects_from_global_state(state)
+        .into_iter()
+        .find(|project| {
+            let project_host_id = string_value(project.get("hostId"));
+            let remote_path = string_value(project.get("remotePath"));
+            (selected_host_id.is_empty() || project_host_id == selected_host_id)
+                && remote_path.starts_with('/')
+        })
+        .ok_or(ZedRemoteError::Validation(
+            "Cannot determine remote workspace or file for Zed",
+        ))?;
+    let host_id =
+        selected_host_id.or_else_nonempty(|| string_value(selected_project.get("hostId")));
+    if host_id.is_empty() {
+        return Err(ZedRemoteError::Validation("Remote host id is required"));
+    }
+    let target = resolve_ssh_target_from_global_state(state, &host_id)?;
+    Ok(json!({
+        "hostId": host_id,
+        "ssh": { "user": target.user, "host": target.host, "port": target.port },
+        "path": string_value(selected_project.get("remotePath")),
+    }))
+}
+
+pub fn fallback_open_request_response(_payload: &Value) -> Value {
+    let path = codex_global_state_path();
+    let result = fs::read_to_string(path)
+        .map_err(ZedRemoteError::StateRead)
+        .and_then(|data| serde_json::from_str::<Value>(&data).map_err(ZedRemoteError::StateParse))
+        .and_then(|state| fallback_open_request_from_global_state(&state));
+    match result {
+        Ok(request) => json!({"status": "ok", "request": request}),
+        Err(error) => json!({"status": "failed", "message": error.to_string()}),
+    }
+}
+
 pub fn resolve_ssh_target_response(payload: &Value) -> Value {
     let host_id = string_value(payload.get("hostId"));
     match resolve_ssh_target_for_host_id(&host_id, None) {

--- a/crates/codex-plus-core/tests/bridge_routes.rs
+++ b/crates/codex-plus-core/tests/bridge_routes.rs
@@ -41,6 +41,10 @@ async fn bridge_routes_cover_all_current_paths() {
             json!({"hostId": "remote-ssh-codex-managed:remote"}),
         ),
         (
+            "/zed-remote/fallback-request",
+            json!({"hostId": "remote-ssh-codex-managed:remote"}),
+        ),
+        (
             "/zed-remote/open",
             json!({"ssh": {"host": "example.com"}, "path": "/home/app.py"}),
         ),
@@ -173,6 +177,22 @@ async fn runtime_status_devtools_repair_and_ads_routes_are_dispatched() {
         )
         .await,
         json!({"status": "ok", "ssh": {"user": "longnv", "host": "192.168.100.31", "port": null}})
+    );
+    assert_eq!(
+        handle_bridge_request(
+            ctx.clone(),
+            "/zed-remote/fallback-request",
+            json!({"hostId": "remote-ssh-codex-managed:remote"}),
+        )
+        .await,
+        json!({
+            "status": "ok",
+            "request": {
+                "hostId": "remote-ssh-codex-managed:remote",
+                "ssh": {"user": "longnv", "host": "192.168.100.31", "port": null},
+                "path": "/Users/longnv/bin/repo/sealos-skills",
+            }
+        })
     );
     assert_eq!(
         handle_bridge_request(
@@ -628,6 +648,18 @@ impl BridgeRuntimeService for FakeRuntime {
         Ok(json!({
             "status": "ok",
             "ssh": {"user": "longnv", "host": "192.168.100.31", "port": null}
+        }))
+    }
+
+    async fn fallback_zed_remote_request(&self, payload: Value) -> anyhow::Result<Value> {
+        assert_eq!(payload["hostId"], json!("remote-ssh-codex-managed:remote"));
+        Ok(json!({
+            "status": "ok",
+            "request": {
+                "hostId": "remote-ssh-codex-managed:remote",
+                "ssh": {"user": "longnv", "host": "192.168.100.31", "port": null},
+                "path": "/Users/longnv/bin/repo/sealos-skills",
+            }
         }))
     }
 

--- a/crates/codex-plus-core/tests/zed_remote.rs
+++ b/crates/codex-plus-core/tests/zed_remote.rs
@@ -110,6 +110,70 @@ fn resolve_ssh_target_from_global_state_for_codex_managed_connection() {
 }
 
 #[test]
+fn fallback_open_request_from_global_state_uses_selected_remote_project() {
+    let state = json!({
+        "selected-remote-host-id": "remote-ssh-codex-managed:remote",
+        "codex-managed-remote-connections": [{
+            "hostId": "remote-ssh-codex-managed:remote",
+            "hostname": "longnv@192.168.100.31",
+            "sshPort": null,
+        }],
+        "remote-projects": [{
+            "id": "032e652b-7956-4e6e-83bd-b29f456c6c3d",
+            "hostId": "remote-ssh-codex-managed:remote",
+            "remotePath": "/Users/longnv/bin/repo/sealos-skills",
+            "label": "sealos-skills",
+        }],
+        "project-order": ["032e652b-7956-4e6e-83bd-b29f456c6c3d"],
+    });
+
+    let request = zed_remote::fallback_open_request_from_global_state(&state).unwrap();
+
+    assert_eq!(
+        request,
+        json!({
+            "hostId": "remote-ssh-codex-managed:remote",
+            "ssh": {"user": "longnv", "host": "192.168.100.31", "port": null},
+            "path": "/Users/longnv/bin/repo/sealos-skills",
+        })
+    );
+}
+
+#[test]
+fn fallback_open_request_from_global_state_prefers_project_order_for_selected_host() {
+    let state = json!({
+        "selected-remote-host-id": "remote-ssh-codex-managed:remote",
+        "codex-managed-remote-connections": [{
+            "hostId": "remote-ssh-codex-managed:remote",
+            "hostname": "longnv@192.168.100.31",
+        }],
+        "remote-projects": [
+            {"id": "old", "hostId": "remote-ssh-codex-managed:remote", "remotePath": "/Users/longnv/bin/repo/old"},
+            {"id": "current", "hostId": "remote-ssh-codex-managed:remote", "remotePath": "/Users/longnv/bin/repo/current"},
+            {"id": "other-host", "hostId": "remote-ssh-codex-managed:other", "remotePath": "/srv/other"}
+        ],
+        "project-order": ["other-host", "current", "old"],
+    });
+
+    let request = zed_remote::fallback_open_request_from_global_state(&state).unwrap();
+
+    assert_eq!(request["hostId"], "remote-ssh-codex-managed:remote");
+    assert_eq!(request["path"], "/Users/longnv/bin/repo/current");
+}
+
+#[test]
+fn fallback_open_request_from_global_state_reports_missing_remote_project() {
+    let state = json!({"selected-remote-host-id": "remote-ssh-codex-managed:remote"});
+
+    let error = zed_remote::fallback_open_request_from_global_state(&state).unwrap_err();
+
+    assert_eq!(
+        error.to_string(),
+        "Cannot determine remote workspace or file for Zed"
+    );
+}
+
+#[test]
 fn resolve_ssh_target_response_reports_missing_host_id() {
     let result = zed_remote::resolve_ssh_target_response(&json!({"hostId": ""}));
 

--- a/tests/test_launcher_user_scripts.py
+++ b/tests/test_launcher_user_scripts.py
@@ -492,6 +492,40 @@ def test_handle_bridge_request_resolves_zed_remote_host(monkeypatch, tmp_path):
     }
 
 
+def test_handle_bridge_request_returns_zed_remote_fallback_request(monkeypatch, tmp_path):
+    from codex_session_delete import zed_remote
+
+    manager = UserScriptManager(tmp_path / "builtin", tmp_path / "user", tmp_path / "config.json")
+    runtime = FakeRuntime(manager)
+    payload = {"hostId": "remote-ssh-codex-managed:remote"}
+
+    monkeypatch.setattr(
+        zed_remote,
+        "fallback_open_request_response",
+        lambda received: {
+            "status": "ok",
+            "request": {
+                "hostId": "remote-ssh-codex-managed:remote",
+                "ssh": {"user": "longnv", "host": "192.168.100.31", "port": None},
+                "path": "/Users/longnv/bin/repo/sealos-skills",
+            },
+            "payload": received,
+        },
+    )
+
+    result = handle_bridge_request(FakeDeleteService(), FakeExportService(), "/zed-remote/fallback-request", payload, runtime)
+
+    assert result == {
+        "status": "ok",
+        "request": {
+            "hostId": "remote-ssh-codex-managed:remote",
+            "ssh": {"user": "longnv", "host": "192.168.100.31", "port": None},
+            "path": "/Users/longnv/bin/repo/sealos-skills",
+        },
+        "payload": payload,
+    }
+
+
 def test_handle_bridge_request_opens_zed_remote(monkeypatch, tmp_path):
     from codex_session_delete import zed_remote
 

--- a/tests/test_renderer_script.py
+++ b/tests/test_renderer_script.py
@@ -1,9 +1,30 @@
 import subprocess
+import tempfile
+import textwrap
 from pathlib import Path
 
 
+RENDERER_SCRIPT = Path("codex_session_delete/inject/renderer-inject.js")
+RUNTIME_RENDERER_SCRIPT = Path("assets/inject/renderer-inject.js")
+RENDERER_SCRIPT_PATHS = (RENDERER_SCRIPT, RUNTIME_RENDERER_SCRIPT)
+
+
+def renderer_script_texts():
+    return [(path, path.read_text(encoding="utf-8")) for path in RENDERER_SCRIPT_PATHS]
+
+
+def run_node_script(source: str):
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".js", delete=False) as handle:
+        handle.write(textwrap.dedent(source))
+        path = Path(handle.name)
+    try:
+        return subprocess.run(["node", str(path)], capture_output=True, text=True)
+    finally:
+        path.unlink(missing_ok=True)
+
+
 def test_renderer_script_exists_and_parses_with_node():
-    script = Path("codex_session_delete/inject/renderer-inject.js")
+    script = RENDERER_SCRIPT
     assert script.exists()
     result = subprocess.run(["node", "--check", str(script)], capture_output=True, text=True)
     assert result.returncode == 0, result.stderr
@@ -611,7 +632,9 @@ def test_renderer_script_includes_user_script_manager_ui_contract():
     assert "-webkit-app-region: no-drag" in text
     assert ".codex-plus-trigger" in text
     assert "app-header-tint" in text
-    assert "flex items-center gap-0.5" in text
+    assert '[class*="flex items-center gap-0.5"]' not in text
+    assert '[class*=\\"ms-auto\\"][class*=\\"flex\\"][class*=\\"items-center\\"]' in text
+    assert '[class*=\\"flex\\"][class*=\\"items-center\\"][class*=\\"gap-1.5\\"]' not in text
     assert "codex-plus-menu-floating" in text
     assert "nativeButtonClass" in text
     assert "removeDuplicateCodexPlusMenus" in text
@@ -769,6 +792,7 @@ def test_renderer_script_contains_zed_remote_probe_and_open_action():
     assert "Zed Remote" in text
     assert 'postJson("/zed-remote/status", {})' in text
     assert 'postJson("/zed-remote/resolve-host", { hostId })' in text
+    assert 'postJson("/zed-remote/fallback-request", {})' in text
     assert 'postJson("/zed-remote/open", nextRequest)' in text
     assert "function zedRemoteContext" in text
     assert "function zedRemoteFileCandidates" in text
@@ -792,10 +816,11 @@ def test_renderer_script_removes_stale_zed_remote_controls_when_fail_closed():
     assert "[data-codex-zed-remote-version]" in remove_code
     assert "delete node.dataset.codexZedRemoteVersion" in remove_code
     assert "removeZedRemoteButtons();\n      removeZedRemoteOpenInMenuItems();\n      return;" in refresh_code
-    assert "const context = zedRemoteContext() || {};" in refresh_code
     assert "if (!status?.platformSupported || (!status.zedAppFound && !status.zedCliFound)) {\n        removeZedRemoteButtons();\n        removeZedRemoteOpenInMenuItems();\n        return;\n      }" in refresh_code
     assert "catch (_) {\n      removeZedRemoteButtons();\n      removeZedRemoteOpenInMenuItems();\n      return;\n    }" in refresh_code
-    assert "removeZedRemoteButtons();\n    const candidates = zedRemoteFileCandidates(context);\n    candidates.forEach(attachZedRemoteButton);\n    refreshZedRemoteOpenInMenus(context);" in refresh_code
+    assert "refreshZedRemoteOpenInMenus(scope);" in refresh_code
+    assert "zedRemoteFileCandidates(context);" not in refresh_code
+    assert "candidates.forEach(attachZedRemoteButton);" not in refresh_code
 
 
 def test_renderer_script_adds_zed_remote_to_open_in_menu():
@@ -803,7 +828,7 @@ def test_renderer_script_adds_zed_remote_to_open_in_menu():
     start = text.index("function createZedRemoteOpenInMenuItem")
     end = text.index("\n\n  async function refreshZedRemoteOpenControls", start)
     menu_code = text[start:end]
-    create_end = text.index("\n\n  function activateZedRemoteOpenInMenuItem", start)
+    create_end = text.index("\n\n  async function activateZedRemoteOpenInMenuItem", start)
     create_code = text[start:create_end]
 
     assert ">Zed<" in menu_code
@@ -823,13 +848,279 @@ def test_renderer_script_adds_zed_remote_to_open_in_menu():
     assert "document.dispatchEvent(new KeyboardEvent(\"keydown\", { key: \"Escape\"" in menu_code
 
 
+def test_renderer_script_injects_zed_into_remote_open_in_menu_without_file_candidate():
+    script = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
+    result = run_node_script(
+        f"""
+        void (async () => {{
+          const assert = require("node:assert");
+
+          class Node {{
+            constructor(tagName = "") {{
+              this.tagName = tagName.toUpperCase();
+              this.children = [];
+              this.parentElement = null;
+              this.dataset = {{}};
+              this.attributes = {{}};
+              this.listeners = {{}};
+              this.className = "";
+              this.nodeType = 1;
+              this._textContent = "";
+              this._innerHTML = "";
+            }}
+            set textContent(value) {{
+              this._textContent = String(value || "");
+            }}
+            get textContent() {{
+              const ownText = this._textContent || "";
+              return ownText + this.children.map((child) => child.textContent).join("");
+            }}
+            set innerHTML(value) {{
+              this._innerHTML = String(value || "");
+              this._textContent = this._innerHTML.replace(/<[^>]*>/g, " ").replace(/\\s+/g, " ").trim();
+            }}
+            get innerHTML() {{
+              return this._innerHTML;
+            }}
+            appendChild(child) {{
+              child.parentElement = this;
+              this.children.push(child);
+              return child;
+            }}
+            insertBefore(child, before) {{
+              child.parentElement = this;
+              const index = this.children.indexOf(before);
+              if (index >= 0) this.children.splice(index, 0, child);
+              else this.children.push(child);
+              return child;
+            }}
+            remove() {{
+              if (!this.parentElement) return;
+              const index = this.parentElement.children.indexOf(this);
+              if (index >= 0) this.parentElement.children.splice(index, 1);
+              this.parentElement = null;
+            }}
+            setAttribute(name, value) {{
+              const stringValue = String(value);
+              this.attributes[name] = stringValue;
+              if (name === "role") this.role = stringValue;
+              if (name.startsWith("data-")) {{
+                const key = name.slice(5).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+                this.dataset[key] = stringValue;
+              }}
+            }}
+            getAttribute(name) {{
+              return Object.prototype.hasOwnProperty.call(this.attributes, name) ? this.attributes[name] : null;
+            }}
+            addEventListener(type, listener) {{
+              this.listeners[type] = listener;
+            }}
+            closest(selector) {{
+              for (let node = this; node; node = node.parentElement) {{
+                if (node.matches(selector)) return node;
+              }}
+              return null;
+            }}
+            matches(selector) {{
+              if (selector.includes('[role="menu"]') && this.getAttribute("role") === "menu") return true;
+              if (selector.includes('[role="menuitem"]') && this.getAttribute("role") === "menuitem") return true;
+              if (selector.includes('.codex-zed-open-in-menu-item') && this.className.includes('codex-zed-open-in-menu-item')) return true;
+              if (selector.includes('[data-codex-zed-open-in-menu="injected"]') && this.getAttribute('data-codex-zed-open-in-menu') === 'injected') return true;
+              return false;
+            }}
+            querySelectorAll(selector) {{
+              const results = [];
+              const visit = (node) => {{
+                for (const child of node.children) {{
+                  if (child.matches(selector)) results.push(child);
+                  visit(child);
+                }}
+              }};
+              visit(this);
+              return results;
+            }}
+            querySelector(selector) {{
+              return this.querySelectorAll(selector)[0] || null;
+            }}
+            get classList() {{
+              return {{
+                add: (...names) => {{
+                  const current = new Set(String(this.className || "").split(/\\s+/).filter(Boolean));
+                  names.forEach((name) => current.add(name));
+                  this.className = Array.from(current).join(" ");
+                }},
+                contains: (name) => String(this.className || "").split(/\\s+/).includes(name),
+              }};
+            }}
+          }}
+
+          class HTMLElement extends Node {{}}
+          class HTMLAnchorElement extends HTMLElement {{}}
+          class Document extends HTMLElement {{}}
+
+          const document = new Document("document");
+          document.body = new HTMLElement("body");
+          document.documentElement = new HTMLElement("html");
+          document.appendChild(document.body);
+          document.createElement = (tagName) => new HTMLElement(tagName);
+          document.getElementById = () => null;
+          document.addEventListener = () => {{}};
+          document.dispatchEvent = () => {{}};
+          document.querySelectorAll = (...args) => document.body.querySelectorAll(...args);
+          document.querySelector = (...args) => document.body.querySelector(...args);
+
+          let mutationCallback = null;
+          const openPayloads = [];
+          global.window = {{
+            __CODEX_SESSION_DELETE_HELPER__: "http://127.0.0.1:57321",
+            __codexSessionDeleteBridge: async (path, payload) => {{
+              if (path === "/zed-remote/status") {{
+                return {{ status: "ok", platformSupported: true, zedAppFound: true, zedCliFound: false }};
+              }}
+              if (path === "/zed-remote/fallback-request") {{
+                return {{
+                  status: "ok",
+                  request: {{
+                    hostId: "remote-ssh-codex-managed:remote",
+                    ssh: {{ user: "longnv", host: "192.168.100.31", port: null }},
+                    path: "/Users/longnv/bin/repo/sealos-skills",
+                  }},
+                }};
+              }}
+              if (path === "/zed-remote/open") {{
+                openPayloads.push(payload);
+                return {{ status: "ok" }};
+              }}
+              return {{ status: "ok" }};
+            }},
+            addEventListener: () => {{}},
+            removeEventListener: () => {{}},
+            dispatchEvent: () => {{}},
+            getComputedStyle: () => ({{}}),
+          }};
+          global.document = document;
+          global.HTMLElement = HTMLElement;
+          global.HTMLAnchorElement = HTMLAnchorElement;
+          global.Document = Document;
+          global.Element = HTMLElement;
+          global.Node = {{ TEXT_NODE: 3 }};
+          global.KeyboardEvent = function KeyboardEvent() {{}};
+          global.PointerEvent = function PointerEvent() {{}};
+          global.MutationObserver = function MutationObserver(callback) {{
+            mutationCallback = callback;
+            this.observe = () => {{}};
+            this.disconnect = () => {{}};
+          }};
+          global.localStorage = {{ getItem: () => JSON.stringify({{ zedRemoteOpen: true }}), setItem: () => {{}} }};
+          const timeoutCallbacks = [];
+          global.setTimeout = (fn) => {{ if (typeof fn === "function") timeoutCallbacks.push(fn); return timeoutCallbacks.length; }};
+          global.clearTimeout = () => {{}};
+          global.setInterval = () => 1;
+          global.clearInterval = () => {{}};
+          global.requestAnimationFrame = (fn) => {{ if (typeof fn === "function") fn(); }};
+          global.location = {{ pathname: "/" }};
+          global.fetch = async () => ({{ ok: true, text: async () => "{{}}" }});
+          global.getComputedStyle = () => ({{}});
+
+          const menu = new HTMLElement("div");
+          menu.setAttribute("role", "menu");
+          const vsCode = new HTMLElement("div");
+          vsCode.setAttribute("role", "menuitem");
+          vsCode.textContent = "VS Code";
+          const cursor = new HTMLElement("div");
+          cursor.setAttribute("role", "menuitem");
+          cursor.textContent = "Cursor";
+          const finder = new HTMLElement("div");
+          finder.setAttribute("role", "menuitem");
+          finder.textContent = "Finder";
+          menu.appendChild(vsCode);
+          menu.appendChild(cursor);
+          menu.appendChild(finder);
+          document.body.appendChild(menu);
+
+          eval({script!r});
+          assert(mutationCallback, "script should register a MutationObserver");
+          mutationCallback([{{ type: "childList", target: document.body, addedNodes: [menu], removedNodes: [] }}]);
+          for (const callback of timeoutCallbacks.splice(0)) callback();
+          await Promise.resolve();
+          await Promise.resolve();
+          for (const callback of timeoutCallbacks.splice(0)) callback();
+          await Promise.resolve();
+          await Promise.resolve();
+
+          assert(menu.textContent.includes("Zed"), "remote Open In menu should receive injected Zed item");
+          const zed = menu.querySelector('[data-codex-zed-open-in-menu="injected"], .codex-zed-open-in-menu-item');
+          assert(zed, "injected Zed menu item should be identifiable");
+          assert.equal(zed.getAttribute("role"), "menuitem");
+          await zed.listeners.click({{
+            type: "click",
+            currentTarget: zed,
+            preventDefault: () => {{}},
+            stopPropagation: () => {{}},
+            stopImmediatePropagation: () => {{}},
+          }});
+          await Promise.resolve();
+          await Promise.resolve();
+          assert.deepEqual(openPayloads, [{{
+            hostId: "remote-ssh-codex-managed:remote",
+            ssh: {{ user: "longnv", host: "192.168.100.31", port: null }},
+            path: "/Users/longnv/bin/repo/sealos-skills",
+          }}]);
+        }})().catch((error) => {{
+          console.error(error);
+          process.exit(1);
+        }});
+        """
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_renderer_script_observes_native_open_in_menu_mounts():
     text = Path("codex_session_delete/inject/renderer-inject.js").read_text(encoding="utf-8")
-    start = text.index("function shouldScheduleScan")
-    end = text.index("\n\n  function runScheduledScan", start)
-    schedule_code = text[start:end]
+    start = text.index("function shouldRefreshZedRemoteMenus")
+    end = text.index("\n\n  function scheduleZedRemoteMenuRefresh", start)
+    menu_schedule_code = text[start:end]
+    scan_start = text.index("function shouldScheduleScan")
+    scan_end = text.index("\n\n  function runScheduledScan", scan_start)
+    scan_schedule_code = text[scan_start:scan_end]
 
-    assert "[role=\"menu\"], [data-radix-popper-content-wrapper]" in schedule_code
+    assert "[role=\"menu\"], [data-radix-popper-content-wrapper]" in menu_schedule_code
+    assert "[role=\"menu\"], [data-radix-popper-content-wrapper]" not in scan_schedule_code
+
+
+def test_renderer_scripts_do_not_refresh_zed_remote_from_global_scan_loop():
+    for path, text in renderer_script_texts():
+        start = text.index("function scanDeferred")
+        end = text.index("\n\n  function runScanStep", start)
+        scan_code = text[start:end]
+
+        assert "refreshZedRemoteOpenControls" not in scan_code, path
+        assert "refreshZedRemoteOpenInMenus" not in scan_code, path
+
+
+def test_renderer_scripts_scope_and_cache_zed_remote_context_lookup():
+    for path, text in renderer_script_texts():
+        start = text.index("function zedRemoteContext")
+        end = text.index("\n\n  function zedRemoteAbsolutePath", start)
+        context_code = text[start:end]
+
+        assert "const zedRemoteContextCacheTtlMs" in text, path
+        assert "let zedRemoteContextCache" in text, path
+        assert "function zedRemoteContext(scope = document)" in context_code, path
+        assert "document.body, ...document.querySelectorAll" not in context_code, path
+        assert "a, button, [role='button'], [role='menuitem'], [role='treeitem']" not in context_code, path
+        assert ".slice(0, 260)" not in context_code, path
+
+
+def test_renderer_scripts_initialize_backend_heartbeat_once():
+    for path, text in renderer_script_texts():
+        start = text.index("function scheduleBackendHeartbeat")
+        end = text.index("\n\n", start)
+        heartbeat_code = text[start:end]
+
+        assert "if (window.__codexPlusBackendHeartbeat) return;" in heartbeat_code, path
+        assert "clearInterval(window.__codexPlusBackendHeartbeat)" not in heartbeat_code, path
 
 
 def test_renderer_script_handles_zed_remote_open_rejection_with_toast():
@@ -897,8 +1188,8 @@ def test_renderer_script_zed_remote_candidate_sources_are_structured():
     assert "zedRemoteAnchorHasOpenFileMetadata" in candidates_code
     assert "span.inline-markdown, code, [class*='inlineMarkdown']" in candidates_code
     scan_relevance_code = text[text.index("const scanRelevantSelector"):text.index("function nodeSelfOrAncestorMatchesScanRelevance")]
-    assert '"span.inline-markdown"' in scan_relevance_code
-    assert "\"[class*='inlineMarkdown']\"" in scan_relevance_code
+    assert '"span.inline-markdown"' not in scan_relevance_code
+    assert "\"[class*='inlineMarkdown']\"" not in scan_relevance_code
 
 
 def test_runtime_renderer_asset_contains_zed_remote_open_controls():

--- a/tests/test_zed_remote.py
+++ b/tests/test_zed_remote.py
@@ -74,6 +74,66 @@ def test_resolve_ssh_target_from_global_state_for_codex_managed_connection():
     assert target == SshTarget(user="longnv", host="192.168.100.31", port=None)
 
 
+def test_fallback_open_request_from_global_state_uses_selected_remote_project():
+    state = {
+        "selected-remote-host-id": "remote-ssh-codex-managed:remote",
+        "codex-managed-remote-connections": [
+            {
+                "hostId": "remote-ssh-codex-managed:remote",
+                "hostname": "longnv@192.168.100.31",
+                "sshPort": None,
+            }
+        ],
+        "remote-projects": [
+            {
+                "id": "032e652b-7956-4e6e-83bd-b29f456c6c3d",
+                "hostId": "remote-ssh-codex-managed:remote",
+                "remotePath": "/Users/longnv/bin/repo/sealos-skills",
+                "label": "sealos-skills",
+            }
+        ],
+        "project-order": ["032e652b-7956-4e6e-83bd-b29f456c6c3d"],
+    }
+
+    request = zed_remote.fallback_open_request_from_global_state(state)
+
+    assert request == {
+        "hostId": "remote-ssh-codex-managed:remote",
+        "ssh": {"user": "longnv", "host": "192.168.100.31", "port": None},
+        "path": "/Users/longnv/bin/repo/sealos-skills",
+    }
+
+
+def test_fallback_open_request_from_global_state_prefers_project_order_for_selected_host():
+    state = {
+        "selected-remote-host-id": "remote-ssh-codex-managed:remote",
+        "codex-managed-remote-connections": [
+            {"hostId": "remote-ssh-codex-managed:remote", "hostname": "longnv@192.168.100.31"}
+        ],
+        "remote-projects": [
+            {"id": "old", "hostId": "remote-ssh-codex-managed:remote", "remotePath": "/Users/longnv/bin/repo/old"},
+            {"id": "current", "hostId": "remote-ssh-codex-managed:remote", "remotePath": "/Users/longnv/bin/repo/current"},
+            {"id": "other-host", "hostId": "remote-ssh-codex-managed:other", "remotePath": "/srv/other"},
+        ],
+        "project-order": ["other-host", "current", "old"],
+    }
+
+    request = zed_remote.fallback_open_request_from_global_state(state)
+
+    assert request["hostId"] == "remote-ssh-codex-managed:remote"
+    assert request["path"] == "/Users/longnv/bin/repo/current"
+
+
+def test_fallback_open_request_response_reports_missing_remote_project(monkeypatch, tmp_path):
+    state_path = tmp_path / ".codex-global-state.json"
+    state_path.write_text('{"selected-remote-host-id":"remote-ssh-codex-managed:remote"}', encoding="utf-8")
+    monkeypatch.setattr(zed_remote, "codex_global_state_path", lambda: state_path)
+
+    result = zed_remote.fallback_open_request_response({})
+
+    assert result == {"status": "failed", "message": "Cannot determine remote workspace or file for Zed"}
+
+
 def test_resolve_ssh_target_response_reports_missing_host_id():
     result = zed_remote.resolve_ssh_target_response({"hostId": ""})
 


### PR DESCRIPTION
Resolve Open In > Zed clicks when the remote menu lacks file metadata.

- add a fallback bridge route that reads the selected remote project from Codex global state
- use the fallback when renderer menu context cannot resolve a file
- keep menu refresh scoped and cover the path with Python, Rust, and renderer tests