### PR TITLE
Reapply thread storage fixes for 1.2.1

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -616,6 +616,12 @@ async fn try_inject_with_context(
 }
 
 fn default_codex_db_path() -> PathBuf {
+    if let Some(codex_home) = std::env::var_os("CODEX_HOME") {
+        let path = PathBuf::from(codex_home);
+        if !path.as_os_str().is_empty() {
+            return path.join("state_5.sqlite");
+        }
+    }
     directories::BaseDirs::new()
         .map(|dirs| dirs.home_dir().to_path_buf())
         .unwrap_or_else(|| PathBuf::from("."))
@@ -717,6 +723,24 @@ mod tests {
 
         assert_eq!(options.debug_port, LaunchOptions::default().debug_port);
         assert_eq!(options.helper_port, LaunchOptions::default().helper_port);
+    }
+
+    #[test]
+    fn default_codex_db_path_uses_codex_home() {
+        let previous = std::env::var_os("CODEX_HOME");
+        let profile_home = PathBuf::from("D:/Codex/CodexSwitcher/profiles/example/.codex");
+        unsafe {
+            std::env::set_var("CODEX_HOME", &profile_home);
+        }
+
+        assert_eq!(default_codex_db_path(), profile_home.join("state_5.sqlite"));
+
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var("CODEX_HOME", value),
+                None => std::env::remove_var("CODEX_HOME"),
+            }
+        }
     }
 
     #[test]

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -5761,6 +5761,17 @@
     }
   }
 
+  function isThreadMissingResult(result) {
+    const message = String(result?.message || "");
+    return result?.status === "failed" && message.includes("Thread not found in local storage");
+  }
+
+  async function removeOrphanedProjectedRow(row, button, ref) {
+    await setProjectlessThreadIds(ref, "remove").catch(() => {});
+    await clearThreadWorkspaceHints(ref).catch(() => {});
+    removeDeletedRow(row, button, ref);
+  }
+
   function updateDeleteButtonOffsets() {
     sessionRows().forEach((row) => {
       const hasArchiveConfirm = Array.from(row.querySelectorAll("button")).some((button) => {
@@ -5786,6 +5797,9 @@
       if (result.status === "server_deleted" || result.status === "local_deleted") {
         removeDeletedRow(row, button, ref);
         showToast(result.message || "删除成功", result.undo_token);
+      } else if (isThreadMissingResult(result)) {
+        await removeOrphanedProjectedRow(row, button, ref);
+        showToast("已移除本地列表中的失效会话", null);
       } else {
         showToast(result.message || "删除失败", null);
       }

--- a/crates/codex-plus-core/tests/assets.rs
+++ b/crates/codex-plus-core/tests/assets.rs
@@ -1,0 +1,11 @@
+#[test]
+fn renderer_removes_orphaned_projected_rows_when_thread_is_missing() {
+    let script = codex_plus_core::assets::renderer_script();
+
+    assert!(script.contains("function isThreadMissingResult"));
+    assert!(script.contains("Thread not found in local storage"));
+    assert!(script.contains("function removeOrphanedProjectedRow"));
+    assert!(script.contains("setProjectlessThreadIds(ref, \"remove\")"));
+    assert!(script.contains("clearThreadWorkspaceHints(ref)"));
+    assert!(script.contains("已移除本地列表中的失效会话"));
+}


### PR DESCRIPTION
## Summary

Reapplies the thread storage fixes on top of the current Rust/Tauri 1.2.1 codebase.

- Respect `CODEX_HOME` when resolving the Codex local SQLite database path.
- Remove stale projected/sidebar thread rows when deletion reports `Thread not found in local storage`.
- Add an asset-level regression test so the injected renderer cleanup remains present.

## Why

Profile/history merge workflows can leave sidebar rows pointing at stale projected thread IDs. The delete flow then reports `Thread not found in local storage` and leaves the row visible. Users running with a switched `CODEX_HOME` can also hit the wrong local storage database if the launcher falls back to the default home path.

## Validation

- `cargo test -p codex-plus-core --test assets`
- `npm run check`
- `cargo build --release -p codex-plus-launcher`
- `npm run vite:build`
- `npm run build`
- Installed patched 1.2.1 binaries locally and verified `codex-plus-plus.exe` stayed running after launch smoke test.
