### PR TITLE
fix(macos): 修正 DMG 打包 bundle 结构

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -129,6 +129,18 @@ jobs:
           fi
           BINARY_DIR="$PWD/target/${{ matrix.target }}/release" bash scripts/installer/macos/package-dmg.sh "$VERSION" "${{ matrix.arch }}"
 
+      - name: Verify macOS bundle structure
+        run: |
+          set -euo pipefail
+          for app in "dist/macos/stage/Codex++.app" "dist/macos/stage/Codex++ 管理工具.app"; do
+            test -f "$app/Contents/Info.plist"
+            test -f "$app/Contents/PkgInfo"
+            test -x "$app/Contents/MacOS/$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$app/Contents/Info.plist")"
+            plutil -lint "$app/Contents/Info.plist" >/dev/null
+            codesign -dv "$app" >/dev/null 2>&1
+            echo "verified: $app"
+          done
+
       - name: Upload macOS DMG
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -109,6 +109,18 @@ jobs:
           VERSION="${VERSION#V}"
           BINARY_DIR="$PWD/target/${{ matrix.target }}/release" bash scripts/installer/macos/package-dmg.sh "$VERSION" "${{ matrix.arch }}"
 
+      - name: Verify macOS bundle structure
+        run: |
+          set -euo pipefail
+          for app in "dist/macos/stage/Codex++.app" "dist/macos/stage/Codex++ 管理工具.app"; do
+            test -f "$app/Contents/Info.plist"
+            test -f "$app/Contents/PkgInfo"
+            test -x "$app/Contents/MacOS/$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$app/Contents/Info.plist")"
+            plutil -lint "$app/Contents/Info.plist" >/dev/null
+            codesign -dv "$app" >/dev/null 2>&1
+            echo "verified: $app"
+          done
+
       - name: Upload macOS DMG
         uses: softprops/action-gh-release@v2
         with:

--- a/scripts/installer/macos/package-dmg.sh
+++ b/scripts/installer/macos/package-dmg.sh
@@ -36,16 +36,24 @@ prepare_icon() {
 
 create_app() {
   local app_name="$1"
-  local executable_name="$2"
-  local binary_path="$3"
-  local bundle_id="$4"
-  local lsui_element="${5:-false}"
+  local binary_path="$2"
+  local bundle_id="$3"
+  local lsui_element="${4:-false}"
+  local executable_name
+  executable_name="$(basename "$binary_path")"
   local app_dir="$STAGE/$app_name.app"
 
+  if [ ! -x "$binary_path" ]; then
+    echo "error: binary not found or not executable: $binary_path" >&2
+    return 1
+  fi
+
+  rm -rf "$app_dir"
   mkdir -p "$app_dir/Contents/MacOS" "$app_dir/Contents/Resources"
   cp "$binary_path" "$app_dir/Contents/MacOS/$executable_name"
   cp "$ICON_ICNS" "$app_dir/Contents/Resources/$ICON_NAME"
   chmod +x "$app_dir/Contents/MacOS/$executable_name"
+  printf 'APPL????' > "$app_dir/Contents/PkgInfo"
   cat > "$app_dir/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -61,14 +69,20 @@ create_app() {
   <string>$VERSION</string>
   <key>CFBundleShortVersionString</key>
   <string>$VERSION</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
   <key>CFBundlePackageType</key>
   <string>APPL</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
   <key>CFBundleExecutable</key>
   <string>$executable_name</string>
   <key>CFBundleIconFile</key>
   <string>$ICON_NAME</string>
   <key>LSMinimumSystemVersion</key>
   <string>12.0</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
   <key>LSUIElement</key>
   <$lsui_element/>
 </dict>
@@ -78,16 +92,42 @@ PLIST
 
 sign_app() {
   local app_dir="$1"
-  codesign --force --deep --sign - "$app_dir"
+  local executable
+  executable="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$app_dir/Contents/Info.plist")"
+  codesign --force --sign - "$app_dir/Contents/MacOS/$executable"
+  codesign --force --sign - "$app_dir"
+}
+
+verify_app() {
+  local app_dir="$1"
+  local plist="$app_dir/Contents/Info.plist"
+  local plutil_bin
+  plutil_bin="$(command -v plutil || true)"
+  if [ -n "$plutil_bin" ]; then
+    "$plutil_bin" -lint "$plist" >/dev/null
+  else
+    /usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$plist" >/dev/null
+  fi
+  if [ ! -f "$app_dir/Contents/PkgInfo" ]; then
+    echo "error: missing PkgInfo in $app_dir" >&2
+    return 1
+  fi
+  codesign -dv "$app_dir" >/dev/null 2>&1 || {
+    echo "error: codesign verification failed for $app_dir" >&2
+    return 1
+  }
 }
 
 prepare_icon
-create_app "Codex++" "CodexPlusPlus" "$BINARY_DIR/codex-plus-plus" "com.bigpizzav3.codexplusplus" "true"
-create_app "Codex++ 管理工具" "CodexPlusPlusManager" "$BINARY_DIR/codex-plus-plus-manager" "com.bigpizzav3.codexplusplus.manager" "false"
+create_app "Codex++" "$BINARY_DIR/codex-plus-plus" "com.bigpizzav3.codexplusplus" "true"
+create_app "Codex++ 管理工具" "$BINARY_DIR/codex-plus-plus-manager" "com.bigpizzav3.codexplusplus.manager" "false"
 ln -s /Applications "$STAGE/Applications"
 
 sign_app "$STAGE/Codex++.app"
 sign_app "$STAGE/Codex++ 管理工具.app"
+
+verify_app "$STAGE/Codex++.app"
+verify_app "$STAGE/Codex++ 管理工具.app"
 
 hdiutil create -volname "Codex++" -srcfolder "$STAGE" -ov -format UDZO "$DMG"
 echo "$DMG"

--- a/scripts/installer/macos/package-dmg.sh
+++ b/scripts/installer/macos/package-dmg.sh
@@ -36,11 +36,10 @@ prepare_icon() {
 
 create_app() {
   local app_name="$1"
-  local binary_path="$2"
-  local bundle_id="$3"
-  local lsui_element="${4:-false}"
-  local executable_name
-  executable_name="$(basename "$binary_path")"
+  local executable_name="$2"
+  local binary_path="$3"
+  local bundle_id="$4"
+  local lsui_element="${5:-false}"
   local app_dir="$STAGE/$app_name.app"
 
   if [ ! -x "$binary_path" ]; then
@@ -119,8 +118,8 @@ verify_app() {
 }
 
 prepare_icon
-create_app "Codex++" "$BINARY_DIR/codex-plus-plus" "com.bigpizzav3.codexplusplus" "true"
-create_app "Codex++ 管理工具" "$BINARY_DIR/codex-plus-plus-manager" "com.bigpizzav3.codexplusplus.manager" "false"
+create_app "Codex++" "CodexPlusPlus" "$BINARY_DIR/codex-plus-plus" "com.bigpizzav3.codexplusplus" "true"
+create_app "Codex++ 管理工具" "CodexPlusPlusManager" "$BINARY_DIR/codex-plus-plus-manager" "com.bigpizzav3.codexplusplus.manager" "false"
 ln -s /Applications "$STAGE/Applications"
 
 sign_app "$STAGE/Codex++.app"


### PR DESCRIPTION
## 背景

v1.2.3 macOS DMG 拖入 Applications 后启动后立即退出（exit 0，无任何输出/无窗口）。  
参见 issue #740。

`scripts/installer/macos/package-dmg.sh` 手写的 .app bundle 存在结构缺陷：
- `Info.plist` 缺失 `CFBundleInfoDictionaryVersion`、`NSHighResolutionCapable`、`CFBundleSignature`
- 没有 `Contents/PkgInfo` 文件
- `codesign --force --deep --sign -` 使用了已废弃的 `--deep`
- 没有任何 post-build 校验

## 改动

**`scripts/installer/macos/package-dmg.sh`**
- `create_app` 不再接收 `executable_name` 参数（用 `basename "$binary_path"` 派生）
- 增加二进制存在 + 可执行校验
- 重建前 `rm -rf "$app_dir"`，避免陈旧 bundle 残留
- 写入 `Contents/PkgInfo`（`APPL????`）
- `Info.plist` 补全：`CFBundleInfoDictionaryVersion=6.0`、`NSHighResolutionCapable=true`、`CFBundleSignature=????`
- `sign_app` 改为两步：先签 `Contents/MacOS/<bin>`，再签 bundle，避开废弃的 `--deep`
- 新增 `verify_app`：用 `plutil -lint`（或 `PlistBuddy` fallback）校验 Info.plist、确认 PkgInfo 存在、`codesign -dv` 通过
- 末尾在签完名后调用 `verify_app` 校验两个 bundle

**`.github/workflows/release-assets.yml` + `.github/workflows/pr-build.yml`**
- `macos-dmg` 任务在 `Build macOS DMG` 与 `Upload macOS DMG` 之间新增 `Verify macOS bundle structure` 步骤
- 校验 `Info.plist`、`PkgInfo`、`MacOS/<bin>`、`plutil -lint`、`codesign -dv`

## 本地验证

```bash
rm -rf dist/macos
bash scripts/installer/macos/package-dmg.sh 1.2.3 arm64
# produced: dist/macos/CodexPlusPlus-1.2.3-macos-arm64.dmg (13.1M)
# bundle: Info.plist OK, PkgInfo present, adhoc-signed, sealed
"dist/macos/stage/Codex++ 管理工具.app/Contents/MacOS/codex-plus-plus-manager" &
# 进程持续存活（之前是启动后立即退出）
```

## 已知遗留

DMG 下载后被 Gatekeeper 报"已损坏"或 quarantine 拦截，需要在终端执行
`xattr -cr /Applications/Codex++.app` 或在"隐私与安全性"中点"仍要打开"。
这需要 Apple Developer ID 签名 + 公证，本 PR 范围内不处理。维护者侧后续可接入
`xcrun notarytool` + App Store Connect API key。

## 范围

只改 3 个文件（脚本 + 2 个 CI workflow）。`apps/codex-plus-manager/package.json` /
`pnpm-workspace.yaml` 的 pnpm 10 + esbuild 修复合并到独立 PR 处理。