### PR TITLE
fix: detect plugin entry in new Codex navigation

### DIFF
--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -91,7 +91,7 @@
     nativeMenuBar: "[class*=\"ms-auto\"][class*=\"flex\"][class*=\"items-center\"]",
     archiveNav: 'button[aria-label="已归档对话"], button[aria-label="Archived conversations"]',
     disabledInstallButton: 'button:disabled, button[aria-disabled="true"], [role="button"][aria-disabled="true"], button[data-disabled], [role="button"][data-disabled], button.cursor-not-allowed, [role="button"].cursor-not-allowed, button.pointer-events-none, [role="button"].pointer-events-none',
-    pluginNavButton: 'nav[role="navigation"] button.h-token-nav-row.w-full',
+    pluginNavButton: 'button, [role="button"]',
     pluginSvgPath: 'svg path[d^="M7.94562 14.0277"]',
   };
 
@@ -1377,7 +1377,9 @@
   }
 
   function pluginEntryButton() {
-    const byIcon = document.querySelector(`${selectors.pluginNavButton} ${selectors.pluginSvgPath}`)?.closest("button");
+    const byIcon = Array.from(document.querySelectorAll(selectors.pluginSvgPath))
+      .map((path) => path.closest(selectors.pluginNavButton))
+      .find((button) => button && /^(插件|Plugins)(\s+-\s+.*)?$/i.test((button.textContent || "").trim()));
     if (byIcon) return byIcon;
     return Array.from(document.querySelectorAll(selectors.pluginNavButton))
       .find((button) => /^(插件|Plugins)(\s+-\s+.*)?$/i.test((button.textContent || "").trim())) || null;

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -99,6 +99,15 @@ fn injection_script_skips_plugin_patch_work_in_relay_mode() {
 }
 
 #[test]
+fn injection_script_detects_plugin_entry_without_legacy_nav_class() {
+    let script = assets::injection_script(57321);
+
+    assert!(script.contains("pluginNavButton: 'button, [role=\"button\"]'"));
+    assert!(script.contains("path.closest(selectors.pluginNavButton)"));
+    assert!(!script.contains("button.h-token-nav-row.w-full"));
+}
+
+#[test]
 fn injection_script_unlocks_nested_disabled_plugin_install_buttons() {
     let script = assets::injection_script(57321);
 


### PR DESCRIPTION
## Summary
- stop relying on the legacy `button.h-token-nav-row.w-full` navigation class to find the plugin entry
- detect plugin entry buttons via the plugin icon path and generic `button, [role=button]` controls
- add a regression assertion so the injected script no longer contains the stale navigation class selector

## Testing
- Static regression checks against the generated injection script
- Not run: `cargo test` locally because the Windows machine used for the fix does not have Rust/Cargo installed