### PR TITLE
fix: correct AUMID generation for Windows Store Codex + fallback to direct execution

### DIFF
--- a/crates/codex-plus-core/src/app_paths.rs
+++ b/crates/codex-plus-core/src/app_paths.rs
@@ -191,12 +191,10 @@ pub fn packaged_app_user_model_id(app_dir: &Path) -> Option<String> {
     if !package_name.starts_with("OpenAI.Codex_") || !package_name.contains("__") {
         return None;
     }
-    let identity_name = package_name.split_once('_')?.0;
-    let publisher_id = package_name.rsplit_once("__")?.1;
-    if publisher_id.is_empty() {
-        return None;
-    }
-    Some(format!("{identity_name}_{publisher_id}!App"))
+    // FIX: MSIX 包的 AUMID 格式就是 PackageFullName!App
+    // 之前错误地只取了 identity_name + publisher_id，丢失了版本号部分
+    // 例如：OpenAI.Codex_26.601.2237.0_x64__2p2nqsd0c76g0!App
+    Some(format!("{}!App", package_name))
 }
 
 fn package_name_from_app_dir(app_dir: &Path) -> Option<String> {

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -457,19 +457,28 @@ impl LaunchHooks for DefaultLaunchHooks {
                 else {
                     unreachable!();
                 };
-                let process_id = activate_packaged_app(app_user_model_id, arguments).await?;
-                return Ok(match activation {
-                    CodexLaunch::PackagedActivation {
-                        app_user_model_id,
-                        arguments,
-                        ..
-                    } => CodexLaunch::PackagedActivation {
-                        app_user_model_id,
-                        arguments,
-                        process_id: Some(process_id),
-                    },
-                    CodexLaunch::Process { .. } => unreachable!(),
-                });
+                match activate_packaged_app(app_user_model_id, arguments).await {
+                    Ok(process_id) => return Ok(match activation {
+                        CodexLaunch::PackagedActivation {
+                            app_user_model_id,
+                            arguments,
+                            ..
+                        } => CodexLaunch::PackagedActivation {
+                            app_user_model_id,
+                            arguments,
+                            process_id: Some(process_id),
+                        },
+                        CodexLaunch::Process { .. } => unreachable!(),
+                    }),
+                    Err(e) => {
+                        // FIX: AUMID 激活失败时回退到直接执行 Codex.exe
+                        // 适用于 Windows Store / MSIX 包版本
+                        eprintln!(
+                            "[WARN] Packaged activation failed for AUMID {}: {}, falling back to direct execution",
+                            app_user_model_id, e
+                        );
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes the bug where CodexPlusPlus cannot launch the Windows Store / MSIX version of Codex due to incorrect AUMID generation.

## Problem

The  function in  incorrectly generates the AUMID by splitting the package name and only keeping the identity prefix and publisher ID, losing the version and architecture parts.

| | Value |
|---|---|
| package_name |  |
| Before (wrong) |  |
| After (correct) |  |

## Changes

### 1. 

Use full  instead of reconstructing from parts:



### 2. 

Add fallback to direct  execution when AUMID activation fails:



## Verification

| Check | Result |
|---|---|
| Codex processes | ✅ 9 processes running |
| CDP port 9229 | ✅ Available |
| CDP bridge | ✅  |
| Injected script | ✅ Loaded |
|  | ✅  |

## Related

- Closes #590
