### PR TITLE
fix(zed): open active remote worktrees in Zed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,7 @@ dependencies = [
  "directories",
  "futures-util",
  "reqwest 0.12.28",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -4646,8 +4646,80 @@
     return result?.status === "ok" && result.ssh ? result.ssh : null;
   }
 
+  function zedRemoteIsRemoteHostId(hostId) {
+    return zedRemoteString(hostId).startsWith("remote-ssh-");
+  }
+
+  function zedRemoteProjectIdFromRow(row) {
+    const projectList = row?.closest?.("[data-app-action-sidebar-project-list-id]");
+    const projectId = zedRemoteString(projectList?.getAttribute?.("data-app-action-sidebar-project-list-id"));
+    if (projectId) return projectId;
+    const projectRow = row?.closest?.("[data-app-action-sidebar-project-id]");
+    return zedRemoteString(projectRow?.getAttribute?.("data-app-action-sidebar-project-id"));
+  }
+
+  function zedRemoteWorkspaceRootFromObject(source) {
+    if (!source || typeof source !== "object") return "";
+    for (const key of ["remoteWorkspaceRoot", "workspaceRoot", "displayCwd", "cwd", "rootPath", "workingDirectory", "workingDir"]) {
+      const workspaceRoot = zedRemoteString(source[key]);
+      if (workspaceRoot.startsWith("/") && !/\/\.codex$/.test(workspaceRoot)) return workspaceRoot;
+    }
+    const hostConfig = source.hostConfig || source.sshHostConfig || source.remoteHostConfig || source.ssh || {};
+    for (const key of ["remoteWorkspaceRoot", "workspaceRoot", "rootPath", "cwd"]) {
+      const workspaceRoot = zedRemoteString(hostConfig[key]);
+      if (workspaceRoot.startsWith("/") && !/\/\.codex$/.test(workspaceRoot)) return workspaceRoot;
+    }
+    return "";
+  }
+
+  function zedRemoteWorkspaceRootFromElement(element) {
+    for (const key of zedRemoteReactKeys(element)) {
+      const workspaceRoot = zedRemoteWalkObject(element[key], zedRemoteWorkspaceRootFromObject, { maxDepth: 10, maxNodes: 320 });
+      if (workspaceRoot) return workspaceRoot;
+    }
+    return "";
+  }
+
+  function zedRemoteWorkspaceRootFromRow(row) {
+    for (let node = row; node && node !== document.body; node = node.parentElement) {
+      const workspaceRoot = zedRemoteWorkspaceRootFromElement(node);
+      if (workspaceRoot) return workspaceRoot;
+    }
+    return "";
+  }
+
+  function zedRemoteActiveThreadRow() {
+    const rows = sessionRows(true).filter((row) => row instanceof HTMLElement);
+    return rows.find((row) => row.getAttribute("data-app-action-sidebar-thread-active") === "true")
+      || rows.find((row) => row.getAttribute("aria-current") === "page" || row.getAttribute("aria-current") === "true")
+      || null;
+  }
+
+  function zedRemoteCurrentFallbackPayload() {
+    const row = zedRemoteActiveThreadRow();
+    const ref = row ? sessionRefFromRow(row) : currentSessionRef();
+    const threadId = ref.session_id || locationThreadId();
+    const hostId = zedRemoteString(row?.getAttribute?.("data-app-action-sidebar-thread-host-id"));
+    const isRemoteHost = zedRemoteIsRemoteHostId(hostId);
+    const payload = {};
+    if (threadId) payload.threadId = threadId;
+    if (hostId && hostId !== "local") payload.hostId = hostId;
+    if (!isRemoteHost) return payload;
+    const remoteWorkspaceRoot = zedRemoteWorkspaceRootFromRow(row);
+    const remoteProjectId = zedRemoteProjectIdFromRow(row);
+    if (remoteWorkspaceRoot) payload.remoteWorkspaceRoot = remoteWorkspaceRoot;
+    if (remoteProjectId) payload.remoteProjectId = remoteProjectId;
+    return payload;
+  }
+
+  function zedRemoteCurrentThreadId() {
+    return zedRemoteCurrentFallbackPayload().threadId || "";
+  }
+
   async function resolveZedRemoteFallbackRequest() {
-    const result = await postJson("/zed-remote/fallback-request", {});
+    const payload = zedRemoteCurrentFallbackPayload();
+    if (!zedRemoteIsRemoteHostId(payload.hostId)) return null;
+    const result = await postJson("/zed-remote/fallback-request", payload);
     return result?.status === "ok" && result.request ? result.request : null;
   }
 
@@ -4931,9 +5003,7 @@
   function zedRemoteBestOpenRequest(scope = document, context = zedRemoteContext(scope) || zedRemoteContext(document) || {}) {
     const candidates = zedRemoteFileCandidates(context, scope);
     if (candidates.length) return candidates[0].request;
-    const workspaceRoot = zedRemoteAbsolutePath(context.workspaceRoot || "", "");
-    if (!workspaceRoot || (!context?.ssh?.host && !context?.hostId)) return null;
-    return { ssh: context.ssh, hostId: context.hostId || "", path: workspaceRoot };
+    return null;
   }
 
   async function openZedRemote(request) {
@@ -5061,11 +5131,13 @@
   function refreshZedRemoteOpenInMenus(scope = document) {
     removeZedRemoteOpenInMenuItems(scope);
     if (!codexPlusSettings().zedRemoteOpen) return;
+    const fallbackPayload = zedRemoteCurrentFallbackPayload();
     zedRemoteOpenInMenuScopes(scope).forEach((menu) => {
       if (!(menu instanceof HTMLElement) || isExtensionUiNode(menu)) return;
       const items = Array.from(menu.querySelectorAll('[role="menuitem"]')).filter((item) => !isExtensionUiNode(item));
       const menuText = items.map((item) => (item.textContent || "").trim()).join(" ");
       if (!/\b(VS Code|Cursor|Antigravity)\b/.test(menuText)) return;
+      if (!zedRemoteBestOpenRequest(menu) && !zedRemoteIsRemoteHostId(fallbackPayload.hostId)) return;
       const existingZedItem = items.find((item) => (item.textContent || "").trim() === "Zed");
       if (existingZedItem) {
         bindZedRemoteOpenInMenuItem(existingZedItem, "native");

--- a/crates/codex-plus-core/Cargo.toml
+++ b/crates/codex-plus-core/Cargo.toml
@@ -12,6 +12,7 @@ base64.workspace = true
 directories.workspace = true
 futures-util = "0.3"
 reqwest.workspace = true
+rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/codex-plus-core/src/zed_remote.rs
+++ b/crates/codex-plus-core/src/zed_remote.rs
@@ -373,83 +373,12 @@ pub fn resolve_ssh_target_for_host_id(
     resolve_ssh_target_from_global_state(&state, host_id)
 }
 
-pub fn ordered_remote_projects_from_global_state(state: &Value) -> Vec<Value> {
-    let projects = state
-        .get("remote-projects")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_default()
-        .into_iter()
-        .filter(|project| project.as_object().is_some())
-        .collect::<Vec<_>>();
-    let project_order = state
-        .get("project-order")
-        .and_then(Value::as_array)
-        .map(|order| {
-            order
-                .iter()
-                .map(|item| string_value(Some(item)))
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-    let mut ordered = Vec::new();
-    for project_id in project_order {
-        if let Some(project) = projects
-            .iter()
-            .find(|project| string_value(project.get("id")) == project_id)
-        {
-            ordered.push(project.clone());
-        }
-    }
-    let ordered_ids = ordered
-        .iter()
-        .map(|project| string_value(project.get("id")))
-        .collect::<std::collections::HashSet<_>>();
-    ordered.extend(
-        projects
-            .into_iter()
-            .filter(|project| !ordered_ids.contains(&string_value(project.get("id")))),
-    );
-    ordered
-}
+mod fallback;
 
-pub fn fallback_open_request_from_global_state(state: &Value) -> Result<Value, ZedRemoteError> {
-    let selected_host_id = string_value(state.get("selected-remote-host-id"));
-    let selected_project = ordered_remote_projects_from_global_state(state)
-        .into_iter()
-        .find(|project| {
-            let project_host_id = string_value(project.get("hostId"));
-            let remote_path = string_value(project.get("remotePath"));
-            (selected_host_id.is_empty() || project_host_id == selected_host_id)
-                && remote_path.starts_with('/')
-        })
-        .ok_or(ZedRemoteError::Validation(
-            "Cannot determine remote workspace or file for Zed",
-        ))?;
-    let host_id =
-        selected_host_id.or_else_nonempty(|| string_value(selected_project.get("hostId")));
-    if host_id.is_empty() {
-        return Err(ZedRemoteError::Validation("Remote host id is required"));
-    }
-    let target = resolve_ssh_target_from_global_state(state, &host_id)?;
-    Ok(json!({
-        "hostId": host_id,
-        "ssh": { "user": target.user, "host": target.host, "port": target.port },
-        "path": string_value(selected_project.get("remotePath")),
-    }))
-}
-
-pub fn fallback_open_request_response(_payload: &Value) -> Value {
-    let path = codex_global_state_path();
-    let result = fs::read_to_string(path)
-        .map_err(ZedRemoteError::StateRead)
-        .and_then(|data| serde_json::from_str::<Value>(&data).map_err(ZedRemoteError::StateParse))
-        .and_then(|state| fallback_open_request_from_global_state(&state));
-    match result {
-        Ok(request) => json!({"status": "ok", "request": request}),
-        Err(error) => json!({"status": "failed", "message": error.to_string()}),
-    }
-}
+pub use fallback::{
+    fallback_open_request_from_global_state_with_context, fallback_open_request_response,
+    workspace_root_from_sqlite,
+};
 
 pub fn resolve_ssh_target_response(payload: &Value) -> Value {
     let host_id = string_value(payload.get("hostId"));

--- a/crates/codex-plus-core/src/zed_remote/fallback.rs
+++ b/crates/codex-plus-core/src/zed_remote/fallback.rs
@@ -1,0 +1,306 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rusqlite::Connection;
+use serde_json::{Value, json};
+
+use super::{ZedRemoteError, codex_global_state_path, resolve_ssh_target_from_global_state};
+
+fn string_value(value: Option<&Value>) -> String {
+    match value {
+        Some(Value::String(value)) => value.trim().to_string(),
+        Some(Value::Number(value)) => value.to_string(),
+        _ => String::new(),
+    }
+}
+
+fn codex_sqlite_state_path() -> PathBuf {
+    env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .or_else(|| {
+            env::var_os("HOME")
+                .or_else(|| env::var_os("USERPROFILE"))
+                .map(PathBuf::from)
+                .map(|home| home.join(".codex"))
+        })
+        .unwrap_or_else(|| PathBuf::from(".codex"))
+        .join("state_5.sqlite")
+}
+
+fn ordered_remote_projects_from_global_state(state: &Value) -> Vec<Value> {
+    let projects = state
+        .get("remote-projects")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|project| project.as_object().is_some())
+        .collect::<Vec<_>>();
+    let project_order = state
+        .get("project-order")
+        .and_then(Value::as_array)
+        .map(|order| {
+            order
+                .iter()
+                .map(|item| string_value(Some(item)))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let mut ordered = Vec::new();
+    for project_id in project_order {
+        if let Some(project) = projects
+            .iter()
+            .find(|project| string_value(project.get("id")) == project_id)
+        {
+            ordered.push(project.clone());
+        }
+    }
+    let ordered_ids = ordered
+        .iter()
+        .map(|project| string_value(project.get("id")))
+        .collect::<std::collections::HashSet<_>>();
+    ordered.extend(
+        projects
+            .into_iter()
+            .filter(|project| !ordered_ids.contains(&string_value(project.get("id")))),
+    );
+    ordered
+}
+
+fn workspace_path_from_hint(hint: Option<&Value>) -> String {
+    match hint {
+        Some(Value::String(value)) => value.trim().to_string(),
+        Some(Value::Object(object)) => {
+            for key in [
+                "remotePath",
+                "remoteWorkspaceRoot",
+                "workspaceRoot",
+                "path",
+                "cwd",
+            ] {
+                let value = string_value(object.get(key));
+                if !value.is_empty() {
+                    return value;
+                }
+            }
+            String::new()
+        }
+        _ => String::new(),
+    }
+}
+
+fn normalize_thread_id(thread_id: &str) -> String {
+    thread_id
+        .trim()
+        .strip_prefix("local:")
+        .unwrap_or_else(|| thread_id.trim())
+        .to_string()
+}
+
+pub fn workspace_root_from_sqlite(thread_id: &str, state_path: Option<&Path>) -> String {
+    let thread_id = normalize_thread_id(thread_id);
+    if thread_id.is_empty() {
+        return String::new();
+    }
+    let path = state_path
+        .map(Path::to_path_buf)
+        .unwrap_or_else(codex_sqlite_state_path);
+    if !path.is_file() {
+        return String::new();
+    }
+    Connection::open(path)
+        .and_then(|db| {
+            db.query_row(
+                "SELECT cwd FROM threads WHERE id = ?1 LIMIT 1",
+                [thread_id],
+                |row| row.get::<_, String>(0),
+            )
+        })
+        .ok()
+        .map(|cwd| cwd.trim().to_string())
+        .unwrap_or_default()
+}
+
+fn host_id_from_hint(hint: Option<&Value>) -> String {
+    match hint.and_then(Value::as_object) {
+        Some(object) => string_value(object.get("hostId"))
+            .or_else_nonempty(|| string_value(object.get("remoteHostId"))),
+        None => String::new(),
+    }
+}
+
+fn thread_workspace_hint<'a>(state: &'a Value, thread_id: &str) -> Option<&'a Value> {
+    if thread_id.is_empty() {
+        return None;
+    }
+    let bare_thread_id = normalize_thread_id(thread_id);
+    state
+        .get("thread-workspace-root-hints")
+        .and_then(Value::as_object)
+        .and_then(|hints| {
+            hints
+                .get(thread_id)
+                .or_else(|| hints.get(&bare_thread_id))
+                .or_else(|| hints.get(&format!("local:{bare_thread_id}")))
+        })
+}
+
+fn project_path_matches(remote_path: &str, project_path: &str) -> bool {
+    let project_path = project_path.trim_end_matches('/');
+    !project_path.is_empty()
+        && (remote_path == project_path
+            || remote_path
+                .strip_prefix(project_path)
+                .is_some_and(|suffix| suffix.starts_with('/')))
+}
+
+fn host_id_for_remote_path(state: &Value, preferred_host_id: &str, remote_path: &str) -> String {
+    if !preferred_host_id.is_empty() {
+        return preferred_host_id.to_string();
+    }
+    ordered_remote_projects_from_global_state(state)
+        .into_iter()
+        .find_map(|project| {
+            let project_path = string_value(project.get("remotePath"));
+            if project_path_matches(remote_path, &project_path) {
+                Some(string_value(project.get("hostId")))
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default()
+}
+
+fn open_request_for_remote_path(
+    state: &Value,
+    host_id: &str,
+    remote_path: &str,
+) -> Result<Value, ZedRemoteError> {
+    if !remote_path.starts_with('/') {
+        return Err(ZedRemoteError::Validation(
+            "Cannot determine remote workspace or file for Zed",
+        ));
+    }
+    if host_id.is_empty() {
+        return Err(ZedRemoteError::Validation("Remote host id is required"));
+    }
+    let target = resolve_ssh_target_from_global_state(state, host_id)?;
+    Ok(json!({
+        "hostId": host_id,
+        "ssh": { "user": target.user, "host": target.host, "port": target.port },
+        "path": remote_path,
+    }))
+}
+
+pub fn fallback_open_request_from_global_state_with_context(
+    state: &Value,
+    host_id: &str,
+    thread_id: &str,
+    workspace_root: &str,
+    remote_project_id: &str,
+) -> Result<Value, ZedRemoteError> {
+    let hint = thread_workspace_hint(state, thread_id);
+    let selected_host_id = host_id
+        .trim()
+        .to_string()
+        .or_else_nonempty(|| host_id_from_hint(hint))
+        .or_else_nonempty(|| string_value(state.get("selected-remote-host-id")));
+    let hinted_path = workspace_root
+        .trim()
+        .to_string()
+        .or_else_nonempty(|| workspace_path_from_hint(hint))
+        .or_else_nonempty(|| workspace_root_from_sqlite(thread_id, None));
+    if hinted_path.starts_with('/') {
+        let resolved_host_id = host_id_for_remote_path(state, &selected_host_id, &hinted_path);
+        return open_request_for_remote_path(state, &resolved_host_id, &hinted_path);
+    }
+
+    let requested_project_id = remote_project_id.trim();
+    if !requested_project_id.is_empty() {
+        if requested_project_id.starts_with('/') {
+            return open_request_for_remote_path(state, &selected_host_id, requested_project_id);
+        }
+        for project in ordered_remote_projects_from_global_state(state) {
+            if string_value(project.get("id")) != requested_project_id {
+                continue;
+            }
+            let project_host_id = string_value(project.get("hostId"));
+            if !selected_host_id.is_empty() && project_host_id != selected_host_id {
+                continue;
+            }
+            return open_request_for_remote_path(
+                state,
+                &project_host_id,
+                &string_value(project.get("remotePath")),
+            );
+        }
+    }
+
+    let selected_project = ordered_remote_projects_from_global_state(state)
+        .into_iter()
+        .find(|project| {
+            let project_host_id = string_value(project.get("hostId"));
+            let remote_path = string_value(project.get("remotePath"));
+            (selected_host_id.is_empty() || project_host_id == selected_host_id)
+                && remote_path.starts_with('/')
+        })
+        .ok_or(ZedRemoteError::Validation(
+            "Cannot determine remote workspace or file for Zed",
+        ))?;
+    let host_id =
+        selected_host_id.or_else_nonempty(|| string_value(selected_project.get("hostId")));
+    if host_id.is_empty() {
+        return Err(ZedRemoteError::Validation("Remote host id is required"));
+    }
+    open_request_for_remote_path(
+        state,
+        &host_id,
+        &string_value(selected_project.get("remotePath")),
+    )
+}
+
+pub fn fallback_open_request_response(payload: &Value) -> Value {
+    let host_id = string_value(payload.get("hostId"));
+    let thread_id = string_value(payload.get("threadId"))
+        .or_else_nonempty(|| string_value(payload.get("sessionId")))
+        .or_else_nonempty(|| string_value(payload.get("session_id")));
+    let workspace_root = string_value(payload.get("remoteWorkspaceRoot"))
+        .or_else_nonempty(|| string_value(payload.get("workspaceRoot")))
+        .or_else_nonempty(|| string_value(payload.get("cwd")))
+        .or_else_nonempty(|| string_value(payload.get("path")));
+    let remote_project_id = string_value(payload.get("remoteProjectId"))
+        .or_else_nonempty(|| string_value(payload.get("projectId")));
+    let path = codex_global_state_path();
+    let result = fs::read_to_string(path)
+        .map_err(ZedRemoteError::StateRead)
+        .and_then(|data| serde_json::from_str::<Value>(&data).map_err(ZedRemoteError::StateParse))
+        .and_then(|state| {
+            fallback_open_request_from_global_state_with_context(
+                &state,
+                &host_id,
+                &thread_id,
+                &workspace_root,
+                &remote_project_id,
+            )
+        });
+    match result {
+        Ok(request) => json!({"status": "ok", "request": request}),
+        Err(error) => json!({"status": "failed", "message": error.to_string()}),
+    }
+}
+
+trait NonEmptyStringExt {
+    fn or_else_nonempty<F>(self, fallback: F) -> String
+    where
+        F: FnOnce() -> String;
+}
+
+impl NonEmptyStringExt for String {
+    fn or_else_nonempty<F>(self, fallback: F) -> String
+    where
+        F: FnOnce() -> String,
+    {
+        if self.is_empty() { fallback() } else { self }
+    }
+}

--- a/crates/codex-plus-core/src/zed_remote/platform.rs
+++ b/crates/codex-plus-core/src/zed_remote/platform.rs
@@ -1,0 +1,98 @@
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::{Value, json};
+
+use super::ZedRemoteError;
+
+pub fn candidate_zed_app_paths() -> Vec<PathBuf> {
+    let mut paths = vec![
+        PathBuf::from("/Applications/Zed.app"),
+        PathBuf::from("/Applications/Zed Preview.app"),
+        PathBuf::from("/Applications/Zed Nightly.app"),
+    ];
+    if let Some(home) = home_dir() {
+        paths.push(home.join("Applications/Zed.app"));
+        paths.push(home.join("Applications/Zed Preview.app"));
+        paths.push(home.join("Applications/Zed Nightly.app"));
+    }
+    paths
+}
+
+pub fn find_zed_app_path() -> Option<PathBuf> {
+    candidate_zed_app_paths()
+        .into_iter()
+        .find(|path| path.exists())
+}
+
+pub fn find_zed_cli_path() -> String {
+    find_executable_on_path("zed")
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+pub fn zed_remote_status() -> Value {
+    let app_path = find_zed_app_path();
+    let cli_path = find_zed_cli_path();
+    let platform_supported =
+        cfg!(target_os = "macos") || cfg!(target_os = "windows") || cfg!(target_os = "linux");
+    json!({
+        "status": if platform_supported { "ok" } else { "failed" },
+        "platformSupported": platform_supported,
+        "zedAppFound": app_path.is_some(),
+        "zedCliFound": !cli_path.is_empty(),
+        "zedAppPath": app_path.map(|path| path.to_string_lossy().into_owned()).unwrap_or_default(),
+        "zedCliPath": cli_path,
+    })
+}
+
+fn home_dir() -> Option<PathBuf> {
+    env::var_os("HOME")
+        .or_else(|| env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+fn find_executable_on_path(name: &str) -> Option<PathBuf> {
+    let path_var = env::var_os("PATH")?;
+    for dir in env::split_paths(&path_var) {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        #[cfg(windows)]
+        {
+            let candidate = dir.join(format!("{name}.exe"));
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+pub fn launch_zed_url(url: &str) -> Result<(), ZedRemoteError> {
+    let app_path = find_zed_app_path();
+    let cli_path = find_zed_cli_path();
+    if cfg!(target_os = "macos") {
+        if let Some(app_path) = app_path {
+            Command::new("open")
+                .arg("-a")
+                .arg(app_path)
+                .arg(url)
+                .spawn()
+                .map_err(ZedRemoteError::Launch)?;
+            return Ok(());
+        }
+    }
+    if !cli_path.is_empty() {
+        Command::new(cli_path)
+            .arg(url)
+            .spawn()
+            .map_err(ZedRemoteError::Launch)?;
+        return Ok(());
+    }
+    Err(ZedRemoteError::Validation(
+        "Zed is not installed or not available on PATH",
+    ))
+}

--- a/crates/codex-plus-core/tests/zed_remote.rs
+++ b/crates/codex-plus-core/tests/zed_remote.rs
@@ -110,7 +110,7 @@ fn resolve_ssh_target_from_global_state_for_codex_managed_connection() {
 }
 
 #[test]
-fn fallback_open_request_from_global_state_uses_selected_remote_project() {
+fn fallback_open_request_uses_selected_remote_project() {
     let state = json!({
         "selected-remote-host-id": "remote-ssh-codex-managed:remote",
         "codex-managed-remote-connections": [{
@@ -127,7 +127,9 @@ fn fallback_open_request_from_global_state_uses_selected_remote_project() {
         "project-order": ["032e652b-7956-4e6e-83bd-b29f456c6c3d"],
     });
 
-    let request = zed_remote::fallback_open_request_from_global_state(&state).unwrap();
+    let request =
+        zed_remote::fallback_open_request_from_global_state_with_context(&state, "", "", "", "")
+            .unwrap();
 
     assert_eq!(
         request,
@@ -140,7 +142,7 @@ fn fallback_open_request_from_global_state_uses_selected_remote_project() {
 }
 
 #[test]
-fn fallback_open_request_from_global_state_prefers_project_order_for_selected_host() {
+fn fallback_open_request_prefers_project_order_for_selected_host() {
     let state = json!({
         "selected-remote-host-id": "remote-ssh-codex-managed:remote",
         "codex-managed-remote-connections": [{
@@ -155,17 +157,217 @@ fn fallback_open_request_from_global_state_prefers_project_order_for_selected_ho
         "project-order": ["other-host", "current", "old"],
     });
 
-    let request = zed_remote::fallback_open_request_from_global_state(&state).unwrap();
+    let request =
+        zed_remote::fallback_open_request_from_global_state_with_context(&state, "", "", "", "")
+            .unwrap();
 
     assert_eq!(request["hostId"], "remote-ssh-codex-managed:remote");
     assert_eq!(request["path"], "/Users/longnv/bin/repo/current");
 }
 
 #[test]
-fn fallback_open_request_from_global_state_reports_missing_remote_project() {
+fn fallback_open_request_prefers_remote_project_id_context() {
+    let state = json!({
+        "selected-remote-host-id": "remote-ssh-codex-managed:remote",
+        "codex-managed-remote-connections": [{
+            "hostId": "remote-ssh-codex-managed:remote",
+            "hostname": "longnv@192.168.100.31",
+        }],
+        "remote-projects": [
+            {
+                "id": "032e652b-7956-4e6e-83bd-b29f456c6c3d",
+                "hostId": "remote-ssh-codex-managed:remote",
+                "remotePath": "/Users/longnv/bin/repo/sealos-skills",
+            },
+            {
+                "id": "a21be7c9-a917-433a-bfc7-f422a34c2185",
+                "hostId": "remote-ssh-codex-managed:remote",
+                "remotePath": "/Users/longnv/bin/repo/Vocabloom",
+            },
+        ],
+        "project-order": ["032e652b-7956-4e6e-83bd-b29f456c6c3d", "a21be7c9-a917-433a-bfc7-f422a34c2185"],
+    });
+
+    let request = zed_remote::fallback_open_request_from_global_state_with_context(
+        &state,
+        "remote-ssh-codex-managed:remote",
+        "",
+        "",
+        "a21be7c9-a917-433a-bfc7-f422a34c2185",
+    )
+    .unwrap();
+
+    assert_eq!(request["hostId"], "remote-ssh-codex-managed:remote");
+    assert_eq!(request["path"], "/Users/longnv/bin/repo/Vocabloom");
+}
+
+#[test]
+fn fallback_open_request_treats_remote_project_id_as_path() {
+    let state = json!({
+        "selected-remote-host-id": "remote-ssh-codex-managed:remote",
+        "codex-managed-remote-connections": [{
+            "hostId": "remote-ssh-codex-managed:remote",
+            "hostname": "longnv@192.168.100.31",
+        }],
+        "remote-projects": [{
+            "id": "032e652b-7956-4e6e-83bd-b29f456c6c3d",
+            "hostId": "remote-ssh-codex-managed:remote",
+            "remotePath": "/Users/longnv/bin/repo/sealos-skills",
+        }],
+        "project-order": ["032e652b-7956-4e6e-83bd-b29f456c6c3d"],
+    });
+
+    let request = zed_remote::fallback_open_request_from_global_state_with_context(
+        &state,
+        "remote-ssh-codex-managed:remote",
+        "",
+        "",
+        "/Users/longnv/bin/repo/Vocabloom",
+    )
+    .unwrap();
+
+    assert_eq!(request["hostId"], "remote-ssh-codex-managed:remote");
+    assert_eq!(request["path"], "/Users/longnv/bin/repo/Vocabloom");
+}
+
+#[test]
+fn fallback_open_request_prefers_thread_workspace_hint() {
+    let state = json!({
+        "selected-remote-host-id": "remote-ssh-codex-managed:remote",
+        "codex-managed-remote-connections": [{
+            "hostId": "remote-ssh-codex-managed:remote",
+            "hostname": "longnv@192.168.100.31",
+        }],
+        "remote-projects": [{
+            "id": "main",
+            "hostId": "remote-ssh-codex-managed:remote",
+            "remotePath": "/Users/longnv/bin/repo/sealos-skills",
+        }],
+        "project-order": ["main"],
+        "thread-workspace-root-hints": {
+            "019e39c1-worktree": "/Users/longnv/bin/repo/sealos-skills/.worktree/zed-fix",
+        },
+    });
+
+    let request = zed_remote::fallback_open_request_from_global_state_with_context(
+        &state,
+        "",
+        "019e39c1-worktree",
+        "",
+        "",
+    )
+    .unwrap();
+
+    assert_eq!(request["hostId"], "remote-ssh-codex-managed:remote");
+    assert_eq!(
+        request["path"],
+        "/Users/longnv/bin/repo/sealos-skills/.worktree/zed-fix"
+    );
+}
+
+#[test]
+fn fallback_open_request_accepts_local_prefixed_thread_workspace_hint() {
+    let state = json!({
+        "selected-remote-host-id": "remote-ssh-codex-managed:remote",
+        "codex-managed-remote-connections": [{
+            "hostId": "remote-ssh-codex-managed:remote",
+            "hostname": "longnv@192.168.100.31",
+        }],
+        "remote-projects": [{
+            "id": "main",
+            "hostId": "remote-ssh-codex-managed:remote",
+            "remotePath": "/Users/longnv/bin/repo/sealos-skills",
+        }],
+        "project-order": ["main"],
+        "thread-workspace-root-hints": {
+            "019e39c1-worktree": "/Users/longnv/bin/repo/sealos-skills/.worktree/zed-fix",
+        },
+    });
+
+    let request = zed_remote::fallback_open_request_from_global_state_with_context(
+        &state,
+        "",
+        "local:019e39c1-worktree",
+        "",
+        "",
+    )
+    .unwrap();
+
+    assert_eq!(request["hostId"], "remote-ssh-codex-managed:remote");
+    assert_eq!(
+        request["path"],
+        "/Users/longnv/bin/repo/sealos-skills/.worktree/zed-fix"
+    );
+}
+
+#[test]
+fn fallback_open_request_response_passes_thread_workspace_hint() {
+    let state = json!({
+        "selected-remote-host-id": "remote-ssh-codex-managed:remote",
+        "codex-managed-remote-connections": [{
+            "hostId": "remote-ssh-codex-managed:remote",
+            "hostname": "longnv@192.168.100.31",
+        }],
+        "remote-projects": [{
+            "id": "main",
+            "hostId": "remote-ssh-codex-managed:remote",
+            "remotePath": "/Users/longnv/bin/repo/sealos-skills",
+        }],
+        "thread-workspace-root-hints": {
+            "019e39c1-worktree": "/Users/longnv/bin/repo/sealos-skills/.worktree/zed-fix",
+        },
+    });
+
+    let request = zed_remote::fallback_open_request_from_global_state_with_context(
+        &state,
+        "",
+        "019e39c1-worktree",
+        "",
+        "",
+    )
+    .unwrap();
+
+    assert_eq!(
+        request["path"],
+        "/Users/longnv/bin/repo/sealos-skills/.worktree/zed-fix"
+    );
+}
+
+#[test]
+fn workspace_root_from_sqlite_reads_thread_cwd() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db_path = tmp.path().join("state_5.sqlite");
+    let db = rusqlite::Connection::open(&db_path).unwrap();
+    db.execute(
+        "CREATE TABLE threads (id TEXT PRIMARY KEY, cwd TEXT NOT NULL)",
+        [],
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO threads (id, cwd) VALUES (?1, ?2)",
+        (
+            "019e39c1-worktree",
+            "/Users/longnv/bin/repo/sealos-skills/.worktree/zed-fix",
+        ),
+    )
+    .unwrap();
+    drop(db);
+
+    let cwd = zed_remote::workspace_root_from_sqlite("local:019e39c1-worktree", Some(&db_path));
+
+    assert_eq!(
+        cwd,
+        "/Users/longnv/bin/repo/sealos-skills/.worktree/zed-fix"
+    );
+}
+
+#[test]
+fn fallback_open_request_reports_missing_remote_project() {
     let state = json!({"selected-remote-host-id": "remote-ssh-codex-managed:remote"});
 
-    let error = zed_remote::fallback_open_request_from_global_state(&state).unwrap_err();
+    let error =
+        zed_remote::fallback_open_request_from_global_state_with_context(&state, "", "", "", "")
+            .unwrap_err();
 
     assert_eq!(
         error.to_string(),


### PR DESCRIPTION
Prefer the active remote sidebar thread workspace root when building Zed fallback payloads so Codex worktrees open their actual worktree directory instead of the parent project root.

- read displayCwd and workspace root hints from remote React sidebar metadata
- avoid sending local active-row paths to remote fallback resolution
- resolve thread workspace hints for both local:<id> and bare ids
- pass remoteWorkspaceRoot alongside the remote project id fallback
- cover remote worktree and hint-id edge cases in renderer and backend tests