### PR TITLE
feat: bundle Inter & JetBrains Mono via @fontsource for offline use

### DIFF
--- a/apps/codex-plus-manager/package-lock.json
+++ b/apps/codex-plus-manager/package-lock.json
@@ -11,6 +11,8 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@fontsource/inter": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "@radix-ui/react-slot": "^1.1.2",
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/cli": "^2.0.0",
@@ -782,6 +784,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/apps/codex-plus-manager/package.json
+++ b/apps/codex-plus-manager/package.json
@@ -14,6 +14,8 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@fontsource/inter": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "@radix-ui/react-slot": "^1.1.2",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/cli": "^2.0.0",

--- a/apps/codex-plus-manager/src/main.tsx
+++ b/apps/codex-plus-manager/src/main.tsx
@@ -2,6 +2,12 @@ import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import "./styles.css";
 
+/* ── Bundled fonts (offline, no Google Fonts request) ──
+     Fontsource packages ship woff2 files that Vite bundles into dist/.
+     CSS @font-face declarations are injected at build time.              */
+import "@fontsource/inter";
+import "@fontsource/jetbrains-mono";
+
 const app = document.getElementById("app");
 
 if (app instanceof HTMLElement) {


### PR DESCRIPTION
## Summary

Replace implicit system-font / Google Fonts assumption with bundled font files shipped inside the Tauri binary via @fontsource npm packages. The app declares `Inter` and `JetBrains Mono` in its CSS `font-family` but never explicitly loads them — this works only when the user has those fonts installed locally or a network request to Google Fonts succeeds offline.

With this change, Inter and JetBrains Mono woff2 files are bundled into the Vite build output via @fontsource side-effect imports, and CSS @font-face rules are injected at build time. No runtime network request needed.

## Changes

- Add `@fontsource/inter`, `@fontsource/jetbrains-mono` as dependencies
- Import both in `src/main.tsx` so Vite bundles the woff2 files at build time

## Testing

- `npm run vite:build` produces dist/ assets that include `inter-*.woff2` and `jetbrains-mono-*.woff2` files
- No regressions in existing functionality

---