### PR TITLE
fix: pr-build.yaml ref_name containing a path separator

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -57,6 +57,7 @@ jobs:
         shell: pwsh
         run: |
           $version = "${{ github.ref_name }}".TrimStart("v", "V")
+          $version = $version -replace '[\\/]', '-'
           if (-not $version -or $version -eq "main") {
             $version = "0.0.0-${{ github.run_number }}"
           }
@@ -124,6 +125,7 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           VERSION="${VERSION#V}"
+          VERSION="${VERSION//\//-}"
           if [ -z "$VERSION" ] || [ "$VERSION" = "main" ]; then
             VERSION="0.0.0-${GITHUB_RUN_NUMBER}"
           fi


### PR DESCRIPTION
PR 的 github.ref_name 会包含 `/`，而 `/` 会被当成路径分隔符导致打包报错，所以要替换成 `-`。
Ref: https://github.com/BigPizzaV3/CodexPlusPlus/actions/runs/27194280038