### PR TITLE
fix(relay): preserve live Codex UI settings / 保留 Codex UI 设置

### DIFF
--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -370,13 +370,32 @@ pub fn apply_relay_profile_to_home_with_switch_rules(
         &profile.context_window,
         &profile.auto_compact_limit,
     )?;
+    let config_with_preserved_live =
+        preserve_live_common_config_for_switch(home, &config_with_limits)?;
 
     if profile.relay_mode == crate::settings::RelayMode::PureApi {
-        apply_relay_files_to_home(home, &config_with_limits, &profile.auth_contents)
+        apply_relay_files_to_home(home, &config_with_preserved_live, &profile.auth_contents)
     } else {
         let auth_contents = official_profile_auth_for_switch(home, &profile.auth_contents)?;
-        apply_relay_files_to_home(home, &config_with_limits, &auth_contents)
+        apply_relay_files_to_home(home, &config_with_preserved_live, &auth_contents)
     }
+}
+
+fn preserve_live_common_config_for_switch(
+    home: &Path,
+    config_contents: &str,
+) -> anyhow::Result<String> {
+    let live_config = read_optional_text(&home.join("config.toml"))?;
+    if live_config.trim().is_empty() {
+        return Ok(config_contents.to_string());
+    }
+
+    let live_common = extract_common_config_from_config(&live_config)?;
+    if live_common.trim().is_empty() {
+        return Ok(config_contents.to_string());
+    }
+
+    merge_common_config_into_config(config_contents, &live_common)
 }
 
 pub fn apply_relay_profile_config_to_home_with_context(

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -2062,6 +2062,95 @@ requires_openai_auth = true
 }
 
 #[test]
+fn apply_relay_profile_to_home_with_switch_rules_preserves_live_ui_settings() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("config.toml"),
+        r##"model_provider = "legacy"
+model = "gpt-5.4"
+personality = "pragmatic"
+
+[desktop]
+appearanceLightCodeThemeId = "raycast"
+accentColor = "#ff6363"
+
+[mcp_servers.codegraph]
+type = "stdio"
+command = "codegraph"
+
+[model_providers.legacy]
+name = "legacy"
+base_url = "https://legacy.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"##,
+    )
+    .unwrap();
+    let profile = RelayProfile {
+        id: "relay-a".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model_provider = "max_ai"
+model = "gpt-5.5"
+personality = "friendly"
+
+[model_providers.max_ai]
+name = "max_ai"
+base_url = "https://max.example/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_to_home_with_switch_rules(temp.path(), &profile, "").unwrap();
+
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    let parsed: toml::Value = toml::from_str(&config).unwrap();
+    assert_eq!(
+        parsed
+            .get("model_provider")
+            .and_then(|value| value.as_str()),
+        Some("max_ai"),
+        "provider-specific routing should still come from the active relay profile"
+    );
+    assert_eq!(
+        parsed.get("personality").and_then(|value| value.as_str()),
+        Some("pragmatic"),
+        "live Codex UI personality should survive relay profile writes"
+    );
+    assert_eq!(
+        parsed
+            .get("desktop")
+            .and_then(|value| value.get("appearanceLightCodeThemeId"))
+            .and_then(|value| value.as_str()),
+        Some("raycast"),
+        "live Codex desktop theme should survive relay profile writes"
+    );
+    assert!(
+        parsed
+            .get("mcp_servers")
+            .and_then(|value| value.get("codegraph"))
+            .is_some(),
+        "live Codex MCP entries should survive relay profile writes"
+    );
+    assert_eq!(
+        parsed
+            .get("model_providers")
+            .and_then(|value| value.get("max_ai"))
+            .and_then(|value| value.get("base_url"))
+            .and_then(|value| value.as_str()),
+        Some("https://max.example/v1"),
+        "provider-specific endpoint should come from the active relay profile"
+    );
+    assert!(
+        !config.contains("[model_providers.legacy]"),
+        "previous provider table should not be preserved as common config"
+    );
+}
+
+#[test]
 fn apply_relay_profile_to_home_with_switch_rules_writes_provider_even_when_auth_has_no_api_key() {
     let temp = tempfile::tempdir().unwrap();
     let profile = RelayProfile {


### PR DESCRIPTION
## Summary / 摘要

- 在 apply active relay profile 前读取现有 live `config.toml`
- 提取非 provider 的 live settings，并合并进生成后的 relay config
- provider-specific routing 仍然由 active relay profile 控制
- 新增 regression test，覆盖 `personality`、`[desktop]`、`[mcp_servers]`，同时确认 endpoint 仍来自 active relay profile

## Root Cause / 根因

CodexPlusPlus apply relay profile 时会把生成后的 relay config 写回 `~/.codex/config.toml`。

如果 relay profile snapshot 已经过期，而用户后来直接在 Codex 里改了主题、personality 或 MCP，那么下一次 profile apply 就可能把这些 live UI settings 重置掉。

这次修复的边界是：relay/profile-owned provider routing 继续生效，但不属于 provider 的 live Codex settings 会被保留。

## Verification / 验证

已通过：

- `git diff --check`

本地受限 / Blocked locally:

- `cargo test -p codex-plus-core apply_relay_profile_to_home_with_switch_rules_preserves_live_ui_settings` 被 Windows 本机缺少 MSVC `link.exe` 阻塞
