### PR TITLE
feat: support launching multiple Codex++ instances

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -36,7 +36,8 @@ impl Default for LauncherHooks {
 #[tokio::main]
 async fn main() -> Result<()> {
     let options = parse_launch_options(std::env::args().skip(1));
-    let Some(_guard) = acquire_single_instance_guard(options.debug_port)? else {
+    let Some(_guard) = acquire_single_instance_guard(options.debug_port, options.guard_port)?
+    else {
         activate_existing_codex_app(&options).await?;
         return Ok(());
     };
@@ -49,40 +50,37 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn acquire_single_instance_guard(debug_port: u16) -> anyhow::Result<Option<std::net::TcpListener>> {
-    acquire_single_instance_guard_with_retry(debug_port, true)
+fn acquire_single_instance_guard(
+    debug_port: u16,
+    guard_port: u16,
+) -> anyhow::Result<Option<std::net::TcpListener>> {
+    acquire_single_instance_guard_with_retry(debug_port, guard_port, true)
 }
 
 fn acquire_single_instance_guard_with_retry(
     debug_port: u16,
+    guard_port: u16,
     allow_stale_recovery: bool,
 ) -> anyhow::Result<Option<std::net::TcpListener>> {
-    match try_acquire_single_instance_guard() {
+    match try_acquire_single_instance_guard(guard_port) {
         Ok(listener) => Ok(Some(listener)),
         Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {
-            log_launcher_already_running(debug_port);
+            log_launcher_already_running(debug_port, guard_port);
             if allow_stale_recovery && should_recover_stale_launcher(debug_port) {
                 codex_plus_core::watcher::stop_launcher_processes();
                 std::thread::sleep(std::time::Duration::from_millis(250));
-                return acquire_single_instance_guard_with_retry(debug_port, false);
+                return acquire_single_instance_guard_with_retry(debug_port, guard_port, false);
             }
             Ok(None)
         }
         Err(error) => Err(error)
-            .with_context(|| {
-                format!(
-                    "failed to acquire launcher guard port {}",
-                    codex_plus_core::ports::LAUNCHER_GUARD_PORT
-                )
-            })
+            .with_context(|| format!("failed to acquire launcher guard port {guard_port}"))
             .map(Some),
     }
 }
 
-fn try_acquire_single_instance_guard() -> std::io::Result<std::net::TcpListener> {
-    codex_plus_core::ports::acquire_loopback_port_guard(
-        codex_plus_core::ports::LAUNCHER_GUARD_PORT,
-    )
+fn try_acquire_single_instance_guard(guard_port: u16) -> std::io::Result<std::net::TcpListener> {
+    codex_plus_core::ports::acquire_loopback_port_guard(guard_port)
 }
 
 fn should_recover_stale_launcher(debug_port: u16) -> bool {
@@ -113,7 +111,10 @@ async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<
         hooks.start_helper(options.helper_port).await?;
     }
     let process_ids = codex_plus_core::watcher::find_codex_processes();
+    #[cfg(windows)]
     let mut activated = false;
+    #[cfg(not(windows))]
+    let activated = false;
     #[cfg(windows)]
     {
         for process_id in &process_ids {
@@ -154,11 +155,11 @@ async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<
     launch_result.map(|_| ())
 }
 
-fn log_launcher_already_running(debug_port: u16) {
+fn log_launcher_already_running(debug_port: u16, guard_port: u16) {
     let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
         "launcher.already_running",
         json!({
-            "guard_port": codex_plus_core::ports::LAUNCHER_GUARD_PORT,
+            "guard_port": guard_port,
             "debug_port": debug_port
         }),
     );
@@ -216,6 +217,21 @@ where
                 if let Some(value) = iter.next() {
                     if let Ok(port) = value.as_ref().parse::<u16>() {
                         options.helper_port = port;
+                    }
+                }
+            }
+            "--guard-port" => {
+                if let Some(value) = iter.next() {
+                    if let Ok(port) = value.as_ref().parse::<u16>() {
+                        options.guard_port = port;
+                    }
+                }
+            }
+            "--codex-arg" => {
+                if let Some(value) = iter.next() {
+                    let value = value.as_ref().trim();
+                    if !value.is_empty() {
+                        options.codex_extra_args.push(value.to_string());
                     }
                 }
             }
@@ -282,6 +298,7 @@ impl LaunchHooks for LauncherHooks {
         app_dir: &Path,
     ) -> anyhow::Result<Option<BridgeContext>> {
         self.runtime.set_debug_port(debug_port);
+        self.runtime.set_app_dir(app_dir);
         Ok(Some(BridgeContext::core_with_data_and_app_dir(
             self.runtime.clone(),
             self.data.clone(),
@@ -417,6 +434,7 @@ impl LauncherDataService {
 
 struct LauncherRuntimeService {
     debug_port: Mutex<u16>,
+    app_dir: Mutex<Option<PathBuf>>,
     websocket_url: Mutex<Option<String>>,
     user_scripts: UserScriptManager,
 }
@@ -425,6 +443,7 @@ impl LauncherRuntimeService {
     fn new(debug_port: u16, user_scripts: UserScriptManager) -> Self {
         Self {
             debug_port: Mutex::new(debug_port),
+            app_dir: Mutex::new(None),
             websocket_url: Mutex::new(None),
             user_scripts,
         }
@@ -432,6 +451,10 @@ impl LauncherRuntimeService {
 
     fn set_debug_port(&self, debug_port: u16) {
         *self.debug_port.lock().unwrap() = debug_port;
+    }
+
+    fn set_app_dir(&self, app_dir: &Path) {
+        *self.app_dir.lock().unwrap() = Some(app_dir.to_path_buf());
     }
 
     fn set_websocket_url(&self, websocket_url: &str) {
@@ -500,6 +523,59 @@ impl BridgeRuntimeService for LauncherRuntimeService {
         Ok(json!({
             "status": "ok",
             "path": manager_path.to_string_lossy()
+        }))
+    }
+
+    async fn launch_new_instance(&self, _payload: Value) -> anyhow::Result<Value> {
+        let current_debug_port = *self.debug_port.lock().unwrap();
+        let app_dir = self.app_dir.lock().unwrap().clone();
+        let next = next_instance_ports(current_debug_port)?;
+        let profile_dir = codex_plus_instance_profile_dir(next.index);
+        std::fs::create_dir_all(&profile_dir)
+            .map_err(|error| anyhow::anyhow!("创建 Codex++ 实例 profile 失败：{error}"))?;
+
+        let launcher_path = std::env::current_exe()
+            .map_err(|error| anyhow::anyhow!("定位 Codex++ launcher 失败：{error}"))?;
+        let mut command = std::process::Command::new(&launcher_path);
+        if let Some(app_dir) = app_dir.as_deref() {
+            command.arg("--app-path").arg(app_dir);
+        }
+        command
+            .arg("--debug-port")
+            .arg(next.debug_port.to_string())
+            .arg("--helper-port")
+            .arg(next.helper_port.to_string())
+            .arg("--guard-port")
+            .arg(next.guard_port.to_string())
+            .arg("--codex-arg")
+            .arg(format!("--user-data-dir={}", profile_dir.to_string_lossy()));
+        #[cfg(windows)]
+        {
+            command.creation_flags(codex_plus_core::windows_create_no_window());
+        }
+        let child = command
+            .spawn()
+            .map_err(|error| anyhow::anyhow!("启动新的 Codex++ 实例失败：{error}"))?;
+        let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+            "launcher.new_instance_spawned",
+            json!({
+                "index": next.index,
+                "debug_port": next.debug_port,
+                "helper_port": next.helper_port,
+                "guard_port": next.guard_port,
+                "profile_dir": profile_dir.to_string_lossy(),
+                "pid": child.id()
+            }),
+        );
+        Ok(json!({
+            "status": "ok",
+            "message": format!("已启动 Codex++ ctx{}", next.index),
+            "index": next.index,
+            "debug_port": next.debug_port,
+            "helper_port": next.helper_port,
+            "guard_port": next.guard_port,
+            "profile_dir": profile_dir.to_string_lossy(),
+            "pid": child.id()
         }))
     }
 
@@ -696,6 +772,52 @@ fn default_user_scripts_config_dir() -> PathBuf {
         .join("Codex++")
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct InstancePorts {
+    index: u16,
+    debug_port: u16,
+    guard_port: u16,
+    helper_port: u16,
+}
+
+fn next_instance_ports(current_debug_port: u16) -> anyhow::Result<InstancePorts> {
+    for index in 2..=60 {
+        let ports = instance_ports(index);
+        if ports.debug_port == current_debug_port {
+            continue;
+        }
+        if !codex_plus_core::ports::can_bind_loopback_port(ports.debug_port) {
+            continue;
+        }
+        if !codex_plus_core::ports::can_bind_loopback_port(ports.guard_port) {
+            continue;
+        }
+        if !codex_plus_core::ports::can_bind_loopback_port(ports.helper_port) {
+            continue;
+        }
+        return Ok(ports);
+    }
+    anyhow::bail!("没有找到可用的 Codex++ 实例端口")
+}
+
+fn instance_ports(index: u16) -> InstancePorts {
+    let offset = index - 2;
+    InstancePorts {
+        index,
+        debug_port: 9230 + offset,
+        guard_port: 57322 + offset * 2,
+        helper_port: 57323 + offset * 2,
+    }
+}
+
+fn codex_plus_instance_profile_dir(index: u16) -> PathBuf {
+    directories::BaseDirs::new()
+        .map(|dirs| dirs.home_dir().join(".codex-plusplus"))
+        .unwrap_or_else(|| PathBuf::from(".codex-plusplus"))
+        .join("profiles")
+        .join(format!("ctx{index}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -709,27 +831,47 @@ mod tests {
             "9333",
             "--helper-port",
             "57322",
+            "--guard-port",
+            "57324",
+            "--codex-arg",
+            "--user-data-dir=/tmp/codex-ctx2",
         ]);
 
         assert_eq!(options.app_dir, Some(PathBuf::from("C:/Codex/App")));
         assert_eq!(options.debug_port, 9333);
         assert_eq!(options.helper_port, 57322);
+        assert_eq!(options.guard_port, 57324);
+        assert_eq!(
+            options.codex_extra_args,
+            vec!["--user-data-dir=/tmp/codex-ctx2".to_string()]
+        );
     }
 
     #[test]
     fn parse_launch_options_ignores_invalid_ports() {
-        let options = parse_launch_options(["--debug-port", "nope", "--helper-port", "70000"]);
+        let options = parse_launch_options([
+            "--debug-port",
+            "nope",
+            "--helper-port",
+            "70000",
+            "--guard-port",
+            "70000",
+        ]);
 
         assert_eq!(options.debug_port, LaunchOptions::default().debug_port);
         assert_eq!(options.helper_port, LaunchOptions::default().helper_port);
+        assert_eq!(options.guard_port, LaunchOptions::default().guard_port);
     }
 
     #[test]
     fn launcher_uses_single_instance_guard_before_launching() {
         let source = include_str!("main.rs");
 
-        assert!(source.contains("acquire_single_instance_guard(options.debug_port)?"));
-        assert!(source.contains("LAUNCHER_GUARD_PORT"));
+        assert!(
+            source
+                .contains("acquire_single_instance_guard(options.debug_port, options.guard_port)?")
+        );
+        assert!(source.contains("guard_port"));
         assert!(source.contains("launcher.already_running"));
     }
 
@@ -741,8 +883,33 @@ mod tests {
             "async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<()> {\n    let hooks = LauncherHooks::default();"
         ));
         assert!(source.contains("hooks.start_helper(options.helper_port).await?"));
-        assert!(source.contains("hooks.ensure_injection(options.debug_port, options.helper_port).await"));
+        assert!(
+            source
+                .contains("hooks.ensure_injection(options.debug_port, options.helper_port).await")
+        );
         assert!(source.contains("injection_ready"));
+    }
+
+    #[test]
+    fn instance_ports_use_stable_codex_plus_groups() {
+        assert_eq!(
+            instance_ports(2),
+            InstancePorts {
+                index: 2,
+                debug_port: 9230,
+                guard_port: 57322,
+                helper_port: 57323,
+            }
+        );
+        assert_eq!(
+            instance_ports(3),
+            InstancePorts {
+                index: 3,
+                debug_port: 9231,
+                guard_port: 57324,
+                helper_port: 57325,
+            }
+        );
     }
 
     #[test]

--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -193,6 +193,10 @@ pub struct LaunchRequest {
     pub debug_port: u16,
     #[serde(default = "default_helper_port")]
     pub helper_port: u16,
+    #[serde(default = "default_guard_port")]
+    pub guard_port: u16,
+    #[serde(default)]
+    pub codex_extra_args: Vec<String>,
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -333,11 +337,16 @@ pub fn restart_codex_plus(request: LaunchRequest) -> CommandResult<Value> {
 fn spawn_codex_plus_launch(request: LaunchRequest, accepted_message: &str) -> CommandResult<Value> {
     let debug_port = request.debug_port;
     let helper_port = request.helper_port;
+    let guard_port = request.guard_port;
+    let codex_extra_args =
+        codex_plus_core::settings::normalize_codex_extra_args(&request.codex_extra_args);
     let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
         "manager.launch_requested",
         json!({
             "debug_port": debug_port,
             "helper_port": helper_port,
+            "guard_port": guard_port,
+            "codex_extra_args_count": codex_extra_args.len(),
             "app_path": request.app_path.trim()
         }),
     );
@@ -347,14 +356,18 @@ fn spawn_codex_plus_launch(request: LaunchRequest, accepted_message: &str) -> Co
             message: accepted_message.to_string(),
             payload: json!({
                 "debugPort": debug_port,
-                "helperPort": helper_port
+                "helperPort": helper_port,
+                "guardPort": guard_port,
+                "codexExtraArgsCount": codex_extra_args.len()
             }),
         },
         Err(error) => failed(
             &format!("启动静默入口失败：{error}"),
             json!({
                 "debugPort": debug_port,
-                "helperPort": helper_port
+                "helperPort": helper_port,
+                "guardPort": guard_port,
+                "codexExtraArgsCount": codex_extra_args.len()
             }),
         ),
     }
@@ -370,7 +383,12 @@ fn spawn_silent_launcher(request: &LaunchRequest) -> anyhow::Result<()> {
         .arg("--debug-port")
         .arg(request.debug_port.to_string())
         .arg("--helper-port")
-        .arg(request.helper_port.to_string());
+        .arg(request.helper_port.to_string())
+        .arg("--guard-port")
+        .arg(request.guard_port.to_string());
+    for arg in codex_plus_core::settings::normalize_codex_extra_args(&request.codex_extra_args) {
+        command.arg("--codex-arg").arg(arg);
+    }
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
@@ -624,8 +642,10 @@ fn normalize_settings_before_save(mut settings: BackendSettings) -> BackendSetti
         normalize_provider_sync_provider_list(settings.provider_sync_saved_providers);
     settings.provider_sync_manual_providers =
         normalize_provider_sync_provider_list(settings.provider_sync_manual_providers);
-    settings.provider_sync_last_selected_provider =
-        settings.provider_sync_last_selected_provider.trim().to_string();
+    settings.provider_sync_last_selected_provider = settings
+        .provider_sync_last_selected_provider
+        .trim()
+        .to_string();
     settings
 }
 
@@ -813,11 +833,10 @@ fn ensure_text_newline(value: &str) -> String {
 #[tauri::command]
 pub async fn load_provider_sync_targets() -> CommandResult<Value> {
     let settings = SettingsStore::default().load().unwrap_or_default();
-    let result = tauri::async_runtime::spawn_blocking(|| {
-        codex_plus_data::load_provider_sync_targets(None)
-    })
-    .await
-    .map_err(|error| anyhow::anyhow!("provider target discovery task failed: {error}"));
+    let result =
+        tauri::async_runtime::spawn_blocking(|| codex_plus_data::load_provider_sync_targets(None))
+            .await
+            .map_err(|error| anyhow::anyhow!("provider target discovery task failed: {error}"));
     match result {
         Ok(mut targets) => {
             let manual = settings
@@ -896,7 +915,9 @@ pub async fn sync_providers_now(target_provider: Option<String>) -> CommandResul
         Ok(sync) => {
             if is_success_sync_status(&sync.status) {
                 persist_provider_sync_selection(
-                    target_for_settings.as_deref().unwrap_or(&sync.target_provider),
+                    target_for_settings
+                        .as_deref()
+                        .unwrap_or(&sync.target_provider),
                 );
             }
             ok(
@@ -2372,6 +2393,10 @@ fn default_debug_port() -> u16 {
 
 fn default_helper_port() -> u16 {
     57321
+}
+
+fn default_guard_port() -> u16 {
+    codex_plus_core::ports::LAUNCHER_GUARD_PORT
 }
 
 fn default_log_lines() -> usize {

--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -551,6 +551,8 @@ export function App() {
     appPath: "",
     debugPort: "9229",
     helperPort: "57321",
+    guardPort: "57320",
+    codexExtraArgs: "",
   });
   const [settingsForm, setSettingsForm] = useState<BackendSettings>({ ...defaultSettings });
   const [providerSyncProgress, setProviderSyncProgress] = useState<ProviderSyncProgress>({
@@ -781,6 +783,8 @@ export function App() {
           appPath: launchForm.appPath,
           debugPort: numberOrDefault(launchForm.debugPort, 9229),
           helperPort: numberOrDefault(launchForm.helperPort, 57321),
+          guardPort: numberOrDefault(launchForm.guardPort, 57320),
+          codexExtraArgs: inputToCodexExtraArgs(launchForm.codexExtraArgs),
         },
       }),
     );
@@ -2179,8 +2183,14 @@ function MaintenanceScreen({
   overview: OverviewResult | null;
   watcher: WatcherResult | null;
   settings: SettingsResult | null;
-  launchForm: { appPath: string; debugPort: string; helperPort: string };
-  onLaunchFormChange: (next: { appPath: string; debugPort: string; helperPort: string }) => void;
+  launchForm: { appPath: string; debugPort: string; helperPort: string; guardPort: string; codexExtraArgs: string };
+  onLaunchFormChange: (next: {
+    appPath: string;
+    debugPort: string;
+    helperPort: string;
+    guardPort: string;
+    codexExtraArgs: string;
+  }) => void;
   removeOwnedData: boolean;
   onRemoveOwnedDataChange: (value: boolean) => void;
   actions: Actions;
@@ -2273,7 +2283,20 @@ function MaintenanceScreen({
                 onChange={(event) => onLaunchFormChange({ ...launchForm, helperPort: event.currentTarget.value })}
               />
             </Field>
+            <Field label="Guard 端口">
+              <Input
+                value={launchForm.guardPort}
+                onChange={(event) => onLaunchFormChange({ ...launchForm, guardPort: event.currentTarget.value })}
+              />
+            </Field>
           </div>
+          <Field label="本次 Codex 参数">
+            <Textarea
+              value={launchForm.codexExtraArgs}
+              onChange={(event) => onLaunchFormChange({ ...launchForm, codexExtraArgs: event.currentTarget.value })}
+              placeholder="每行一个参数，例如 --user-data-dir=/Users/ruler/Library/Application Support/Codex++ Instances/ctx2"
+            />
+          </Field>
           <Toolbar>
             <Button onClick={() => void actions.launch()}>启动 Codex++</Button>
             <Button variant="secondary" onClick={() => void actions.saveManualCodexAppPath()}>

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -1083,6 +1083,7 @@
     effectiveServiceTier: null,
     effectiveMode: "standard",
   };
+  let codexPlusNewInstanceInFlight = false;
   const codexDefaultServiceTierSetting = { key: "default-service-tier", default: null };
   const codexServiceTierFallbackFastValue = "priority";
   const codexServiceTierModulePromises = new Map();
@@ -1678,6 +1679,24 @@
     }
   }
 
+  async function launchCodexPlusNewInstance(source = "manual") {
+    if (codexPlusNewInstanceInFlight) return;
+    codexPlusNewInstanceInFlight = true;
+    showToast("正在启动新的 Codex++ 窗口…", null);
+    try {
+      const result = await postJson("/launcher/new-instance", { source });
+      if (result?.status === "ok") {
+        showToast(result.message || "已启动新的 Codex++ 窗口", null);
+      } else {
+        showToast(result?.message || "启动新的 Codex++ 窗口失败", null);
+      }
+    } catch (error) {
+      showToast(`启动新的 Codex++ 窗口失败：${error?.message || error}`, null);
+    } finally {
+      codexPlusNewInstanceInFlight = false;
+    }
+  }
+
   function refreshCodexPlusBackendToggles() {
     document.querySelectorAll(".codex-plus-toggle[data-codex-backend-setting]").forEach((button) => {
       const key = button.getAttribute("data-codex-backend-setting");
@@ -2040,6 +2059,10 @@
               <button type="button" class="codex-plus-action-button" data-codex-open-manager="true">打开管理工具</button>
             </div>
             <div class="codex-plus-row">
+              <div><div class="codex-plus-row-title">新建 Codex++ 窗口</div><div class="codex-plus-row-description">使用独立 profile、端口和 launcher 启动新的 Codex，并自动连接 Codex++；快捷键 Command+Shift+N。</div></div>
+              <button type="button" class="codex-plus-action-button" data-codex-launch-new-instance="true">新建窗口</button>
+            </div>
+            <div class="codex-plus-row">
               <div><div class="codex-plus-row-title">原生菜单栏位置</div><div class="codex-plus-row-description">把 Codex++ 菜单插入顶部原生菜单栏；默认关闭以避免页面重渲染冲突。</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="nativeMenuPlacement"><span></span></button>
             </div>
@@ -2137,6 +2160,10 @@
       }
       if (target?.closest("[data-codex-open-manager]")) {
         openManagerFromCodex();
+        return;
+      }
+      if (target?.closest("[data-codex-launch-new-instance]")) {
+        launchCodexPlusNewInstance("menu");
         return;
       }
       if (target?.closest("[data-codex-plus-discord]")) {
@@ -7103,6 +7130,30 @@
 
   window.__codexPlusConversationViewCleanup = cleanupConversationView;
 
+  function codexPlusNewInstanceShortcutIgnored(event) {
+    const target = event?.target instanceof Element ? event.target : null;
+    if (!target) return false;
+    if (target.closest("input, textarea, select")) return true;
+    return !!target.closest("[contenteditable='true'], [role='textbox']");
+  }
+
+  function installCodexPlusNewInstanceShortcut() {
+    if (window.__codexPlusNewInstanceShortcutInstalled === "1") return;
+    if (window.__codexPlusNewInstanceShortcutHandler) {
+      document.removeEventListener("keydown", window.__codexPlusNewInstanceShortcutHandler, true);
+    }
+    window.__codexPlusNewInstanceShortcutHandler = (event) => {
+      if (!(event.metaKey && event.shiftKey && !event.ctrlKey && !event.altKey)) return;
+      if (String(event.key || "").toLowerCase() !== "n") return;
+      if (codexPlusNewInstanceShortcutIgnored(event)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      launchCodexPlusNewInstance("shortcut");
+    };
+    document.addEventListener("keydown", window.__codexPlusNewInstanceShortcutHandler, true);
+    window.__codexPlusNewInstanceShortcutInstalled = "1";
+  }
+
   function ensureConversationViewRuntime() {
     if (conversationViewState.ro && conversationViewState.mo && conversationViewState.pollId) return;
     conversationViewState.ro = conversationViewState.ro || new ResizeObserver(() => scheduleConversationViewAlign());
@@ -7132,6 +7183,7 @@
     installStyle();
     installCodexServiceTierDispatcherPatch();
     installCodexPlusMenu();
+    installCodexPlusNewInstanceShortcut();
     scheduleBackendHeartbeat();
     installDeleteButtonEventDelegation();
     updateThreadScrollHandlers();

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -65,6 +65,8 @@ pub struct LaunchOptions {
     pub app_dir: Option<PathBuf>,
     pub debug_port: u16,
     pub helper_port: u16,
+    pub guard_port: u16,
+    pub codex_extra_args: Vec<String>,
     pub status_store: StatusStore,
 }
 
@@ -74,6 +76,8 @@ impl Default for LaunchOptions {
             app_dir: None,
             debug_port: 9229,
             helper_port: 57321,
+            guard_port: crate::ports::LAUNCHER_GUARD_PORT,
+            codex_extra_args: Vec::new(),
             status_store: StatusStore::default(),
         }
     }
@@ -220,6 +224,9 @@ where
     let debug_port = hooks.select_debug_port(options.debug_port);
     let mut helper_port = hooks.select_helper_port(options.helper_port);
     let settings = hooks.load_settings().await?;
+    let mut codex_extra_args = settings.codex_extra_args.clone();
+    codex_extra_args.extend(options.codex_extra_args.clone());
+    codex_extra_args = normalize_codex_extra_args(&codex_extra_args);
     let app_dir = hooks.resolve_app_dir(options.app_dir.as_deref(), &settings)?;
     let status_store = options.status_store.clone();
     let mut helper_started = false;
@@ -240,14 +247,16 @@ where
         }
 
         let launch = hooks
-            .launch_codex(&app_dir, debug_port, &settings.codex_extra_args)
+            .launch_codex(&app_dir, debug_port, &codex_extra_args)
             .await?;
         launched = Some(launch.clone());
         keep_launched_on_error = true;
 
         let mut injection_degraded = false;
         if settings.enhancements_enabled {
-            let injection_ready = hooks.ensure_injection(debug_port, helper_port, &app_dir).await;
+            let injection_ready = hooks
+                .ensure_injection(debug_port, helper_port, &app_dir)
+                .await;
             if injection_ready {
                 keep_launched_on_error = false;
                 hooks.start_bridge_watchdog(debug_port, helper_port).await?;
@@ -1294,15 +1303,24 @@ pub fn build_macos_open_command(
     debug_port: u16,
     extra_args: &[String],
 ) -> Vec<String> {
-    let mut command = vec![
-        "open".to_string(),
-        "-W".to_string(),
+    let mut command = vec!["open".to_string(), "-W".to_string()];
+    if has_user_data_dir_arg(extra_args) {
+        command.push("-n".to_string());
+    }
+    command.extend([
         "-a".to_string(),
         app_dir.to_string_lossy().to_string(),
         "--args".to_string(),
-    ];
+    ]);
     command.extend(build_codex_arguments(debug_port, extra_args));
     command
+}
+
+fn has_user_data_dir_arg(extra_args: &[String]) -> bool {
+    extra_args.iter().any(|arg| {
+        let trimmed = arg.trim();
+        trimmed == "--user-data-dir" || trimmed.starts_with("--user-data-dir=")
+    })
 }
 
 pub fn build_macos_cleanup_command(

--- a/crates/codex-plus-core/src/routes.rs
+++ b/crates/codex-plus-core/src/routes.rs
@@ -76,6 +76,9 @@ pub trait BridgeRuntimeService: Send + Sync {
     async fn reload_user_scripts(&self) -> anyhow::Result<Value>;
     async fn open_devtools(&self) -> anyhow::Result<Value>;
     async fn open_manager(&self) -> anyhow::Result<Value>;
+    async fn launch_new_instance(&self, _payload: Value) -> anyhow::Result<Value> {
+        anyhow::bail!("New Codex++ instance launch is not wired in core launcher hooks")
+    }
     async fn backend_status(&self) -> anyhow::Result<Value>;
     async fn repair_backend(&self) -> anyhow::Result<Value>;
     async fn codex_model_catalog(&self) -> anyhow::Result<Value>;
@@ -127,7 +130,9 @@ pub async fn handle_bridge_request(
     );
     let result = match path {
         "/settings/get" => settings_value(&ctx, ctx.settings.get_settings().await).await,
-        "/settings/set" => settings_value(&ctx, ctx.settings.set_settings(payload.clone()).await).await,
+        "/settings/set" => {
+            settings_value(&ctx, ctx.settings.set_settings(payload.clone()).await).await
+        }
         "/user-scripts/list" => ctx.runtime.user_script_inventory().await,
         "/user-scripts/set-enabled" => {
             let enabled = payload
@@ -159,6 +164,7 @@ pub async fn handle_bridge_request(
         "/user-scripts/reload" => ctx.runtime.reload_user_scripts().await,
         "/devtools/open" => ctx.runtime.open_devtools().await,
         "/manager/open" => ctx.runtime.open_manager().await,
+        "/launcher/new-instance" => ctx.runtime.launch_new_instance(payload.clone()).await,
         "/backend/status" => ctx.runtime.backend_status().await,
         "/backend/repair" => ctx.runtime.repair_backend().await,
         "/codex-model-catalog" | "/codex-config-model" => ctx.runtime.codex_model_catalog().await,
@@ -585,10 +591,16 @@ fn spawn_manager(manager_path: &Path) -> anyhow::Result<()> {
         .map_err(|error| anyhow::anyhow!("启动管理工具失败：{error}"))
 }
 
-fn settings_payload_value(settings: BackendSettings, codex_app_version: String) -> anyhow::Result<Value> {
+fn settings_payload_value(
+    settings: BackendSettings,
+    codex_app_version: String,
+) -> anyhow::Result<Value> {
     let mut value = serde_json::to_value(settings)?;
     if let Some(object) = value.as_object_mut() {
-        object.insert("codexAppVersion".to_string(), Value::String(codex_app_version));
+        object.insert(
+            "codexAppVersion".to_string(),
+            Value::String(codex_app_version),
+        );
     }
     Ok(value)
 }

--- a/crates/codex-plus-core/tests/bridge_routes.rs
+++ b/crates/codex-plus-core/tests/bridge_routes.rs
@@ -854,6 +854,7 @@ async fn launch_lifecycle_uses_hook_supplied_bridge_context_for_injection() {
             debug_port: 9229,
             helper_port: 57321,
             status_store: StatusStore::new(temp.path().join("latest-status.json")),
+            ..LaunchOptions::default()
         },
         &hooks,
     )

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -320,6 +320,16 @@ fn launcher_macos_open_command_appends_extra_codex_arguments_after_args() {
 }
 
 #[test]
+fn launcher_macos_open_command_uses_new_instance_for_user_data_dir() {
+    let extra_args = vec!["--user-data-dir=/tmp/codex-ctx2".to_string()];
+    let command = build_macos_open_command(Path::new("/Applications/Codex.app"), 9230, &extra_args);
+
+    assert!(command.contains(&"-n".to_string()));
+    assert!(command.contains(&"--remote-debugging-port=9230".to_string()));
+    assert!(command.contains(&"--user-data-dir=/tmp/codex-ctx2".to_string()));
+}
+
+#[test]
 fn ports_windows_falls_back_to_ephemeral_when_requested_is_busy() {
     let selected = select_platform_loopback_port_with(9229, true, |_| false, || 43001);
 
@@ -427,6 +437,7 @@ async fn launch_lifecycle_runs_sync_before_launch_writes_success_and_shutdowns_o
             debug_port: 9229,
             helper_port: 57321,
             status_store,
+            ..LaunchOptions::default()
         },
         &hooks,
     )
@@ -479,6 +490,7 @@ async fn launch_lifecycle_passes_configured_extra_args_to_codex_launch() {
             debug_port: 9229,
             helper_port: 57321,
             status_store,
+            ..LaunchOptions::default()
         },
         &hooks,
     )
@@ -492,6 +504,38 @@ async fn launch_lifecycle_passes_configured_extra_args_to_codex_launch() {
             .unwrap()
             .contains(&"launch:9229:--force_high_performance_gpu".to_string())
     );
+}
+
+#[tokio::test]
+async fn launch_lifecycle_merges_per_launch_extra_args_to_codex_launch() {
+    let temp = tempfile::tempdir().unwrap();
+    let app_dir = temp.path().join("Codex.app");
+    std::fs::create_dir_all(&app_dir).unwrap();
+    let status_store = StatusStore::new(temp.path().join("latest-status.json"));
+    let events = Arc::new(Mutex::new(Vec::<String>::new()));
+    let hooks = FakeHooks::new(events.clone()).with_settings(BackendSettings {
+        codex_extra_args: vec!["--force_high_performance_gpu".to_string()],
+        ..BackendSettings::default()
+    });
+
+    let handle = launch_and_inject_with_hooks(
+        LaunchOptions {
+            app_dir: Some(app_dir),
+            debug_port: 9230,
+            helper_port: 57323,
+            codex_extra_args: vec!["--user-data-dir=/tmp/codex-ctx2".to_string()],
+            status_store,
+            ..LaunchOptions::default()
+        },
+        &hooks,
+    )
+    .await
+    .unwrap();
+    handle.wait_for_codex_exit().await.unwrap();
+
+    assert!(events.lock().unwrap().contains(
+        &"launch:9230:--force_high_performance_gpu,--user-data-dir=/tmp/codex-ctx2".to_string()
+    ));
 }
 
 #[tokio::test]
@@ -512,6 +556,7 @@ async fn launch_lifecycle_keeps_js_injection_in_relay_mode() {
             debug_port: 9229,
             helper_port: 57321,
             status_store,
+            ..LaunchOptions::default()
         },
         &hooks,
     )
@@ -553,6 +598,7 @@ async fn launch_lifecycle_skips_helper_and_injection_when_enhancements_disabled(
             debug_port: 9229,
             helper_port: 57321,
             status_store,
+            ..LaunchOptions::default()
         },
         &hooks,
     )
@@ -588,6 +634,7 @@ async fn launch_lifecycle_does_not_apply_active_relay_profile_before_starting_co
             debug_port: 9229,
             helper_port: 57321,
             status_store,
+            ..LaunchOptions::default()
         },
         &hooks,
     )
@@ -618,6 +665,7 @@ async fn launch_lifecycle_skips_active_relay_profile_when_supplier_config_disabl
             debug_port: 9229,
             helper_port: 57321,
             status_store,
+            ..LaunchOptions::default()
         },
         &hooks,
     )
@@ -669,6 +717,7 @@ experimental_bearer_token = "sk-test"
             debug_port: 9229,
             helper_port: 57321,
             status_store,
+            ..LaunchOptions::default()
         },
         &hooks,
     )
@@ -696,6 +745,7 @@ async fn launch_lifecycle_enters_degraded_mode_and_retries_when_injection_fails(
             debug_port: 9229,
             helper_port: 57321,
             status_store: status_store.clone(),
+            ..LaunchOptions::default()
         },
         &hooks,
     )
@@ -740,6 +790,7 @@ async fn launch_lifecycle_cleans_helper_when_launch_fails_after_helper_started()
             debug_port: 9229,
             helper_port: 57321,
             status_store: status_store.clone(),
+            ..LaunchOptions::default()
         },
         &hooks,
     )
@@ -804,6 +855,7 @@ async fn launch_starts_helper_when_chat_protocol_proxy_is_enabled() {
             debug_port: 9229,
             helper_port: 58000,
             status_store,
+            ..LaunchOptions::default()
         },
         &hooks,
     )
@@ -847,6 +899,7 @@ async fn launch_lifecycle_cleans_helper_and_codex_when_status_save_fails() {
             debug_port: 9229,
             helper_port: 57321,
             status_store,
+            ..LaunchOptions::default()
         },
         &hooks,
     )
@@ -891,6 +944,7 @@ async fn launch_lifecycle_keeps_packaged_process_id_running_and_retries_when_inj
             debug_port: 9229,
             helper_port: 57321,
             status_store,
+            ..LaunchOptions::default()
         },
         &hooks,
     )
@@ -1086,7 +1140,7 @@ impl LaunchHooks for FakeHooks {
         Ok(())
     }
 
-    async fn ensure_injection(&self, debug_port: u16, helper_port: u16) -> bool {
+    async fn ensure_injection(&self, debug_port: u16, helper_port: u16, _app_dir: &Path) -> bool {
         self.event(format!("inject:{debug_port}:{helper_port}"));
         self.inject_error.is_none()
     }


### PR DESCRIPTION
## Summary

This PR adds first-class support for opening additional Codex++ managed Codex windows from an existing injected Codex++ session.

The current launcher uses fixed debug/helper/guard ports and the default Codex user data directory, so opening another Codex window usually activates the existing instance instead of creating an independent Codex++ connected session. This change gives follow-up instances their own port group and `--user-data-dir`, while keeping the original default launch behavior unchanged.

## Changes

- Add per-launch `guard_port` and `codex_extra_args` support to `LaunchOptions` and the launcher CLI.
- Use `open -n` on macOS when a `--user-data-dir` argument is present so a separate Codex app instance is created.
- Add a bridge route, `/launcher/new-instance`, that spawns the current Codex++ launcher with the next available port group.
- Allocate stable Codex++ instance groups:
  - ctx2: debug `9230`, guard `57322`, helper `57323`
  - ctx3: debug `9231`, guard `57324`, helper `57325`
  - and so on, skipping groups whose ports are already occupied.
- Store additional Codex instance profiles under `~/.codex-plusplus/profiles/ctxN`.
- Add a Codex++ menu action and `Command+Shift+N` shortcut to launch a new Codex++ window.
- Expose guard port and per-launch Codex args in the manager launch form for manual testing/debugging.

## Testing

```bash
cargo +1.88.0 test -p codex-plus-launcher
cargo +1.88.0 test -p codex-plus-core --test cdp_bridge --test bridge_routes --test launcher
npm run check
```

Notes:

- `cargo fmt --check` currently reports unrelated formatting changes in existing files outside this PR. To keep this PR focused, I formatted only the Rust files touched by this change using `rustfmt +1.88.0 --edition 2024`.
- Tests pass on macOS arm64. Existing warnings remain in `codex-plus-core` for unused Windows install/proxy helpers.
