### PR TITLE
feat(relay): add custom User-Agent configuration

### DIFF
--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -135,6 +135,7 @@ type RelayProfile = {
   contextWindow: string;
   autoCompactLimit: string;
   modelList: string;
+  userAgent: string;
 };
 
 type RelayContextSelection = {
@@ -401,6 +402,7 @@ const defaultSettings: BackendSettings = {
       contextWindow: "",
       autoCompactLimit: "",
       modelList: "",
+      userAgent: "",
     },
   ],
   relayCommonConfigContents: "",
@@ -2667,6 +2669,15 @@ function RelayProfileEditor({
             </div>
           </Field>
         ) : null}
+        {showApiFields ? (
+          <Field className="relay-field-user-agent" label="User-Agent">
+            <Input
+              value={profile.userAgent}
+              onChange={(event) => updateDraft({ userAgent: event.currentTarget.value })}
+              placeholder="留空使用默认值"
+            />
+          </Field>
+        ) : null}
       </div>
       {showApiFields && profile.protocol === "chatCompletions" ? (
         <div className="hint-line relay-protocol-hint">
@@ -3879,6 +3890,7 @@ function normalizeSettings(settings: BackendSettings): BackendSettings {
             contextWindow: "",
             autoCompactLimit: "",
             modelList: "",
+            userAgent: "",
           },
         ];
   const activeRelayId = profiles.some((profile) => profile.id === settings.activeRelayId)
@@ -3927,6 +3939,7 @@ function normalizeRelayProfile(profile: RelayProfile, defaultContextSelection = 
     contextWindow: profile.contextWindow || "",
     autoCompactLimit: profile.autoCompactLimit || "",
     modelList: profile.modelList || "",
+    userAgent: profile.userAgent || "",
   };
   if (!normalized.configContents.trim() || !normalized.authContents.trim()) {
     normalized = withGeneratedRelayFiles(normalized);
@@ -4450,6 +4463,7 @@ function createRelayProfile(settings: BackendSettings): RelayProfile {
     contextWindow: "",
     autoCompactLimit: "",
     modelList: "",
+    userAgent: "",
   };
   return withGeneratedRelayFiles(next);
 }

--- a/crates/codex-plus-core/src/ccs_import.rs
+++ b/crates/codex-plus-core/src/ccs_import.rs
@@ -129,8 +129,11 @@ fn set_current_codex_provider_in_settings(path: &Path, source_id: &str) -> anyho
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    fs::write(path, format!("{}\n", serde_json::to_string_pretty(&settings)?))
-        .with_context(|| format!("failed to write cc-switch settings {}", path.display()))?;
+    fs::write(
+        path,
+        format!("{}\n", serde_json::to_string_pretty(&settings)?),
+    )
+    .with_context(|| format!("failed to write cc-switch settings {}", path.display()))?;
     Ok(())
 }
 
@@ -229,6 +232,7 @@ pub fn relay_profile_from_ccs(
         auto_compact_limit: String::new(),
         model_insert_mode: Default::default(),
         model_list: String::new(),
+        user_agent: String::new(),
     }
 }
 

--- a/crates/codex-plus-core/src/http_client.rs
+++ b/crates/codex-plus-core/src/http_client.rs
@@ -1,3 +1,8 @@
 pub fn proxied_client(user_agent: &str) -> anyhow::Result<reqwest::Client> {
-    Ok(reqwest::Client::builder().user_agent(user_agent).build()?)
+    let ua = if user_agent.trim().is_empty() {
+        format!("CodexPlusPlus/{}", env!("CARGO_PKG_VERSION"))
+    } else {
+        user_agent.trim().to_string()
+    };
+    Ok(reqwest::Client::builder().user_agent(ua).build()?)
 }

--- a/crates/codex-plus-core/src/model_catalog.rs
+++ b/crates/codex-plus-core/src/model_catalog.rs
@@ -529,7 +529,7 @@ pub async fn fetch_relay_profile_model_ids(
         anyhow::bail!("Base URL 不能为空");
     }
     let endpoint = models_endpoint(&source.base_url);
-    let client = crate::http_client::proxied_client("CodexPlusPlus/1.0")?;
+    let client = crate::http_client::proxied_client(&profile.user_agent)?;
     let (models, status) = fetch_models_from_source(&client, &source).await;
     if models.is_empty() {
         let message = status

--- a/crates/codex-plus-core/src/protocol_proxy.rs
+++ b/crates/codex-plus-core/src/protocol_proxy.rs
@@ -412,7 +412,8 @@ pub async fn open_responses_proxy_request(body: &str) -> anyhow::Result<Upstream
         .and_then(Value::as_bool)
         .unwrap_or(false);
     let chat_request = responses_to_chat_completions(request_json.clone())?;
-    let upstream = reqwest::Client::new()
+    let client = crate::http_client::proxied_client(&relay.user_agent)?;
+    let upstream = client
         .post(chat_completions_url(&relay.base_url))
         .bearer_auth(relay.api_key.trim())
         .header(reqwest::header::CONTENT_TYPE, "application/json")
@@ -448,7 +449,8 @@ pub async fn open_models_proxy_request() -> anyhow::Result<UpstreamProxyResponse
         anyhow::bail!("Chat Completions 上游 Key 不能为空");
     }
 
-    let upstream = reqwest::Client::new()
+    let client = crate::http_client::proxied_client(&relay.user_agent)?;
+    let upstream = client
         .get(models_url(&relay.base_url))
         .bearer_auth(relay.api_key.trim())
         .send()

--- a/crates/codex-plus-core/src/settings.rs
+++ b/crates/codex-plus-core/src/settings.rs
@@ -75,6 +75,12 @@ pub struct RelayProfile {
     pub model_insert_mode: RelayModelInsertMode,
     #[serde(rename = "modelList", default)]
     pub model_list: String,
+    #[serde(
+        rename = "userAgent",
+        default,
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub user_agent: String,
 }
 
 impl Default for RelayProfile {
@@ -100,6 +106,7 @@ impl Default for RelayProfile {
             auto_compact_limit: String::new(),
             model_insert_mode: RelayModelInsertMode::Patch,
             model_list: String::new(),
+            user_agent: String::new(),
         }
     }
 }
@@ -237,6 +244,7 @@ impl BackendSettings {
                 auto_compact_limit: String::new(),
                 model_insert_mode: RelayModelInsertMode::Patch,
                 model_list: String::new(),
+                user_agent: String::new(),
             };
         }
 
@@ -281,6 +289,7 @@ impl BackendSettings {
             auto_compact_limit: String::new(),
             model_insert_mode: RelayModelInsertMode::Patch,
             model_list: String::new(),
+            user_agent: String::new(),
         }
     }
 }


### PR DESCRIPTION
Allow custom User-Agent header in relay proxy requests. This enables using APIs that restrict access to specific Agent Clients (e.g. 百炼 Coding Plan) by checking UA header.

Users can set custom UA in relay profile to bypass client restrictions. Defaults to CodexPlusPlus/VERSION when empty.