### PR TITLE
修复新建对话服务模式标识显示

### DIFF
--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -4922,6 +4922,24 @@
       });
   }
 
+  function codexServiceTierVisibleComposerFooters() {
+    return Array.from(document.querySelectorAll(".composer-footer"))
+      .filter(codexServiceTierBadgeVisibleElement)
+      .sort((left, right) => {
+        const leftRect = left.getBoundingClientRect();
+        const rightRect = right.getBoundingClientRect();
+        return (rightRect.bottom - leftRect.bottom) || (rightRect.width - leftRect.width);
+      });
+  }
+
+  function codexServiceTierFindComposerEl() {
+    const footer = codexServiceTierVisibleComposerFooters()[0];
+    if (footer) return footer;
+    const threadComposer = conversationViewFindComposerEl();
+    if (threadComposer && codexServiceTierBadgeVisibleElement(threadComposer)) return threadComposer;
+    return null;
+  }
+
   function codexServiceTierBadgeAnchor(composer) {
     const providerNames = codexServiceTierKnownProviderNames();
     const buttons = codexServiceTierBadgeButtonCandidates(composer);
@@ -4935,7 +4953,8 @@
   }
 
   function codexServiceTierComposerFooter(composer) {
-    return composer?.querySelector?.(".composer-footer") || document.querySelector(".composer-footer");
+    if (composer?.matches?.(".composer-footer")) return composer;
+    return composer?.querySelector?.(".composer-footer") || codexServiceTierVisibleComposerFooters()[0] || null;
   }
 
   function codexServiceTierBadgeFooterGroup(composer) {
@@ -4980,7 +4999,7 @@
   }
 
   function installCodexServiceTierBadge() {
-    const composer = conversationViewFindComposerEl();
+    const composer = codexServiceTierFindComposerEl();
     const placement = composer ? codexServiceTierBadgePlacement(composer) : null;
     const existingBadges = Array.from(document.querySelectorAll(`[data-codex-service-tier-badge="true"]`));
     if (!composer || !placement?.parent) {

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -203,6 +203,8 @@ fn injection_script_exposes_fast_service_tier_control() {
     assert!(script.contains("wireCodexServiceTierBadge"));
     assert!(script.contains("codexServiceTierBadgePlacement"));
     assert!(script.contains("codexServiceTierBadgeFooterGroup"));
+    assert!(script.contains("codexServiceTierFindComposerEl"));
+    assert!(script.contains("codexServiceTierVisibleComposerFooters"));
     assert!(script.contains("data-codex-service-tier-badge"));
     assert!(script.contains("codexServiceTierBadgeWired"));
     assert!(script.contains("setAttribute(\"role\", \"button\")"));


### PR DESCRIPTION
## 变更
- 修复新建对话页的 composer footer 不显示服务模式 badge 的问题。
- service tier badge 现在优先从当前可见 `.composer-footer` 定位插入点，已有 thread 页和新建对话页都走同一套 footer 插入逻辑。
- 保留 thread composer finder 作为兜底，不影响对话宽度和 thread scroll 相关逻辑。

## 原因
新建对话页和已有 thread 页视觉上是同一个输入框，但 DOM 外层不完全一致。之前 badge 只从 thread 页特有的 composer class 定位，导致新建对话页找不到 composer 后直接移除 badge。

## 验证
- `node --check assets\inject\renderer-inject.js`
- `cargo fmt --check`
- `cargo test -p codex-plus-core --test cdp_bridge`
- `git diff --check`
- 运行态 CDP smoke：badge 可插入 composer footer，显示当前 effective mode，并保持 clickable button 语义。
- 运行态 fallback smoke：当 thread composer 外层 class 不存在时，仍可从可见 `.composer-footer` 插入 badge。
