### PR TITLE
修复 Windows 单实例端口异常占用导致无法启动

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,6 +358,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "directories",
+ "fs2",
  "futures-util",
  "reqwest 0.12.28",
  "rusqlite",
@@ -957,6 +958,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -49,16 +49,27 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-fn acquire_single_instance_guard(debug_port: u16) -> anyhow::Result<Option<std::net::TcpListener>> {
+fn acquire_single_instance_guard(
+    debug_port: u16,
+) -> anyhow::Result<Option<codex_plus_core::ports::LoopbackPortGuard>> {
     acquire_single_instance_guard_with_retry(debug_port, true)
 }
 
 fn acquire_single_instance_guard_with_retry(
     debug_port: u16,
     allow_stale_recovery: bool,
-) -> anyhow::Result<Option<std::net::TcpListener>> {
+) -> anyhow::Result<Option<codex_plus_core::ports::LoopbackPortGuard>> {
     match try_acquire_single_instance_guard() {
-        Ok(listener) => Ok(Some(listener)),
+        Ok(guard) => {
+            if let Some(fallback_lock_path) = guard.fallback_path() {
+                log_launcher_guard_fallback(fallback_lock_path);
+            }
+            Ok(Some(guard))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+            log_launcher_already_running(debug_port);
+            Ok(None)
+        }
         Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {
             log_launcher_already_running(debug_port);
             if allow_stale_recovery && should_recover_stale_launcher(debug_port) {
@@ -79,10 +90,21 @@ fn acquire_single_instance_guard_with_retry(
     }
 }
 
-fn try_acquire_single_instance_guard() -> std::io::Result<std::net::TcpListener> {
-    codex_plus_core::ports::acquire_loopback_port_guard(
+fn try_acquire_single_instance_guard() -> std::io::Result<codex_plus_core::ports::LoopbackPortGuard>
+{
+    codex_plus_core::ports::acquire_resilient_loopback_port_guard(
         codex_plus_core::ports::LAUNCHER_GUARD_PORT,
     )
+}
+
+fn log_launcher_guard_fallback(fallback_lock_path: &Path) {
+    let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+        "launcher.guard_fallback",
+        json!({
+            "requested_guard_port": codex_plus_core::ports::LAUNCHER_GUARD_PORT,
+            "fallback_lock_path": fallback_lock_path
+        }),
+    );
 }
 
 fn should_recover_stale_launcher(debug_port: u16) -> bool {
@@ -741,7 +763,10 @@ mod tests {
             "async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<()> {\n    let hooks = LauncherHooks::default();"
         ));
         assert!(source.contains("hooks.start_helper(options.helper_port).await?"));
-        assert!(source.contains("hooks.ensure_injection(options.debug_port, options.helper_port).await"));
+        assert!(
+            source
+                .contains("hooks.ensure_injection(options.debug_port, options.helper_port).await")
+        );
         assert!(source.contains("injection_ready"));
     }
 

--- a/apps/codex-plus-manager/src-tauri/src/lib.rs
+++ b/apps/codex-plus-manager/src-tauri/src/lib.rs
@@ -115,12 +115,32 @@ fn install_panic_logger() {
     }));
 }
 
-fn acquire_single_instance_guard() -> Option<std::net::TcpListener> {
-    match codex_plus_core::ports::acquire_loopback_port_guard(
+fn acquire_single_instance_guard() -> Option<codex_plus_core::ports::LoopbackPortGuard> {
+    match codex_plus_core::ports::acquire_resilient_loopback_port_guard(
         codex_plus_core::ports::MANAGER_GUARD_PORT,
     ) {
-        Ok(listener) => Some(listener),
+        Ok(guard) => {
+            if let Some(fallback_lock_path) = guard.fallback_path() {
+                let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+                    "manager.guard_fallback",
+                    serde_json::json!({
+                        "requested_guard_port": codex_plus_core::ports::MANAGER_GUARD_PORT,
+                        "fallback_lock_path": fallback_lock_path
+                    }),
+                );
+            }
+            Some(guard)
+        }
         Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {
+            let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+                "manager.already_running",
+                serde_json::json!({
+                    "guard_port": codex_plus_core::ports::MANAGER_GUARD_PORT
+                }),
+            );
+            None
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
             let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
                 "manager.already_running",
                 serde_json::json!({
@@ -138,7 +158,9 @@ fn acquire_single_instance_guard() -> Option<std::net::TcpListener> {
                 }),
             );
             match std::net::TcpListener::bind(("127.0.0.1", 0)) {
-                Ok(listener) => Some(listener),
+                Ok(listener) => Some(codex_plus_core::ports::LoopbackPortGuard::listener(
+                    listener,
+                )),
                 Err(fallback_error) => {
                     let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
                         "manager.guard_fallback_failed",

--- a/crates/codex-plus-core/Cargo.toml
+++ b/crates/codex-plus-core/Cargo.toml
@@ -11,6 +11,7 @@ async-trait = "0.1"
 base64.workspace = true
 directories.workspace = true
 futures-util = "0.3"
+fs2.workspace = true
 reqwest.workspace = true
 rusqlite.workspace = true
 serde.workspace = true

--- a/crates/codex-plus-core/src/ports.rs
+++ b/crates/codex-plus-core/src/ports.rs
@@ -1,4 +1,8 @@
+use std::fs::File;
 use std::net::{TcpListener, ToSocketAddrs};
+use std::path::{Path, PathBuf};
+
+use fs2::FileExt;
 
 pub const LAUNCHER_GUARD_PORT: u16 = 57320;
 pub const MANAGER_GUARD_PORT: u16 = 57319;
@@ -53,4 +57,191 @@ pub fn can_connect_loopback_port(port: u16) -> bool {
 
 pub fn acquire_loopback_port_guard(port: u16) -> std::io::Result<TcpListener> {
     TcpListener::bind(("127.0.0.1", port))
+}
+
+#[derive(Debug)]
+pub struct LoopbackPortGuard {
+    _lock_file: Option<File>,
+    lock_path: Option<PathBuf>,
+    _listener: Option<TcpListener>,
+    using_fallback_lock: bool,
+}
+
+impl LoopbackPortGuard {
+    pub fn listener(listener: TcpListener) -> Self {
+        Self {
+            _lock_file: None,
+            lock_path: None,
+            _listener: Some(listener),
+            using_fallback_lock: false,
+        }
+    }
+
+    fn locked_listener(file: File, path: PathBuf, listener: TcpListener) -> Self {
+        Self {
+            _lock_file: Some(file),
+            lock_path: Some(path),
+            _listener: Some(listener),
+            using_fallback_lock: false,
+        }
+    }
+
+    fn fallback_lock(file: File, path: PathBuf) -> Self {
+        Self {
+            _lock_file: Some(file),
+            lock_path: Some(path),
+            _listener: None,
+            using_fallback_lock: true,
+        }
+    }
+
+    pub fn fallback_path(&self) -> Option<&Path> {
+        self.using_fallback_lock
+            .then_some(())
+            .and_then(|_| self.lock_path.as_deref())
+    }
+}
+
+pub fn acquire_resilient_loopback_port_guard(port: u16) -> std::io::Result<LoopbackPortGuard> {
+    acquire_resilient_loopback_port_guard_at(port, &crate::paths::default_app_state_dir())
+}
+
+fn acquire_resilient_loopback_port_guard_at(
+    port: u16,
+    state_dir: &Path,
+) -> std::io::Result<LoopbackPortGuard> {
+    acquire_resilient_loopback_port_guard_with(
+        port,
+        state_dir,
+        acquire_loopback_port_guard,
+        can_connect_loopback_port,
+    )
+}
+
+fn acquire_resilient_loopback_port_guard_with(
+    port: u16,
+    state_dir: &Path,
+    bind: impl Fn(u16) -> std::io::Result<TcpListener>,
+    can_connect: impl Fn(u16) -> bool,
+) -> std::io::Result<LoopbackPortGuard> {
+    if port == 0 {
+        return bind(port).map(LoopbackPortGuard::listener);
+    }
+
+    let (file, path) = acquire_lock_guard(port, state_dir)?;
+    match bind(port) {
+        Ok(listener) => Ok(LoopbackPortGuard::locked_listener(file, path, listener)),
+        Err(error) if error.kind() == std::io::ErrorKind::AddrInUse && can_connect(port) => {
+            Err(error)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {
+            Ok(LoopbackPortGuard::fallback_lock(file, path))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn acquire_lock_guard(port: u16, state_dir: &Path) -> std::io::Result<(File, PathBuf)> {
+    let dir = state_dir.join("locks");
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join(format!("loopback-port-{port}.lock"));
+    let file = File::options()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)?;
+    file.try_lock_exclusive().map_err(normalize_lock_error)?;
+    Ok((file, path))
+}
+
+fn normalize_lock_error(error: std::io::Error) -> std::io::Error {
+    match error.raw_os_error() {
+        Some(33) => std::io::Error::new(
+            std::io::ErrorKind::WouldBlock,
+            "loopback port guard lock is already held",
+        ),
+        _ => error,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resilient_guard_holds_lock_and_listener_when_requested_port_is_available() {
+        let temp = tempfile::tempdir().unwrap();
+        let port = find_available_loopback_port();
+
+        let guard = acquire_resilient_loopback_port_guard_at(port, temp.path()).unwrap();
+
+        assert!(guard.lock_path.is_some());
+        assert!(guard._listener.is_some());
+        assert!(guard.fallback_path().is_none());
+    }
+
+    #[test]
+    fn resilient_guard_reports_lock_conflict_when_instance_lock_is_held() {
+        let temp = tempfile::tempdir().unwrap();
+        let port = find_available_loopback_port();
+        let _guard = acquire_resilient_loopback_port_guard_at(port, temp.path()).unwrap();
+
+        let second = acquire_resilient_loopback_port_guard_at(port, temp.path()).unwrap_err();
+
+        assert_eq!(second.kind(), std::io::ErrorKind::WouldBlock);
+    }
+
+    #[test]
+    fn resilient_guard_reports_conflict_when_requested_port_is_connectable() {
+        let temp = tempfile::tempdir().unwrap();
+        let error = acquire_resilient_loopback_port_guard_with(
+            57319,
+            temp.path(),
+            |_| {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::AddrInUse,
+                    "port busy",
+                ))
+            },
+            |_| true,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AddrInUse);
+    }
+
+    #[test]
+    fn resilient_guard_uses_lock_fallback_when_requested_port_is_not_connectable() {
+        let temp = tempfile::tempdir().unwrap();
+        let guard = acquire_resilient_loopback_port_guard_with(
+            57319,
+            temp.path(),
+            |_| {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::AddrInUse,
+                    "stale port",
+                ))
+            },
+            |_| false,
+        )
+        .unwrap();
+
+        assert!(guard._listener.is_none());
+        assert!(guard.fallback_path().is_some());
+
+        let second = acquire_resilient_loopback_port_guard_with(
+            57319,
+            temp.path(),
+            |_| {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::AddrInUse,
+                    "stale port",
+                ))
+            },
+            |_| false,
+        )
+        .unwrap_err();
+        assert_eq!(second.kind(), std::io::ErrorKind::WouldBlock);
+    }
 }

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -1086,7 +1086,7 @@ impl LaunchHooks for FakeHooks {
         Ok(())
     }
 
-    async fn ensure_injection(&self, debug_port: u16, helper_port: u16) -> bool {
+    async fn ensure_injection(&self, debug_port: u16, helper_port: u16, _app_dir: &Path) -> bool {
         self.event(format!("inject:{debug_port}:{helper_port}"));
         self.inject_error.is_none()
     }


### PR DESCRIPTION
在 Windows 上，Codex++ 管理工具和启动器依赖固定本地端口作为单实例守护。遇到端口被系统异常占用但实际不可连接时，程序会误判为已有实例正在运行，导致管理工具或 Codex++ 本体无法正常启动。

本次改动新增基于锁文件的兜底守护：固定端口可用时继续使用端口；端口被真实实例占用时仍保持单实例语义；端口处于异常占用且不可连接状态时，改用用户状态目录下的锁文件继续启动，避免静默退出。

同时补充了相关测试，覆盖端口可用、真实占用、异常占用不可连接和锁冲突场景。