### PR TITLE
fix: 修复中转硅基流动时，Codex提示“unsupported call”问题

### DIFF
--- a/crates/codex-plus-core/src/protocol_proxy.rs
+++ b/crates/codex-plus-core/src/protocol_proxy.rs
@@ -1039,7 +1039,9 @@ impl ChatSseState {
                 state.call_id = id;
             }
             if let Some(name) = name_delta {
-                state.name = name;
+                if !name.is_empty() {
+                    state.name = name;
+                }
             }
             if !args_delta.is_empty() {
                 state.arguments.push_str(&args_delta);


### PR DESCRIPTION
修复中转硅基流动api时，codex调用工具提示“unsupported call”问题。

通过日志分析：
硅基流动的流式 SSE 响应中，第一个 tool_calls delta 正确包含 function.name: "shell_command"，但后续 delta 将 function.name 设为空字符串 "" 而非省略该字段。
protocol_proxy.rs 的 push_tool_call_delta_into 无条件覆盖 state.name：
硅基流动 SSE:  
Delta 1 → name="shell_command"  → state.name = "shell_command" ✅
Delta 2 → name=""                           → state.name = ""              ❌ 覆盖了！
导致最终转换后的 Responses 输出中工具名称为空，Codex 客户端无法匹配 "unsupported call"。