### PR TITLE
Fix provider sync for multiple session_meta records

### DIFF
--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -1,6 +1,6 @@
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value, json};
+use serde_json::{json, Map, Value};
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -63,14 +63,25 @@ pub struct ProviderSyncTargetList {
 #[derive(Debug, Clone)]
 struct SessionChange {
     path: PathBuf,
-    original_first_line: String,
-    next_first_line: String,
-    separator: String,
+    original_text: String,
+    next_text: String,
+    original_session_meta_lines: Vec<String>,
     thread_id: Option<String>,
     cwd: Option<String>,
     has_user_event: bool,
     rewrite_needed: bool,
     original_mtime: Option<SystemTime>,
+}
+
+#[derive(Debug, Default)]
+struct RolloutRewrite {
+    next_text: String,
+    rewrite_needed: bool,
+    thread_id: Option<String>,
+    cwd: Option<String>,
+    providers: Vec<String>,
+    original_session_meta_lines: Vec<String>,
+    session_meta_count: usize,
 }
 
 #[derive(Debug, Default)]
@@ -120,19 +131,20 @@ pub fn run_provider_sync_with_target(
             0,
         );
     }
-    let target_provider = match resolve_target_provider(&home.join("config.toml"), explicit_target_provider) {
-        Ok(provider) => provider,
-        Err(message) => {
-            return result(
-                ProviderSyncStatus::Skipped,
-                message,
-                DEFAULT_PROVIDER,
-                None,
-                0,
-                0,
-            );
-        }
-    };
+    let target_provider =
+        match resolve_target_provider(&home.join("config.toml"), explicit_target_provider) {
+            Ok(provider) => provider,
+            Err(message) => {
+                return result(
+                    ProviderSyncStatus::Skipped,
+                    message,
+                    DEFAULT_PROVIDER,
+                    None,
+                    0,
+                    0,
+                );
+            }
+        };
     let lock_dir = home.join("tmp/provider-sync.lock");
     if acquire_lock(&lock_dir).is_err() {
         return result(
@@ -476,61 +488,86 @@ fn collect_session_changes(home: &Path, target_provider: &str) -> anyhow::Result
             }
             Err(error) => return Err(error.into()),
         };
-        let (first_line, separator) = split_first_line(&text);
-        if first_line.trim().is_empty() {
+        let rewrite = rewrite_rollout_session_meta_providers(&text, target_provider)?;
+        if rewrite.session_meta_count == 0 {
             continue;
         }
-        let Ok(mut record) = serde_json::from_str::<Value>(&first_line) else {
-            continue;
-        };
-        let Some(payload) = record.get_mut("payload").and_then(Value::as_object_mut) else {
-            continue;
-        };
-        let thread_id = payload
-            .get("id")
-            .and_then(Value::as_str)
-            .map(ToString::to_string);
-        let cwd = payload
-            .get("cwd")
-            .and_then(Value::as_str)
-            .and_then(to_desktop_workspace_path);
-        let has_user_event =
-            separator.contains("\"user_message\"") || separator.contains("\"user_input\"");
-        let rewrite_needed =
-            payload.get("model_provider").and_then(Value::as_str) != Some(target_provider);
+        let has_user_event = text.contains("\"user_message\"") || text.contains("\"user_input\"");
         if text.contains("encrypted_content") {
-            let provider = payload
-                .get("model_provider")
-                .and_then(Value::as_str)
-                .unwrap_or("(missing)")
-                .to_string();
-            *collected
-                .encrypted_content_counts
-                .entry(provider)
-                .or_insert(0) += 1;
+            for provider in &rewrite.providers {
+                *collected
+                    .encrypted_content_counts
+                    .entry(provider.clone())
+                    .or_insert(0) += 1;
+            }
         }
-        if rewrite_needed {
-            payload.insert("model_provider".to_string(), json!(target_provider));
-        }
-        let next_first_line = if rewrite_needed {
-            serde_json::to_string(&record)?
-        } else {
-            first_line.clone()
-        };
         let original_mtime = fs::metadata(&path).and_then(|m| m.modified()).ok();
         collected.changes.push(SessionChange {
             path,
-            original_first_line: first_line,
-            next_first_line,
-            separator,
-            thread_id,
-            cwd,
+            original_text: text,
+            next_text: rewrite.next_text,
+            original_session_meta_lines: rewrite.original_session_meta_lines,
+            thread_id: rewrite.thread_id,
+            cwd: rewrite.cwd,
             has_user_event,
-            rewrite_needed,
+            rewrite_needed: rewrite.rewrite_needed,
             original_mtime,
         });
     }
     Ok(collected)
+}
+
+fn rewrite_rollout_session_meta_providers(
+    text: &str,
+    target_provider: &str,
+) -> anyhow::Result<RolloutRewrite> {
+    let mut rewrite = RolloutRewrite::default();
+    for segment in text.split_inclusive('\n') {
+        let (line, line_ending) = split_line_ending(segment);
+        let mut next_line = line.to_string();
+        if !line.trim().is_empty() {
+            if let Ok(mut record) = serde_json::from_str::<Value>(line) {
+                if record.get("type").and_then(Value::as_str) == Some("session_meta") {
+                    let Some(payload) = record.get_mut("payload").and_then(Value::as_object_mut)
+                    else {
+                        rewrite.next_text.push_str(&next_line);
+                        rewrite.next_text.push_str(line_ending);
+                        continue;
+                    };
+                    rewrite.session_meta_count += 1;
+                    rewrite.original_session_meta_lines.push(line.to_string());
+                    if rewrite.thread_id.is_none() {
+                        rewrite.thread_id = payload
+                            .get("id")
+                            .and_then(Value::as_str)
+                            .map(ToString::to_string);
+                    }
+                    if rewrite.cwd.is_none() {
+                        rewrite.cwd = payload
+                            .get("cwd")
+                            .and_then(Value::as_str)
+                            .and_then(to_desktop_workspace_path);
+                    }
+                    let provider = payload
+                        .get("model_provider")
+                        .and_then(Value::as_str)
+                        .unwrap_or("(missing)")
+                        .to_string();
+                    rewrite.providers.push(provider);
+                    if payload.get("model_provider").and_then(Value::as_str)
+                        != Some(target_provider)
+                    {
+                        payload.insert("model_provider".to_string(), json!(target_provider));
+                        next_line = serde_json::to_string(&record)?;
+                        rewrite.rewrite_needed = true;
+                    }
+                }
+            }
+        }
+        rewrite.next_text.push_str(&next_line);
+        rewrite.next_text.push_str(line_ending);
+    }
+    Ok(rewrite)
 }
 
 fn rollout_files(home: &Path) -> anyhow::Result<Vec<PathBuf>> {
@@ -553,20 +590,25 @@ fn rollout_provider_ids(home: &Path) -> anyhow::Result<Vec<String>> {
             Err(error) if is_locked_io_error(&error) => continue,
             Err(error) => return Err(error.into()),
         };
-        let (first_line, _) = split_first_line(&text);
-        let Ok(record) = serde_json::from_str::<Value>(&first_line) else {
-            continue;
-        };
-        let Some(provider) = record
-            .get("payload")
-            .and_then(Value::as_object)
-            .and_then(|payload| payload.get("model_provider"))
-            .and_then(Value::as_str)
-        else {
-            continue;
-        };
-        if is_valid_provider_id_for_discovery(provider) {
-            ids.insert(provider.to_string());
+        for segment in text.split_inclusive('\n') {
+            let (line, _) = split_line_ending(segment);
+            let Ok(record) = serde_json::from_str::<Value>(line) else {
+                continue;
+            };
+            if record.get("type").and_then(Value::as_str) != Some("session_meta") {
+                continue;
+            }
+            let Some(provider) = record
+                .get("payload")
+                .and_then(Value::as_object)
+                .and_then(|payload| payload.get("model_provider"))
+                .and_then(Value::as_str)
+            else {
+                continue;
+            };
+            if is_valid_provider_id_for_discovery(provider) {
+                ids.insert(provider.to_string());
+            }
         }
     }
     Ok(sorted_provider_ids(ids))
@@ -588,11 +630,13 @@ fn collect_rollout_files(root: &Path, files: &mut Vec<PathBuf>) -> anyhow::Resul
     Ok(())
 }
 
-fn split_first_line(text: &str) -> (String, String) {
-    if let Some(index) = text.find('\n') {
-        (text[..index].to_string(), text[index..].to_string())
+fn split_line_ending(segment: &str) -> (&str, &str) {
+    if let Some(line) = segment.strip_suffix("\r\n") {
+        (line, "\r\n")
+    } else if let Some(line) = segment.strip_suffix('\n') {
+        (line, "\n")
     } else {
-        (text.to_string(), String::new())
+        (segment, "")
     }
 }
 
@@ -673,8 +717,7 @@ fn create_backup(
         .map(|change| {
             json!({
                 "path": change.path.to_string_lossy(),
-                "originalFirstLine": change.original_first_line,
-                "separator": change.separator,
+                "originalSessionMetaLines": change.original_session_meta_lines,
             })
         })
         .collect::<Vec<_>>();
@@ -701,10 +744,7 @@ fn create_backup(
 fn apply_session_changes(changes: &[SessionChange]) -> anyhow::Result<AppliedSessionChanges> {
     let mut applied = AppliedSessionChanges::default();
     for change in changes {
-        match fs::write(
-            &change.path,
-            format!("{}{}", change.next_first_line, change.separator),
-        ) {
+        match fs::write(&change.path, &change.next_text) {
             Ok(()) => {}
             Err(error) if is_locked_io_error(&error) => {
                 applied
@@ -722,10 +762,7 @@ fn apply_session_changes(changes: &[SessionChange]) -> anyhow::Result<AppliedSes
 
 fn restore_session_changes(changes: &[SessionChange]) -> anyhow::Result<()> {
     for change in changes {
-        fs::write(
-            &change.path,
-            format!("{}{}", change.original_first_line, change.separator),
-        )?;
+        fs::write(&change.path, &change.original_text)?;
         restore_file_mtime(&change.path, change.original_mtime);
     }
     Ok(())
@@ -908,9 +945,9 @@ fn normalized_global_state(state: &Map<String, Value>) -> Map<String, Value> {
         .and_then(Value::as_object)
     {
         let mut next_open_targets = open_targets.clone();
-        if let Some(per_path) = copy_resolved_object_keys(
-            open_targets.get("perPath").and_then(Value::as_object),
-        ) {
+        if let Some(per_path) =
+            copy_resolved_object_keys(open_targets.get("perPath").and_then(Value::as_object))
+        {
             next_open_targets.insert("perPath".to_string(), Value::Object(per_path));
         }
         next.insert(

--- a/crates/codex-plus-data/tests/provider_sync.rs
+++ b/crates/codex-plus-data/tests/provider_sync.rs
@@ -1,6 +1,6 @@
 use codex_plus_data::{
-    ProviderSyncStatus, ProviderSyncTargetSource, load_provider_sync_targets, run_provider_sync,
-    run_provider_sync_with_target,
+    load_provider_sync_targets, run_provider_sync, run_provider_sync_with_target,
+    ProviderSyncStatus, ProviderSyncTargetSource,
 };
 use rusqlite::Connection;
 use serde_json::json;
@@ -21,6 +21,27 @@ fn write_rollout(path: &Path, provider: &str, thread_id: &str, cwd: &str) {
     });
     let event = json!({"type": "event_msg", "payload": {"type": "user_message"}});
     fs::write(path, format!("{first}\n{event}\n")).unwrap();
+}
+
+fn write_rollout_with_providers(path: &Path, providers: &[&str], thread_id: &str, cwd: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let mut lines = Vec::new();
+    for provider in providers {
+        lines.push(
+            json!({
+                "type": "session_meta",
+                "payload": {
+                    "id": thread_id,
+                    "model_provider": provider,
+                    "cwd": cwd
+                }
+            })
+            .to_string(),
+        );
+        lines.push(json!({"type": "event_msg", "payload": {"type": "task_started"}}).to_string());
+    }
+    lines.push(json!({"type": "event_msg", "payload": {"type": "user_message"}}).to_string());
+    fs::write(path, format!("{}\n", lines.join("\n"))).unwrap();
 }
 
 fn create_state_db(path: &Path) {
@@ -177,6 +198,67 @@ experimental_bearer_token = "sk-test"
         )
         .unwrap();
     assert_eq!(provider, "custom");
+}
+
+#[test]
+fn provider_sync_rewrites_all_session_meta_model_providers() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    fs::create_dir(&home).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    let rollout = home.join("sessions/2026/rollout-multi-meta.jsonl");
+    write_rollout_with_providers(
+        &rollout,
+        &["openai", "ccx", "CodexPlusPlus"],
+        "thread-1",
+        "C:/workspace",
+    );
+    create_state_db(&home.join("state_5.sqlite"));
+
+    let result = run_provider_sync(Some(&home));
+
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert_eq!(result.target_provider, "apigather");
+    assert_eq!(result.changed_session_files, 1);
+
+    let providers = fs::read_to_string(&rollout)
+        .unwrap()
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter(|record| record["type"] == "session_meta")
+        .map(|record| {
+            record["payload"]["model_provider"]
+                .as_str()
+                .unwrap()
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(providers, vec!["apigather", "apigather", "apigather"]);
+}
+
+#[test]
+fn provider_sync_target_discovery_reads_all_session_meta_providers() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    fs::create_dir(&home).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"custom\"\n").unwrap();
+    write_rollout_with_providers(
+        &home.join("sessions/2026/rollout-multi-meta.jsonl"),
+        &["openai", "ccx", "CodexPlusPlus"],
+        "thread-1",
+        "C:/workspace",
+    );
+
+    let targets = load_provider_sync_targets(Some(&home));
+    let ids = targets
+        .targets
+        .iter()
+        .map(|target| target.id.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(ids.contains(&"openai"));
+    assert!(ids.contains(&"ccx"));
+    assert!(ids.contains(&"CodexPlusPlus"));
 }
 
 #[test]


### PR DESCRIPTION
## 中文说明

这个 PR 修复 Provider Sync 在同步历史会话 provider 时只修改 rollout 文件中第一条 `session_meta` 的问题。

### 背景

Codex 的一个 `rollout-*.jsonl` 会话文件里可能包含多条 `session_meta`。例如，一个会话被继续、恢复，或者在不同 provider 状态下运行后，文件里可能出现这样的内容：

```jsonl
{"type":"session_meta","payload":{"model_provider":"openai"}}
{"type":"session_meta","payload":{"model_provider":"ccx"}}
{"type":"session_meta","payload":{"model_provider":"CodexPlusPlus"}}
```

### 以前是什么样子

旧实现只读取并重写 rollout 文件的第一行，也就是只修改第一条 `session_meta`。

结果是：

```text
openai -> target provider
ccx -> unchanged
CodexPlusPlus -> unchanged
```

但 Codex 在重建或读取本地线程状态时，可能会使用后面的 `session_meta.model_provider`。因此即使 Provider Sync 修改了第一条记录和 `state_5.sqlite`，后续重新索引时仍可能读到后面的旧 provider，导致历史会话仍然无法在当前 provider 下显示。

### 现在改成什么样子

这个 PR 将 Provider Sync 的 rollout 重写逻辑从“只处理第一行”改为“逐行扫描整个 JSONL 文件”。

现在会：

- 扫描整个 `rollout-*.jsonl` 文件；
- 找到所有 `type == "session_meta"` 的记录；
- 将每一条 `payload.model_provider` 都改成目标 provider；
- 保留普通事件行、非 JSON 行和原有换行；
- 仍然按文件计数 `changed_session_files`，不是按 `session_meta` 数计数；
- 更新 provider target discovery，让它扫描所有 `session_meta`，而不是只看第一行。

修复后，上面的例子会变成：

```jsonl
{"type":"session_meta","payload":{"model_provider":"target-provider"}}
{"type":"session_meta","payload":{"model_provider":"target-provider"}}
{"type":"session_meta","payload":{"model_provider":"target-provider"}}
```

这样 rollout 文件里的所有 provider 记录和 `state_5.sqlite` 中的 provider 状态可以保持一致，避免 Codex 后续从较晚的 `session_meta` 读回旧 provider。

### 具体改动

- 修改 `crates/codex-plus-data/src/provider_sync.rs`
  - 将原来的 first-line rewrite 改为全文件 JSONL line-by-line rewrite。
  - 新增逻辑：重写所有 `session_meta.payload.model_provider`。
  - 调整 backup manifest，记录所有原始 `session_meta` 行。
  - 更新 provider discovery，使其扫描所有 `session_meta` 记录。

- 修改 `crates/codex-plus-data/tests/provider_sync.rs`
  - 新增多 `session_meta` rollout 的测试 helper。
  - 新增两个回归测试：
    - `provider_sync_rewrites_all_session_meta_model_providers`
    - `provider_sync_target_discovery_reads_all_session_meta_providers`

### 验证

已在本地 Windows 环境验证：

```powershell
rustfmt --check crates/codex-plus-data/src/provider_sync.rs crates/codex-plus-data/tests/provider_sync.rs
cargo test -p codex-plus-data provider_sync --no-run
D:\download2026\codex-rust-target\debug\deps\provider_sync-*.exe --nocapture
```

结果：

```text
15 provider_sync tests passed
0 failed
```

---

## English Description

This PR fixes Provider Sync only rewriting the first `session_meta` record in each rollout JSONL file.

### Background

A Codex `rollout-*.jsonl` session file may contain multiple `session_meta` records. For example, after a session is continued, resumed, or used across different provider states, the rollout file may contain records like this:

```jsonl
{"type":"session_meta","payload":{"model_provider":"openai"}}
{"type":"session_meta","payload":{"model_provider":"ccx"}}
{"type":"session_meta","payload":{"model_provider":"CodexPlusPlus"}}
```

### Previous behavior

The previous implementation only read and rewrote the first line of the rollout file, so only the first `session_meta` record was updated.

The result was:

```text
openai -> target provider
ccx -> unchanged
CodexPlusPlus -> unchanged
```

However, Codex may use a later `session_meta.model_provider` when rebuilding or reading local thread state. As a result, even if Provider Sync updated the first record and `state_5.sqlite`, a later re-index could still pick up the old provider from a later `session_meta`, causing historical sessions to remain hidden under the current provider.

### New behavior

This PR changes Provider Sync from “rewrite only the first line” to “scan and rewrite the entire JSONL file line by line”.

It now:

- scans the full `rollout-*.jsonl` file;
- finds every record where `type == "session_meta"`;
- rewrites every `payload.model_provider` to the target provider;
- preserves normal event lines, non-JSON lines, and original line endings;
- keeps `changed_session_files` counted per file, not per `session_meta`;
- updates provider target discovery to scan all `session_meta` records instead of only the first line.

After this fix, the example above becomes:

```jsonl
{"type":"session_meta","payload":{"model_provider":"target-provider"}}
{"type":"session_meta","payload":{"model_provider":"target-provider"}}
{"type":"session_meta","payload":{"model_provider":"target-provider"}}
```

This keeps all provider records in the rollout file consistent with `state_5.sqlite`, preventing Codex from later reading an older provider from a later `session_meta`.

### Changes

- Updated `crates/codex-plus-data/src/provider_sync.rs`
  - Replaced first-line rewrite with full JSONL line-by-line rewrite.
  - Added logic to rewrite every `session_meta.payload.model_provider`.
  - Updated the backup manifest to record all original `session_meta` lines.
  - Updated provider discovery to scan all `session_meta` records.

- Updated `crates/codex-plus-data/tests/provider_sync.rs`
  - Added a helper for rollout files with multiple `session_meta` records.
  - Added two regression tests:
    - `provider_sync_rewrites_all_session_meta_model_providers`
    - `provider_sync_target_discovery_reads_all_session_meta_providers`

### Validation

Validated locally on Windows:

```powershell
rustfmt --check crates/codex-plus-data/src/provider_sync.rs crates/codex-plus-data/tests/provider_sync.rs
cargo test -p codex-plus-data provider_sync --no-run
D:\download2026\codex-rust-target\debug\deps\provider_sync-*.exe --nocapture
```

Result:

```text
15 provider_sync tests passed
0 failed
```