### PR TITLE
feat: add provider presets selector for quick setup

### DIFF
--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -49,6 +49,8 @@ import {
   Wrench,
   type LucideIcon,
 } from "lucide-react";
+import { ProviderPresetSelector } from "@/components/ProviderPresetSelector";
+import type { PresetPatch } from "@/components/ProviderPresetSelector";
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 
 import { Badge as UiBadge } from "@/components/ui/badge";
@@ -3098,6 +3100,13 @@ function RelayProfileEditor({
           </Button>
         )}
       </div>
+      {isNew ? (
+        <ProviderPresetSelector
+          onSelect={(patch: PresetPatch) => {
+            updateDraft(patch as unknown as Partial<RelayProfile>);
+          }}
+        />
+      ) : null}
       <div className="relay-fields">
         <Field className="relay-field-name" label="名称">
           <Input

--- a/apps/codex-plus-manager/src/components/ProviderPresetSelector.tsx
+++ b/apps/codex-plus-manager/src/components/ProviderPresetSelector.tsx
@@ -33,7 +33,7 @@ const categoryLabels: Record<string, string> = {
   third_party: "第三方",
 };
 
-export function usePresetPatch(preset: ProviderPreset): PresetPatch {
+export function createPresetPatch(preset: ProviderPreset): PresetPatch {
   return {
     name: preset.name,
     baseUrl: preset.baseUrl,
@@ -43,7 +43,7 @@ export function usePresetPatch(preset: ProviderPreset): PresetPatch {
     testModel: preset.model,
     modelList: preset.modelList?.join("\n") ?? "",
     relayMode: preset.category === "official" ? "official" : "pureApi",
-    officialMixApiKey: preset.category === "official" ? false : false,
+    officialMixApiKey: false,
   };
 }
 
@@ -60,6 +60,7 @@ export function ProviderPresetSelector({
     <div className="preset-selector">
       <button
         className="preset-toggle"
+        aria-expanded={!collapsed}
         onClick={() => setCollapsed((c) => !c)}
         type="button"
       >
@@ -68,18 +69,18 @@ export function ProviderPresetSelector({
       </button>
 
       {!collapsed && (
-        <div className="preset-grid">
+        <div className="preset-grid" role="region" aria-label="供应商预设列表">
           {categories.map((cat) => (
             <div className="preset-category" key={cat}>
-              <div className="preset-category-label">
+              <h3 className="preset-category-label">
                 {categoryLabels[cat] || cat}
-              </div>
+              </h3>
               <div className="preset-category-items">
                 {PRESETS.filter((p) => p.category === cat).map((preset) => (
                   <button
                     className="preset-item"
                     key={preset.id}
-                    onClick={() => onSelect(usePresetPatch(preset))}
+                    onClick={() => onSelect(createPresetPatch(preset))}
                     title={`${preset.websiteUrl ?? ""}\n${preset.baseUrl}`}
                     type="button"
                   >

--- a/apps/codex-plus-manager/src/components/ProviderPresetSelector.tsx
+++ b/apps/codex-plus-manager/src/components/ProviderPresetSelector.tsx
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import type { ProviderPreset, RelayProtocol } from "../presets";
+import { PRESETS } from "../presets";
+
+export type RelayProfile = {
+  id: string;
+  linkedCcsProviderId: string;
+  name: string;
+  model: string;
+  baseUrl: string;
+  upstreamBaseUrl: string;
+  apiKey: string;
+  protocol: RelayProtocol;
+  relayMode: string;
+  officialMixApiKey: boolean;
+  testModel: string;
+  configContents: string;
+  authContents: string;
+  useCommonConfig: boolean;
+  contextWindow: string;
+  autoCompactLimit: string;
+  modelInsertMode: string;
+  modelList: string;
+  userAgent: string;
+};
+
+export type PresetPatch = Partial<RelayProfile>;
+
+const categoryLabels: Record<string, string> = {
+  official: "官方",
+  cn_official: "中国官方",
+  aggregator: "聚合/中转",
+  third_party: "第三方",
+};
+
+export function usePresetPatch(preset: ProviderPreset): PresetPatch {
+  return {
+    name: preset.name,
+    baseUrl: preset.baseUrl,
+    upstreamBaseUrl: preset.baseUrl,
+    protocol: preset.protocol,
+    model: preset.model,
+    testModel: preset.model,
+    modelList: preset.modelList?.join("\n") ?? "",
+    relayMode: preset.category === "official" ? "official" : "pureApi",
+    officialMixApiKey: preset.category === "official" ? false : false,
+  };
+}
+
+export function ProviderPresetSelector({
+  onSelect,
+}: {
+  onSelect: (patch: PresetPatch) => void;
+}) {
+  const [collapsed, setCollapsed] = useState(true);
+
+  const categories = [...new Set(PRESETS.map((p) => p.category))];
+
+  return (
+    <div className="preset-selector">
+      <button
+        className="preset-toggle"
+        onClick={() => setCollapsed((c) => !c)}
+        type="button"
+      >
+        <span>{collapsed ? "从预设模板创建" : "收起预设模板"}</span>
+        <small>{collapsed ? `共 ${PRESETS.length} 个供应商` : ""}</small>
+      </button>
+
+      {!collapsed && (
+        <div className="preset-grid">
+          {categories.map((cat) => (
+            <div className="preset-category" key={cat}>
+              <div className="preset-category-label">
+                {categoryLabels[cat] || cat}
+              </div>
+              <div className="preset-category-items">
+                {PRESETS.filter((p) => p.category === cat).map((preset) => (
+                  <button
+                    className="preset-item"
+                    key={preset.id}
+                    onClick={() => onSelect(usePresetPatch(preset))}
+                    title={`${preset.websiteUrl ?? ""}\n${preset.baseUrl}`}
+                    type="button"
+                  >
+                    <span className="preset-item-name">{preset.name}</span>
+                    <span className="preset-item-protocol">
+                      {preset.protocol === "chatCompletions"
+                        ? "Chat"
+                        : "Responses"}
+                    </span>
+                    <span className="preset-item-model">{preset.model}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/codex-plus-manager/src/presets.ts
+++ b/apps/codex-plus-manager/src/presets.ts
@@ -1,0 +1,262 @@
+/**
+ * Codex++ 供应商预设
+ * 基于 cc-switch (MIT) 的 codexProviderPresets.ts，作者 Jason Young
+ * https://github.com/farion1231/cc-switch
+ *
+ * 提供一键填充供应商配置的预设模板，包括 Base URL、协议、模型列表等。
+ * 去掉了 cc-switch 原始的商业合作标记（isPartner、partnerPromotionKey）。
+ */
+
+export type PresetCategory = "official" | "aggregator" | "third_party" | "cn_official";
+
+export type RelayProtocol = "responses" | "chatCompletions";
+
+export interface ProviderPreset {
+  id: string;
+  name: string;
+  websiteUrl?: string;
+  apiKeyUrl?: string;
+  category: PresetCategory;
+  baseUrl: string;
+  protocol: RelayProtocol;
+  model: string;
+  modelList?: string[];
+}
+
+/**
+ * 预设列表。选择任一预设会自动填充：
+ * - name     → 供应商名称
+ * - baseUrl  → API 端点
+ * - protocol → responses / chatCompletions（根据上游实际协议）
+ * - model    → 默认模型名
+ * - modelList → 可选模型清单（换行分隔）
+ */
+export const PRESETS: ProviderPreset[] = [
+  // ── 官方 ──
+  {
+    id: "openai",
+    name: "OpenAI Official",
+    category: "official",
+    baseUrl: "https://api.openai.com/v1",
+    protocol: "responses",
+    model: "gpt-5.5",
+    websiteUrl: "https://chatgpt.com/codex",
+  },
+
+  // ── 中国官方 ──
+  {
+    id: "deepseek",
+    name: "DeepSeek",
+    websiteUrl: "https://platform.deepseek.com",
+    apiKeyUrl: "https://platform.deepseek.com/api_keys",
+    category: "cn_official",
+    baseUrl: "https://api.deepseek.com",
+    protocol: "chatCompletions",
+    model: "deepseek-v4-flash",
+    modelList: ["deepseek-v4-flash", "deepseek-v4-pro"],
+  },
+  {
+    id: "zhipu-glm",
+    name: "Zhipu GLM",
+    websiteUrl: "https://open.bigmodel.cn",
+    apiKeyUrl: "https://www.bigmodel.cn/claude-code?ic=RRVJPB5SII",
+    category: "cn_official",
+    baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+    protocol: "chatCompletions",
+    model: "glm-5.1",
+    modelList: ["glm-5.1"],
+  },
+  {
+    id: "kimi",
+    name: "Kimi",
+    websiteUrl: "https://platform.moonshot.cn",
+    apiKeyUrl: "https://platform.moonshot.cn/console/api-keys",
+    category: "cn_official",
+    baseUrl: "https://api.moonshot.cn/v1",
+    protocol: "chatCompletions",
+    model: "kimi-k2.6",
+    modelList: ["kimi-k2.6"],
+  },
+  {
+    id: "bailian",
+    name: "Bailian (Qwen)",
+    websiteUrl: "https://bailian.console.aliyun.com",
+    apiKeyUrl: "https://bailian.console.aliyun.com/#/api-key",
+    category: "cn_official",
+    baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    protocol: "chatCompletions",
+    model: "qwen3-coder-plus",
+    modelList: ["qwen3-coder-plus", "qwen3-max"],
+  },
+  {
+    id: "stepfun",
+    name: "StepFun",
+    websiteUrl: "https://platform.stepfun.com/step-plan",
+    apiKeyUrl: "https://platform.stepfun.com/interface-key",
+    category: "cn_official",
+    baseUrl: "https://api.stepfun.com/step_plan/v1",
+    protocol: "chatCompletions",
+    model: "step-3.5-flash-2603",
+    modelList: ["step-3.5-flash-2603", "step-3.5-flash"],
+  },
+  {
+    id: "minimax",
+    name: "MiniMax",
+    websiteUrl: "https://platform.minimaxi.com",
+    apiKeyUrl: "https://platform.minimaxi.com/subscribe/coding-plan",
+    category: "cn_official",
+    baseUrl: "https://api.minimaxi.com/v1",
+    protocol: "chatCompletions",
+    model: "MiniMax-M2.7",
+    modelList: ["MiniMax-M2.7"],
+  },
+  {
+    id: "volcano-ark",
+    name: "火山引擎 Ark",
+    websiteUrl: "https://www.volcengine.com/product/ark",
+    apiKeyUrl: "https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey",
+    category: "cn_official",
+    baseUrl: "https://ark.cn-beijing.volces.com/api/coding/v3",
+    protocol: "chatCompletions",
+    model: "ark-code-latest",
+    modelList: ["ark-code-latest"],
+  },
+  {
+    id: "baidu-qianfan",
+    name: "百度千帆 Coding Plan",
+    category: "cn_official",
+    baseUrl: "https://qianfan.baidubce.com/v2/coding",
+    protocol: "chatCompletions",
+    model: "qianfan-code-latest",
+    websiteUrl: "https://cloud.baidu.com/product/qianfan_modelbuilder",
+  },
+  {
+    id: "xiaomi-mimo",
+    name: "小米 MiMo",
+    category: "cn_official",
+    baseUrl: "https://api.xiaomimimo.com/v1",
+    protocol: "chatCompletions",
+    model: "mimo-v2.5-pro",
+    modelList: ["mimo-v2.5-pro"],
+    websiteUrl: "https://platform.xiaomimimo.com",
+  },
+  {
+    id: "modelscope",
+    name: "ModelScope",
+    category: "cn_official",
+    baseUrl: "https://api-inference.modelscope.cn/v1",
+    protocol: "chatCompletions",
+    model: "ZhipuAI/GLM-5.1",
+    modelList: ["ZhipuAI/GLM-5.1"],
+    websiteUrl: "https://modelscope.cn",
+  },
+  {
+    id: "longcat",
+    name: "Longcat",
+    category: "cn_official",
+    baseUrl: "https://api.longcat.chat/openai/v1",
+    protocol: "chatCompletions",
+    model: "LongCat-Flash-Chat",
+    modelList: ["LongCat-Flash-Chat"],
+    websiteUrl: "https://longcat.chat/platform",
+  },
+
+  // ── 聚合/中转 ──
+  {
+    id: "siliconflow",
+    name: "SiliconFlow",
+    websiteUrl: "https://siliconflow.cn",
+    apiKeyUrl: "https://cloud.siliconflow.cn/i/drGuwc9k",
+    category: "aggregator",
+    baseUrl: "https://api.siliconflow.cn/v1",
+    protocol: "chatCompletions",
+    model: "Pro/MiniMaxAI/MiniMax-M2.7",
+    modelList: ["Pro/MiniMaxAI/MiniMax-M2.7"],
+  },
+  {
+    id: "openrouter",
+    name: "OpenRouter",
+    websiteUrl: "https://openrouter.ai",
+    apiKeyUrl: "https://openrouter.ai/keys",
+    category: "aggregator",
+    baseUrl: "https://openrouter.ai/api/v1",
+    protocol: "chatCompletions",
+    model: "gpt-5.5",
+  },
+  {
+    id: "aihubmix",
+    name: "AiHubMix",
+    category: "aggregator",
+    baseUrl: "https://aihubmix.com/v1",
+    protocol: "responses",
+    model: "gpt-5.5",
+    websiteUrl: "https://aihubmix.com",
+  },
+  {
+    id: "apikeyfun",
+    name: "APIKEY.FUN",
+    category: "aggregator",
+    baseUrl: "https://api.apikey.fun/v1",
+    protocol: "responses",
+    model: "gpt-5.5",
+    modelList: ["gpt-5.5"],
+    websiteUrl: "https://apikey.fun",
+  },
+  {
+    id: "pateway",
+    name: "PatewayAI",
+    category: "aggregator",
+    baseUrl: "https://api.pateway.ai/v1",
+    protocol: "responses",
+    model: "gpt-5.5",
+    websiteUrl: "https://pateway.ai",
+  },
+  {
+    id: "therouter",
+    name: "TheRouter",
+    category: "aggregator",
+    baseUrl: "https://api.therouter.ai/v1",
+    protocol: "chatCompletions",
+    model: "openai/gpt-5.3-codex",
+    websiteUrl: "https://therouter.ai",
+  },
+  {
+    id: "novita",
+    name: "Novita AI",
+    category: "aggregator",
+    baseUrl: "https://api.novita.ai/openai/v1",
+    protocol: "chatCompletions",
+    model: "zai-org/glm-5.1",
+    modelList: ["zai-org/glm-5.1"],
+    websiteUrl: "https://novita.ai",
+  },
+  {
+    id: "shengsuanyun",
+    name: "Shengsuanyun",
+    category: "aggregator",
+    baseUrl: "https://router.shengsuanyun.com/api/v1",
+    protocol: "chatCompletions",
+    model: "openai/gpt-5.5",
+    websiteUrl: "https://www.shengsuanyun.com",
+  },
+  {
+    id: "ccsub",
+    name: "CCSub",
+    category: "aggregator",
+    baseUrl: "https://www.ccsub.net/v1",
+    protocol: "responses",
+    model: "gpt-5.5",
+    websiteUrl: "https://www.ccsub.net",
+  },
+
+  // ── 第三方 ──
+  {
+    id: "azure",
+    name: "Azure OpenAI",
+    category: "third_party",
+    baseUrl: "https://YOUR_RESOURCE_NAME.openai.azure.com/openai",
+    protocol: "responses",
+    model: "gpt-5.5",
+    websiteUrl: "https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/codex",
+  },
+];

--- a/apps/codex-plus-manager/src/styles.css
+++ b/apps/codex-plus-manager/src/styles.css
@@ -2220,3 +2220,101 @@ body {
     width: fit-content;
   }
 }
+
+/* ── 供应商预设选择器 ── */
+.preset-selector {
+  margin-bottom: 16px;
+}
+
+.preset-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 12px 16px;
+  background: var(--surface-secondary);
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background 0.15s;
+}
+
+.preset-toggle:hover {
+  background: var(--surface-tertiary);
+}
+
+.preset-toggle small {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.preset-grid {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.preset-category {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.preset-category-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-tertiary);
+  padding: 0 4px;
+}
+
+.preset-category-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.preset-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--surface-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  transition: all 0.15s;
+  text-align: left;
+}
+
+.preset-item:hover {
+  background: var(--accent-bg);
+  border-color: var(--accent);
+}
+
+.preset-item-name {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.preset-item-protocol {
+  font-size: 10px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--surface-tertiary);
+  color: var(--text-tertiary);
+}
+
+.preset-item-model {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/apps/codex-plus-manager/src/styles.css
+++ b/apps/codex-plus-manager/src/styles.css
@@ -2232,21 +2232,32 @@ body {
   justify-content: space-between;
   width: 100%;
   padding: 12px 16px;
-  background: var(--surface-secondary);
-  border: 1px dashed var(--border);
+  min-height: 44px;
+  background: hsl(var(--muted));
+  border: 1px dashed hsl(var(--border));
   border-radius: 8px;
   cursor: pointer;
   font-size: 14px;
-  transition: background 0.15s;
+  color: hsl(var(--foreground));
+  transition: background 0.15s var(--motion-ease), border-color 0.15s var(--motion-ease);
 }
 
 .preset-toggle:hover {
-  background: var(--surface-tertiary);
+  background: hsl(var(--accent));
+}
+
+.preset-toggle:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 2px;
+}
+
+.preset-toggle:active {
+  transform: scale(0.98);
 }
 
 .preset-toggle small {
   font-size: 12px;
-  color: var(--text-tertiary);
+  color: hsl(var(--muted-foreground));
 }
 
 .preset-grid {
@@ -2267,7 +2278,7 @@ body {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  color: var(--text-tertiary);
+  color: hsl(var(--muted-foreground));
   padding: 0 4px;
 }
 
@@ -2281,24 +2292,34 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 12px;
-  background: var(--surface-secondary);
-  border: 1px solid var(--border);
+  padding: 8px 14px;
+  min-height: 44px;
+  background: hsl(var(--muted));
+  border: 1px solid hsl(var(--border));
   border-radius: 6px;
   cursor: pointer;
   font-size: 13px;
-  transition: all 0.15s;
+  color: hsl(var(--foreground));
+  transition: all 0.15s var(--motion-ease);
   text-align: left;
 }
 
 .preset-item:hover {
-  background: var(--accent-bg);
-  border-color: var(--accent);
+  background: hsl(var(--accent));
+  border-color: hsl(var(--ring));
+}
+
+.preset-item:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 2px;
+}
+
+.preset-item:active {
+  transform: scale(0.97);
 }
 
 .preset-item-name {
   font-weight: 600;
-  color: var(--text-primary);
 }
 
 .preset-item-protocol {
@@ -2306,13 +2327,13 @@ body {
   font-weight: 500;
   padding: 1px 6px;
   border-radius: 4px;
-  background: var(--surface-tertiary);
-  color: var(--text-tertiary);
+  background: hsl(var(--background));
+  color: hsl(var(--muted-foreground));
 }
 
 .preset-item-model {
   font-size: 11px;
-  color: var(--text-tertiary);
+  color: hsl(var(--muted-foreground));
   max-width: 160px;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## 说明

新增供应商预设系统。创建新供应商时，可以从预设列表中选择，自动填充名称、Base URL、协议、模型等字段，减少手动配置错误。

## 预设列表

涵盖 20+ 主流供应商，按分类组织：

**官方**：OpenAI
**中国官方**：DeepSeek、Zhipu GLM、Kimi、Bailian (Qwen)、StepFun、MiniMax、火山 Ark、千帆、小米 MiMo、ModelScope、Longcat
**聚合/中转**：SiliconFlow、OpenRouter、AiHubMix、APIKEY.FUN、PatewayAI、TheRouter、Novita AI、Shengsuanyun、CCSub
**第三方**：Azure OpenAI

## 实现

- `src/presets.ts` — 预设数据，基于 cc-switch (MIT) presets，保留版权声明
- `src/components/ProviderPresetSelector.tsx` — 预设选择器 UI 组件，按分类分组
- 仅新建供应商时显示预设选择，编辑现有供应商不显示，不影响已有配置

## 截图

（选择预设后自动填充 Base URL、协议、模型、模型列表等字段）

基于 cc-switch (MIT) 的 codexProviderPresets.ts，作者 Jason Young
https://github.com/farion1231/cc-switch

Co-Authored-By: Claude <noreply@anthropic.com>