### PR TITLE
fix(macos): add Applications link to DMG（增加 MacOs 的 Application 安装链接）

### DIFF
--- a/scripts/installer/macos/package-dmg.sh
+++ b/scripts/installer/macos/package-dmg.sh
@@ -76,9 +76,18 @@ create_app() {
 PLIST
 }
 
+sign_app() {
+  local app_dir="$1"
+  codesign --force --deep --sign - "$app_dir"
+}
+
 prepare_icon
 create_app "Codex++" "CodexPlusPlus" "$BINARY_DIR/codex-plus-plus" "com.bigpizzav3.codexplusplus" "true"
 create_app "Codex++ 管理工具" "CodexPlusPlusManager" "$BINARY_DIR/codex-plus-plus-manager" "com.bigpizzav3.codexplusplus.manager" "false"
+ln -s /Applications "$STAGE/Applications"
+
+sign_app "$STAGE/Codex++.app"
+sign_app "$STAGE/Codex++ 管理工具.app"
 
 hdiutil create -volname "Codex++" -srcfolder "$STAGE" -ov -format UDZO "$DMG"
 echo "$DMG"


### PR DESCRIPTION
## 摘要
- 在 macOS DMG 的 staging 目录中加入标准的 `/Applications` 符号链接，确保 Finder 的拖拽安装可以正常工作。
- 在生成镜像前对两个 app 包执行 ad-hoc 签名，使 bundle 结构与最终生成的 DMG 保持一致。

## 验证
- 已成功重新生成 macOS arm64 DMG。
- 挂载镜像后确认根目录包含 `Applications`、`Codex++.app` 和 `Codex++ 管理工具.app`。
- 已验证两个 app 二进制均为 arm64，且 `hdiutil verify` 通过。