### PR TITLE
feat: add CC Switch config ownership coordination

### DIFF
--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -402,6 +402,16 @@ pub fn load_settings() -> CommandResult<SettingsPayload> {
 }
 
 #[tauri::command]
+pub fn get_config_coordination_status() -> CommandResult<codex_plus_core::config_coordinator::CoordinationStatus> {
+    let settings =
+        settings_with_live_ccs_profiles(SettingsStore::default().load().unwrap_or_default());
+    ok(
+        "已读取配置协调状态。",
+        codex_plus_core::config_coordinator::coordination_status(&settings),
+    )
+}
+
+#[tauri::command]
 pub fn save_settings(settings: BackendSettings) -> CommandResult<SettingsPayload> {
     let mut settings = normalize_settings_before_save(settings);
     if settings.ccs_link_enabled {
@@ -1761,6 +1771,12 @@ pub fn apply_relay_injection() -> CommandResult<RelayPayload> {
     }
     let relay = settings.active_relay_profile();
     log_relay_apply_request("manager.apply_relay_injection", &settings, &relay);
+    if let Some(result) = try_apply_linked_ccs_provider(&settings, &relay) {
+        return result;
+    }
+    if let Some(result) = guard_live_write_or_fail(&settings, false) {
+        return result;
+    }
     if relay_has_complete_files(&relay) {
         return match codex_plus_core::relay_config::apply_relay_profile_to_home_with_switch_rules(
             &home,
@@ -1865,6 +1881,12 @@ pub fn apply_pure_api_injection() -> CommandResult<RelayPayload> {
         );
     }
     let relay = settings.active_relay_profile();
+    if let Some(result) = try_apply_linked_ccs_provider(&settings, &relay) {
+        return result;
+    }
+    if let Some(result) = guard_live_write_or_fail(&settings, false) {
+        return result;
+    }
     log_relay_apply_request("manager.apply_pure_api_injection", &settings, &relay);
     if relay_has_complete_files(&relay) {
         return match codex_plus_core::relay_config::apply_relay_profile_to_home_with_switch_rules(
@@ -1960,6 +1982,12 @@ pub fn clear_relay_injection() -> CommandResult<RelayPayload> {
         settings_with_live_ccs_profiles(SettingsStore::default().load().unwrap_or_default());
     let relay = settings.active_relay_profile();
     log_manager_event("manager.clear_relay_injection.start", json!({}));
+    if let Some(result) = try_apply_linked_ccs_provider(&settings, &relay) {
+        return result;
+    }
+    if let Some(result) = guard_live_write_or_fail(&settings, false) {
+        return result;
+    }
     let auth_contents = (relay.relay_mode == codex_plus_core::settings::RelayMode::Official
         && !relay.official_mix_api_key
         && !relay.auth_contents.trim().is_empty())
@@ -1995,6 +2023,64 @@ pub fn clear_relay_injection() -> CommandResult<RelayPayload> {
             )
         }
     }
+}
+
+fn try_apply_linked_ccs_provider(
+    settings: &BackendSettings,
+    relay: &codex_plus_core::settings::RelayProfile,
+) -> Option<CommandResult<RelayPayload>> {
+    if !settings.ccs_link_enabled {
+        return None;
+    }
+    if codex_plus_core::config_coordinator::effective_ownership(settings)
+        != codex_plus_core::settings::ConfigOwnership::CcSwitch
+    {
+        return None;
+    }
+    let source_id = relay.linked_ccs_provider_id.trim();
+    if source_id.is_empty() {
+        return None;
+    }
+    let home = codex_plus_core::relay_config::default_codex_home_dir();
+    match codex_plus_core::config_coordinator::apply_linked_ccs_provider_to_home(
+        source_id,
+        &relay_combined_common_config(settings),
+    ) {
+        Ok(result) => {
+            let status = codex_plus_core::relay_config::relay_status_from_home(&home);
+            log_relay_apply_result(
+                "manager.apply_relay_injection.ccswitch_coordinated",
+                relay,
+                &status,
+                result.backup_path.as_ref(),
+                None,
+            );
+            Some(ok(
+                "已通过 cc-switch 联动应用当前供应商配置，避免与 CC Switch 发生覆盖冲突。",
+                relay_payload(status, result.backup_path),
+            ))
+        }
+        Err(error) => {
+            let status = codex_plus_core::relay_config::relay_status_from_home(&home);
+            Some(failed(
+                &format!("通过 cc-switch 联动应用供应商失败：{error}"),
+                relay_payload(status, None),
+            ))
+        }
+    }
+}
+
+fn guard_live_write_or_fail(
+    settings: &BackendSettings,
+    force: bool,
+) -> Option<CommandResult<RelayPayload>> {
+    let decision = codex_plus_core::config_coordinator::evaluate_live_write(settings, force);
+    if decision.allowed {
+        return None;
+    }
+    let home = codex_plus_core::relay_config::default_codex_home_dir();
+    let status = codex_plus_core::relay_config::relay_status_from_home(&home);
+    Some(failed(&decision.message, relay_payload(status, None)))
 }
 
 fn relay_has_complete_files(relay: &codex_plus_core::settings::RelayProfile) -> bool {

--- a/apps/codex-plus-manager/src-tauri/src/lib.rs
+++ b/apps/codex-plus-manager/src-tauri/src/lib.rs
@@ -35,6 +35,7 @@ pub fn run() {
             commands::launch_codex_plus,
             commands::restart_codex_plus,
             commands::load_settings,
+            commands::get_config_coordination_status,
             commands::save_settings,
             commands::list_local_sessions,
             commands::list_zed_remote_projects,

--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -251,6 +251,8 @@ type CoordinationStatus = {
   guidance: string;
 };
 
+type CoordinationStatusResult = CommandResult<CoordinationStatus>;
+
 type LocalSession = {
   id: string;
   title: string;
@@ -1525,8 +1527,8 @@ export function App() {
       refreshRelay,
       refreshRelayFiles,
       refreshCoordinationStatus: async () => {
-        const result = await run(() => call<CommandResult<CoordinationStatus>>("get_config_coordination_status"));
-        return result?.payload ?? null;
+        const result = await run(() => call<CoordinationStatusResult>("get_config_coordination_status"));
+        return result?.status === "ok" ? result : null;
       },
       refreshLiveContextEntries,
       syncLiveContextEntries,

--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -100,6 +100,7 @@ type BackendSettings = {
   providerSyncLastSelectedProvider: string;
   relayProfilesEnabled: boolean;
   ccsLinkEnabled: boolean;
+  configOwnership: ConfigOwnership;
   enhancementsEnabled: boolean;
   codexAppPluginEntryUnlock: boolean;
   codexAppPluginMarketplaceUnlock: boolean;
@@ -135,6 +136,7 @@ type BackendSettings = {
 
 type ZedOpenStrategy = "addToFocusedWorkspace" | "reuseWindow" | "newWindow" | "default";
 type LaunchMode = "patch" | "relay";
+type ConfigOwnership = "auto" | "codexPlusPlus" | "ccSwitch";
 
 type RelayProfile = {
   id: string;
@@ -234,6 +236,20 @@ type RelayFilesResult = CommandResult<{
   configContents: string;
   authContents: string;
 }>;
+
+type CoordinationStatus = {
+  ccswitchDetected: boolean;
+  configuredOwnership: ConfigOwnership;
+  effectiveOwnership: ConfigOwnership;
+  lastWriter: string | null;
+  conflictDetected: boolean;
+  conflictMessage: string;
+  ccswitchCurrentProviderId: string | null;
+  ccswitchCurrentProviderName: string | null;
+  liveModelProvider: string;
+  canWriteLiveConfig: boolean;
+  guidance: string;
+};
 
 type LocalSession = {
   id: string;
@@ -508,6 +524,7 @@ const defaultSettings: BackendSettings = {
   providerSyncLastSelectedProvider: "",
   relayProfilesEnabled: true,
   ccsLinkEnabled: false,
+  configOwnership: "auto",
   enhancementsEnabled: true,
   codexAppPluginEntryUnlock: true,
   codexAppPluginMarketplaceUnlock: true,
@@ -1507,6 +1524,10 @@ export function App() {
       },
       refreshRelay,
       refreshRelayFiles,
+      refreshCoordinationStatus: async () => {
+        const result = await run(() => call<CommandResult<CoordinationStatus>>("get_config_coordination_status"));
+        return result?.payload ?? null;
+      },
       refreshLiveContextEntries,
       syncLiveContextEntries,
       importCcsProviders,
@@ -1721,6 +1742,7 @@ type Actions = {
   setLaunchMode: (launchMode: LaunchMode) => Promise<void>;
   refreshRelay: () => Promise<void>;
   refreshRelayFiles: () => Promise<RelayFilesResult | null>;
+  refreshCoordinationStatus: () => Promise<CoordinationStatus | null>;
   refreshLiveContextEntries: () => Promise<LiveContextEntriesResult | null>;
   syncLiveContextEntries: (settings: BackendSettings, silent?: boolean) => Promise<LiveContextEntriesResult | null>;
   importCcsProviders: () => Promise<void>;
@@ -1935,9 +1957,31 @@ function RelayScreen({
             />
             <span>
               <strong>联动 cc-switch</strong>
-              <small>开启后读取 cc-switch Codex 供应商并保存时回写；同时使用多个管理工具可能导致 config.toml / auth.json 被反复覆盖。</small>
+              <small>开启后读取 cc-switch Codex 供应商并保存时回写；建议配合“配置所有权”避免与 CC Switch 互相覆盖。</small>
             </span>
           </label>
+          <label className="switch-row relay-ownership-row">
+            <span>
+              <strong>配置所有权</strong>
+              <small>决定由谁写入 ~/.codex/config.toml 与 auth.json。auto 在开启联动且检测到 CC Switch 时交由 CC Switch 管理。</small>
+            </span>
+            <select
+              value={normalized.configOwnership}
+              disabled={!normalized.relayProfilesEnabled}
+              onChange={(event) => {
+                const next = {
+                  ...normalized,
+                  configOwnership: event.currentTarget.value as ConfigOwnership,
+                };
+                void saveRelaySettings(next);
+              }}
+            >
+              <option value="auto">自动（推荐）</option>
+              <option value="ccSwitch">CC Switch 管理</option>
+              <option value="codexPlusPlus">Codex++ 管理</option>
+            </select>
+          </label>
+          <CoordinationStatusBanner form={normalized} actions={actions} />
           <div className="relay-add-row">
             <Button
               variant="secondary"
@@ -4463,6 +4507,46 @@ function contextSelectionForAllEntries(settings: BackendSettings): RelayContextS
   };
 }
 
+function normalizeConfigOwnership(value: ConfigOwnership | undefined): ConfigOwnership {
+  if (value === "codexPlusPlus" || value === "ccSwitch" || value === "auto") return value;
+  return "auto";
+}
+
+function configOwnershipLabel(value: ConfigOwnership): string {
+  if (value === "codexPlusPlus") return "Codex++";
+  if (value === "ccSwitch") return "CC Switch";
+  return "自动";
+}
+
+function CoordinationStatusBanner({
+  form,
+  actions,
+}: {
+  form: BackendSettings;
+  actions: Actions;
+}) {
+  const [status, setStatus] = useState<CoordinationStatus | null>(null);
+  useEffect(() => {
+    void actions.refreshCoordinationStatus().then(setStatus);
+  }, [actions, form.ccsLinkEnabled, form.configOwnership, form.relayProfilesEnabled, form.activeRelayId]);
+  if (!status) return null;
+  const tone = status.conflictDetected ? "failed" : status.effectiveOwnership === "ccSwitch" ? "success" : "info";
+  return (
+    <div className={`relay-coordination-banner relay-coordination-${tone}`}>
+      <strong>配置协调状态</strong>
+      <p>{status.guidance}</p>
+      {status.ccswitchDetected ? (
+        <small>
+          有效所有权：{configOwnershipLabel(status.effectiveOwnership)}；live model_provider：{status.liveModelProvider || "（空）"}
+          {status.ccswitchCurrentProviderName ? `；CC Switch 当前：${status.ccswitchCurrentProviderName}` : ""}
+          {status.lastWriter ? `；上次写入方：${status.lastWriter}` : ""}
+        </small>
+      ) : null}
+      {status.conflictDetected ? <small>{status.conflictMessage}</small> : null}
+    </div>
+  );
+}
+
 function relayProfileSourceLabel(profile: RelayProfile) {
   return profile.linkedCcsProviderId ? "cc-switch 联动" : "本地";
 }
@@ -4470,6 +4554,9 @@ function relayProfileSourceLabel(profile: RelayProfile) {
 function relayProfileEditorStatus(profile: RelayProfile, form: BackendSettings, isNew: boolean) {
   if (isNew) return "新建供应商需要先保存到列表";
   if (!form.relayProfilesEnabled) return "供应商配置总开关已关闭；当前只保存配置，不写入 Codex live 文件";
+  if (profile.linkedCcsProviderId && form.ccsLinkEnabled && form.configOwnership !== "codexPlusPlus") {
+    return "联动 cc-switch；切换时从 cc-switch 数据库应用配置，避免覆盖冲突";
+  }
   if (profile.linkedCcsProviderId && form.ccsLinkEnabled) return "联动 cc-switch；保存后会回写外部供应商数据库";
   if (profile.linkedCcsProviderId) return "联动 cc-switch；当前未开启保存回写";
   return profile.id === form.activeRelayId ? "当前正在使用" : "编辑后保存列表，再切换模式时会使用新配置";
@@ -4578,6 +4665,7 @@ function normalizeSettings(settings: BackendSettings): BackendSettings {
     ...settings,
     relayProfilesEnabled: settings.relayProfilesEnabled !== false,
     ccsLinkEnabled: settings.ccsLinkEnabled === true,
+    configOwnership: normalizeConfigOwnership(settings.configOwnership),
     relayCommonConfigContents,
     relayContextConfigContents,
     relayProfiles: profiles,

--- a/crates/codex-plus-core/src/ccs_import.rs
+++ b/crates/codex-plus-core/src/ccs_import.rs
@@ -171,6 +171,30 @@ pub fn write_linked_profiles_to_db(
     Ok(written)
 }
 
+pub fn current_codex_provider_from_db(path: &Path) -> anyhow::Result<Option<CcsProviderImport>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let conn = Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| format!("failed to open provider database {}", path.display()))?;
+    let mut stmt = conn.prepare(
+        "SELECT id, name, settings_config
+         FROM providers
+         WHERE app_type = 'codex' AND is_current = 1
+         ORDER BY COALESCE(sort_index, 999999), created_at ASC
+         LIMIT 1",
+    )?;
+    let mut rows = stmt.query([])?;
+    let Some(row) = rows.next()? else {
+        return Ok(None);
+    };
+    let source_id: String = row.get(0)?;
+    let name: String = row.get(1)?;
+    let settings_config: String = row.get(2)?;
+    let config = serde_json::from_str::<Value>(&settings_config).unwrap_or_default();
+    Ok(import_from_ccs_value(&source_id, &name, &config))
+}
+
 pub fn list_codex_providers_from_db(path: &Path) -> anyhow::Result<Vec<CcsProviderImport>> {
     if !path.exists() {
         return Ok(Vec::new());
@@ -236,7 +260,7 @@ pub fn relay_profile_from_ccs(
     }
 }
 
-fn apply_ccs_provider_to_profile(profile: &mut RelayProfile, provider: &CcsProviderImport) {
+pub fn apply_ccs_provider_to_profile(profile: &mut RelayProfile, provider: &CcsProviderImport) {
     profile.linked_ccs_provider_id = provider.source_id.clone();
     profile.name = provider.name.clone();
     profile.base_url = provider.base_url.clone();
@@ -269,7 +293,7 @@ fn profile_to_ccs_settings_config(profile: &RelayProfile) -> anyhow::Result<Valu
     }))
 }
 
-fn import_from_ccs_value(source_id: &str, name: &str, config: &Value) -> Option<CcsProviderImport> {
+pub fn import_from_ccs_value(source_id: &str, name: &str, config: &Value) -> Option<CcsProviderImport> {
     let base_url = extract_base_url(config).unwrap_or_default();
     let api_key = extract_api_key(config).unwrap_or_default();
     let protocol = extract_protocol(config);
@@ -734,6 +758,35 @@ base_url = "https://toml.example/v1"
         assert_eq!(name, "After");
         assert_eq!(settings_config["auth"]["OPENAI_API_KEY"], "sk-after");
         assert_eq!(settings_config["config"], "model_provider = \"custom\"\n");
+    }
+
+    #[test]
+    fn current_codex_provider_from_db_returns_active_provider() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join(format!("{}-{}.db", "cc", "switch"));
+        create_ccs_db(&db);
+        insert_provider(&db, "old", "Old", json!({ "config": "old" }), 0);
+        insert_provider(
+            &db,
+            "new",
+            "New",
+            json!({
+                "auth": { "OPENAI_API_KEY": "sk-new" },
+                "config": "model_provider = \"new\"\n"
+            }),
+            1,
+        );
+        Connection::open(&db)
+            .unwrap()
+            .execute(
+                "UPDATE providers SET is_current = 1 WHERE id = 'new' AND app_type = 'codex'",
+                [],
+            )
+            .unwrap();
+
+        let current = current_codex_provider_from_db(&db).unwrap().unwrap();
+        assert_eq!(current.source_id, "new");
+        assert_eq!(current.name, "New");
     }
 
     #[test]

--- a/crates/codex-plus-core/src/config_coordinator.rs
+++ b/crates/codex-plus-core/src/config_coordinator.rs
@@ -1,0 +1,352 @@
+use std::collections::hash_map::DefaultHasher;
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+
+use crate::ccs_import::{self, CcsProviderImport};
+use crate::relay_config::{self, RelayApplyResult};
+use crate::settings::{BackendSettings, ConfigOwnership};
+
+const WRITE_MARKER_FILE: &str = "config-write-marker.json";
+const WRITER_CODEX_PLUS_PLUS: &str = "codexplusplus";
+const WRITER_CC_SWITCH: &str = "ccswitch";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiveConfigFingerprint {
+    pub config_hash: String,
+    pub auth_hash: String,
+    pub model_provider: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigWriteMarker {
+    pub writer: String,
+    pub fingerprint: LiveConfigFingerprint,
+    pub written_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoordinationStatus {
+    pub ccswitch_detected: bool,
+    pub configured_ownership: ConfigOwnership,
+    pub effective_ownership: ConfigOwnership,
+    pub last_writer: Option<String>,
+    pub conflict_detected: bool,
+    pub conflict_message: String,
+    pub ccswitch_current_provider_id: Option<String>,
+    pub ccswitch_current_provider_name: Option<String>,
+    pub live_model_provider: String,
+    pub can_write_live_config: bool,
+    pub guidance: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveConfigWriteDecision {
+    pub allowed: bool,
+    pub message: String,
+}
+
+pub fn detect_ccswitch() -> bool {
+    ccs_import::default_ccs_db_path().exists()
+}
+
+pub fn effective_ownership(settings: &BackendSettings) -> ConfigOwnership {
+    match settings.config_ownership {
+        ConfigOwnership::Auto => {
+            if settings.ccs_link_enabled && detect_ccswitch() {
+                ConfigOwnership::CcSwitch
+            } else {
+                ConfigOwnership::CodexPlusPlus
+            }
+        }
+        other => other,
+    }
+}
+
+pub fn write_marker_path() -> PathBuf {
+    crate::paths::default_app_state_dir().join(WRITE_MARKER_FILE)
+}
+
+pub fn fingerprint_from_home(home: &std::path::Path) -> LiveConfigFingerprint {
+    let config_path = home.join("config.toml");
+    let auth_path = home.join("auth.json");
+    let config_bytes = fs::read(&config_path).unwrap_or_default();
+    let auth_bytes = fs::read(&auth_path).unwrap_or_default();
+    let config_text = String::from_utf8_lossy(&config_bytes);
+    LiveConfigFingerprint {
+        config_hash: hash_bytes(&config_bytes),
+        auth_hash: hash_bytes(&auth_bytes),
+        model_provider: relay_config::root_key_string(&config_text, "model_provider")
+            .unwrap_or_default(),
+    }
+}
+
+pub fn read_write_marker() -> Option<ConfigWriteMarker> {
+    let path = write_marker_path();
+    let text = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+pub fn record_write_marker(writer: &str, home: &std::path::Path) -> anyhow::Result<()> {
+    let marker = ConfigWriteMarker {
+        writer: writer.to_string(),
+        fingerprint: fingerprint_from_home(home),
+        written_at_ms: now_ms(),
+    };
+    let path = write_marker_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    crate::settings::atomic_write(
+        &path,
+        format!("{}\n", serde_json::to_string_pretty(&marker)?).as_bytes(),
+    )
+}
+
+pub fn detect_external_modification(home: &std::path::Path) -> Option<String> {
+    let marker = read_write_marker()?;
+    let current = fingerprint_from_home(home);
+    if marker.fingerprint == current {
+        return None;
+    }
+    let writer = marker.writer.trim();
+    if writer == WRITER_CODEX_PLUS_PLUS {
+        Some(
+            "检测到 config.toml / auth.json 在 Codex++ 上次写入后被外部修改。\
+             这通常由 CC Switch 切换供应商引起。"
+                .to_string(),
+        )
+    } else if writer == WRITER_CC_SWITCH {
+        Some(
+            "检测到 live 配置与 CC Switch 上次写入记录不一致。\
+             请先在 CC Switch 中重新启用当前供应商，或刷新 Codex++ 联动状态。"
+                .to_string(),
+        )
+    } else {
+        Some(
+            "检测到 config.toml / auth.json 与 Codex++ 记录不一致，\
+             可能已被其他工具改写。"
+                .to_string(),
+        )
+    }
+}
+
+pub fn coordination_status(settings: &BackendSettings) -> CoordinationStatus {
+    let home = relay_config::default_codex_home_dir();
+    let ccswitch_detected = detect_ccswitch();
+    let configured = settings.config_ownership;
+    let effective = effective_ownership(settings);
+    let live = fingerprint_from_home(&home);
+    let marker = read_write_marker();
+    let current_ccs = current_ccs_codex_provider();
+    let conflict_message = detect_external_modification(&home).unwrap_or_default();
+    let conflict_detected = !conflict_message.is_empty();
+    let can_write = evaluate_live_write(settings, false).allowed;
+    let guidance = coordination_guidance(
+        settings,
+        effective,
+        ccswitch_detected,
+        conflict_detected,
+        &current_ccs,
+        &live.model_provider,
+    );
+
+    CoordinationStatus {
+        ccswitch_detected,
+        configured_ownership: configured,
+        effective_ownership: effective,
+        last_writer: marker.map(|value| value.writer),
+        conflict_detected,
+        conflict_message,
+        ccswitch_current_provider_id: current_ccs.as_ref().map(|provider| provider.source_id.clone()),
+        ccswitch_current_provider_name: current_ccs.as_ref().map(|provider| provider.name.clone()),
+        live_model_provider: live.model_provider,
+        can_write_live_config: can_write,
+        guidance,
+    }
+}
+
+pub fn evaluate_live_write(settings: &BackendSettings, force: bool) -> LiveConfigWriteDecision {
+    if !settings.relay_profiles_enabled {
+        return LiveConfigWriteDecision {
+            allowed: false,
+            message: "供应商配置总开关已关闭，Codex++ 不会写入 config.toml / auth.json。".to_string(),
+        };
+    }
+
+    let effective = effective_ownership(settings);
+    if effective == ConfigOwnership::CcSwitch && !settings.ccs_link_enabled {
+        return LiveConfigWriteDecision {
+            allowed: false,
+            message: "当前配置所有权为 CC Switch，但未开启联动 cc-switch。\
+                      请开启联动，或将配置所有权改为 Codex++。"
+                .to_string(),
+        };
+    }
+
+    if effective == ConfigOwnership::CcSwitch && !force {
+        return LiveConfigWriteDecision {
+            allowed: false,
+            message: "当前由 CC Switch 管理 Codex 供应商配置。\
+                      Codex++ 不会直接覆盖 live 配置；请通过联动供应商切换，或在 CC Switch 中切换后刷新。"
+                .to_string(),
+        };
+    }
+
+    if detect_ccswitch()
+        && effective == ConfigOwnership::CodexPlusPlus
+        && !force
+        && let Some(conflict) = detect_external_modification(&relay_config::default_codex_home_dir())
+    {
+        return LiveConfigWriteDecision {
+            allowed: false,
+            message: format!(
+                "{conflict} 若确认由 Codex++ 接管，请先将“配置所有权”设为 Codex++ 并强制切换。"
+            ),
+        };
+    }
+
+    LiveConfigWriteDecision {
+        allowed: true,
+        message: String::new(),
+    }
+}
+
+pub fn apply_linked_ccs_provider_to_home(
+    source_id: &str,
+    common_config_contents: &str,
+) -> anyhow::Result<RelayApplyResult> {
+    let provider = current_ccs_codex_provider_by_id(source_id)
+        .with_context(|| format!("未在 cc-switch 中找到 Codex 供应商 {source_id}"))?;
+    apply_ccs_provider_import_to_home(&provider, common_config_contents)
+}
+
+pub fn apply_current_ccs_provider_to_home(
+    common_config_contents: &str,
+) -> anyhow::Result<RelayApplyResult> {
+    let provider = current_ccs_codex_provider()
+        .ok_or_else(|| anyhow::anyhow!("cc-switch 中未找到当前启用的 Codex 供应商"))?;
+    apply_ccs_provider_import_to_home(&provider, common_config_contents)
+}
+
+pub fn sync_active_profile_from_ccs(settings: &mut BackendSettings) -> bool {
+    if !settings.ccs_link_enabled {
+        return false;
+    }
+    let Some(current) = current_ccs_codex_provider() else {
+        return false;
+    };
+    if let Some(profile) = settings
+        .relay_profiles
+        .iter_mut()
+        .find(|profile| profile.linked_ccs_provider_id == current.source_id)
+    {
+        settings.active_relay_id = profile.id.clone();
+        ccs_import::apply_ccs_provider_to_profile(profile, &current);
+        return true;
+    }
+    let existing_ids = settings
+        .relay_profiles
+        .iter()
+        .map(|profile| profile.id.clone())
+        .collect::<Vec<_>>();
+    let mut profile = ccs_import::relay_profile_from_ccs(&current, &existing_ids);
+    ccs_import::apply_ccs_provider_to_profile(&mut profile, &current);
+    settings.active_relay_id = profile.id.clone();
+    settings.relay_profiles.push(profile);
+    true
+}
+
+fn apply_ccs_provider_import_to_home(
+    provider: &CcsProviderImport,
+    common_config_contents: &str,
+) -> anyhow::Result<RelayApplyResult> {
+    let home = relay_config::default_codex_home_dir();
+    let config_with_common = relay_config::merge_common_config_into_config(
+        &provider.config_contents,
+        common_config_contents,
+    )?;
+    let result = relay_config::apply_relay_files_to_home(
+        &home,
+        &config_with_common,
+        &provider.auth_contents,
+    )?;
+    record_write_marker(WRITER_CC_SWITCH, &home)?;
+    Ok(result)
+}
+
+pub fn current_ccs_codex_provider() -> Option<CcsProviderImport> {
+    ccs_import::current_codex_provider_from_db(&ccs_import::default_ccs_db_path())
+        .ok()
+        .flatten()
+}
+
+pub fn current_ccs_codex_provider_by_id(source_id: &str) -> Option<CcsProviderImport> {
+    let source_id = source_id.trim();
+    if source_id.is_empty() {
+        return None;
+    }
+    ccs_import::list_codex_providers_from_db(&ccs_import::default_ccs_db_path())
+        .ok()?
+        .into_iter()
+        .find(|provider| provider.source_id == source_id)
+}
+
+fn coordination_guidance(
+    settings: &BackendSettings,
+    effective: ConfigOwnership,
+    ccswitch_detected: bool,
+    conflict_detected: bool,
+    current_ccs: &Option<CcsProviderImport>,
+    live_model_provider: &str,
+) -> String {
+    if !ccswitch_detected {
+        return "未检测到 CC Switch，Codex++ 将独立管理 ~/.codex/config.toml。".to_string();
+    }
+    if conflict_detected {
+        return "检测到配置冲突：请统一只在一个工具中切换供应商，或明确设置“配置所有权”。".to_string();
+    }
+    match effective {
+        ConfigOwnership::CcSwitch => {
+            let provider = current_ccs
+                .as_ref()
+                .map(|value| value.name.as_str())
+                .unwrap_or("未知");
+            format!(
+                "当前由 CC Switch 管理供应商配置。Codex++ 会通过联动读取/回写 cc-switch 数据库，\
+                 不会直接覆盖 live 配置。CC Switch 当前供应商：{provider}；live model_provider：{live_model_provider}。"
+            )
+        }
+        ConfigOwnership::CodexPlusPlus => {
+            if settings.ccs_link_enabled {
+                "已开启 cc-switch 联动，但配置所有权仍为 Codex++。切换供应商时 Codex++ 会写入 live 配置，\
+                 可能覆盖 CC Switch 的选择。"
+                    .to_string()
+            } else {
+                "Codex++ 独立管理 live 配置。若同时使用 CC Switch，建议开启联动并设为 auto/ccswitch 所有权。"
+                    .to_string()
+            }
+        }
+        ConfigOwnership::Auto => "自动模式会根据联动开关和 CC Switch 是否存在选择所有权。".to_string(),
+    }
+}
+
+fn hash_bytes(bytes: &[u8]) -> String {
+    let mut hasher = DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -380,6 +380,30 @@ impl LaunchHooks for DefaultLaunchHooks {
         if !settings.relay_profiles_enabled {
             return Ok(());
         }
+        if crate::config_coordinator::effective_ownership(settings)
+            == crate::settings::ConfigOwnership::CcSwitch
+        {
+            let _ = crate::diagnostic_log::append_diagnostic_log(
+                "launcher.apply_active_relay_profile.skipped",
+                serde_json::json!({
+                    "reason": "ccswitch_ownership",
+                    "activeRelayId": settings.active_relay_id
+                }),
+            );
+            return Ok(());
+        }
+        let write_decision = crate::config_coordinator::evaluate_live_write(settings, false);
+        if !write_decision.allowed {
+            let _ = crate::diagnostic_log::append_diagnostic_log(
+                "launcher.apply_active_relay_profile.skipped",
+                serde_json::json!({
+                    "reason": "write_guard",
+                    "message": write_decision.message,
+                    "activeRelayId": settings.active_relay_id
+                }),
+            );
+            return Ok(());
+        }
         let profile = settings.active_relay_profile();
         let home = crate::relay_config::default_codex_home_dir();
         let common_config = crate::relay_config::normalize_config_text(

--- a/crates/codex-plus-core/src/lib.rs
+++ b/crates/codex-plus-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod app_paths;
 pub mod assets;
 pub mod bridge;
 pub mod ccs_import;
+pub mod config_coordinator;
 pub mod cdp;
 pub mod cli_wrapper;
 pub mod diagnostic_log;

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -823,6 +823,10 @@ fn write_codex_live_atomic(
         }
     }
 
+    if config_text.is_some() || auth_bytes.is_some() {
+        let _ = crate::config_coordinator::record_write_marker("codexplusplus", home);
+    }
+
     Ok(backup_path)
 }
 
@@ -1980,7 +1984,7 @@ mod tests {
     }
 }
 
-fn root_key_string(contents: &str, key: &str) -> Option<String> {
+pub fn root_key_string(contents: &str, key: &str) -> Option<String> {
     root_key_value(contents, key).map(unquote_toml_string)
 }
 

--- a/crates/codex-plus-core/src/settings.rs
+++ b/crates/codex-plus-core/src/settings.rs
@@ -10,6 +10,15 @@ use toml_edit::{DocumentMut, Item};
 use crate::zed_remote::ZedOpenStrategy;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum ConfigOwnership {
+    #[default]
+    Auto,
+    CodexPlusPlus,
+    CcSwitch,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum LaunchMode {
     #[default]
@@ -158,6 +167,8 @@ pub struct BackendSettings {
     pub relay_profiles_enabled: bool,
     #[serde(rename = "ccsLinkEnabled", default)]
     pub ccs_link_enabled: bool,
+    #[serde(rename = "configOwnership", default)]
+    pub config_ownership: ConfigOwnership,
     #[serde(rename = "enhancementsEnabled", default = "default_true")]
     pub enhancements_enabled: bool,
     #[serde(rename = "codexAppPluginEntryUnlock", default = "default_true")]
@@ -237,6 +248,7 @@ impl Default for BackendSettings {
             provider_sync_last_selected_provider: String::new(),
             relay_profiles_enabled: true,
             ccs_link_enabled: false,
+            config_ownership: ConfigOwnership::Auto,
             enhancements_enabled: true,
             codex_app_plugin_entry_unlock: true,
             codex_app_plugin_marketplace_unlock: true,
@@ -517,6 +529,11 @@ fn merge_known_setting_fields(target: &mut Map<String, Value>, source: &Map<Stri
     }
     if let Some(value) = source.get("ccsLinkEnabled").and_then(Value::as_bool) {
         target.insert("ccsLinkEnabled".to_string(), Value::Bool(value));
+    }
+    if let Some(value) = source.get("configOwnership") {
+        if serde_json::from_value::<ConfigOwnership>(value.clone()).is_ok() {
+            target.insert("configOwnership".to_string(), value.clone());
+        }
     }
     if let Some(value) = source.get("enhancementsEnabled").and_then(Value::as_bool) {
         target.insert("enhancementsEnabled".to_string(), Value::Bool(value));

--- a/crates/codex-plus-core/tests/config_coordinator.rs
+++ b/crates/codex-plus-core/tests/config_coordinator.rs
@@ -1,0 +1,100 @@
+use codex_plus_core::ccs_import;
+use codex_plus_core::config_coordinator;
+use codex_plus_core::settings::{BackendSettings, ConfigOwnership};
+use rusqlite::params;
+use serde_json::json;
+
+fn create_ccs_db(path: &std::path::Path) {
+    let conn = rusqlite::Connection::open(path).unwrap();
+    conn.execute(
+        "CREATE TABLE providers (
+            id TEXT NOT NULL,
+            app_type TEXT NOT NULL,
+            name TEXT NOT NULL,
+            settings_config TEXT NOT NULL,
+            created_at INTEGER,
+            sort_index INTEGER,
+            is_current BOOLEAN NOT NULL DEFAULT 0,
+            PRIMARY KEY (id, app_type)
+        )",
+        [],
+    )
+    .unwrap();
+}
+
+fn insert_provider(path: &std::path::Path, id: &str, name: &str, config: serde_json::Value, current: bool) {
+    let conn = rusqlite::Connection::open(path).unwrap();
+    conn.execute(
+        "INSERT INTO providers (id, app_type, name, settings_config, created_at, sort_index, is_current)
+         VALUES (?1, 'codex', ?2, ?3, 1000, 0, ?4)",
+        params![id, name, config.to_string(), current as i64],
+    )
+    .unwrap();
+}
+
+#[test]
+fn effective_ownership_auto_prefers_ccswitch_when_linked() {
+    let mut settings = BackendSettings::default();
+    settings.ccs_link_enabled = true;
+    settings.config_ownership = ConfigOwnership::Auto;
+    assert_eq!(
+        config_coordinator::effective_ownership(&settings),
+        ConfigOwnership::CcSwitch
+    );
+}
+
+#[test]
+fn evaluate_live_write_blocks_when_ccswitch_owns_config() {
+    let mut settings = BackendSettings::default();
+    settings.ccs_link_enabled = true;
+    settings.config_ownership = ConfigOwnership::CcSwitch;
+    let decision = config_coordinator::evaluate_live_write(&settings, false);
+    assert!(!decision.allowed);
+    assert!(decision.message.contains("CC Switch"));
+}
+
+#[test]
+fn detect_external_modification_after_foreign_write() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join(".codex");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::write(home.join("config.toml"), "model_provider = \"custom\"\n").unwrap();
+    std::fs::write(home.join("auth.json"), "{}\n").unwrap();
+    config_coordinator::record_write_marker("codexplusplus", &home).unwrap();
+
+    std::fs::write(home.join("config.toml"), "model_provider = \"openai\"\n").unwrap();
+    let conflict = config_coordinator::detect_external_modification(&home);
+    assert!(conflict.is_some());
+}
+
+#[test]
+fn current_codex_provider_from_db_reads_active_provider() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("cc-switch.db");
+    create_ccs_db(&db);
+    insert_provider(
+        &db,
+        "relay-a",
+        "Relay A",
+        json!({
+            "auth": { "OPENAI_API_KEY": "sk-a" },
+            "config": "model_provider = \"relay-a\"\n\n[model_providers.relay-a]\nbase_url = \"https://relay-a.example/v1\"\n"
+        }),
+        true,
+    );
+    insert_provider(
+        &db,
+        "relay-b",
+        "Relay B",
+        json!({
+            "auth": { "OPENAI_API_KEY": "sk-b" },
+            "config": "model_provider = \"relay-b\"\n"
+        }),
+        false,
+    );
+
+    let provider = ccs_import::current_codex_provider_from_db(&db).unwrap().unwrap();
+    assert_eq!(provider.source_id, "relay-a");
+    assert_eq!(provider.name, "Relay A");
+    assert!(provider.config_contents.contains("relay-a"));
+}


### PR DESCRIPTION
## 问题

当用户同时使用 Codex++ 和 CC Switch 管理 Codex 供应商时，两者都会写入 `~/.codex/config.toml` 和 `auth.json`，导致「最后写入者覆盖前者」：

- Codex++ 选混合注入 + CC Switch 选官方登录 → 最终走官方登录
- CC Switch 选中转 + Codex++ 选官方登录 → 最终走中转

现有「联动 cc-switch」只同步数据库，无法防止 live 配置被反复覆盖。

## 方案

引入 **配置所有权协调（Config Ownership Coordination）**：

1. 新增 `configOwnership` 设置：`auto` / `ccSwitch` / `codexPlusPlus`
2. 写入前检测 CC Switch 是否存在、live 配置是否被外部修改
3. `ccSwitch` 所有权下，供应商切换从 CC Switch DB 快照应用，而非 Codex++ profile 直写
4. launcher 在 CC Switch 所有权下跳过自动 apply，避免启动时覆盖
5. UI 展示协调状态与冲突提示

## 使用建议

同时用两个工具时：

- 开启「联动 cc-switch」
- 配置所有权设为「自动」或「CC Switch 管理」
- 在 CC Switch 中切换供应商；Codex++ 负责增强注入（CDP 脚本等）

## 测试

- [ ] `cargo test -p codex-plus-core config_coordinator`
- [ ] `cargo test -p codex-plus-core ccs_import`
- [ ] 手动：Codex++ 混合注入 + CC Switch 官方登录，确认不再互相覆盖
- [ ] 手动：CC Switch 切换中转后，Codex++ 启动不 revert 配置