### PR TITLE
feat: detect unexpected Codex stop and notify user

### DIFF
--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -586,6 +586,7 @@ export function App() {
     debugPort: "9229",
     helperPort: "57321",
   });
+  const prevLaunchStatusRef = useRef<string | null>(null);
   const [settingsForm, setSettingsForm] = useState<BackendSettings>({ ...defaultSettings });
   const [providerSyncProgress, setProviderSyncProgress] = useState<ProviderSyncProgress>({
     active: false,
@@ -615,6 +616,13 @@ export function App() {
   const refreshOverview = async (silent = false) => {
     const result = await run(() => call<OverviewResult>("load_overview"));
     if (result) {
+      // 崩溃检测：进程从运行状态变为停止/失败 → 弹出通知
+      const prev = prevLaunchStatusRef.current;
+      const current = result.latest_launch?.status;
+      if (prev && prev === "running" && current && (current === "stopped" || current === "failed" || current === "crashed")) {
+        showNotice("Codex 意外停止", `进程状态：${current}。是否要重新启动？`, "failed");
+      }
+      prevLaunchStatusRef.current = current ?? null;
       setOverview(result);
       if (!silent) showResultNotice("概览已检查", result, { silentSuccess: true });
     }


### PR DESCRIPTION
## Summary

When Codex stops unexpectedly (crashes), the overview polling now detects the status transition from "running" to "stopped"/"failed" and shows a notice dialog alerting the user.

Previously, users would only see the status silently change to "stopped" without any notification.

## Changes

- Added `prevLaunchStatusRef` to track previous `latest_launch.status`
- In `refreshOverview`, before updating state, check if status went from "running" → "stopped"/"failed"/"crashed"
- Shows notice via existing `showNotice()` mechanism when crash is detected

## Why this matters

This is a minimal change (8 lines) that significantly improves UX by surfacing process failures instead of relying on users to notice a status change in the UI.