### PR TITLE
fix: detect standalone Codex installations on Windows

### DIFF
--- a/crates/codex-plus-core/src/app_paths.rs
+++ b/crates/codex-plus-core/src/app_paths.rs
@@ -94,10 +94,36 @@ pub fn resolve_codex_app_dir(app_dir: Option<&Path>) -> Option<PathBuf> {
         return normalize_codex_app_path(app_dir);
     }
     if cfg!(target_os = "macos") {
-        find_macos_codex_app_default()
-    } else {
-        find_latest_codex_app_dir_default()
+        return find_macos_codex_app_default();
     }
+    // Windows: try MS Store version first, then standalone install
+    find_latest_codex_app_dir_default()
+        .or_else(|| find_standalone_codex_app_dir())
+}
+
+/// Search for standalone Codex installations (non-MS Store).
+///
+/// Common paths:
+/// - %LOCALAPPDATA%\OpenAI\Codex\bin\  (standalone installer)
+/// - %LOCALAPPDATA%\OpenAI\Codex\      (user data root)
+/// - %LOCALAPPDATA%\Programs\OpenAI\Codex\ (alternative)
+pub fn find_standalone_codex_app_dir() -> Option<PathBuf> {
+    let local_appdata = std::env::var_os("LOCALAPPDATA")?;
+
+    let candidates: &[PathBuf] = &[
+        PathBuf::from(&local_appdata).join("OpenAI").join("Codex").join("bin"),
+        PathBuf::from(&local_appdata).join("OpenAI").join("Codex"),
+        PathBuf::from(&local_appdata).join("Programs").join("OpenAI").join("Codex"),
+    ];
+
+    for candidate in candidates {
+        if let Some(path) = normalize_codex_app_path(candidate) {
+            if build_codex_executable(&path).exists() {
+                return Some(path);
+            }
+        }
+    }
+    None
 }
 
 pub fn resolve_codex_app_dir_with_saved(


### PR DESCRIPTION
@
## Problem

On Windows, `resolve_codex_app_dir` only searches `C:\Program Files\WindowsApps\` for MS Store versions of Codex. Users who installed Codex via the standalone installer get a "Codex App directory not found" error.

The standalone installer places Codex at `%LOCALAPPDATA%\OpenAI\Codex\bin\codex.exe`, which is not in WindowsApps.

## Reproduce

1. Install Codex via the standalone installer (not MS Store)
2. Run Codex++ Manager
3. Try to launch Codex → fails with "Codex App directory not found"

## Fix

Added `find_standalone_codex_app_dir()` that searches common standalone installation paths as a fallback:

1. `%LOCALAPPDATA%\OpenAI\Codex\bin\`
2. `%LOCALAPPDATA%\OpenAI\Codex\`
3. `%LOCALAPPDATA%\Programs\OpenAI\Codex\`

The search only runs when no MS Store version is found, preserving backward compatibility.

## Test

- [x] Compiles on Windows (cargo check)
- [x] Finds Codex at `%LOCALAPPDATA%\OpenAI\Codex\bin\`
- [x] Falls back correctly when MS Store version is not present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@