### PR TITLE
[codex] 为 token 统计插件补充 thread usage history bridge

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -336,6 +336,13 @@ impl BridgeDataService for LauncherDataService {
             .map_err(|error| anyhow::anyhow!("export markdown task failed: {error}"))
     }
 
+    async fn thread_usage_history(&self, session: SessionRef) -> anyhow::Result<Value> {
+        let adapter = self.storage_adapter();
+        tokio::task::spawn_blocking(move || adapter.codex_thread_usage_history(&session))
+            .await
+            .map_err(|error| anyhow::anyhow!("thread usage history task failed: {error}"))
+    }
+
     async fn find_archived_thread_by_title(
         &self,
         title: String,

--- a/crates/codex-plus-core/src/routes.rs
+++ b/crates/codex-plus-core/src/routes.rs
@@ -79,6 +79,7 @@ pub trait BridgeDataService: Send + Sync {
     async fn delete(&self, session: SessionRef) -> anyhow::Result<DeleteResult>;
     async fn undo(&self, undo_token: String) -> anyhow::Result<DeleteResult>;
     async fn export_markdown(&self, session: SessionRef) -> anyhow::Result<ExportResult>;
+    async fn thread_usage_history(&self, session: SessionRef) -> anyhow::Result<Value>;
     async fn find_archived_thread_by_title(
         &self,
         title: String,
@@ -179,6 +180,11 @@ pub async fn handle_bridge_request(
                 .export_markdown(session_from_payload(&payload))
                 .await,
         ),
+        "/thread-usage-history" => {
+            ctx.data
+                .thread_usage_history(session_from_payload(&payload))
+                .await
+        }
         "/archived-thread" => {
             let title = payload
                 .get("title")
@@ -474,6 +480,15 @@ impl BridgeDataService for UnavailableDataService {
             filename: None,
             markdown: None,
         })
+    }
+
+    async fn thread_usage_history(&self, session: SessionRef) -> anyhow::Result<Value> {
+        Ok(json!({
+            "status": "failed",
+            "session_id": session.session_id,
+            "message": "Thread usage history service is not wired in core launcher hooks",
+            "history": []
+        }))
     }
 
     async fn find_archived_thread_by_title(

--- a/crates/codex-plus-core/tests/bridge_routes.rs
+++ b/crates/codex-plus-core/tests/bridge_routes.rs
@@ -65,6 +65,10 @@ async fn bridge_routes_cover_all_current_paths() {
             "/export-markdown",
             json!({"session_id": "s1", "title": "First"}),
         ),
+        (
+            "/thread-usage-history",
+            json!({"session_id": "s1", "title": "First"}),
+        ),
         ("/archived-thread", json!({"title": "Archived"})),
         (
             "/move-thread-workspace",
@@ -301,6 +305,37 @@ async fn data_routes_forward_payloads_to_data_service() {
         )
         .await["filename"],
         "First.md"
+    );
+    assert_eq!(
+        handle_bridge_request(
+            ctx.clone(),
+            "/thread-usage-history",
+            json!({"session_id": "s1", "title": "First"}),
+        )
+        .await,
+        json!({
+            "status": "ok",
+            "session_id": "s1",
+            "history": [
+                {
+                    "source": "rollout-history",
+                    "conversation_id": "local:s1",
+                    "turn_id": "turn-1",
+                    "observed_at": "2026-06-02T05:00:00Z",
+                    "usage": {
+                        "inputTokens": 1200,
+                        "outputTokens": 120,
+                        "totalTokens": 1320,
+                        "cachedTokens": 900,
+                        "cacheReadTokens": 0,
+                        "cacheCreationTokens": 0,
+                        "contextUsed": 1320,
+                        "contextLimit": 258400,
+                        "hasBreakdown": true
+                    }
+                }
+            ]
+        })
     );
     assert_eq!(
         handle_bridge_request(
@@ -1046,6 +1081,32 @@ impl BridgeDataService for FakeData {
             filename: Some("First.md".to_string()),
             markdown: Some("# First\n".to_string()),
         })
+    }
+
+    async fn thread_usage_history(&self, session: SessionRef) -> anyhow::Result<Value> {
+        Ok(json!({
+            "status": "ok",
+            "session_id": session.session_id,
+            "history": [
+                {
+                    "source": "rollout-history",
+                    "conversation_id": "local:s1",
+                    "turn_id": "turn-1",
+                    "observed_at": "2026-06-02T05:00:00Z",
+                    "usage": {
+                        "inputTokens": 1200,
+                        "outputTokens": 120,
+                        "totalTokens": 1320,
+                        "cachedTokens": 900,
+                        "cacheReadTokens": 0,
+                        "cacheCreationTokens": 0,
+                        "contextUsed": 1320,
+                        "contextLimit": 258400,
+                        "hasBreakdown": true
+                    }
+                }
+            ]
+        }))
     }
 
     async fn find_archived_thread_by_title(

--- a/crates/codex-plus-data/src/storage.rs
+++ b/crates/codex-plus-data/src/storage.rs
@@ -1,10 +1,12 @@
 use crate::BackupStore;
 use codex_plus_core::models::{DeleteResult, DeleteStatus, SessionRef};
 use rusqlite::types::{ToSqlOutput, Value as SqlValue, ValueRef};
-use rusqlite::{Connection, ToSql};
+use rusqlite::{Connection, OptionalExtension, ToSql};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use std::collections::HashSet;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -339,6 +341,68 @@ impl SQLiteStorageAdapter {
         )
     }
 
+    pub fn codex_thread_usage_history(&self, session: &SessionRef) -> serde_json::Value {
+        if !self.db_path.exists() {
+            return json!({
+                "status": "failed",
+                "session_id": session.session_id,
+                "message": format!("Database not found: {}", self.db_path.to_string_lossy()),
+                "history": []
+            });
+        }
+        let result = (|| -> anyhow::Result<Value> {
+            let db = Connection::open(&self.db_path)?;
+            if schema_kind(&db)? != Some(SchemaKind::CodexThreads)
+                || !has_columns(&db, "threads", &["rollout_path"])?
+            {
+                return Ok(json!({
+                    "status": "failed",
+                    "session_id": session.session_id,
+                    "message": "Unsupported local storage schema",
+                    "history": []
+                }));
+            }
+            let thread_id = normalize_codex_thread_id(&session.session_id);
+            let rollout_path: Option<String> = db.query_row(
+                "SELECT rollout_path FROM threads WHERE id = ?1",
+                [&thread_id],
+                |row| row.get(0),
+            ).optional()?;
+            let Some(rollout_path) = rollout_path.filter(|path| !path.trim().is_empty()) else {
+                return Ok(json!({
+                    "status": "failed",
+                    "session_id": thread_id,
+                    "message": "Thread rollout path is empty",
+                    "history": []
+                }));
+            };
+            let rollout = PathBuf::from(&rollout_path);
+            if !rollout.is_file() {
+                return Ok(json!({
+                    "status": "failed",
+                    "session_id": thread_id,
+                    "message": format!("rollout file not found: {rollout_path}"),
+                    "history": []
+                }));
+            }
+            let history = read_rollout_usage_history(&rollout, &thread_id)?;
+            Ok(json!({
+                "status": "ok",
+                "session_id": thread_id,
+                "rollout_path": rollout_path,
+                "history": history,
+            }))
+        })();
+        result.unwrap_or_else(|err| {
+            json!({
+                "status": "failed",
+                "session_id": session.session_id,
+                "message": err.to_string(),
+                "history": []
+            })
+        })
+    }
+
     fn delete_generic_session(
         &self,
         db: &mut Connection,
@@ -538,6 +602,100 @@ fn local_deleted(session_id: &str, token: &str, backup_path: &Path) -> DeleteRes
         undo_token: Some(token.to_string()),
         backup_path: Some(backup_path.to_string_lossy().to_string()),
     }
+}
+
+fn read_rollout_usage_history(
+    rollout_path: &Path,
+    thread_id: &str,
+) -> anyhow::Result<Vec<Value>> {
+    let file = File::open(rollout_path)?;
+    let reader = BufReader::new(file);
+    let mut current_turn_id = String::new();
+    let mut history = Vec::new();
+
+    for line in reader.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: Value = match serde_json::from_str(&line) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        match value.get("type").and_then(Value::as_str).unwrap_or_default() {
+            "turn_context" => {
+                current_turn_id = value
+                    .get("payload")
+                    .and_then(|payload| payload.get("turn_id"))
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+            }
+            "event_msg" => {
+                let payload = match value.get("payload") {
+                    Some(payload) if payload.get("type").and_then(Value::as_str) == Some("token_count") => payload,
+                    _ => continue,
+                };
+                let info = match payload.get("info") {
+                    Some(info) => info,
+                    None => continue,
+                };
+                let last = info.get("last_token_usage");
+                let total = info.get("total_token_usage");
+                let model_context_window = info
+                    .get("model_context_window")
+                    .and_then(Value::as_i64)
+                    .unwrap_or(0);
+                let input_tokens = last
+                    .and_then(|usage| usage.get("input_tokens"))
+                    .and_then(Value::as_i64)
+                    .unwrap_or(0);
+                let output_tokens = last
+                    .and_then(|usage| usage.get("output_tokens"))
+                    .and_then(Value::as_i64)
+                    .unwrap_or(0);
+                let total_tokens = last
+                    .and_then(|usage| usage.get("total_tokens"))
+                    .and_then(Value::as_i64)
+                    .unwrap_or_else(|| {
+                        total.and_then(|usage| usage.get("total_tokens"))
+                            .and_then(Value::as_i64)
+                            .unwrap_or(0)
+                    });
+                let cached_tokens = last
+                    .and_then(|usage| usage.get("cached_input_tokens"))
+                    .and_then(Value::as_i64)
+                    .unwrap_or(0);
+                let context_used = total
+                    .and_then(|usage| usage.get("total_tokens"))
+                    .and_then(Value::as_i64)
+                    .unwrap_or(total_tokens);
+                if input_tokens <= 0 && output_tokens <= 0 && total_tokens <= 0 && context_used <= 0 {
+                    continue;
+                }
+                history.push(json!({
+                    "source": "rollout-history",
+                    "conversation_id": format!("local:{thread_id}"),
+                    "turn_id": current_turn_id,
+                    "observed_at": value.get("timestamp").and_then(Value::as_str).unwrap_or_default(),
+                    "usage": {
+                        "inputTokens": input_tokens,
+                        "outputTokens": output_tokens,
+                        "totalTokens": total_tokens,
+                        "cachedTokens": cached_tokens,
+                        "cacheReadTokens": 0,
+                        "cacheCreationTokens": 0,
+                        "contextUsed": context_used,
+                        "contextLimit": model_context_window,
+                        "hasBreakdown": input_tokens > 0 || output_tokens > 0 || cached_tokens > 0,
+                    }
+                }));
+            }
+            _ => {}
+        }
+    }
+
+    Ok(history)
 }
 
 fn failed_with_undo(

--- a/crates/codex-plus-data/tests/storage_adapter.rs
+++ b/crates/codex-plus-data/tests/storage_adapter.rs
@@ -578,4 +578,79 @@ fn archived_lookup_workspace_move_and_sort_keys_match_expected_shape() {
             ]
         })
     );
+
+    assert_eq!(
+        adapter.codex_thread_usage_history(&session("local:t1", "Codex Thread")),
+        json!({
+            "status": "ok",
+            "session_id": "t1",
+            "rollout_path": rollout_path.to_string_lossy().to_string(),
+            "history": []
+        })
+    );
+}
+
+#[test]
+fn thread_usage_history_reads_rollout_token_count_events() {
+    let tmp = tempdir().unwrap();
+    let db_path = tmp.path().join("state_5.sqlite");
+    let rollout_path = tmp.path().join("rollout.jsonl");
+    fs::write(
+        &rollout_path,
+        concat!(
+            "{\"type\":\"turn_context\",\"payload\":{\"turn_id\":\"turn-1\"}}\n",
+            "{\"timestamp\":\"2026-06-02T05:00:00Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":5000,\"cached_input_tokens\":1500,\"output_tokens\":500,\"total_tokens\":5500},\"last_token_usage\":{\"input_tokens\":1200,\"cached_input_tokens\":900,\"output_tokens\":120,\"total_tokens\":1320},\"model_context_window\":258400}}}\n",
+            "{\"timestamp\":\"2026-06-02T05:00:01Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"ignore\"}}\n",
+            "{\"type\":\"turn_context\",\"payload\":{\"turn_id\":\"turn-2\"}}\n",
+            "{\"timestamp\":\"2026-06-02T05:01:00Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":7000,\"cached_input_tokens\":2500,\"output_tokens\":750,\"total_tokens\":7750},\"last_token_usage\":{\"input_tokens\":2000,\"cached_input_tokens\":1200,\"output_tokens\":250,\"total_tokens\":2250},\"model_context_window\":258400}}}\n"
+        ),
+    )
+    .unwrap();
+    create_codex_thread_db(&db_path, &rollout_path);
+    let adapter = SQLiteStorageAdapter::new(&db_path, BackupStore::new(tmp.path().join("backups")));
+
+    assert_eq!(
+        adapter.codex_thread_usage_history(&session("local:t1", "Codex Thread")),
+        json!({
+            "status": "ok",
+            "session_id": "t1",
+            "rollout_path": rollout_path.to_string_lossy().to_string(),
+            "history": [
+                {
+                    "source": "rollout-history",
+                    "conversation_id": "local:t1",
+                    "turn_id": "turn-1",
+                    "observed_at": "2026-06-02T05:00:00Z",
+                    "usage": {
+                        "inputTokens": 1200,
+                        "outputTokens": 120,
+                        "totalTokens": 1320,
+                        "cachedTokens": 900,
+                        "cacheReadTokens": 0,
+                        "cacheCreationTokens": 0,
+                        "contextUsed": 5500,
+                        "contextLimit": 258400,
+                        "hasBreakdown": true
+                    }
+                },
+                {
+                    "source": "rollout-history",
+                    "conversation_id": "local:t1",
+                    "turn_id": "turn-2",
+                    "observed_at": "2026-06-02T05:01:00Z",
+                    "usage": {
+                        "inputTokens": 2000,
+                        "outputTokens": 250,
+                        "totalTokens": 2250,
+                        "cachedTokens": 1200,
+                        "cacheReadTokens": 0,
+                        "cacheCreationTokens": 0,
+                        "contextUsed": 7750,
+                        "contextLimit": 258400,
+                        "hasBreakdown": true
+                    }
+                }
+            ]
+        })
+    );
 }

--- a/docs/release/20260602191421483_token统计历史恢复bridge发布说明.md
+++ b/docs/release/20260602191421483_token统计历史恢复bridge发布说明.md
@@ -1,0 +1,37 @@
+# Token 统计历史恢复 Bridge 发布说明
+
+生成时间：2026-06-02 19:14
+
+## 变更摘要
+
+本次为 `Codex Token Usage` 插件补齐宿主侧历史恢复能力，解决“程序重启后本地无缓存时，插件无法从历史对话恢复每轮调用统计”的问题。
+
+## 主要改动
+
+1. 在 `BridgeDataService` 增加 `thread_usage_history` 路由能力。
+2. 在 `LauncherDataService` 接入本地线程历史读取。
+3. 在 `SQLiteStorageAdapter` 中新增 `codex_thread_usage_history`：
+   - 按线程 `rollout_path` 读取本地 `rollout-*.jsonl`
+   - 解析 `turn_context.turn_id`
+   - 解析 `event_msg.token_count.info.last_token_usage`
+   - 同时保留 `total_token_usage.total_tokens` 作为 `contextUsed`
+4. 补充 bridge 路由测试与 rollout 历史解析测试。
+
+## 生效效果
+
+- 插件在无 `sessionStorage`、无页面内存账本时，仍可向宿主请求当前会话历史调用记录。
+- 历史恢复结果可按：
+  - 同项目不同会话隔离
+  - 同会话不同轮次隔离
+  - 只显示当前会话最新一轮
+
+## 验证结果
+
+已通过：
+
+- `cargo test -p codex-plus-core bridge_routes --manifest-path Cargo.toml`
+- `cargo test -p codex-plus-data storage_adapter --manifest-path Cargo.toml`
+
+## 注意事项
+
+该能力是 `Codex Token Usage 0.1.6` 的配套宿主支持。若仅更新脚本市场仓、未更新 `CodexPlusPlus`，则“重启后按历史恢复统计”不会完整生效。


### PR DESCRIPTION
## 背景

Codex Token Usage 插件在应用重启后，如果本地缓存不存在，就无法恢复当前会话最近一轮的 token 调用统计。插件侧已经完成账本聚合与恢复逻辑，但宿主侧此前没有提供一个稳定的历史 usage 读取入口。

## 根因

历史 token 调用信息真实存在于 Codex rollout 文件中，但缺少一条可供 user script 安全访问的 bridge 路由。结果就是：

- 插件能做实时聚合；
- 但在重启后，拿不到历史 per-call usage；
- 最终只能显示空值或残留缓存值。

## 本次修改

### 1. 数据层新增 thread usage history 读取能力
- 在 `codex-plus-data` 中新增 `codex_thread_usage_history(&SessionRef)`。
- 读取 `threads.rollout_path` 指向的 rollout jsonl。
- 解析 `turn_context` 与 `event_msg.type == token_count`。
- 提取 `last_token_usage` 作为单次调用 usage。
- 提取累计 `total_token_usage.total_tokens` 作为 `contextUsed`。

### 2. Core bridge 新增路由
- 新增 `/thread-usage-history`。
- 将请求透传到 data service，返回当前 thread 的历史 usage 明细。

### 3. Launcher bridge 接线
- 在 launcher data service 中补齐 `thread_usage_history(...)`，让 user script 可以通过 bridge 访问历史账本源数据。

## 验证

已执行：

- `cargo test -p codex-plus-core bridge_routes --manifest-path /Users/albertluo/workSpace/albertLuo/createSomethingNew/CodexPlusPlus/Cargo.toml`
- `cargo test -p codex-plus-data thread_usage_history_reads_rollout_token_count_events --manifest-path /Users/albertluo/workSpace/albertLuo/createSomethingNew/CodexPlusPlus/Cargo.toml`

以上测试均通过。当前仍有仓库既有 warning（Windows uninstall/proxy dead code），与本次改动无关。

## 影响

配合插件市场侧的 0.1.6 脚本版本，应用重启后即使缓存为空，也可以从历史 rollout 中重建当前会话最近一轮的调用统计。
