### PR TITLE
fix(relay-test): 測試模型回退優先用 profile 自身 model

### DIFF
--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -1673,12 +1673,20 @@ pub async fn test_relay_profile(profile: RelayProfile) -> CommandResult<RelayPro
     };
     let settings =
         settings_with_live_ccs_profiles(SettingsStore::default().load().unwrap_or_default());
-    let test_model = if profile.test_model.trim().is_empty() {
-        settings.relay_test_model.trim()
+    let test_model: String = if !profile.test_model.trim().is_empty() {
+        // 1. 使用者在該供應商明確填的測試模型
+        profile.test_model.trim().to_string()
     } else {
-        profile.test_model.trim()
+        // 2. 該供應商自己 config.toml 裡的 model（避免串味）
+        let from_profile = codex_plus_core::relay_config::relay_profile_model(&profile);
+        if from_profile.trim().is_empty() {
+            // 3. 最後才用全域預設
+            settings.relay_test_model.trim().to_string()
+        } else {
+            from_profile
+        }
     };
-    match codex_plus_core::relay_config::test_relay_profile(&profile, test_model).await {
+    match codex_plus_core::relay_config::test_relay_profile(&profile, &test_model).await {
         Ok(result) => {
             let status = if result.http_status < 400 {
                 "ok"

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -1444,7 +1444,9 @@ fn codex_auth_api_key(auth_contents: &str) -> Option<String> {
         .map(ToString::to_string)
 }
 
-fn relay_profile_model(profile: &RelayProfile) -> String {
+/// 解析 profile 實際使用的模型：優先取 config.toml 裡的 `model =`，
+/// 否則退回 profile.model 欄位。供應商測試用它做回退，避免串到別家供應商的模型名。
+pub fn relay_profile_model(profile: &RelayProfile) -> String {
     root_key_string(&profile.config_contents, "model")
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| profile.model.trim().to_string())
@@ -1947,6 +1949,34 @@ mod tests {
         assert!(profile.config_contents.contains("model_provider = \"ai\""));
         assert!(profile.config_contents.contains("[model_providers.ai]"));
         assert!(!profile.config_contents.contains("[model_providers.custom]"));
+    }
+
+    #[test]
+    fn relay_profile_model_prefers_config_then_field_then_empty() {
+        // 1. 供應商測試的回退第一級：config.toml 的 model = 優先
+        let from_config = RelayProfile {
+            config_contents: "model = \"deepseek-v4-flash\"\nmodel_provider = \"custom\"\n"
+                .to_string(),
+            model: "should-not-be-used".to_string(),
+            ..RelayProfile::default()
+        };
+        assert_eq!(relay_profile_model(&from_config), "deepseek-v4-flash");
+
+        // 2. config 沒寫 model 時退回 profile.model 欄位
+        let from_field = RelayProfile {
+            config_contents: "model_provider = \"custom\"\n".to_string(),
+            model: "deepseek-v4-pro".to_string(),
+            ..RelayProfile::default()
+        };
+        assert_eq!(relay_profile_model(&from_field), "deepseek-v4-pro");
+
+        // 3. 兩者皆空 → 空字串；呼叫端據此才回退到全域 relayTestModel
+        let empty = RelayProfile {
+            config_contents: String::new(),
+            model: String::new(),
+            ..RelayProfile::default()
+        };
+        assert!(relay_profile_model(&empty).trim().is_empty());
     }
 }
 


### PR DESCRIPTION
供應商測試時，若 profile 未填 testModel，原本直接回退到全域
relayTestModel（預設 gpt-5.4-mini），導致對非 OpenAI 供應商（如
DeepSeek）發出不存在的模型名而 HTTP 400。

改為三級回退：
  profile.testModel → profile config.toml 的 model= → 全域 relayTestModel

複用既有的 relay_profile_model（改為 pub），並補回歸測試。