### PR TITLE
fix(cdp): support IPv6 loopback target discovery

### DIFF
--- a/crates/codex-plus-core/src/cdp.rs
+++ b/crates/codex-plus-core/src/cdp.rs
@@ -18,12 +18,31 @@ pub struct CdpTarget {
 }
 
 pub async fn list_targets(debug_port: u16) -> anyhow::Result<Vec<CdpTarget>> {
-    let url = format!("http://127.0.0.1:{debug_port}/json");
     let client = reqwest::Client::builder()
         .no_proxy()
         .timeout(CDP_HTTP_TIMEOUT)
         .build()
         .context("failed to build CDP HTTP client")?;
+
+    let urls = [
+        format!("http://127.0.0.1:{debug_port}/json"),
+        format!("http://[::1]:{debug_port}/json"),
+    ];
+    let mut errors = Vec::new();
+    for url in urls {
+        match query_targets_url(&client, &url).await {
+            Ok(targets) => return Ok(targets),
+            Err(error) => errors.push(format!("{url}: {error:#}")),
+        }
+    }
+
+    bail!(
+        "failed to query CDP targets on loopback addresses: {}",
+        errors.join("; ")
+    )
+}
+
+async fn query_targets_url(client: &reqwest::Client, url: &str) -> anyhow::Result<Vec<CdpTarget>> {
     let response = client
         .get(url)
         .send()

--- a/crates/codex-plus-core/src/install/macos.rs
+++ b/crates/codex-plus-core/src/install/macos.rs
@@ -2,7 +2,6 @@
 use std::fs;
 #[cfg(target_os = "macos")]
 use std::os::unix::fs::PermissionsExt;
-#[cfg(target_os = "macos")]
 use std::path::Path;
 
 use super::{
@@ -31,12 +30,39 @@ pub fn build_app_bundle(options: &InstallOptions, manager: bool) -> MacosAppBund
         },
         binary,
     );
+    let (target, binary_source, binary_target_name) =
+        if is_bundle_executable_target(&target, executable_name) {
+            let sidecar = target
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .join(binary);
+            (sidecar, Some(target), Some(binary.to_string()))
+        } else {
+            (target, None, None)
+        };
     let identifier_suffix = if manager { ".manager" } else { "" };
     MacosAppBundle {
         app_path: install_root.join(format!("{display_name}.app")),
         info_plist: info_plist(display_name, executable_name, identifier_suffix),
         launch_script: format!("#!/bin/sh\nexec \"{}\"\n", target.to_string_lossy()),
+        binary_source,
+        binary_target_name,
     }
+}
+
+fn is_bundle_executable_target(target: &Path, executable_name: &str) -> bool {
+    target.file_name().and_then(|name| name.to_str()) == Some(executable_name)
+        && target
+            .parent()
+            .and_then(|parent| parent.file_name())
+            .and_then(|name| name.to_str())
+            == Some("MacOS")
+        && target
+            .parent()
+            .and_then(|parent| parent.parent())
+            .and_then(|parent| parent.file_name())
+            .and_then(|name| name.to_str())
+            == Some("Contents")
 }
 
 #[cfg(target_os = "macos")]
@@ -76,6 +102,17 @@ fn write_bundle(bundle: &MacosAppBundle) -> anyhow::Result<()> {
     fs::create_dir_all(&macos)?;
     fs::create_dir_all(&resources)?;
     fs::write(contents.join("Info.plist"), &bundle.info_plist)?;
+    if let (Some(source), Some(target_name)) = (&bundle.binary_source, &bundle.binary_target_name) {
+        if source.exists() {
+            let target = macos.join(target_name);
+            if source != &target {
+                fs::copy(source, &target)?;
+                let mut permissions = fs::metadata(&target)?.permissions();
+                permissions.set_mode(0o755);
+                fs::set_permissions(target, permissions)?;
+            }
+        }
+    }
     let executable = macos.join(executable_name_from_plist(&bundle.info_plist));
     fs::write(&executable, &bundle.launch_script)?;
     let mut permissions = fs::metadata(&executable)?.permissions();

--- a/crates/codex-plus-core/src/install/mod.rs
+++ b/crates/codex-plus-core/src/install/mod.rs
@@ -48,6 +48,8 @@ pub struct MacosAppBundle {
     pub app_path: PathBuf,
     pub info_plist: String,
     pub launch_script: String,
+    pub binary_source: Option<PathBuf>,
+    pub binary_target_name: Option<String>,
 }
 
 impl ShortcutState {

--- a/crates/codex-plus-core/src/watcher.rs
+++ b/crates/codex-plus-core/src/watcher.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
-use std::net::{SocketAddr, TcpStream};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream};
 use std::path::{Path, PathBuf};
+#[cfg(windows)]
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
@@ -53,8 +54,12 @@ pub fn disable_watcher() -> std::io::Result<()> {
 }
 
 pub fn cdp_listening(port: u16) -> bool {
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
-    TcpStream::connect_timeout(&addr, Duration::from_millis(500)).is_ok()
+    [
+        SocketAddr::from((Ipv4Addr::LOCALHOST, port)),
+        SocketAddr::from((Ipv6Addr::LOCALHOST, port)),
+    ]
+    .into_iter()
+    .any(|addr| TcpStream::connect_timeout(&addr, Duration::from_millis(500)).is_ok())
 }
 
 pub fn build_spawn_launcher_command(launcher_path: &str, debug_port: u16) -> Vec<String> {

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -1,6 +1,6 @@
 use codex_plus_core::assets;
 use codex_plus_core::bridge::{self, BRIDGE_BINDING_NAME};
-use codex_plus_core::cdp::{CdpTarget, pick_page_target};
+use codex_plus_core::cdp::{CdpTarget, list_targets, pick_page_target};
 use futures_util::{SinkExt, StreamExt};
 use serde_json::json;
 use std::future::Future;
@@ -493,6 +493,46 @@ fn pick_page_target_rejects_non_pages_and_pages_without_websocket() {
             .to_string()
             .contains("No injectable Codex page target found")
     );
+}
+
+#[tokio::test]
+async fn list_targets_can_query_ipv6_loopback_cdp_endpoint() {
+    let listener = TcpListener::bind("[::1]:0")
+        .await
+        .expect("IPv6 loopback listener should bind");
+    let port = listener.local_addr().unwrap().port();
+    let body = serde_json::to_vec(&json!([
+        {
+            "id": "page-1",
+            "type": "page",
+            "title": "Codex",
+            "url": "app://-/index.html",
+            "webSocketDebuggerUrl": format!("ws://[::1]:{port}/devtools/page/page-1"),
+        }
+    ]))
+    .unwrap();
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("request should arrive");
+        let mut request = [0_u8; 1024];
+        let _ = stream.readable().await;
+        let _ = stream.try_read(&mut request);
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        stream
+            .try_write(response.as_bytes())
+            .expect("response headers should write");
+        stream.try_write(&body).expect("response body should write");
+    });
+
+    let targets = list_targets(port)
+        .await
+        .expect("CDP target query should fall back to IPv6 loopback");
+
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].id, "page-1");
+    server.await.expect("server task should complete");
 }
 
 #[tokio::test]

--- a/crates/codex-plus-core/tests/installers.rs
+++ b/crates/codex-plus-core/tests/installers.rs
@@ -95,6 +95,26 @@ fn companion_binary_path_resolves_macos_silent_app_next_to_manager_app() {
 }
 
 #[test]
+fn macos_bundle_does_not_wrap_the_bundle_executable_in_itself() {
+    let options = InstallOptions {
+        install_root: Some("/Applications".into()),
+        launcher_path: Some("/Applications/Codex++.app/Contents/MacOS/CodexPlusPlus".into()),
+        manager_path: Some(
+            "/Applications/Codex++ 管理工具.app/Contents/MacOS/CodexPlusPlusManager".into(),
+        ),
+        remove_owned_data: false,
+    };
+
+    let silent = build_macos_app_bundle(&options, false);
+    let manager = build_macos_app_bundle(&options, true);
+
+    assert!(!silent.launch_script.contains("CodexPlusPlus\""));
+    assert!(!manager.launch_script.contains("CodexPlusPlusManager\""));
+    assert!(silent.launch_script.contains("codex-plus-plus"));
+    assert!(manager.launch_script.contains("codex-plus-plus-manager"));
+}
+
+#[test]
 fn windows_default_install_root_uses_known_folder_before_userprofile_desktop() {
     let strategy = default_install_root_strategy();
 

--- a/crates/codex-plus-core/tests/watcher.rs
+++ b/crates/codex-plus-core/tests/watcher.rs
@@ -14,6 +14,14 @@ fn cdp_listening_returns_true_for_bound_loopback_port() {
 }
 
 #[test]
+fn cdp_listening_returns_true_for_bound_ipv6_loopback_port() {
+    let listener = std::net::TcpListener::bind("[::1]:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    assert!(cdp_listening(port));
+}
+
+#[test]
 fn cdp_listening_returns_false_for_closed_port() {
     let port = {
         let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();


### PR DESCRIPTION
## Summary

This PR hardens Codex++ CDP discovery and macOS entrypoint repair paths that can surface as `failed to query CDP targets`.

Addresses #442.
Related to #239.
Related to #282.

## Background

Several reports mention `failed to query CDP targets`, but they are not all on the same platform or environment:

- #442 reports a macOS Apple Silicon case where Codex / Chromium listens on `[::1]:9229`, while Codex++ only tries `127.0.0.1:9229`.
- #239 reports `failed to query CDP targets` on Windows with debug port `9229`.
- #282 reports the same visible error on Windows after changing ports.

Because #239 and #282 may have different root causes, this PR intentionally references them as related issues rather than using auto-closing keywords for those reports.

## Changes

- Try both IPv4 and IPv6 loopback URLs when querying CDP targets:
  - `http://127.0.0.1:{port}/json`
  - `http://[::1]:{port}/json`
- Update the watcher CDP probe to treat either IPv4 or IPv6 loopback listeners as available.
- Prevent macOS entrypoint repair from generating a wrapper that points back to the app bundle executable itself, which can leave the installed app unable to launch the real Codex++ binary.
- Add regression tests for:
  - IPv6-only CDP target querying
  - IPv6 CDP listening detection
  - macOS entrypoint self-wrapper prevention

## Verification

Passed:

```bash
ASDF_RUST_VERSION=stable cargo test -p codex-plus-core --test cdp_bridge list_targets_can_query_ipv6_loopback_cdp_endpoint -- --nocapture
ASDF_RUST_VERSION=stable cargo test -p codex-plus-core --test watcher --test installers
```

Notes:

`ASDF_RUST_VERSION=stable cargo test -p codex-plus-core --test cdp_bridge` currently has an unrelated upstream-main failure in `injection_script_loads_backend_settings_before_initial_scan`, which still expects the old script string `if (attempt < 60)`. The new IPv6 CDP regression test passes.
