### PR TITLE
fix: preserve rollout file mtime during provider sync

### DIFF
--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -38,6 +38,7 @@ struct SessionChange {
     cwd: Option<String>,
     has_user_event: bool,
     rewrite_needed: bool,
+    original_mtime: Option<SystemTime>,
 }
 
 pub fn run_provider_sync(codex_home: Option<&Path>) -> ProviderSyncResult {
@@ -245,6 +246,7 @@ fn collect_session_changes(
         } else {
             first_line.clone()
         };
+        let original_mtime = fs::metadata(&path).and_then(|m| m.modified()).ok();
         changes.push(SessionChange {
             path,
             original_first_line: first_line,
@@ -254,6 +256,7 @@ fn collect_session_changes(
             cwd,
             has_user_event,
             rewrite_needed,
+            original_mtime,
         });
     }
     Ok(changes)
@@ -370,6 +373,7 @@ fn apply_session_changes(changes: &[SessionChange]) -> anyhow::Result<()> {
             &change.path,
             format!("{}{}", change.next_first_line, change.separator),
         )?;
+        restore_file_mtime(&change.path, change.original_mtime);
     }
     Ok(())
 }
@@ -380,8 +384,16 @@ fn restore_session_changes(changes: &[SessionChange]) -> anyhow::Result<()> {
             &change.path,
             format!("{}{}", change.original_first_line, change.separator),
         )?;
+        restore_file_mtime(&change.path, change.original_mtime);
     }
     Ok(())
+}
+
+fn restore_file_mtime(path: &Path, mtime: Option<SystemTime>) {
+    let Some(mtime) = mtime else { return };
+    let Ok(file) = fs::File::options().write(true).open(path) else { return };
+    let times = std::fs::FileTimes::new().set_modified(mtime);
+    let _ = file.set_times(times);
 }
 
 fn table_columns(db: &Connection, table: &str) -> anyhow::Result<HashSet<String>> {

--- a/crates/codex-plus-data/tests/provider_sync.rs
+++ b/crates/codex-plus-data/tests/provider_sync.rs
@@ -3,6 +3,7 @@ use rusqlite::Connection;
 use serde_json::json;
 use std::fs;
 use std::path::Path;
+use std::time::{Duration, SystemTime};
 use tempfile::tempdir;
 
 fn write_rollout(path: &Path, provider: &str, thread_id: &str, cwd: &str) {
@@ -267,4 +268,41 @@ fn provider_sync_skips_when_home_missing_or_lock_exists_and_prunes_backups() {
         .filter(|entry| entry.as_ref().unwrap().path().is_dir())
         .count();
     assert_eq!(backups, 5);
+}
+
+#[test]
+fn provider_sync_preserves_rollout_mtime() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    fs::create_dir(&home).unwrap();
+    fs::write(
+        home.join("config.toml"),
+        "model_provider = \"apigather\"\n",
+    )
+    .unwrap();
+    let rollout = home.join("sessions/2026/rollout-mtime.jsonl");
+    write_rollout(&rollout, "openai", "thread-1", "C:/workspace");
+
+    let past = SystemTime::now() - Duration::from_secs(86400);
+    let file = fs::File::options().write(true).open(&rollout).unwrap();
+    file.set_times(fs::FileTimes::new().set_modified(past))
+        .unwrap();
+    drop(file);
+
+    let mtime_before = fs::metadata(&rollout).unwrap().modified().unwrap();
+
+    let result = run_provider_sync(Some(&home));
+
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert_eq!(result.changed_session_files, 1);
+
+    let mtime_after = fs::metadata(&rollout).unwrap().modified().unwrap();
+    let drift = mtime_after
+        .duration_since(mtime_before)
+        .or_else(|e| Ok::<_, std::convert::Infallible>(e.duration()))
+        .unwrap();
+    assert!(
+        drift < Duration::from_secs(2),
+        "mtime drifted by {drift:?}, expected < 2s"
+    );
 }


### PR DESCRIPTION
## Summary

- Provider sync rewrites the first line of every rollout file (`model_provider` field) using `fs::write()`, which resets the file's mtime to the current time. This causes all chat sessions to appear as "just now" and destroys the sort order in the Codex UI.
- This PR records the original mtime before rewriting and restores it afterwards using `File::set_times()`, applying to both the forward sync path (`apply_session_changes`) and the rollback path (`restore_session_changes`).
- Adds a regression test `provider_sync_preserves_rollout_mtime` that sets a rollout file's mtime to 24 hours in the past, runs provider sync, and asserts the mtime drift is less than 2 seconds.

Fixes #244

## Test plan

- [x] `cargo test -p codex-plus-data` — all 19 tests pass (6 provider_sync + 11 storage_adapter + 2 markdown)
- [x] `cargo build --release` — builds successfully on macOS arm64
- [x] Local verification: switched provider, confirmed chat session timestamps are preserved

Made with [Cursor](https://cursor.com)