### PR TITLE
fix : gpt5.5 最大上下文窗口，这导致gpt5.5开1M上下文未被正确透传

### DIFF
--- a/crates/codex-plus-core/assets/codex-models.json
+++ b/crates/codex-plus-core/assets/codex-models.json
@@ -17,7 +17,7 @@
       },
       "supports_parallel_tool_calls": true,
       "context_window": 272000,
-      "max_context_window": 272000,
+      "max_context_window": 1000000,
       "auto_compact_token_limit": null,
       "reasoning_summary_format": "experimental",
       "default_reasoning_summary": "none",


### PR DESCRIPTION
fix : gpt5.5 最大上下文窗口，这导致gpt5.5开1M上下文未被正确透传