### PR TITLE
feat: 支持配置额外的 Codex 启动参数

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -171,8 +171,11 @@ impl LaunchHooks for LauncherHooks {
         &self,
         app_dir: &Path,
         debug_port: u16,
+        extra_args: &[String],
     ) -> anyhow::Result<codex_plus_core::launcher::CodexLaunch> {
-        self.core.launch_codex(app_dir, debug_port).await
+        self.core
+            .launch_codex(app_dir, debug_port, extra_args)
+            .await
     }
 
     async fn bridge_context(&self, debug_port: u16) -> anyhow::Result<Option<BridgeContext>> {

--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -69,6 +69,7 @@ type OverviewResult = CommandResult<{
 
 type BackendSettings = {
   codexAppPath: string;
+  codexExtraArgs: string[];
   providerSyncEnabled: boolean;
   enhancementsEnabled: boolean;
   launchMode: LaunchMode;
@@ -189,6 +190,7 @@ const routes: Array<{ id: Route; label: string; icon: LucideIcon }> = [
 
 const defaultSettings: BackendSettings = {
   codexAppPath: "",
+  codexExtraArgs: [],
   providerSyncEnabled: false,
   enhancementsEnabled: true,
   launchMode: "patch",
@@ -1442,6 +1444,29 @@ function SettingsScreen({
           </Toolbar>
         </CardContent>
       </Panel>
+      <Panel>
+        <CardHead title="Codex 启动参数" detail="启动 Codex App 时追加到默认 CDP 参数后。留空则保持默认启动行为。" />
+        <CardContent>
+          <Field label="额外参数">
+            <Textarea
+              className="launch-args-input"
+              placeholder="--force_high_performance_gpu"
+              spellCheck={false}
+              value={codexExtraArgsToInput(form.codexExtraArgs)}
+              onChange={(event) =>
+                onFormChange({
+                  ...form,
+                  codexExtraArgs: inputToCodexExtraArgs(event.currentTarget.value),
+                })
+              }
+            />
+          </Field>
+          <p className="field-hint">每行一个参数，例如 --force_high_performance_gpu。不需要填写 open 或 --args。</p>
+          <Toolbar>
+            <Button onClick={() => void actions.saveSettings()}>保存设置</Button>
+          </Toolbar>
+        </CardContent>
+      </Panel>
     </>
   );
 }
@@ -1752,7 +1777,7 @@ function routeSubtitle(route: Route) {
     recommendations: "赞助商推荐与普通推荐",
     maintenance: "入口安装、修复、Watcher 与手动启动",
     about: "版本信息、项目链接与 GitHub Release 更新",
-    settings: "主题与命令包装器设置",
+    settings: "主题、命令包装器和启动参数",
     logs: "最近状态文件内容",
     diagnostics: "可复制的运行诊断报告",
   };
@@ -1836,6 +1861,14 @@ function normalizeSettings(settings: BackendSettings): BackendSettings {
     ? settings.activeRelayId
     : profiles[0]?.id || "default";
   return syncLegacyRelayFields({ ...defaultSettings, ...settings, relayProfiles: profiles, activeRelayId });
+}
+
+function codexExtraArgsToInput(args: string[] | undefined) {
+  return (args ?? []).join("\n");
+}
+
+function inputToCodexExtraArgs(value: string) {
+  return value === "" ? [] : value.split(/\r?\n/);
 }
 
 function activeRelayProfile(settings: BackendSettings): RelayProfile {

--- a/apps/codex-plus-manager/src/styles.css
+++ b/apps/codex-plus-manager/src/styles.css
@@ -794,6 +794,12 @@ body {
   font-weight: 600;
 }
 
+.field-hint {
+  margin: -4px 0 12px;
+  color: hsl(var(--muted-foreground));
+  font-size: 12px;
+}
+
 .form-row {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -820,6 +826,13 @@ body {
   font-size: 12px;
   line-height: 1.45;
   white-space: pre;
+}
+
+.launch-args-input {
+  min-height: 112px;
+  font-family: Consolas, "SFMono-Regular", monospace;
+  font-size: 12px;
+  line-height: 1.45;
 }
 
 .log-view.tall {

--- a/crates/codex-plus-core/src/app_paths.rs
+++ b/crates/codex-plus-core/src/app_paths.rs
@@ -187,16 +187,11 @@ pub fn codex_app_version(app_dir: &Path) -> Option<String> {
 }
 
 pub fn packaged_app_user_model_id(app_dir: &Path) -> Option<String> {
-    let package_dir = if app_dir
-        .file_name()
-        .and_then(OsStr::to_str)
-        .is_some_and(|name| name.eq_ignore_ascii_case("app"))
-    {
-        app_dir.parent()?
-    } else {
-        app_dir
-    };
-    let package_name = package_dir.file_name()?.to_str()?;
+    let path = app_dir.to_string_lossy().replace('\\', "/");
+    let package_name = path
+        .split('/')
+        .rev()
+        .find(|part| part.starts_with("OpenAI.Codex_") && part.contains("__"))?;
     if !package_name.starts_with("OpenAI.Codex_") || !package_name.contains("__") {
         return None;
     }

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -12,7 +12,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 
-use crate::settings::{BackendSettings, SettingsStore};
+use crate::settings::{BackendSettings, SettingsStore, normalize_codex_extra_args};
 use crate::status::{LaunchStatus, StatusStore};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -125,7 +125,12 @@ pub trait LaunchHooks: Send + Sync {
     async fn load_settings(&self) -> anyhow::Result<BackendSettings>;
     async fn run_provider_sync(&self) -> anyhow::Result<()>;
     async fn start_helper(&self, helper_port: u16) -> anyhow::Result<()>;
-    async fn launch_codex(&self, app_dir: &Path, debug_port: u16) -> anyhow::Result<CodexLaunch>;
+    async fn launch_codex(
+        &self,
+        app_dir: &Path,
+        debug_port: u16,
+        extra_args: &[String],
+    ) -> anyhow::Result<CodexLaunch>;
     async fn bridge_context(
         &self,
         _debug_port: u16,
@@ -201,7 +206,9 @@ where
             helper_started = true;
         }
 
-        let launch = hooks.launch_codex(&app_dir, debug_port).await?;
+        let launch = hooks
+            .launch_codex(&app_dir, debug_port, &settings.codex_extra_args)
+            .await?;
         launched = Some(launch.clone());
 
         if settings.enhancements_enabled {
@@ -346,9 +353,14 @@ impl LaunchHooks for DefaultLaunchHooks {
         Ok(())
     }
 
-    async fn launch_codex(&self, app_dir: &Path, debug_port: u16) -> anyhow::Result<CodexLaunch> {
+    async fn launch_codex(
+        &self,
+        app_dir: &Path,
+        debug_port: u16,
+        extra_args: &[String],
+    ) -> anyhow::Result<CodexLaunch> {
         if cfg!(windows) {
-            if let Some(activation) = build_packaged_activation(app_dir, debug_port) {
+            if let Some(activation) = build_packaged_activation(app_dir, debug_port, extra_args) {
                 let CodexLaunch::PackagedActivation {
                     app_user_model_id,
                     arguments,
@@ -382,7 +394,7 @@ impl LaunchHooks for DefaultLaunchHooks {
             } else {
                 MacosCleanupPolicy::QuitIfNotPreviouslyRunning
             };
-            let command = build_macos_open_command(app_dir, debug_port);
+            let command = build_macos_open_command(app_dir, debug_port, extra_args);
             let executable = command
                 .first()
                 .ok_or_else(|| anyhow::anyhow!("macOS open command is empty"))?;
@@ -401,7 +413,7 @@ impl LaunchHooks for DefaultLaunchHooks {
             });
         }
 
-        let command = build_codex_command(app_dir, debug_port);
+        let command = build_codex_command(app_dir, debug_port, extra_args);
         let executable = command
             .first()
             .ok_or_else(|| anyhow::anyhow!("Codex command is empty"))?;
@@ -647,27 +659,33 @@ fn sanitize_diagnostic_event(event: &str) -> String {
     }
 }
 
-pub fn build_codex_arguments(debug_port: u16) -> Vec<String> {
-    vec![
+pub fn build_codex_arguments(debug_port: u16, extra_args: &[String]) -> Vec<String> {
+    let mut args = vec![
         format!("--remote-debugging-port={debug_port}"),
         format!("--remote-allow-origins=http://127.0.0.1:{debug_port}"),
-    ]
+    ];
+    args.extend(normalize_codex_extra_args(extra_args));
+    args
 }
 
-pub fn build_codex_command(app_dir: &Path, debug_port: u16) -> Vec<String> {
+pub fn build_codex_command(app_dir: &Path, debug_port: u16, extra_args: &[String]) -> Vec<String> {
     let mut command = vec![
         crate::app_paths::build_codex_executable(app_dir)
             .to_string_lossy()
             .to_string(),
     ];
-    command.extend(build_codex_arguments(debug_port));
+    command.extend(build_codex_arguments(debug_port, extra_args));
     command
 }
 
-pub fn build_packaged_activation(app_dir: &Path, debug_port: u16) -> Option<CodexLaunch> {
+pub fn build_packaged_activation(
+    app_dir: &Path,
+    debug_port: u16,
+    extra_args: &[String],
+) -> Option<CodexLaunch> {
     Some(CodexLaunch::PackagedActivation {
         app_user_model_id: crate::app_paths::packaged_app_user_model_id(app_dir)?,
-        arguments: command_line_arguments(&build_codex_arguments(debug_port)),
+        arguments: command_line_arguments(&build_codex_arguments(debug_port, extra_args)),
         process_id: None,
     })
 }
@@ -811,7 +829,11 @@ async fn try_inject(debug_port: u16, helper_port: u16) -> anyhow::Result<()> {
     .await
 }
 
-pub fn build_macos_open_command(app_dir: &Path, debug_port: u16) -> Vec<String> {
+pub fn build_macos_open_command(
+    app_dir: &Path,
+    debug_port: u16,
+    extra_args: &[String],
+) -> Vec<String> {
     let mut command = vec![
         "open".to_string(),
         "-W".to_string(),
@@ -819,7 +841,7 @@ pub fn build_macos_open_command(app_dir: &Path, debug_port: u16) -> Vec<String> 
         app_dir.to_string_lossy().to_string(),
         "--args".to_string(),
     ];
-    command.extend(build_codex_arguments(debug_port));
+    command.extend(build_codex_arguments(debug_port, extra_args));
     command
 }
 

--- a/crates/codex-plus-core/src/settings.rs
+++ b/crates/codex-plus-core/src/settings.rs
@@ -39,6 +39,8 @@ impl Default for RelayProfile {
 pub struct BackendSettings {
     #[serde(rename = "codexAppPath", default)]
     pub codex_app_path: String,
+    #[serde(rename = "codexExtraArgs", default)]
+    pub codex_extra_args: Vec<String>,
     #[serde(rename = "providerSyncEnabled", default)]
     pub provider_sync_enabled: bool,
     #[serde(rename = "enhancementsEnabled", default = "default_true")]
@@ -71,6 +73,7 @@ impl Default for BackendSettings {
     fn default() -> Self {
         Self {
             codex_app_path: String::new(),
+            codex_extra_args: Vec::new(),
             provider_sync_enabled: false,
             enhancements_enabled: true,
             launch_mode: LaunchMode::Patch,
@@ -160,6 +163,14 @@ where
         .unwrap_or_else(default_api_key_env))
 }
 
+pub fn normalize_codex_extra_args(args: &[String]) -> Vec<String> {
+    args.iter()
+        .map(|arg| arg.trim())
+        .filter(|arg| !arg.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
 #[derive(Debug, Clone)]
 pub struct SettingsStore {
     path: PathBuf,
@@ -192,7 +203,9 @@ impl SettingsStore {
     }
 
     pub fn save(&self, settings: &BackendSettings) -> anyhow::Result<()> {
-        let bytes = serde_json::to_vec_pretty(settings)?;
+        let mut settings = settings.clone();
+        settings.codex_extra_args = normalize_codex_extra_args(&settings.codex_extra_args);
+        let bytes = serde_json::to_vec_pretty(&settings)?;
         atomic_write(&self.path, &bytes)
     }
 
@@ -231,6 +244,22 @@ impl SettingsStore {
 fn merge_known_setting_fields(target: &mut Map<String, Value>, source: &Map<String, Value>) {
     if let Some(value) = source.get("codexAppPath").and_then(Value::as_str) {
         target.insert("codexAppPath".to_string(), Value::String(value.to_string()));
+    }
+    if let Some(value) = source.get("codexExtraArgs").and_then(Value::as_array) {
+        let args = value
+            .iter()
+            .filter_map(Value::as_str)
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        target.insert(
+            "codexExtraArgs".to_string(),
+            Value::Array(
+                normalize_codex_extra_args(&args)
+                    .into_iter()
+                    .map(Value::String)
+                    .collect(),
+            ),
+        );
     }
     if let Some(value) = source.get("providerSyncEnabled").and_then(Value::as_bool) {
         target.insert("providerSyncEnabled".to_string(), Value::Bool(value));
@@ -345,6 +374,7 @@ mod tests {
         assert!(!settings.provider_sync_enabled);
         assert!(settings.enhancements_enabled);
         assert!(settings.codex_app_path.is_empty());
+        assert!(settings.codex_extra_args.is_empty());
         assert_eq!(settings.launch_mode, LaunchMode::Patch);
         assert_eq!(settings.relay_base_url, default_relay_base_url());
         assert!(settings.relay_api_key.is_empty());
@@ -365,6 +395,23 @@ mod tests {
         assert_eq!(settings.cli_wrapper_api_key, "sk-test");
         assert_eq!(settings.cli_wrapper_api_key_env, "CUSTOM_OPENAI_API_KEY");
         assert_eq!(settings.relay_base_url, default_relay_base_url());
+        assert!(settings.codex_extra_args.is_empty());
+    }
+
+    #[test]
+    fn settings_deserialize_reads_codex_extra_args() {
+        let settings: BackendSettings = serde_json::from_str(
+            r#"{"codexExtraArgs":["--force_high_performance_gpu"," --ignored-trimmed-by-ui "]}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            settings.codex_extra_args,
+            vec![
+                "--force_high_performance_gpu".to_string(),
+                " --ignored-trimmed-by-ui ".to_string(),
+            ]
+        );
     }
 
     #[test]
@@ -395,6 +442,7 @@ mod tests {
             cli_wrapper_base_url: "https://example.test".to_string(),
             cli_wrapper_api_key: "sk-test".to_string(),
             cli_wrapper_api_key_env: "CUSTOM_ENV".to_string(),
+            codex_extra_args: vec!["--force_high_performance_gpu".to_string()],
             ..BackendSettings::default()
         };
 
@@ -424,6 +472,7 @@ mod tests {
             "enhancementsEnabled": false,
             "relayBaseUrl": "https://relay.example.test/v1",
             "relayApiKey": "sk-relay",
+            "codexExtraArgs": ["--force_high_performance_gpu", "", "  ", " --enable-gpu "],
             "cliWrapperApiKeyEnv": "",
             "unknownKey": "ignored"
             }))
@@ -434,6 +483,13 @@ mod tests {
         assert!(!updated.enhancements_enabled);
         assert_eq!(updated.relay_base_url, "https://relay.example.test/v1");
         assert_eq!(updated.relay_api_key, "sk-relay");
+        assert_eq!(
+            updated.codex_extra_args,
+            vec![
+                "--force_high_performance_gpu".to_string(),
+                "--enable-gpu".to_string(),
+            ]
+        );
         assert!(updated.cli_wrapper_enabled);
         assert_eq!(updated.cli_wrapper_base_url, "https://old.test");
         assert_eq!(updated.cli_wrapper_api_key, "old-key");
@@ -524,6 +580,42 @@ mod tests {
 
         assert!(updated.provider_sync_enabled);
         assert_eq!(saved["providerSyncEnabled"], json!(true));
+        assert_eq!(saved["codexExtraArgs"], Value::Null);
+        assert_eq!(saved["customField"], json!({"nested": true}));
+    }
+
+    #[test]
+    fn settings_store_update_persists_codex_extra_args_and_preserves_unknown_fields() {
+        let dir = temp_dir();
+        let path = dir.join("settings.json");
+        let store = SettingsStore::new(path.clone());
+        std::fs::write(
+            &path,
+            r#"{"providerSyncEnabled":false,"customField":{"nested":true}}"#,
+        )
+        .unwrap();
+
+        let updated = store
+            .update(json!({
+                "codexExtraArgs": ["--force_high_performance_gpu", "--enable-features=UseOzonePlatform"]
+            }))
+            .unwrap();
+        let saved: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+
+        assert_eq!(
+            updated.codex_extra_args,
+            vec![
+                "--force_high_performance_gpu".to_string(),
+                "--enable-features=UseOzonePlatform".to_string(),
+            ]
+        );
+        assert_eq!(
+            saved["codexExtraArgs"],
+            json!([
+                "--force_high_performance_gpu",
+                "--enable-features=UseOzonePlatform"
+            ])
+        );
         assert_eq!(saved["customField"], json!({"nested": true}));
     }
 

--- a/crates/codex-plus-core/tests/bridge_routes.rs
+++ b/crates/codex-plus-core/tests/bridge_routes.rs
@@ -802,6 +802,7 @@ impl LaunchHooks for ContextHooks {
         &self,
         _app_dir: &std::path::Path,
         _debug_port: u16,
+        _extra_args: &[String],
     ) -> anyhow::Result<CodexLaunch> {
         Ok(CodexLaunch::Process {
             command: vec!["codex".to_string()],

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -172,15 +172,40 @@ fn launcher_builds_debug_arguments_and_commands() {
     let app_dir = PathBuf::from(r"C:\Codex\app");
 
     assert_eq!(
-        build_codex_arguments(9229),
+        build_codex_arguments(9229, &[]),
         vec![
             "--remote-debugging-port=9229".to_string(),
             "--remote-allow-origins=http://127.0.0.1:9229".to_string(),
         ]
     );
-    let command = build_codex_command(&app_dir, 9229);
+    let command = build_codex_command(&app_dir, 9229, &[]);
     assert_eq!(command[1], "--remote-debugging-port=9229");
     assert_eq!(command[2], "--remote-allow-origins=http://127.0.0.1:9229");
+}
+
+#[test]
+fn launcher_appends_extra_codex_arguments_after_debug_arguments() {
+    let app_dir = PathBuf::from(r"C:\Codex\app");
+    let extra_args = vec![
+        "--force_high_performance_gpu".to_string(),
+        "  ".to_string(),
+        "--enable-features=UseOzonePlatform".to_string(),
+    ];
+
+    assert_eq!(
+        build_codex_arguments(9229, &extra_args),
+        vec![
+            "--remote-debugging-port=9229".to_string(),
+            "--remote-allow-origins=http://127.0.0.1:9229".to_string(),
+            "--force_high_performance_gpu".to_string(),
+            "--enable-features=UseOzonePlatform".to_string(),
+        ]
+    );
+    let command = build_codex_command(&app_dir, 9229, &extra_args);
+    assert_eq!(command[1], "--remote-debugging-port=9229");
+    assert_eq!(command[2], "--remote-allow-origins=http://127.0.0.1:9229");
+    assert_eq!(command[3], "--force_high_performance_gpu");
+    assert_eq!(command[4], "--enable-features=UseOzonePlatform");
 }
 
 #[test]
@@ -194,11 +219,30 @@ fn launcher_constructs_windows_packaged_activation_without_real_app() {
         "OpenAI.Codex_2p2nqsd0c76g0!App"
     );
     assert_eq!(
-        build_packaged_activation(&app_dir, 9229).unwrap(),
+        build_packaged_activation(&app_dir, 9229, &[]).unwrap(),
         CodexLaunch::PackagedActivation {
             app_user_model_id: "OpenAI.Codex_2p2nqsd0c76g0!App".to_string(),
             arguments: "--remote-debugging-port=9229 --remote-allow-origins=http://127.0.0.1:9229"
                 .to_string(),
+            process_id: None,
+        }
+    );
+}
+
+#[test]
+fn launcher_packaged_activation_appends_extra_codex_arguments() {
+    let app_dir = PathBuf::from(
+        r"C:\Program Files\WindowsApps\OpenAI.Codex_26.506.2212.0_x64__2p2nqsd0c76g0\app",
+    );
+    let extra_args = vec!["--force_high_performance_gpu".to_string()];
+
+    assert_eq!(
+        build_packaged_activation(&app_dir, 9229, &extra_args).unwrap(),
+        CodexLaunch::PackagedActivation {
+            app_user_model_id: "OpenAI.Codex_2p2nqsd0c76g0!App".to_string(),
+            arguments:
+                "--remote-debugging-port=9229 --remote-allow-origins=http://127.0.0.1:9229 --force_high_performance_gpu"
+                    .to_string(),
             process_id: None,
         }
     );
@@ -226,13 +270,32 @@ fn launcher_windows_packaged_process_management_uses_native_api() {
 
 #[test]
 fn launcher_macos_open_command_waits_for_app_exit() {
-    let command = build_macos_open_command(Path::new("/Applications/Codex.app"), 9229);
+    let command = build_macos_open_command(Path::new("/Applications/Codex.app"), 9229, &[]);
 
     assert_eq!(command[0], "open");
     assert!(command.contains(&"-W".to_string()));
     assert!(command.contains(&"-a".to_string()));
     assert!(command.contains(&"--args".to_string()));
     assert!(command.contains(&"--remote-debugging-port=9229".to_string()));
+}
+
+#[test]
+fn launcher_macos_open_command_appends_extra_codex_arguments_after_args() {
+    let extra_args = vec!["--force_high_performance_gpu".to_string()];
+    let command = build_macos_open_command(Path::new("/Applications/Codex.app"), 9229, &extra_args);
+    let args_index = command
+        .iter()
+        .position(|part| part == "--args")
+        .expect("macOS command should contain --args");
+
+    assert_eq!(
+        &command[args_index + 1..],
+        &[
+            "--remote-debugging-port=9229".to_string(),
+            "--remote-allow-origins=http://127.0.0.1:9229".to_string(),
+            "--force_high_performance_gpu".to_string(),
+        ]
+    );
 }
 
 #[test]
@@ -457,6 +520,39 @@ async fn launch_lifecycle_runs_sync_before_launch_writes_success_and_shutdowns_o
             .codex_app
             .as_deref(),
         Some(app_dir.to_string_lossy().as_ref())
+    );
+}
+
+#[tokio::test]
+async fn launch_lifecycle_passes_configured_extra_args_to_codex_launch() {
+    let temp = tempfile::tempdir().unwrap();
+    let app_dir = temp.path().join("Codex.app");
+    std::fs::create_dir_all(&app_dir).unwrap();
+    let status_store = StatusStore::new(temp.path().join("latest-status.json"));
+    let events = Arc::new(Mutex::new(Vec::<String>::new()));
+    let hooks = FakeHooks::new(events.clone()).with_settings(BackendSettings {
+        codex_extra_args: vec!["--force_high_performance_gpu".to_string()],
+        ..BackendSettings::default()
+    });
+
+    let handle = launch_and_inject_with_hooks(
+        LaunchOptions {
+            app_dir: Some(app_dir),
+            debug_port: 9229,
+            helper_port: 57321,
+            status_store,
+        },
+        &hooks,
+    )
+    .await
+    .unwrap();
+    handle.wait_for_codex_exit().await.unwrap();
+
+    assert!(
+        events
+            .lock()
+            .unwrap()
+            .contains(&"launch:9229:--force_high_performance_gpu".to_string())
     );
 }
 
@@ -861,9 +957,18 @@ impl LaunchHooks for FakeHooks {
         Ok(())
     }
 
-    async fn launch_codex(&self, app_dir: &Path, debug_port: u16) -> anyhow::Result<CodexLaunch> {
+    async fn launch_codex(
+        &self,
+        app_dir: &Path,
+        debug_port: u16,
+        extra_args: &[String],
+    ) -> anyhow::Result<CodexLaunch> {
         assert!(app_dir.ends_with("Codex.app"));
-        self.event(format!("launch:{debug_port}"));
+        if extra_args.is_empty() {
+            self.event(format!("launch:{debug_port}"));
+        } else {
+            self.event(format!("launch:{debug_port}:{}", extra_args.join(",")));
+        }
         if let Some(message) = &self.launch_error {
             anyhow::bail!(message.clone());
         }


### PR DESCRIPTION
## 背景
在部分 Intel 芯片的 macOS 设备或特定系统版本下，Codex App 启动后可能出现异常遮罩层，影响正常使用。实测追加 `--force_high_performance_gpu` 启动参数后可以规避该问题。

考虑到类似兼容性问题后续可能还需要通过其他启动参数处理，因此本次改动没有硬编码某个具体参数，而是提供一个通用的“额外 Codex 启动参数”配置入口。

## 变更摘要
- 在后端设置中新增可配置的 Codex 启动参数字段：`codexExtraArgs`。
- 在设置页面新增文本框，支持每行填写一个额外启动参数。
- 启动 Codex App 时，将用户配置的额外参数追加到默认 CDP 参数之后，覆盖 macOS open、普通可执行文件启动和 Windows packaged activation 场景。

## 截图
### 添加参数前
<img width="730" height="474" alt="image" src="https://github.com/user-attachments/assets/f9d979df-81b5-4a1b-a412-fdd0b6592e10" />

### 添加参数后
<img width="736" height="487" alt="image" src="https://github.com/user-attachments/assets/cd86016e-8973-4ae1-aaad-184adbe0b048" />

## 测试情况
- `volta run --node 22 npm run check`
- `volta run --node 22 npm run vite:build`
- `cargo test -p codex-plus-core extra`
- `cargo test -p codex-plus-core settings`
- `cargo build --release`

