### PR TITLE
增强 Windows Computer Use 启动前检查与 CDP 就绪判定

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -129,14 +129,8 @@ async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<
     let settings = hooks.load_settings().await?;
     hooks.ensure_computer_use_config(&settings).await?;
     let app_dir = hooks.resolve_app_dir(options.app_dir.as_deref(), &settings)?;
-    let launch_result = hooks
-        .launch_codex(&app_dir, options.debug_port, &settings.codex_extra_args)
-        .await;
     let mut helper_started = false;
-    if settings.enhancements_enabled {
-        hooks.start_helper(options.helper_port).await?;
-        helper_started = true;
-    }
+
     let result = async {
         let process_ids = codex_plus_core::watcher::find_codex_processes();
         let activated = {
@@ -156,19 +150,60 @@ async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<
                 false
             }
         };
-        let injection_ready = if settings.enhancements_enabled {
-            hooks
+        let cdp_listening_before_launch = codex_plus_core::watcher::cdp_listening(options.debug_port);
+        if settings.enhancements_enabled {
+            hooks.start_helper(options.helper_port).await?;
+            helper_started = true;
+        }
+        let mut injection_ready = false;
+        if settings.enhancements_enabled && cdp_listening_before_launch {
+            injection_ready = hooks
                 .ensure_injection(options.debug_port, options.helper_port, &app_dir)
+                .await;
+        }
+
+        let should_launch = existing_instance_should_launch(cdp_listening_before_launch, injection_ready);
+        let mut launch_ok = None;
+        let mut launch_error = None;
+        if should_launch {
+            match hooks
+                .launch_codex(&app_dir, options.debug_port, &settings.codex_extra_args)
                 .await
-        } else {
-            false
-        };
-        if injection_ready {
-            hooks
-                .start_bridge_watchdog(options.debug_port, options.helper_port)
-                .await?;
+            {
+                Ok(_) => {
+                    launch_ok = Some(true);
+                    if settings.enhancements_enabled {
+                        injection_ready = hooks
+                            .ensure_injection(options.debug_port, options.helper_port, &app_dir)
+                            .await;
+                    }
+                }
+                Err(error) => {
+                    launch_ok = Some(false);
+                    launch_error = Some(error.to_string());
+                    let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+                        "launcher.activate_existing_codex",
+                        json!({
+                            "app_dir": app_dir.to_string_lossy(),
+                            "debug_port": options.debug_port,
+                            "helper_port": options.helper_port,
+                            "process_ids": process_ids,
+                            "activated": activated,
+                            "cdp_listening_before_launch": cdp_listening_before_launch,
+                            "injection_ready": injection_ready,
+                            "launch_attempted": should_launch,
+                            "launch_ok": launch_ok,
+                            "launch_error": launch_error
+                        }),
+                    );
+                    return Err(error);
+                }
+            }
+        }
+
+        if injection_ready || !settings.enhancements_enabled {
             hooks.write_status("running").await;
-        } else if settings.enhancements_enabled {
+        } else {
             hooks.write_status("running_degraded").await;
         }
         let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
@@ -179,18 +214,24 @@ async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<
                 "helper_port": options.helper_port,
                 "process_ids": process_ids,
                 "activated": activated,
+                "cdp_listening_before_launch": cdp_listening_before_launch,
                 "injection_ready": injection_ready,
-                "launch_ok": launch_result.is_ok(),
-                "launch_error": launch_result.as_ref().err().map(|error| error.to_string())
+                "launch_attempted": should_launch,
+                "launch_ok": launch_ok,
+                "launch_error": launch_error
             }),
         );
-        launch_result.map(|_| ())
+        Ok(())
     }
     .await;
     if helper_started {
         hooks.shutdown_helper(options.helper_port).await;
     }
     result
+}
+
+fn existing_instance_should_launch(cdp_listening: bool, injection_ready: bool) -> bool {
+    !cdp_listening && !injection_ready
 }
 
 fn log_launcher_already_running(debug_port: u16) {
@@ -655,7 +696,7 @@ async fn try_inject_with_context(
     runtime: Arc<LauncherRuntimeService>,
 ) -> anyhow::Result<()> {
     let targets = codex_plus_core::cdp::list_targets(debug_port).await?;
-    let target = codex_plus_core::cdp::pick_page_target(&targets)?;
+    let target = codex_plus_core::cdp::pick_injectable_codex_page_target(&targets)?;
     let websocket_url = target
         .web_socket_debugger_url
         .as_deref()
@@ -799,20 +840,11 @@ mod tests {
     }
 
     #[test]
-    fn existing_instance_path_starts_helper_and_ensures_injection() {
-        let source = include_str!("main.rs").replace("\r\n", "\n");
-
-        assert!(source.contains(
-            "async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<()> {\n    let hooks = LauncherHooks::default();"
-        ));
-        assert!(source.contains("hooks.ensure_computer_use_config(&settings).await?"));
-        assert!(source.contains("hooks.start_helper(options.helper_port).await?"));
-        assert!(source.contains("hooks.shutdown_helper(options.helper_port).await"));
-        assert!(
-            source
-                .contains("hooks.ensure_injection(options.debug_port, options.helper_port).await")
-        );
-        assert!(source.contains("injection_ready"));
+    fn existing_instance_launches_only_when_cdp_is_unavailable() {
+        assert!(existing_instance_should_launch(false, false));
+        assert!(!existing_instance_should_launch(true, false));
+        assert!(!existing_instance_should_launch(true, true));
+        assert!(!existing_instance_should_launch(false, true));
     }
 
     #[test]

--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -132,49 +132,58 @@ async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<
     let launch_result = hooks
         .launch_codex(&app_dir, options.debug_port, &settings.codex_extra_args)
         .await;
+    let mut helper_started = false;
     if settings.enhancements_enabled {
         hooks.start_helper(options.helper_port).await?;
+        helper_started = true;
     }
-    let process_ids = codex_plus_core::watcher::find_codex_processes();
-    let mut activated = false;
-    #[cfg(windows)]
-    {
-        for process_id in &process_ids {
-            if codex_plus_core::windows_activate_process_window(*process_id) {
-                activated = true;
-                break;
+    let result = async {
+        let process_ids = codex_plus_core::watcher::find_codex_processes();
+        let mut activated = false;
+        #[cfg(windows)]
+        {
+            for process_id in &process_ids {
+                if codex_plus_core::windows_activate_process_window(*process_id) {
+                    activated = true;
+                    break;
+                }
             }
         }
+        let injection_ready = if settings.enhancements_enabled {
+            hooks
+                .ensure_injection(options.debug_port, options.helper_port, &app_dir)
+                .await
+        } else {
+            false
+        };
+        if injection_ready {
+            hooks
+                .start_bridge_watchdog(options.debug_port, options.helper_port)
+                .await?;
+            hooks.write_status("running").await;
+        } else if settings.enhancements_enabled {
+            hooks.write_status("running_degraded").await;
+        }
+        let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+            "launcher.activate_existing_codex",
+            json!({
+                "app_dir": app_dir.to_string_lossy(),
+                "debug_port": options.debug_port,
+                "helper_port": options.helper_port,
+                "process_ids": process_ids,
+                "activated": activated,
+                "injection_ready": injection_ready,
+                "launch_ok": launch_result.is_ok(),
+                "launch_error": launch_result.as_ref().err().map(|error| error.to_string())
+            }),
+        );
+        launch_result.map(|_| ())
     }
-    let injection_ready = if settings.enhancements_enabled {
-        hooks
-            .ensure_injection(options.debug_port, options.helper_port, &app_dir)
-            .await
-    } else {
-        false
-    };
-    if injection_ready {
-        hooks
-            .start_bridge_watchdog(options.debug_port, options.helper_port)
-            .await?;
-        hooks.write_status("running").await;
-    } else if settings.enhancements_enabled {
-        hooks.write_status("running_degraded").await;
+    .await;
+    if helper_started {
+        hooks.shutdown_helper(options.helper_port).await;
     }
-    let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
-        "launcher.activate_existing_codex",
-        json!({
-            "app_dir": app_dir.to_string_lossy(),
-            "debug_port": options.debug_port,
-            "helper_port": options.helper_port,
-            "process_ids": process_ids,
-            "activated": activated,
-            "injection_ready": injection_ready,
-            "launch_ok": launch_result.is_ok(),
-            "launch_error": launch_result.as_ref().err().map(|error| error.to_string())
-        }),
-    );
-    launch_result.map(|_| ())
+    result
 }
 
 fn log_launcher_already_running(debug_port: u16) {
@@ -791,6 +800,7 @@ mod tests {
         ));
         assert!(source.contains("hooks.ensure_computer_use_config(&settings).await?"));
         assert!(source.contains("hooks.start_helper(options.helper_port).await?"));
+        assert!(source.contains("hooks.shutdown_helper(options.helper_port).await"));
         assert!(
             source
                 .contains("hooks.ensure_injection(options.debug_port, options.helper_port).await")

--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -139,16 +139,23 @@ async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<
     }
     let result = async {
         let process_ids = codex_plus_core::watcher::find_codex_processes();
-        let mut activated = false;
-        #[cfg(windows)]
-        {
-            for process_id in &process_ids {
-                if codex_plus_core::windows_activate_process_window(*process_id) {
-                    activated = true;
-                    break;
+        let activated = {
+            #[cfg(windows)]
+            {
+                let mut activated = false;
+                for process_id in &process_ids {
+                    if codex_plus_core::windows_activate_process_window(*process_id) {
+                        activated = true;
+                        break;
+                    }
                 }
+                activated
             }
-        }
+            #[cfg(not(windows))]
+            {
+                false
+            }
+        };
         let injection_ready = if settings.enhancements_enabled {
             hooks
                 .ensure_injection(options.debug_port, options.helper_port, &app_dir)

--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -127,6 +127,7 @@ fn should_recover_stale_launcher(debug_port: u16) -> bool {
 async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<()> {
     let hooks = LauncherHooks::default();
     let settings = hooks.load_settings().await?;
+    hooks.ensure_computer_use_config(&settings).await?;
     let app_dir = hooks.resolve_app_dir(options.app_dir.as_deref(), &settings)?;
     let launch_result = hooks
         .launch_codex(&app_dir, options.debug_port, &settings.codex_extra_args)
@@ -283,6 +284,13 @@ impl LaunchHooks for LauncherHooks {
         self.core.apply_active_relay_profile(settings).await
     }
 
+    async fn ensure_computer_use_config(
+        &self,
+        settings: &codex_plus_core::settings::BackendSettings,
+    ) -> anyhow::Result<()> {
+        self.core.ensure_computer_use_config(settings).await
+    }
+
     async fn start_helper(&self, helper_port: u16) -> anyhow::Result<()> {
         self.core.start_helper(helper_port).await
     }
@@ -322,6 +330,13 @@ impl LaunchHooks for LauncherHooks {
 
     async fn inject(&self, debug_port: u16, helper_port: u16) -> anyhow::Result<()> {
         self.core.inject(debug_port, helper_port).await
+    }
+
+    async fn start_computer_use_guard_watchdog(
+        &self,
+        settings: &codex_plus_core::settings::BackendSettings,
+    ) -> anyhow::Result<()> {
+        self.core.start_computer_use_guard_watchdog(settings).await
     }
 
     async fn write_status(&self, status: &str) {
@@ -774,12 +789,24 @@ mod tests {
         assert!(source.contains(
             "async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<()> {\n    let hooks = LauncherHooks::default();"
         ));
+        assert!(source.contains("hooks.ensure_computer_use_config(&settings).await?"));
         assert!(source.contains("hooks.start_helper(options.helper_port).await?"));
         assert!(
             source
                 .contains("hooks.ensure_injection(options.debug_port, options.helper_port).await")
         );
         assert!(source.contains("injection_ready"));
+    }
+
+    #[test]
+    fn launcher_hooks_forward_computer_use_guard_methods() {
+        let source = include_str!("main.rs");
+
+        assert!(source.contains("async fn ensure_computer_use_config"));
+        assert!(source.contains("self.core.ensure_computer_use_config(settings).await"));
+        assert!(source.contains("async fn start_computer_use_guard_watchdog"));
+        assert!(source.contains("self.core"));
+        assert!(source.contains(".start_computer_use_guard_watchdog(settings)"));
     }
 
     #[test]

--- a/crates/codex-plus-core/src/cdp.rs
+++ b/crates/codex-plus-core/src/cdp.rs
@@ -58,19 +58,10 @@ async fn query_targets_url(client: &reqwest::Client, url: &str) -> anyhow::Resul
 }
 
 pub fn pick_page_target(targets: &[CdpTarget]) -> anyhow::Result<CdpTarget> {
-    let pages = targets.iter().filter(|target| {
-        target.target_type == "page"
-            && target
-                .web_socket_debugger_url
-                .as_deref()
-                .is_some_and(|url| !url.is_empty())
-    });
-
     let mut first_page = None;
-    for target in pages {
+    for target in targets.iter().filter(|target| is_injectable_page_target(target)) {
         first_page.get_or_insert(target);
-        let haystack = format!("{} {}", target.title, target.url).to_lowercase();
-        if haystack.contains("codex") {
+        if is_codex_page_target(target) {
             return Ok(target.clone());
         }
     }
@@ -79,5 +70,31 @@ pub fn pick_page_target(targets: &[CdpTarget]) -> anyhow::Result<CdpTarget> {
         return Ok(target.clone());
     }
 
+    bail!("No injectable page target found")
+}
+
+pub fn pick_injectable_codex_page_target(targets: &[CdpTarget]) -> anyhow::Result<CdpTarget> {
+    for target in targets.iter().filter(|target| is_injectable_page_target(target)) {
+        if is_codex_page_target(target) {
+            return Ok(target.clone());
+        }
+    }
+
     bail!("No injectable Codex page target found")
+}
+
+pub fn is_injectable_page_target(target: &CdpTarget) -> bool {
+    target.target_type == "page"
+        && target
+            .web_socket_debugger_url
+            .as_deref()
+            .is_some_and(|url| !url.is_empty())
+}
+
+pub fn is_codex_page_target(target: &CdpTarget) -> bool {
+    if target.target_type != "page" {
+        return false;
+    }
+    let haystack = format!("{} {}", target.title, target.url).to_lowercase();
+    haystack.contains("codex")
 }

--- a/crates/codex-plus-core/src/computer_use_guard.rs
+++ b/crates/codex-plus-core/src/computer_use_guard.rs
@@ -1,0 +1,698 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use toml_edit::{Array, DocumentMut, Item, Table};
+
+const BUNDLED_MARKETPLACE: &str = "openai-bundled";
+const BUNDLED_MARKETPLACE_PLUGINS: &[&str] = &["browser", "chrome", "computer-use", "latex"];
+const COMPUTER_USE_PLUGINS: &[&str] = &[
+    "browser@openai-bundled",
+    "chrome@openai-bundled",
+    "computer-use@openai-bundled",
+];
+const COMPUTER_USE_EXE: &str = "codex-computer-use.exe";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GuardResult {
+    pub changed: bool,
+    pub notify_exe: Option<PathBuf>,
+}
+
+pub(crate) fn ensure_computer_use_config(home: &Path) -> anyhow::Result<GuardResult> {
+    #[cfg(windows)]
+    {
+        ensure_computer_use_config_windows(home)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = home;
+        Ok(GuardResult {
+            changed: false,
+            notify_exe: None,
+        })
+    }
+}
+
+#[cfg(windows)]
+fn ensure_computer_use_config_windows(home: &Path) -> anyhow::Result<GuardResult> {
+    let config_path = home.join("config.toml");
+    let existing = match std::fs::read(&config_path) {
+        Ok(bytes) => String::from_utf8(bytes)
+            .with_context(|| format!("failed to read UTF-8 {}", config_path.display()))?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to read {}", config_path.display()));
+        }
+    };
+    let marketplace_path = ensure_openai_bundled_marketplace(home)?;
+    let notify_exe = find_computer_use_notify_exe(home);
+    let updated = if let Some(marketplace_path) = marketplace_path.as_deref() {
+        guard_config_text_with_marketplace(
+            &existing,
+            notify_exe.as_deref(),
+            Some(marketplace_path),
+        )?
+    } else {
+        guard_config_text(&existing, notify_exe.as_deref())?
+    };
+    let changed = updated.as_bytes() != existing.as_bytes();
+    if changed {
+        crate::settings::atomic_write(&config_path, updated.as_bytes())?;
+    }
+    Ok(GuardResult {
+        changed,
+        notify_exe,
+    })
+}
+
+pub(crate) fn guard_config_text(
+    config_text: &str,
+    notify_exe: Option<&Path>,
+) -> anyhow::Result<String> {
+    guard_config_text_with_marketplace(config_text, notify_exe, None)
+}
+
+pub(crate) fn guard_config_text_with_marketplace(
+    config_text: &str,
+    notify_exe: Option<&Path>,
+    marketplace_path: Option<&Path>,
+) -> anyhow::Result<String> {
+    let without_bom = config_text.trim_start_matches('\u{feff}');
+    let mut doc = parse_toml_document(without_bom)?;
+
+    let features = table_mut_or_insert(&mut doc, "features")?;
+    features["js_repl"] = toml_edit::value(true);
+
+    for plugin_id in COMPUTER_USE_PLUGINS {
+        ensure_plugin_enabled(&mut doc, plugin_id)?;
+    }
+
+    if let Some(notify_exe) = notify_exe {
+        let mut notify = Array::default();
+        notify.push(notify_exe.to_string_lossy().as_ref());
+        notify.push("turn-ended");
+        doc["notify"] = toml_edit::value(notify);
+    }
+
+    if let Some(marketplace_path) = marketplace_path {
+        ensure_openai_bundled_marketplace_config(&mut doc, marketplace_path)?;
+    }
+
+    Ok(ensure_trailing_newline(doc.to_string()))
+}
+
+pub(crate) fn find_computer_use_notify_exe(home: &Path) -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        find_computer_use_notify_exe_windows(home)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = home;
+        None
+    }
+}
+
+#[cfg(windows)]
+fn find_computer_use_notify_exe_windows(home: &Path) -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(local_app_data) = std::env::var_os("LOCALAPPDATA") {
+        collect_named_files(
+            &PathBuf::from(local_app_data)
+                .join("OpenAI")
+                .join("Codex")
+                .join("runtimes")
+                .join("cua_node"),
+            COMPUTER_USE_EXE,
+            12,
+            &mut candidates,
+        );
+    }
+    if candidates.is_empty() {
+        collect_named_files(
+            &home
+                .join("plugins")
+                .join("cache")
+                .join("openai-bundled")
+                .join("computer-use"),
+            COMPUTER_USE_EXE,
+            12,
+            &mut candidates,
+        );
+    }
+    candidates.sort_by(|left, right| {
+        modified_millis(right)
+            .cmp(&modified_millis(left))
+            .then_with(|| left.cmp(right))
+    });
+    candidates.into_iter().next()
+}
+
+#[cfg(windows)]
+fn collect_named_files(root: &Path, file_name: &str, depth: usize, output: &mut Vec<PathBuf>) {
+    if depth == 0 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file() {
+            if path
+                .file_name()
+                .and_then(|value| value.to_str())
+                .is_some_and(|name| name.eq_ignore_ascii_case(file_name))
+            {
+                output.push(path);
+            }
+        } else if path.is_dir() {
+            collect_named_files(&path, file_name, depth - 1, output);
+        }
+    }
+}
+
+#[cfg(windows)]
+fn modified_millis(path: &Path) -> u128 {
+    std::fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0)
+}
+
+#[cfg(windows)]
+pub(crate) fn ensure_openai_bundled_marketplace(home: &Path) -> anyhow::Result<Option<PathBuf>> {
+    let active = home
+        .join(".tmp")
+        .join("bundled-marketplaces")
+        .join(BUNDLED_MARKETPLACE);
+    if is_complete_openai_bundled_marketplace(&active) {
+        return Ok(Some(active));
+    }
+    if let Some(configured) = configured_openai_bundled_marketplace(home) {
+        if is_complete_openai_bundled_marketplace(&configured) {
+            return Ok(Some(configured));
+        }
+    }
+
+    let parent = active
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("invalid bundled marketplace path"))?;
+    std::fs::create_dir_all(parent)?;
+
+    let staging = parent.join(format!(
+        "{BUNDLED_MARKETPLACE}.guard-staging-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+    ));
+    if staging.exists() {
+        std::fs::remove_dir_all(&staging)?;
+    }
+
+    if let Some(source) = find_complete_openai_bundled_marketplace(parent, &active) {
+        copy_dir_recursive(&source, &staging)?;
+    } else if can_build_marketplace_from_cache(home) {
+        build_marketplace_from_cache(home, &staging)?;
+    } else {
+        return Ok(None);
+    }
+
+    match replace_active_marketplace(&active, &staging) {
+        Ok(()) => Ok(Some(active)),
+        Err(_) if is_complete_openai_bundled_marketplace(&staging) => {
+            // Windows can keep the active marketplace directory pinned while
+            // Codex extension hosts are still alive. Pointing config at the
+            // complete staging marketplace still restores plugin discovery.
+            Ok(Some(staging))
+        }
+        Err(error) => Err(error).with_context(|| {
+            format!(
+                "failed to replace active bundled marketplace at {}",
+                active.display()
+            )
+        }),
+    }
+}
+
+#[cfg(windows)]
+fn configured_openai_bundled_marketplace(home: &Path) -> Option<PathBuf> {
+    let config = std::fs::read_to_string(home.join("config.toml")).ok()?;
+    let without_bom = config.trim_start_matches('\u{feff}');
+    let doc = parse_toml_document(without_bom).ok()?;
+    let source = doc
+        .get("marketplaces")?
+        .as_table()?
+        .get(BUNDLED_MARKETPLACE)?
+        .as_table()?
+        .get("source")?
+        .as_str()?;
+    Some(path_from_configured_marketplace_source(source))
+}
+
+#[cfg(windows)]
+fn path_from_configured_marketplace_source(source: &str) -> PathBuf {
+    source
+        .strip_prefix(r"\\?\")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(source))
+}
+
+#[cfg(windows)]
+fn is_complete_openai_bundled_marketplace(path: &Path) -> bool {
+    if !path
+        .join(".agents")
+        .join("plugins")
+        .join("marketplace.json")
+        .is_file()
+    {
+        return false;
+    }
+    BUNDLED_MARKETPLACE_PLUGINS.iter().all(|plugin| {
+        path.join("plugins")
+            .join(plugin)
+            .join(".codex-plugin")
+            .join("plugin.json")
+            .is_file()
+    })
+}
+
+#[cfg(windows)]
+fn find_complete_openai_bundled_marketplace(parent: &Path, active: &Path) -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return None;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path == active || !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        if name.starts_with(BUNDLED_MARKETPLACE) && is_complete_openai_bundled_marketplace(&path) {
+            candidates.push(path);
+        }
+    }
+    candidates.sort_by(|left, right| {
+        modified_millis(right)
+            .cmp(&modified_millis(left))
+            .then_with(|| left.cmp(right))
+    });
+    candidates.into_iter().next()
+}
+
+#[cfg(windows)]
+fn cache_plugin_root(home: &Path, plugin: &str) -> PathBuf {
+    home.join("plugins")
+        .join("cache")
+        .join(BUNDLED_MARKETPLACE)
+        .join(plugin)
+}
+
+#[cfg(windows)]
+fn can_build_marketplace_from_cache(home: &Path) -> bool {
+    BUNDLED_MARKETPLACE_PLUGINS
+        .iter()
+        .all(|plugin| latest_cache_plugin_version(home, plugin).is_some())
+}
+
+#[cfg(windows)]
+fn latest_cache_plugin_version(home: &Path, plugin: &str) -> Option<PathBuf> {
+    let root = cache_plugin_root(home, plugin);
+    let mut candidates = Vec::new();
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return None;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.join(".codex-plugin").join("plugin.json").is_file() {
+            candidates.push(path);
+        }
+    }
+    candidates.sort_by(|left, right| {
+        let left_name = left
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or_default();
+        let right_name = right
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or_default();
+        right_name
+            .cmp(left_name)
+            .then_with(|| modified_millis(right).cmp(&modified_millis(left)))
+    });
+    candidates.into_iter().next()
+}
+
+#[cfg(windows)]
+fn build_marketplace_from_cache(home: &Path, staging: &Path) -> anyhow::Result<()> {
+    let plugins_dir = staging.join("plugins");
+    std::fs::create_dir_all(staging.join(".agents").join("plugins"))?;
+    std::fs::create_dir_all(&plugins_dir)?;
+    std::fs::write(
+        staging
+            .join(".agents")
+            .join("plugins")
+            .join("marketplace.json"),
+        bundled_marketplace_json().as_bytes(),
+    )?;
+    for plugin in BUNDLED_MARKETPLACE_PLUGINS {
+        let Some(source) = latest_cache_plugin_version(home, plugin) else {
+            anyhow::bail!("missing cached {plugin} plugin for openai-bundled marketplace");
+        };
+        copy_dir_recursive(&source, &plugins_dir.join(plugin))?;
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn bundled_marketplace_json() -> String {
+    let plugins = [
+        ("browser", "Engineering"),
+        ("chrome", "Productivity"),
+        ("computer-use", "Productivity"),
+        ("latex", "Research"),
+    ]
+    .into_iter()
+    .map(|(name, category)| {
+        serde_json::json!({
+            "name": name,
+            "source": {
+                "source": "local",
+                "path": format!("./plugins/{name}")
+            },
+            "policy": {
+                "installation": "AVAILABLE",
+                "authentication": "ON_INSTALL"
+            },
+            "category": category
+        })
+    })
+    .collect::<Vec<_>>();
+    serde_json::to_string_pretty(&serde_json::json!({
+        "name": BUNDLED_MARKETPLACE,
+        "interface": {
+            "displayName": "OpenAI Bundled"
+        },
+        "plugins": plugins
+    }))
+    .expect("bundled marketplace JSON should serialize")
+}
+
+#[cfg(windows)]
+fn replace_active_marketplace(active: &Path, staging: &Path) -> anyhow::Result<()> {
+    if active.exists() {
+        let backup = active.with_file_name(format!(
+            "{BUNDLED_MARKETPLACE}.bak-guard-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis()
+        ));
+        std::fs::rename(active, backup)?;
+    }
+    std::fs::rename(staging, active)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn copy_dir_recursive(source: &Path, destination: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(destination)?;
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if source_path.is_dir() {
+            copy_dir_recursive(&source_path, &destination_path)?;
+        } else {
+            std::fs::copy(&source_path, &destination_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn ensure_openai_bundled_marketplace_config(
+    doc: &mut DocumentMut,
+    marketplace_path: &Path,
+) -> anyhow::Result<()> {
+    let marketplaces = table_mut_or_insert(doc, "marketplaces")?;
+    if marketplaces
+        .get(BUNDLED_MARKETPLACE)
+        .and_then(Item::as_table)
+        .is_none()
+    {
+        marketplaces[BUNDLED_MARKETPLACE] = toml_edit::table();
+    }
+    marketplaces[BUNDLED_MARKETPLACE]["source_type"] = toml_edit::value("local");
+    marketplaces[BUNDLED_MARKETPLACE]["source"] =
+        toml_edit::value(windows_extended_path(marketplace_path));
+    Ok(())
+}
+
+fn windows_extended_path(path: &Path) -> String {
+    let value = path.to_string_lossy();
+    if value.starts_with(r"\\?\") {
+        value.into_owned()
+    } else {
+        format!(r"\\?\{value}")
+    }
+}
+
+fn parse_toml_document(contents: &str) -> anyhow::Result<DocumentMut> {
+    if contents.trim().is_empty() {
+        Ok(DocumentMut::new())
+    } else {
+        contents
+            .parse::<DocumentMut>()
+            .with_context(|| "config.toml TOML parse failed")
+    }
+}
+
+fn table_mut_or_insert<'a>(doc: &'a mut DocumentMut, key: &str) -> anyhow::Result<&'a mut Table> {
+    if !doc.as_table().contains_key(key) {
+        doc[key] = toml_edit::table();
+    }
+    if doc.get(key).and_then(Item::as_table).is_none() {
+        doc[key] = toml_edit::table();
+    }
+    doc.get_mut(key)
+        .and_then(Item::as_table_mut)
+        .ok_or_else(|| anyhow::anyhow!("{key} must be a TOML table"))
+}
+
+fn ensure_plugin_enabled(doc: &mut DocumentMut, plugin_id: &str) -> anyhow::Result<()> {
+    let plugins = table_mut_or_insert(doc, "plugins")?;
+    if !plugins.contains_key(plugin_id) {
+        plugins[plugin_id] = toml_edit::table();
+    }
+    if plugins.get(plugin_id).and_then(Item::as_table).is_none() {
+        plugins[plugin_id] = toml_edit::table();
+    }
+    plugins[plugin_id]["enabled"] = toml_edit::value(true);
+    Ok(())
+}
+
+fn ensure_trailing_newline(mut contents: String) -> String {
+    if !contents.ends_with('\n') {
+        contents.push('\n');
+    }
+    contents
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guard_config_text_repairs_computer_use_settings() {
+        let updated = guard_config_text(
+            "\u{feff}notify = [\"old.exe\", \"turn-ended\"]\n\n[features]\njs_repl = false\n\n[plugins.\"computer-use@openai-bundled\"]\nenabled = false\n",
+            Some(Path::new(r"C:\tools\codex-computer-use.exe")),
+        )
+        .unwrap();
+
+        assert!(!updated.as_bytes().starts_with(&[0xef, 0xbb, 0xbf]));
+        assert!(updated.contains("js_repl = true"));
+        assert!(updated.contains("[plugins.\"browser@openai-bundled\"]"));
+        assert!(updated.contains("[plugins.\"chrome@openai-bundled\"]"));
+        assert!(updated.contains("[plugins.\"computer-use@openai-bundled\"]"));
+        assert!(updated.contains("enabled = true"));
+        let parsed = updated.parse::<DocumentMut>().unwrap();
+        let notify = parsed["notify"].as_array().unwrap();
+        assert_eq!(
+            notify.get(0).and_then(|value| value.as_str()),
+            Some(r"C:\tools\codex-computer-use.exe")
+        );
+        assert_eq!(
+            notify.get(1).and_then(|value| value.as_str()),
+            Some("turn-ended")
+        );
+        assert!(!updated.contains("old.exe"));
+    }
+
+    #[test]
+    fn guard_config_text_creates_missing_sections() {
+        let updated = guard_config_text("model = \"gpt-5\"\n", None).unwrap();
+
+        assert!(updated.contains("[features]"));
+        assert!(updated.contains("js_repl = true"));
+        for plugin_id in COMPUTER_USE_PLUGINS {
+            assert!(updated.contains(&format!("[plugins.\"{plugin_id}\"]")));
+        }
+        assert!(!updated.contains("notify ="));
+    }
+
+    #[test]
+    fn guard_config_text_writes_openai_bundled_marketplace_source() {
+        let updated = guard_config_text_with_marketplace(
+            "model = \"gpt-5\"\n\n[marketplaces.openai-bundled]\nsource_type = \"remote\"\nsource = \"old\"\n",
+            None,
+            Some(Path::new(r"C:\Users\me\.codex\.tmp\bundled-marketplaces\openai-bundled")),
+        )
+        .unwrap();
+        let parsed = updated.parse::<DocumentMut>().unwrap();
+        assert_eq!(
+            parsed["marketplaces"]["openai-bundled"]["source_type"].as_str(),
+            Some("local")
+        );
+        assert_eq!(
+            parsed["marketplaces"]["openai-bundled"]["source"].as_str(),
+            Some(r"\\?\C:\Users\me\.codex\.tmp\bundled-marketplaces\openai-bundled")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn ensure_openai_bundled_marketplace_rebuilds_damaged_active_from_cache() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path();
+        let active = home
+            .join(".tmp")
+            .join("bundled-marketplaces")
+            .join(BUNDLED_MARKETPLACE);
+        std::fs::create_dir_all(active.join("plugins").join("chrome").join(".codex-plugin"))
+            .unwrap();
+        std::fs::write(
+            active
+                .join("plugins")
+                .join("chrome")
+                .join(".codex-plugin")
+                .join("plugin.json"),
+            "{}",
+        )
+        .unwrap();
+
+        for plugin in BUNDLED_MARKETPLACE_PLUGINS {
+            let root = home
+                .join("plugins")
+                .join("cache")
+                .join(BUNDLED_MARKETPLACE)
+                .join(plugin)
+                .join("26.608.12217");
+            std::fs::create_dir_all(root.join(".codex-plugin")).unwrap();
+            std::fs::write(root.join(".codex-plugin").join("plugin.json"), "{}").unwrap();
+            std::fs::write(root.join("payload.txt"), plugin).unwrap();
+        }
+
+        let repaired = ensure_openai_bundled_marketplace(home).unwrap().unwrap();
+        assert_eq!(repaired, active);
+        assert!(
+            active
+                .join(".agents")
+                .join("plugins")
+                .join("marketplace.json")
+                .is_file()
+        );
+        let marketplace = std::fs::read_to_string(
+            active
+                .join(".agents")
+                .join("plugins")
+                .join("marketplace.json"),
+        )
+        .unwrap();
+        assert!(marketplace.contains("\"computer-use\""));
+        for plugin in BUNDLED_MARKETPLACE_PLUGINS {
+            assert!(
+                active
+                    .join("plugins")
+                    .join(plugin)
+                    .join(".codex-plugin")
+                    .join("plugin.json")
+                    .is_file()
+            );
+            assert_eq!(
+                std::fs::read_to_string(active.join("plugins").join(plugin).join("payload.txt"))
+                    .unwrap(),
+                *plugin
+            );
+        }
+        let backup_count = std::fs::read_dir(active.parent().unwrap())
+            .unwrap()
+            .flatten()
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("openai-bundled.bak-guard-")
+            })
+            .count();
+        assert_eq!(backup_count, 1);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn ensure_openai_bundled_marketplace_reuses_configured_complete_staging() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path();
+        let parent = home.join(".tmp").join("bundled-marketplaces");
+        let active = parent.join(BUNDLED_MARKETPLACE);
+        let configured = parent.join("openai-bundled.guard-staging-existing");
+        std::fs::create_dir_all(active.join("plugins")).unwrap();
+        std::fs::create_dir_all(configured.join(".agents").join("plugins")).unwrap();
+        std::fs::write(
+            configured
+                .join(".agents")
+                .join("plugins")
+                .join("marketplace.json"),
+            "{}",
+        )
+        .unwrap();
+        for plugin in BUNDLED_MARKETPLACE_PLUGINS {
+            let plugin_root = configured
+                .join("plugins")
+                .join(plugin)
+                .join(".codex-plugin");
+            std::fs::create_dir_all(&plugin_root).unwrap();
+            std::fs::write(plugin_root.join("plugin.json"), "{}").unwrap();
+        }
+        let source = format!(r"\\?\{}", configured.display());
+        std::fs::write(
+            home.join("config.toml"),
+            format!(
+                "[marketplaces.openai-bundled]\nsource_type = \"local\"\nsource = '{}'\n",
+                source
+            ),
+        )
+        .unwrap();
+
+        let repaired = ensure_openai_bundled_marketplace(home).unwrap().unwrap();
+        assert_eq!(repaired, configured);
+        let guard_staging_count = std::fs::read_dir(parent)
+            .unwrap()
+            .flatten()
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("openai-bundled.guard-staging-")
+            })
+            .count();
+        assert_eq!(guard_staging_count, 1);
+    }
+}

--- a/crates/codex-plus-core/src/computer_use_guard.rs
+++ b/crates/codex-plus-core/src/computer_use_guard.rs
@@ -31,17 +31,20 @@ pub(crate) struct GuardArtifacts {
     pub notify_exe: Option<PathBuf>,
     pub marketplace_path: Option<PathBuf>,
     pub sky_package_json: Option<PathBuf>,
+    pub runtime_exports_needed: bool,
 }
 
 pub(crate) fn resolve_computer_use_guard_artifacts(home: &Path) -> anyhow::Result<GuardArtifacts> {
     #[cfg(windows)]
     {
         let notify_exe = find_computer_use_notify_exe(home);
+        let runtime_exports_needed = computer_use_client_needs_sky_internal_export(home)?;
         Ok(GuardArtifacts {
             sky_package_json: find_sky_package_json_for_notify_exe(notify_exe.as_deref())
                 .or_else(find_latest_sky_package_json),
             notify_exe,
             marketplace_path: ensure_openai_bundled_marketplace(home)?,
+            runtime_exports_needed,
         })
     }
     #[cfg(not(windows))]
@@ -51,6 +54,7 @@ pub(crate) fn resolve_computer_use_guard_artifacts(home: &Path) -> anyhow::Resul
             notify_exe: None,
             marketplace_path: None,
             sky_package_json: None,
+            runtime_exports_needed: false,
         })
     }
 }

--- a/crates/codex-plus-core/src/computer_use_guard.rs
+++ b/crates/codex-plus-core/src/computer_use_guard.rs
@@ -18,14 +18,41 @@ pub(crate) struct GuardResult {
     pub notify_exe: Option<PathBuf>,
 }
 
-pub(crate) fn ensure_computer_use_config(home: &Path) -> anyhow::Result<GuardResult> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GuardArtifacts {
+    pub notify_exe: Option<PathBuf>,
+    pub marketplace_path: Option<PathBuf>,
+}
+
+pub(crate) fn resolve_computer_use_guard_artifacts(home: &Path) -> anyhow::Result<GuardArtifacts> {
     #[cfg(windows)]
     {
-        ensure_computer_use_config_windows(home)
+        Ok(GuardArtifacts {
+            notify_exe: find_computer_use_notify_exe(home),
+            marketplace_path: ensure_openai_bundled_marketplace(home)?,
+        })
     }
     #[cfg(not(windows))]
     {
         let _ = home;
+        Ok(GuardArtifacts {
+            notify_exe: None,
+            marketplace_path: None,
+        })
+    }
+}
+
+pub(crate) fn ensure_computer_use_config_with_artifacts(
+    home: &Path,
+    artifacts: &GuardArtifacts,
+) -> anyhow::Result<GuardResult> {
+    #[cfg(windows)]
+    {
+        ensure_computer_use_config_with_artifacts_windows(home, artifacts)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = (home, artifacts);
         Ok(GuardResult {
             changed: false,
             notify_exe: None,
@@ -34,7 +61,10 @@ pub(crate) fn ensure_computer_use_config(home: &Path) -> anyhow::Result<GuardRes
 }
 
 #[cfg(windows)]
-fn ensure_computer_use_config_windows(home: &Path) -> anyhow::Result<GuardResult> {
+fn ensure_computer_use_config_with_artifacts_windows(
+    home: &Path,
+    artifacts: &GuardArtifacts,
+) -> anyhow::Result<GuardResult> {
     let config_path = home.join("config.toml");
     let existing = match std::fs::read(&config_path) {
         Ok(bytes) => String::from_utf8(bytes)
@@ -44,16 +74,14 @@ fn ensure_computer_use_config_windows(home: &Path) -> anyhow::Result<GuardResult
             return Err(error).with_context(|| format!("failed to read {}", config_path.display()));
         }
     };
-    let marketplace_path = ensure_openai_bundled_marketplace(home)?;
-    let notify_exe = find_computer_use_notify_exe(home);
-    let updated = if let Some(marketplace_path) = marketplace_path.as_deref() {
+    let updated = if let Some(marketplace_path) = artifacts.marketplace_path.as_deref() {
         guard_config_text_with_marketplace(
             &existing,
-            notify_exe.as_deref(),
+            artifacts.notify_exe.as_deref(),
             Some(marketplace_path),
         )?
     } else {
-        guard_config_text(&existing, notify_exe.as_deref())?
+        guard_config_text(&existing, artifacts.notify_exe.as_deref())?
     };
     let changed = updated.as_bytes() != existing.as_bytes();
     if changed {
@@ -61,7 +89,7 @@ fn ensure_computer_use_config_windows(home: &Path) -> anyhow::Result<GuardResult
     }
     Ok(GuardResult {
         changed,
-        notify_exe,
+        notify_exe: artifacts.notify_exe.clone(),
     })
 }
 

--- a/crates/codex-plus-core/src/computer_use_guard.rs
+++ b/crates/codex-plus-core/src/computer_use_guard.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(windows), allow(dead_code))]
+
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;

--- a/crates/codex-plus-core/src/computer_use_guard.rs
+++ b/crates/codex-plus-core/src/computer_use_guard.rs
@@ -13,6 +13,12 @@ const COMPUTER_USE_PLUGINS: &[&str] = &[
     "computer-use@openai-bundled",
 ];
 const COMPUTER_USE_EXE: &str = "codex-computer-use.exe";
+const COMPUTER_USE_CLIENT_SCRIPT: &str = "computer-use-client.mjs";
+const SKY_INTERNAL_COMPUTER_USE_CLIENT_EXPORT: &str =
+    "./dist/project/cua/sky_js/src/targets/windows/internal/computer_use_client_base.js";
+const SKY_INTERNAL_COMPUTER_USE_CLIENT_IMPORT: &str =
+    "@oai/sky/dist/project/cua/sky_js/src/targets/windows/internal/computer_use_client_base.js";
+const SKY_PACKAGE_EXPORTS_BACKUP: &str = "package.json.bak-codexpp-runtime-exports";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GuardResult {
@@ -24,13 +30,17 @@ pub(crate) struct GuardResult {
 pub(crate) struct GuardArtifacts {
     pub notify_exe: Option<PathBuf>,
     pub marketplace_path: Option<PathBuf>,
+    pub sky_package_json: Option<PathBuf>,
 }
 
 pub(crate) fn resolve_computer_use_guard_artifacts(home: &Path) -> anyhow::Result<GuardArtifacts> {
     #[cfg(windows)]
     {
+        let notify_exe = find_computer_use_notify_exe(home);
         Ok(GuardArtifacts {
-            notify_exe: find_computer_use_notify_exe(home),
+            sky_package_json: find_sky_package_json_for_notify_exe(notify_exe.as_deref())
+                .or_else(find_latest_sky_package_json),
+            notify_exe,
             marketplace_path: ensure_openai_bundled_marketplace(home)?,
         })
     }
@@ -40,6 +50,7 @@ pub(crate) fn resolve_computer_use_guard_artifacts(home: &Path) -> anyhow::Resul
         Ok(GuardArtifacts {
             notify_exe: None,
             marketplace_path: None,
+            sky_package_json: None,
         })
     }
 }
@@ -89,9 +100,101 @@ fn ensure_computer_use_config_with_artifacts_windows(
     if changed {
         crate::settings::atomic_write(&config_path, updated.as_bytes())?;
     }
+    let runtime_compat = ensure_computer_use_runtime_exports_compat_windows(
+        home,
+        artifacts.sky_package_json.as_deref(),
+    )?;
     Ok(GuardResult {
-        changed,
+        changed: changed || runtime_compat.changed,
         notify_exe: artifacts.notify_exe.clone(),
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RuntimeCompatResult {
+    pub changed: bool,
+    pub package_json: Option<PathBuf>,
+    pub backup_path: Option<PathBuf>,
+}
+
+#[cfg(not(windows))]
+pub(crate) fn ensure_computer_use_runtime_exports_compat(
+    home: &Path,
+) -> anyhow::Result<RuntimeCompatResult> {
+    let _ = home;
+    Ok(RuntimeCompatResult {
+        changed: false,
+        package_json: None,
+        backup_path: None,
+    })
+}
+
+#[cfg(windows)]
+#[allow(dead_code)]
+pub(crate) fn ensure_computer_use_runtime_exports_compat(
+    home: &Path,
+) -> anyhow::Result<RuntimeCompatResult> {
+    ensure_computer_use_runtime_exports_compat_windows(
+        home,
+        find_latest_sky_package_json().as_deref(),
+    )
+}
+
+#[cfg(windows)]
+fn ensure_computer_use_runtime_exports_compat_windows(
+    home: &Path,
+    sky_package_json: Option<&Path>,
+) -> anyhow::Result<RuntimeCompatResult> {
+    if !computer_use_client_needs_sky_internal_export(home)? {
+        return Ok(RuntimeCompatResult {
+            changed: false,
+            package_json: sky_package_json.map(Path::to_path_buf),
+            backup_path: None,
+        });
+    }
+    let Some(package_json) = sky_package_json else {
+        return Ok(RuntimeCompatResult {
+            changed: false,
+            package_json: None,
+            backup_path: None,
+        });
+    };
+    if !sky_internal_computer_use_client_file_exists(package_json) {
+        return Ok(RuntimeCompatResult {
+            changed: false,
+            package_json: Some(package_json.to_path_buf()),
+            backup_path: None,
+        });
+    }
+
+    let existing = std::fs::read_to_string(package_json)
+        .with_context(|| format!("failed to read {}", package_json.display()))?;
+    let Some(updated) = add_sky_internal_computer_use_export(&existing)? else {
+        return Ok(RuntimeCompatResult {
+            changed: false,
+            package_json: Some(package_json.to_path_buf()),
+            backup_path: None,
+        });
+    };
+
+    let backup_path = package_json
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("invalid @oai/sky package.json path"))?
+        .join(SKY_PACKAGE_EXPORTS_BACKUP);
+    if !backup_path.exists() {
+        std::fs::copy(package_json, &backup_path).with_context(|| {
+            format!(
+                "failed to back up {} to {}",
+                package_json.display(),
+                backup_path.display()
+            )
+        })?;
+    }
+    atomic_write_runtime_file(package_json, updated.as_bytes())?;
+    Ok(RuntimeCompatResult {
+        changed: true,
+        package_json: Some(package_json.to_path_buf()),
+        backup_path: Some(backup_path),
     })
 }
 
@@ -210,6 +313,141 @@ fn modified_millis(path: &Path) -> u128 {
         .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|duration| duration.as_millis())
         .unwrap_or(0)
+}
+
+#[cfg(windows)]
+fn computer_use_client_needs_sky_internal_export(home: &Path) -> anyhow::Result<bool> {
+    let mut candidates = Vec::new();
+    collect_named_files(
+        &home
+            .join("plugins")
+            .join("cache")
+            .join("openai-bundled")
+            .join("computer-use"),
+        COMPUTER_USE_CLIENT_SCRIPT,
+        8,
+        &mut candidates,
+    );
+    candidates.sort_by(|left, right| {
+        modified_millis(right)
+            .cmp(&modified_millis(left))
+            .then_with(|| left.cmp(right))
+    });
+    for candidate in candidates {
+        let contents = std::fs::read_to_string(&candidate)
+            .with_context(|| format!("failed to read {}", candidate.display()))?;
+        if contents.contains(SKY_INTERNAL_COMPUTER_USE_CLIENT_IMPORT) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(windows)]
+fn find_sky_package_json_for_notify_exe(notify_exe: Option<&Path>) -> Option<PathBuf> {
+    let notify_exe = notify_exe?;
+    for ancestor in notify_exe.ancestors() {
+        if ancestor
+            .file_name()
+            .and_then(|value| value.to_str())
+            .is_some_and(|name| name.eq_ignore_ascii_case("sky"))
+            && ancestor
+                .parent()
+                .and_then(|parent| parent.file_name())
+                .and_then(|value| value.to_str())
+                .is_some_and(|name| name.eq_ignore_ascii_case("@oai"))
+        {
+            let package_json = ancestor.join("package.json");
+            if package_json.is_file() {
+                return Some(package_json);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(windows)]
+fn find_latest_sky_package_json() -> Option<PathBuf> {
+    let local_app_data = std::env::var_os("LOCALAPPDATA")?;
+    let runtimes = PathBuf::from(local_app_data)
+        .join("OpenAI")
+        .join("Codex")
+        .join("runtimes")
+        .join("cua_node");
+    let Ok(entries) = std::fs::read_dir(runtimes) else {
+        return None;
+    };
+    let mut candidates: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| {
+            entry
+                .path()
+                .join("bin")
+                .join("node_modules")
+                .join("@oai")
+                .join("sky")
+                .join("package.json")
+        })
+        .filter(|path| path.is_file())
+        .collect();
+    candidates.sort_by(|left, right| {
+        modified_millis(right)
+            .cmp(&modified_millis(left))
+            .then_with(|| left.cmp(right))
+    });
+    candidates.into_iter().next()
+}
+
+#[cfg(windows)]
+fn sky_internal_computer_use_client_file_exists(package_json: &Path) -> bool {
+    let Some(package_root) = package_json.parent() else {
+        return false;
+    };
+    package_root
+        .join(SKY_INTERNAL_COMPUTER_USE_CLIENT_EXPORT.trim_start_matches("./"))
+        .is_file()
+}
+
+fn add_sky_internal_computer_use_export(contents: &str) -> anyhow::Result<Option<String>> {
+    let mut package: serde_json::Value =
+        serde_json::from_str(contents).with_context(|| "@oai/sky package.json parse failed")?;
+    let Some(exports) = package
+        .get_mut("exports")
+        .and_then(|value| value.as_object_mut())
+    else {
+        return Ok(None);
+    };
+    if exports.contains_key(SKY_INTERNAL_COMPUTER_USE_CLIENT_EXPORT) {
+        return Ok(None);
+    }
+    exports.insert(
+        SKY_INTERNAL_COMPUTER_USE_CLIENT_EXPORT.to_string(),
+        serde_json::Value::String(SKY_INTERNAL_COMPUTER_USE_CLIENT_EXPORT.to_string()),
+    );
+    let mut updated = serde_json::to_string_pretty(&package)?;
+    updated.push('\n');
+    Ok(Some(updated))
+}
+
+#[cfg(windows)]
+fn atomic_write_runtime_file(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("invalid runtime file path"))?;
+    let temp = parent.join(format!(
+        ".{}.codexpp-tmp",
+        path.file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("package.json")
+    ));
+    std::fs::write(&temp, bytes).with_context(|| format!("failed to write {}", temp.display()))?;
+    match std::fs::rename(&temp, path) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let _ = std::fs::remove_file(&temp);
+            Err(error).with_context(|| format!("failed to replace {}", path.display()))
+        }
+    }
 }
 
 #[cfg(windows)]
@@ -595,6 +833,198 @@ mod tests {
             parsed["marketplaces"]["openai-bundled"]["source"].as_str(),
             Some(r"\\?\C:\Users\me\.codex\.tmp\bundled-marketplaces\openai-bundled")
         );
+    }
+
+    #[test]
+    fn add_sky_internal_computer_use_export_adds_exact_subpath() {
+        let updated = add_sky_internal_computer_use_export(
+            r#"{
+  "name": "@oai/sky",
+  "exports": {
+    ".": "./dist/project/cua/sky_js/src/index.js"
+  }
+}"#,
+        )
+        .unwrap()
+        .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&updated).unwrap();
+
+        assert_eq!(
+            parsed["exports"][SKY_INTERNAL_COMPUTER_USE_CLIENT_EXPORT].as_str(),
+            Some(SKY_INTERNAL_COMPUTER_USE_CLIENT_EXPORT)
+        );
+        assert!(updated.ends_with('\n'));
+    }
+
+    #[test]
+    fn add_sky_internal_computer_use_export_is_idempotent() {
+        let updated = add_sky_internal_computer_use_export(&format!(
+            r#"{{
+  "name": "@oai/sky",
+  "exports": {{
+    ".": "./dist/project/cua/sky_js/src/index.js",
+    "{SKY_INTERNAL_COMPUTER_USE_CLIENT_EXPORT}": "{SKY_INTERNAL_COMPUTER_USE_CLIENT_EXPORT}"
+  }}
+}}"#
+        ))
+        .unwrap();
+
+        assert!(updated.is_none());
+    }
+
+    #[test]
+    fn add_sky_internal_computer_use_export_ignores_non_object_exports() {
+        let updated =
+            add_sky_internal_computer_use_export(r#"{ "name": "@oai/sky", "exports": "." }"#)
+                .unwrap();
+
+        assert!(updated.is_none());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn runtime_exports_compat_is_noop_off_windows() {
+        let temp = tempfile::tempdir().unwrap();
+        let result = ensure_computer_use_runtime_exports_compat(temp.path()).unwrap();
+
+        assert!(!result.changed);
+        assert!(result.package_json.is_none());
+        assert!(result.backup_path.is_none());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn runtime_exports_compat_adds_missing_exact_export() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join(".codex");
+        let script = home
+            .join("plugins")
+            .join("cache")
+            .join("openai-bundled")
+            .join("computer-use")
+            .join("26.608.12217")
+            .join("scripts")
+            .join(COMPUTER_USE_CLIENT_SCRIPT);
+        std::fs::create_dir_all(script.parent().unwrap()).unwrap();
+        std::fs::write(
+            &script,
+            format!("import {{ x }} from \"{SKY_INTERNAL_COMPUTER_USE_CLIENT_IMPORT}\";\n"),
+        )
+        .unwrap();
+
+        let package_json = temp.path().join("@oai").join("sky").join("package.json");
+        let internal_file = package_json
+            .parent()
+            .unwrap()
+            .join(SKY_INTERNAL_COMPUTER_USE_CLIENT_EXPORT.trim_start_matches("./"));
+        std::fs::create_dir_all(internal_file.parent().unwrap()).unwrap();
+        std::fs::write(
+            &internal_file,
+            "export class WindowsComputerUseClientBase {}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &package_json,
+            r#"{
+  "name": "@oai/sky",
+  "exports": {
+    ".": "./dist/project/cua/sky_js/src/index.js"
+  }
+}
+"#,
+        )
+        .unwrap();
+
+        let result =
+            ensure_computer_use_runtime_exports_compat_windows(&home, Some(&package_json)).unwrap();
+
+        assert!(result.changed);
+        assert_eq!(result.package_json.as_deref(), Some(package_json.as_path()));
+        assert!(result.backup_path.as_deref().unwrap().is_file());
+        let parsed: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&package_json).unwrap()).unwrap();
+        assert_eq!(
+            parsed["exports"][SKY_INTERNAL_COMPUTER_USE_CLIENT_EXPORT].as_str(),
+            Some(SKY_INTERNAL_COMPUTER_USE_CLIENT_EXPORT)
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn runtime_exports_compat_skips_when_internal_file_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join(".codex");
+        let script = home
+            .join("plugins")
+            .join("cache")
+            .join("openai-bundled")
+            .join("computer-use")
+            .join("26.608.12217")
+            .join("scripts")
+            .join(COMPUTER_USE_CLIENT_SCRIPT);
+        std::fs::create_dir_all(script.parent().unwrap()).unwrap();
+        std::fs::write(
+            &script,
+            format!("import {{ x }} from \"{SKY_INTERNAL_COMPUTER_USE_CLIENT_IMPORT}\";\n"),
+        )
+        .unwrap();
+        let package_json = temp.path().join("@oai").join("sky").join("package.json");
+        std::fs::create_dir_all(package_json.parent().unwrap()).unwrap();
+        std::fs::write(
+            &package_json,
+            r#"{ "name": "@oai/sky", "exports": { ".": "./index.js" } }"#,
+        )
+        .unwrap();
+
+        let result =
+            ensure_computer_use_runtime_exports_compat_windows(&home, Some(&package_json)).unwrap();
+
+        assert!(!result.changed);
+        assert!(
+            !package_json
+                .parent()
+                .unwrap()
+                .join(SKY_PACKAGE_EXPORTS_BACKUP)
+                .exists()
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn runtime_exports_compat_skips_when_plugin_script_no_longer_needs_patch() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join(".codex");
+        let script = home
+            .join("plugins")
+            .join("cache")
+            .join("openai-bundled")
+            .join("computer-use")
+            .join("26.608.12217")
+            .join("scripts")
+            .join(COMPUTER_USE_CLIENT_SCRIPT);
+        std::fs::create_dir_all(script.parent().unwrap()).unwrap();
+        std::fs::write(&script, "import { sky } from \"@oai/sky\";\n").unwrap();
+        let package_json = temp.path().join("@oai").join("sky").join("package.json");
+        let internal_file = package_json
+            .parent()
+            .unwrap()
+            .join(SKY_INTERNAL_COMPUTER_USE_CLIENT_EXPORT.trim_start_matches("./"));
+        std::fs::create_dir_all(internal_file.parent().unwrap()).unwrap();
+        std::fs::write(
+            &internal_file,
+            "export class WindowsComputerUseClientBase {}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &package_json,
+            r#"{ "name": "@oai/sky", "exports": { ".": "./index.js" } }"#,
+        )
+        .unwrap();
+
+        let result =
+            ensure_computer_use_runtime_exports_compat_windows(&home, Some(&package_json)).unwrap();
+
+        assert!(!result.changed);
     }
 
     #[cfg(windows)]

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -209,6 +209,7 @@ pub struct DefaultLaunchHooks {
     helper: Mutex<Option<HelperRuntime>>,
     bridge_watchdog: Mutex<Option<BridgeWatchdogRuntime>>,
     computer_use_guard_watchdog: Mutex<Option<ComputerUseGuardWatchdogRuntime>>,
+    computer_use_guard_artifacts: Mutex<Option<crate::computer_use_guard::GuardArtifacts>>,
 }
 
 struct HelperRuntime {
@@ -439,7 +440,9 @@ impl LaunchHooks for DefaultLaunchHooks {
 
     async fn ensure_computer_use_config(&self, _settings: &BackendSettings) -> anyhow::Result<()> {
         let home = crate::relay_config::default_codex_home_dir();
-        crate::computer_use_guard::ensure_computer_use_config(&home)?;
+        let artifacts = crate::computer_use_guard::resolve_computer_use_guard_artifacts(&home)?;
+        crate::computer_use_guard::ensure_computer_use_config_with_artifacts(&home, &artifacts)?;
+        *self.computer_use_guard_artifacts.lock().await = Some(artifacts);
         Ok(())
     }
 
@@ -628,9 +631,10 @@ impl LaunchHooks for DefaultLaunchHooks {
         #[cfg(windows)]
         {
             let home = crate::relay_config::default_codex_home_dir();
+            let artifacts = self.computer_use_guard_artifacts.lock().await.clone();
             let (shutdown, mut shutdown_rx) = tokio::sync::oneshot::channel();
             let task = tokio::spawn(async move {
-                run_post_launch_computer_use_guard(home, &mut shutdown_rx).await;
+                run_post_launch_computer_use_guard(home, artifacts, &mut shutdown_rx).await;
             });
             if let Some(runtime) = self
                 .computer_use_guard_watchdog
@@ -1317,6 +1321,15 @@ fn cdp_target_fingerprints(targets: &[crate::cdp::CdpTarget]) -> HashSet<String>
     targets.iter().map(cdp_target_fingerprint).collect()
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CdpTargetReadiness {
+    Ready,
+    NotPage,
+    MissingWebsocket,
+    NotCodexContext,
+    Preexisting,
+}
+
 async fn cdp_json_ready_once(
     client: &reqwest::Client,
     debug_port: u16,
@@ -1326,8 +1339,23 @@ async fn cdp_json_ready_once(
         return false;
     };
     targets.iter().any(|target| {
-        is_codex_cdp_target(target)
-            && !preexisting_targets.contains(&cdp_target_fingerprint(target))
+        let readiness = cdp_target_readiness(target, preexisting_targets);
+        let accepted = readiness == CdpTargetReadiness::Ready;
+        let _ = crate::diagnostic_log::append_diagnostic_log(
+            "launcher.cdp_readiness_target",
+            serde_json::json!({
+                "debug_port": debug_port,
+                "target_id": target.id,
+                "target_type": target.target_type,
+                "title": target.title,
+                "url": target.url,
+                "has_websocket": target.web_socket_debugger_url.as_deref().is_some_and(|url| !url.is_empty()),
+                "fingerprint": cdp_target_fingerprint(target),
+                "readiness": format!("{readiness:?}"),
+                "accepted": accepted
+            }),
+        );
+        accepted
     })
 }
 
@@ -1361,18 +1389,31 @@ fn cdp_target_fingerprint(target: &crate::cdp::CdpTarget) -> String {
 }
 
 fn is_codex_cdp_target(target: &crate::cdp::CdpTarget) -> bool {
+    cdp_target_readiness(target, &HashSet::new()) == CdpTargetReadiness::Ready
+}
+
+fn cdp_target_readiness(
+    target: &crate::cdp::CdpTarget,
+    preexisting_targets: &HashSet<String>,
+) -> CdpTargetReadiness {
     if target.target_type != "page" {
-        return false;
+        return CdpTargetReadiness::NotPage;
     }
     if !target
         .web_socket_debugger_url
         .as_deref()
         .is_some_and(|url| !url.is_empty())
     {
-        return false;
+        return CdpTargetReadiness::MissingWebsocket;
+    }
+    if preexisting_targets.contains(&cdp_target_fingerprint(target)) {
+        return CdpTargetReadiness::Preexisting;
     }
     let haystack = format!("{} {}", target.title, target.url).to_lowercase();
-    haystack.contains("codex")
+    if !haystack.contains("codex") {
+        return CdpTargetReadiness::NotCodexContext;
+    }
+    CdpTargetReadiness::Ready
 }
 
 async fn retry_injection(debug_port: u16, helper_port: u16) -> anyhow::Result<()> {
@@ -1584,6 +1625,7 @@ async fn is_macos_app_running(app_dir: &Path) -> bool {
 #[cfg(windows)]
 async fn run_post_launch_computer_use_guard(
     home: PathBuf,
+    mut artifacts: Option<crate::computer_use_guard::GuardArtifacts>,
     shutdown_rx: &mut tokio::sync::oneshot::Receiver<()>,
 ) {
     let mut previous_delay = 0_u64;
@@ -1601,7 +1643,29 @@ async fn run_post_launch_computer_use_guard(
             }
         }
         let attempt = index + 1;
-        match crate::computer_use_guard::ensure_computer_use_config(&home) {
+        let resolved_artifacts = match artifacts.take() {
+            Some(artifacts) => artifacts,
+            None => match crate::computer_use_guard::resolve_computer_use_guard_artifacts(&home) {
+                Ok(resolved) => resolved,
+                Err(error) => {
+                    let _ = crate::diagnostic_log::append_diagnostic_log(
+                        "computer_use_guard.post_launch_failed",
+                        serde_json::json!({
+                            "attempt": attempt,
+                            "delay_seconds": delay,
+                            "phase": "resolve_artifacts",
+                            "message": error.to_string()
+                        }),
+                    );
+                    continue;
+                }
+            },
+        };
+        artifacts = Some(resolved_artifacts.clone());
+        match crate::computer_use_guard::ensure_computer_use_config_with_artifacts(
+            &home,
+            &resolved_artifacts,
+        ) {
             Ok(result) => {
                 let _ = crate::diagnostic_log::append_diagnostic_log(
                     "computer_use_guard.post_launch_ok",
@@ -1867,6 +1931,61 @@ mod tests {
             "https://codex.local/",
             None,
         )));
+    }
+
+    #[test]
+    fn cdp_readiness_rejects_preexisting_codex_target() {
+        let target = cdp_target(
+            "target-1",
+            "page",
+            "Codex",
+            "https://codex.local/",
+            Some("ws://127.0.0.1:9229/devtools/page/target-1"),
+        );
+        let mut preexisting = HashSet::new();
+        preexisting.insert(cdp_target_fingerprint(&target));
+
+        assert_eq!(
+            cdp_target_readiness(&target, &preexisting),
+            CdpTargetReadiness::Preexisting
+        );
+    }
+
+    #[test]
+    fn cdp_readiness_reports_rejection_reasons() {
+        assert_eq!(
+            cdp_target_readiness(
+                &cdp_target(
+                    "target-1",
+                    "worker",
+                    "Codex Worker",
+                    "https://codex.local/",
+                    Some("ws://127.0.0.1:9229/devtools/page/target-1"),
+                ),
+                &HashSet::new(),
+            ),
+            CdpTargetReadiness::NotPage
+        );
+        assert_eq!(
+            cdp_target_readiness(
+                &cdp_target("target-2", "page", "Other App", "https://example.test/", None),
+                &HashSet::new(),
+            ),
+            CdpTargetReadiness::MissingWebsocket
+        );
+        assert_eq!(
+            cdp_target_readiness(
+                &cdp_target(
+                    "target-3",
+                    "page",
+                    "Other App",
+                    "https://example.test/",
+                    Some("ws://127.0.0.1:9229/devtools/page/target-3"),
+                ),
+                &HashSet::new(),
+            ),
+            CdpTargetReadiness::NotCodexContext
+        );
     }
 
     #[test]

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -1625,8 +1625,12 @@ async fn is_macos_app_running(app_dir: &Path) -> bool {
 }
 
 #[cfg_attr(not(windows), allow(dead_code))]
-fn post_launch_guard_artifacts_ready(artifacts: &crate::computer_use_guard::GuardArtifacts) -> bool {
-    artifacts.notify_exe.is_some() && artifacts.marketplace_path.is_some()
+fn post_launch_guard_artifacts_ready(
+    artifacts: &crate::computer_use_guard::GuardArtifacts,
+) -> bool {
+    artifacts.notify_exe.is_some()
+        && artifacts.marketplace_path.is_some()
+        && (!artifacts.runtime_exports_needed || artifacts.sky_package_json.is_some())
 }
 
 #[cfg_attr(not(windows), allow(dead_code))]
@@ -1679,13 +1683,14 @@ async fn run_post_launch_computer_use_guard(
                 }
             },
         };
-        artifacts = Some(resolved_artifacts.clone());
+        let artifacts_ready = post_launch_guard_artifacts_ready(&resolved_artifacts);
+        artifacts = artifacts_ready.then_some(resolved_artifacts.clone());
         match crate::computer_use_guard::ensure_computer_use_config_with_artifacts(
             &home,
             &resolved_artifacts,
         ) {
             Ok(result) => {
-                if !result.changed && post_launch_guard_artifacts_ready(&resolved_artifacts) {
+                if !result.changed && artifacts_ready {
                     stable_unchanged_attempts += 1;
                 } else {
                     stable_unchanged_attempts = 0;
@@ -2062,6 +2067,7 @@ mod tests {
             notify_exe: Some(PathBuf::from("codex-computer-use.exe")),
             marketplace_path: Some(PathBuf::from("openai-bundled")),
             sky_package_json: None,
+            runtime_exports_needed: false,
         };
 
         assert!(!should_stop_post_launch_computer_use_guard(2, &artifacts));
@@ -2074,14 +2080,32 @@ mod tests {
             notify_exe: None,
             marketplace_path: Some(PathBuf::from("openai-bundled")),
             sky_package_json: None,
+            runtime_exports_needed: false,
         };
         let missing_marketplace = crate::computer_use_guard::GuardArtifacts {
             notify_exe: Some(PathBuf::from("codex-computer-use.exe")),
             marketplace_path: None,
             sky_package_json: None,
+            runtime_exports_needed: false,
+        };
+        let missing_runtime_package = crate::computer_use_guard::GuardArtifacts {
+            notify_exe: Some(PathBuf::from("codex-computer-use.exe")),
+            marketplace_path: Some(PathBuf::from("openai-bundled")),
+            sky_package_json: None,
+            runtime_exports_needed: true,
         };
 
-        assert!(!should_stop_post_launch_computer_use_guard(3, &missing_notify));
-        assert!(!should_stop_post_launch_computer_use_guard(3, &missing_marketplace));
+        assert!(!should_stop_post_launch_computer_use_guard(
+            3,
+            &missing_notify
+        ));
+        assert!(!should_stop_post_launch_computer_use_guard(
+            3,
+            &missing_marketplace
+        ));
+        assert!(!should_stop_post_launch_computer_use_guard(
+            3,
+            &missing_runtime_package
+        ));
     }
 }

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -18,6 +18,8 @@ use crate::status::{LaunchStatus, StatusStore};
 
 #[cfg(windows)]
 const POST_LAUNCH_COMPUTER_USE_GUARD_SECONDS: &[u64] = &[0, 5, 15, 30, 60, 120, 180, 240, 300];
+#[cfg_attr(not(windows), allow(dead_code))]
+const POST_LAUNCH_COMPUTER_USE_GUARD_STABLE_ATTEMPTS: usize = 3;
 const PACKAGED_CDP_READY_ATTEMPTS: usize = 10;
 const PACKAGED_CDP_READY_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
 
@@ -283,7 +285,7 @@ where
             } else {
                 let degraded = launch_status(
                     "running_degraded",
-                    "Codex 已启动，Codex++ 增强仍在等待页面就绪。",
+                    "Codex launched; Codex++ enhancements are still waiting for the page bridge.",
                     debug_port,
                     helper_port,
                     &app_dir,
@@ -1483,7 +1485,7 @@ pub async fn check_and_reinject_bridge(debug_port: u16, helper_port: u16) -> boo
 
 async fn bridge_health_ok(debug_port: u16) -> anyhow::Result<bool> {
     let targets = crate::cdp::list_targets(debug_port).await?;
-    let target = crate::cdp::pick_page_target(&targets)?;
+    let target = crate::cdp::pick_injectable_codex_page_target(&targets)?;
     let websocket_url = target
         .web_socket_debugger_url
         .as_deref()
@@ -1508,7 +1510,7 @@ fn runtime_evaluate_result_is_true(result: &Value) -> bool {
 
 async fn try_inject(debug_port: u16, helper_port: u16) -> anyhow::Result<()> {
     let targets = crate::cdp::list_targets(debug_port).await?;
-    let target = crate::cdp::pick_page_target(&targets)?;
+    let target = crate::cdp::pick_injectable_codex_page_target(&targets)?;
     let websocket_url = target
         .web_socket_debugger_url
         .as_deref()
@@ -1622,6 +1624,20 @@ async fn is_macos_app_running(app_dir: &Path) -> bool {
             .eq_ignore_ascii_case("true")
 }
 
+#[cfg_attr(not(windows), allow(dead_code))]
+fn post_launch_guard_artifacts_ready(artifacts: &crate::computer_use_guard::GuardArtifacts) -> bool {
+    artifacts.notify_exe.is_some() && artifacts.marketplace_path.is_some()
+}
+
+#[cfg_attr(not(windows), allow(dead_code))]
+fn should_stop_post_launch_computer_use_guard(
+    stable_unchanged_attempts: usize,
+    artifacts: &crate::computer_use_guard::GuardArtifacts,
+) -> bool {
+    stable_unchanged_attempts >= POST_LAUNCH_COMPUTER_USE_GUARD_STABLE_ATTEMPTS
+        && post_launch_guard_artifacts_ready(artifacts)
+}
+
 #[cfg(windows)]
 async fn run_post_launch_computer_use_guard(
     home: PathBuf,
@@ -1629,6 +1645,7 @@ async fn run_post_launch_computer_use_guard(
     shutdown_rx: &mut tokio::sync::oneshot::Receiver<()>,
 ) {
     let mut previous_delay = 0_u64;
+    let mut stable_unchanged_attempts = 0_usize;
     for (index, delay) in POST_LAUNCH_COMPUTER_USE_GUARD_SECONDS
         .iter()
         .copied()
@@ -1648,6 +1665,7 @@ async fn run_post_launch_computer_use_guard(
             None => match crate::computer_use_guard::resolve_computer_use_guard_artifacts(&home) {
                 Ok(resolved) => resolved,
                 Err(error) => {
+                    stable_unchanged_attempts = 0;
                     let _ = crate::diagnostic_log::append_diagnostic_log(
                         "computer_use_guard.post_launch_failed",
                         serde_json::json!({
@@ -1667,19 +1685,40 @@ async fn run_post_launch_computer_use_guard(
             &resolved_artifacts,
         ) {
             Ok(result) => {
+                if !result.changed && post_launch_guard_artifacts_ready(&resolved_artifacts) {
+                    stable_unchanged_attempts += 1;
+                } else {
+                    stable_unchanged_attempts = 0;
+                }
                 let _ = crate::diagnostic_log::append_diagnostic_log(
                     "computer_use_guard.post_launch_ok",
                     serde_json::json!({
                         "attempt": attempt,
                         "delay_seconds": delay,
                         "changed": result.changed,
+                        "stable_unchanged_attempts": stable_unchanged_attempts,
                         "notify_exe": result
                             .notify_exe
                             .map(|path| path.to_string_lossy().to_string())
                     }),
                 );
+                if should_stop_post_launch_computer_use_guard(
+                    stable_unchanged_attempts,
+                    &resolved_artifacts,
+                ) {
+                    let _ = crate::diagnostic_log::append_diagnostic_log(
+                        "computer_use_guard.post_launch_stable_stop",
+                        serde_json::json!({
+                            "attempt": attempt,
+                            "delay_seconds": delay,
+                            "stable_unchanged_attempts": stable_unchanged_attempts
+                        }),
+                    );
+                    return;
+                }
             }
             Err(error) => {
+                stable_unchanged_attempts = 0;
                 let _ = crate::diagnostic_log::append_diagnostic_log(
                     "computer_use_guard.post_launch_failed",
                     serde_json::json!({
@@ -2015,5 +2054,31 @@ mod tests {
             cdp_target_fingerprint(&target),
             "ws://127.0.0.1:9229/devtools/page/target-1"
         );
+    }
+
+    #[test]
+    fn post_launch_guard_stops_after_stable_ready_artifacts() {
+        let artifacts = crate::computer_use_guard::GuardArtifacts {
+            notify_exe: Some(PathBuf::from("codex-computer-use.exe")),
+            marketplace_path: Some(PathBuf::from("openai-bundled")),
+        };
+
+        assert!(!should_stop_post_launch_computer_use_guard(2, &artifacts));
+        assert!(should_stop_post_launch_computer_use_guard(3, &artifacts));
+    }
+
+    #[test]
+    fn post_launch_guard_keeps_retrying_until_artifacts_are_ready() {
+        let missing_notify = crate::computer_use_guard::GuardArtifacts {
+            notify_exe: None,
+            marketplace_path: Some(PathBuf::from("openai-bundled")),
+        };
+        let missing_marketplace = crate::computer_use_guard::GuardArtifacts {
+            notify_exe: Some(PathBuf::from("codex-computer-use.exe")),
+            marketplace_path: None,
+        };
+
+        assert!(!should_stop_post_launch_computer_use_guard(3, &missing_notify));
+        assert!(!should_stop_post_launch_computer_use_guard(3, &missing_marketplace));
     }
 }

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -2061,6 +2061,7 @@ mod tests {
         let artifacts = crate::computer_use_guard::GuardArtifacts {
             notify_exe: Some(PathBuf::from("codex-computer-use.exe")),
             marketplace_path: Some(PathBuf::from("openai-bundled")),
+            sky_package_json: None,
         };
 
         assert!(!should_stop_post_launch_computer_use_guard(2, &artifacts));
@@ -2072,10 +2073,12 @@ mod tests {
         let missing_notify = crate::computer_use_guard::GuardArtifacts {
             notify_exe: None,
             marketplace_path: Some(PathBuf::from("openai-bundled")),
+            sky_package_json: None,
         };
         let missing_marketplace = crate::computer_use_guard::GuardArtifacts {
             notify_exe: Some(PathBuf::from("codex-computer-use.exe")),
             marketplace_path: None,
+            sky_package_json: None,
         };
 
         assert!(!should_stop_post_launch_computer_use_guard(3, &missing_notify));

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -14,6 +15,11 @@ use tokio::sync::Mutex;
 
 use crate::settings::{BackendSettings, SettingsStore, normalize_codex_extra_args};
 use crate::status::{LaunchStatus, StatusStore};
+
+#[cfg(windows)]
+const POST_LAUNCH_COMPUTER_USE_GUARD_SECONDS: &[u64] = &[0, 5, 15, 30, 60, 120, 180, 240, 300];
+const PACKAGED_CDP_READY_ATTEMPTS: usize = 10;
+const PACKAGED_CDP_READY_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CodexLaunch {
@@ -127,6 +133,9 @@ pub trait LaunchHooks: Send + Sync {
     async fn apply_active_relay_profile(&self, _settings: &BackendSettings) -> anyhow::Result<()> {
         Ok(())
     }
+    async fn ensure_computer_use_config(&self, _settings: &BackendSettings) -> anyhow::Result<()> {
+        Ok(())
+    }
     async fn start_helper(&self, helper_port: u16) -> anyhow::Result<()>;
     async fn launch_codex(
         &self,
@@ -182,6 +191,12 @@ pub trait LaunchHooks: Send + Sync {
     ) -> anyhow::Result<()> {
         Ok(())
     }
+    async fn start_computer_use_guard_watchdog(
+        &self,
+        _settings: &BackendSettings,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
     async fn write_status(&self, status: &str);
     async fn wait_for_codex_exit(&self, launch: &CodexLaunch) -> anyhow::Result<()>;
     async fn shutdown_helper(&self, helper_port: u16);
@@ -193,6 +208,7 @@ pub struct DefaultLaunchHooks {
     child: Mutex<Option<Child>>,
     helper: Mutex<Option<HelperRuntime>>,
     bridge_watchdog: Mutex<Option<BridgeWatchdogRuntime>>,
+    computer_use_guard_watchdog: Mutex<Option<ComputerUseGuardWatchdogRuntime>>,
 }
 
 struct HelperRuntime {
@@ -201,6 +217,11 @@ struct HelperRuntime {
 }
 
 struct BridgeWatchdogRuntime {
+    shutdown: tokio::sync::oneshot::Sender<()>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+struct ComputerUseGuardWatchdogRuntime {
     shutdown: tokio::sync::oneshot::Sender<()>,
     task: tokio::task::JoinHandle<()>,
 }
@@ -230,6 +251,10 @@ where
         if settings.provider_sync_enabled {
             hooks.run_provider_sync().await?;
         }
+        if settings.relay_profiles_enabled {
+            hooks.apply_active_relay_profile(&settings).await?;
+        }
+        hooks.ensure_computer_use_config(&settings).await?;
         let protocol_proxy_enabled = relay_protocol_proxy_enabled(&settings);
         if protocol_proxy_enabled {
             helper_port = crate::protocol_proxy::DEFAULT_PROTOCOL_PROXY_PORT;
@@ -244,10 +269,13 @@ where
             .await?;
         launched = Some(launch.clone());
         keep_launched_on_error = true;
+        hooks.start_computer_use_guard_watchdog(&settings).await?;
 
         let mut injection_degraded = false;
         if settings.enhancements_enabled {
-            let injection_ready = hooks.ensure_injection(debug_port, helper_port, &app_dir).await;
+            let injection_ready = hooks
+                .ensure_injection(debug_port, helper_port, &app_dir)
+                .await;
             if injection_ready {
                 keep_launched_on_error = false;
                 hooks.start_bridge_watchdog(debug_port, helper_port).await?;
@@ -359,7 +387,7 @@ impl LaunchHooks for DefaultLaunchHooks {
     }
 
     fn select_debug_port(&self, requested: u16) -> u16 {
-        crate::ports::select_platform_loopback_port(requested)
+        crate::ports::select_packaged_codex_debug_port(requested)
     }
 
     fn select_helper_port(&self, requested: u16) -> u16 {
@@ -406,6 +434,12 @@ impl LaunchHooks for DefaultLaunchHooks {
             &profile,
             &common_config,
         )?;
+        Ok(())
+    }
+
+    async fn ensure_computer_use_config(&self, _settings: &BackendSettings) -> anyhow::Result<()> {
+        let home = crate::relay_config::default_codex_home_dir();
+        crate::computer_use_guard::ensure_computer_use_config(&home)?;
         Ok(())
     }
 
@@ -458,8 +492,26 @@ impl LaunchHooks for DefaultLaunchHooks {
                 else {
                     unreachable!();
                 };
+                let app_user_model_id_for_log = app_user_model_id.clone();
+                let preexisting_cdp_targets = query_cdp_targets(debug_port).await;
+                let preexisting_cdp_target_ids = cdp_target_fingerprints(&preexisting_cdp_targets);
+                if preexisting_cdp_targets.iter().any(is_codex_cdp_target) {
+                    let _ = crate::diagnostic_log::append_diagnostic_log(
+                        "launcher.packaged_activation_reuse_preexisting_cdp",
+                        serde_json::json!({
+                            "debug_port": debug_port,
+                            "app_user_model_id": app_user_model_id_for_log,
+                            "preexisting_cdp_target_count": preexisting_cdp_targets.len()
+                        }),
+                    );
+                    return Ok(CodexLaunch::PackagedActivation {
+                        app_user_model_id: app_user_model_id.clone(),
+                        arguments: arguments.clone(),
+                        process_id: None,
+                    });
+                }
                 let process_id = activate_packaged_app(app_user_model_id, arguments).await?;
-                return Ok(match activation {
+                let packaged_launch = match activation {
                     CodexLaunch::PackagedActivation {
                         app_user_model_id,
                         arguments,
@@ -470,7 +522,27 @@ impl LaunchHooks for DefaultLaunchHooks {
                         process_id: Some(process_id),
                     },
                     CodexLaunch::Process { .. } => unreachable!(),
-                });
+                };
+                if cdp_json_ready(
+                    debug_port,
+                    PACKAGED_CDP_READY_ATTEMPTS,
+                    PACKAGED_CDP_READY_DELAY,
+                    &preexisting_cdp_target_ids,
+                )
+                .await
+                {
+                    return Ok(packaged_launch);
+                }
+                let _ = crate::diagnostic_log::append_diagnostic_log(
+                    "launcher.packaged_activation_cdp_unready_direct_fallback",
+                    serde_json::json!({
+                        "debug_port": debug_port,
+                        "app_user_model_id": app_user_model_id_for_log,
+                        "process_id": process_id,
+                        "preexisting_cdp_target_count": preexisting_cdp_targets.len()
+                    }),
+                );
+                let _ = terminate_windows_process_id(process_id).await;
             }
         }
 
@@ -549,6 +621,30 @@ impl LaunchHooks for DefaultLaunchHooks {
         Ok(())
     }
 
+    async fn start_computer_use_guard_watchdog(
+        &self,
+        _settings: &BackendSettings,
+    ) -> anyhow::Result<()> {
+        #[cfg(windows)]
+        {
+            let home = crate::relay_config::default_codex_home_dir();
+            let (shutdown, mut shutdown_rx) = tokio::sync::oneshot::channel();
+            let task = tokio::spawn(async move {
+                run_post_launch_computer_use_guard(home, &mut shutdown_rx).await;
+            });
+            if let Some(runtime) = self
+                .computer_use_guard_watchdog
+                .lock()
+                .await
+                .replace(ComputerUseGuardWatchdogRuntime { shutdown, task })
+            {
+                let _ = runtime.shutdown.send(());
+                let _ = runtime.task.await;
+            }
+        }
+        Ok(())
+    }
+
     async fn write_status(&self, _status: &str) {}
 
     async fn wait_for_codex_exit(&self, launch: &CodexLaunch) -> anyhow::Result<()> {
@@ -569,6 +665,10 @@ impl LaunchHooks for DefaultLaunchHooks {
     }
 
     async fn shutdown_helper(&self, _helper_port: u16) {
+        if let Some(runtime) = self.computer_use_guard_watchdog.lock().await.take() {
+            let _ = runtime.shutdown.send(());
+            let _ = runtime.task.await;
+        }
         if let Some(runtime) = self.bridge_watchdog.lock().await.take() {
             let _ = runtime.shutdown.send(());
             let _ = runtime.task.await;
@@ -1173,6 +1273,108 @@ pub fn build_packaged_activation(
     })
 }
 
+async fn cdp_json_ready(
+    debug_port: u16,
+    attempts: usize,
+    delay: std::time::Duration,
+    preexisting_targets: &HashSet<String>,
+) -> bool {
+    let client = match reqwest::Client::builder()
+        .no_proxy()
+        .timeout(std::time::Duration::from_millis(500))
+        .build()
+    {
+        Ok(client) => client,
+        Err(_) => return false,
+    };
+    for attempt in 0..attempts {
+        if cdp_json_ready_once(&client, debug_port, preexisting_targets).await {
+            return true;
+        }
+        if attempt + 1 < attempts {
+            tokio::time::sleep(delay).await;
+        }
+    }
+    false
+}
+
+async fn query_cdp_targets(debug_port: u16) -> Vec<crate::cdp::CdpTarget> {
+    let client = match reqwest::Client::builder()
+        .no_proxy()
+        .timeout(std::time::Duration::from_millis(500))
+        .build()
+    {
+        Ok(client) => client,
+        Err(_) => return Vec::new(),
+    };
+    let Some(targets) = query_cdp_targets_once(&client, debug_port).await else {
+        return Vec::new();
+    };
+    targets
+}
+
+fn cdp_target_fingerprints(targets: &[crate::cdp::CdpTarget]) -> HashSet<String> {
+    targets.iter().map(cdp_target_fingerprint).collect()
+}
+
+async fn cdp_json_ready_once(
+    client: &reqwest::Client,
+    debug_port: u16,
+    preexisting_targets: &HashSet<String>,
+) -> bool {
+    let Some(targets) = query_cdp_targets_once(client, debug_port).await else {
+        return false;
+    };
+    targets.iter().any(|target| {
+        is_codex_cdp_target(target)
+            && !preexisting_targets.contains(&cdp_target_fingerprint(target))
+    })
+}
+
+async fn query_cdp_targets_once(
+    client: &reqwest::Client,
+    debug_port: u16,
+) -> Option<Vec<crate::cdp::CdpTarget>> {
+    for url in [
+        format!("http://127.0.0.1:{debug_port}/json"),
+        format!("http://[::1]:{debug_port}/json"),
+    ] {
+        let Ok(response) = client.get(url).send().await else {
+            continue;
+        };
+        let Ok(response) = response.error_for_status() else {
+            continue;
+        };
+        let Ok(targets) = response.json::<Vec<crate::cdp::CdpTarget>>().await else {
+            continue;
+        };
+        return Some(targets);
+    }
+    None
+}
+
+fn cdp_target_fingerprint(target: &crate::cdp::CdpTarget) -> String {
+    if !target.id.is_empty() {
+        return target.id.clone();
+    }
+    target.web_socket_debugger_url.clone().unwrap_or_default()
+}
+
+fn is_codex_cdp_target(target: &crate::cdp::CdpTarget) -> bool {
+    if target.target_type != "page" {
+        return false;
+    }
+    if !target
+        .web_socket_debugger_url
+        .as_deref()
+        .is_some_and(|url| !url.is_empty())
+    {
+        return false;
+    }
+    let haystack = format!("{} {}", target.title, target.url).to_lowercase();
+    haystack.contains("codex")
+}
+
 async fn retry_injection(debug_port: u16, helper_port: u16) -> anyhow::Result<()> {
     let mut last_error = None;
     for _ in 0..20 {
@@ -1380,6 +1582,54 @@ async fn is_macos_app_running(app_dir: &Path) -> bool {
 }
 
 #[cfg(windows)]
+async fn run_post_launch_computer_use_guard(
+    home: PathBuf,
+    shutdown_rx: &mut tokio::sync::oneshot::Receiver<()>,
+) {
+    let mut previous_delay = 0_u64;
+    for (index, delay) in POST_LAUNCH_COMPUTER_USE_GUARD_SECONDS
+        .iter()
+        .copied()
+        .enumerate()
+    {
+        let wait_seconds = delay.saturating_sub(previous_delay);
+        previous_delay = delay;
+        if wait_seconds > 0 {
+            tokio::select! {
+                _ = &mut *shutdown_rx => return,
+                _ = tokio::time::sleep(std::time::Duration::from_secs(wait_seconds)) => {}
+            }
+        }
+        let attempt = index + 1;
+        match crate::computer_use_guard::ensure_computer_use_config(&home) {
+            Ok(result) => {
+                let _ = crate::diagnostic_log::append_diagnostic_log(
+                    "computer_use_guard.post_launch_ok",
+                    serde_json::json!({
+                        "attempt": attempt,
+                        "delay_seconds": delay,
+                        "changed": result.changed,
+                        "notify_exe": result
+                            .notify_exe
+                            .map(|path| path.to_string_lossy().to_string())
+                    }),
+                );
+            }
+            Err(error) => {
+                let _ = crate::diagnostic_log::append_diagnostic_log(
+                    "computer_use_guard.post_launch_failed",
+                    serde_json::json!({
+                        "attempt": attempt,
+                        "delay_seconds": delay,
+                        "message": error.to_string()
+                    }),
+                );
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
 async fn wait_for_windows_process_id(process_id: u32) -> anyhow::Result<()> {
     tokio::task::spawn_blocking(move || wait_for_windows_process_id_blocking(process_id))
         .await
@@ -1564,5 +1814,87 @@ fn activate_packaged_app_blocking(app_user_model_id: &str, arguments: &str) -> a
             CoUninitialize();
         }
         result.map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cdp_target(
+        id: &str,
+        target_type: &str,
+        title: &str,
+        url: &str,
+        ws: Option<&str>,
+    ) -> crate::cdp::CdpTarget {
+        crate::cdp::CdpTarget {
+            id: id.to_string(),
+            target_type: target_type.to_string(),
+            title: title.to_string(),
+            url: url.to_string(),
+            web_socket_debugger_url: ws.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn cdp_readiness_accepts_only_codex_page_targets_with_websocket() {
+        assert!(is_codex_cdp_target(&cdp_target(
+            "target-1",
+            "page",
+            "Codex",
+            "https://codex.local/",
+            Some("ws://127.0.0.1:9229/devtools/page/target-1"),
+        )));
+        assert!(!is_codex_cdp_target(&cdp_target(
+            "target-2",
+            "page",
+            "Other App",
+            "https://example.test/",
+            Some("ws://127.0.0.1:9229/devtools/page/target-2"),
+        )));
+        assert!(!is_codex_cdp_target(&cdp_target(
+            "target-3",
+            "worker",
+            "Codex Worker",
+            "https://codex.local/",
+            Some("ws://127.0.0.1:9229/devtools/page/target-3"),
+        )));
+        assert!(!is_codex_cdp_target(&cdp_target(
+            "target-4",
+            "page",
+            "Codex",
+            "https://codex.local/",
+            None,
+        )));
+    }
+
+    #[test]
+    fn cdp_target_fingerprint_prefers_stable_id() {
+        let target = cdp_target(
+            "target-1",
+            "page",
+            "Codex",
+            "https://codex.local/",
+            Some("ws://127.0.0.1:9229/devtools/page/target-1"),
+        );
+
+        assert_eq!(cdp_target_fingerprint(&target), "target-1");
+    }
+
+    #[test]
+    fn cdp_target_fingerprint_falls_back_to_websocket_url() {
+        let target = cdp_target(
+            "",
+            "page",
+            "Codex",
+            "https://codex.local/",
+            Some("ws://127.0.0.1:9229/devtools/page/target-1"),
+        );
+
+        assert_eq!(
+            cdp_target_fingerprint(&target),
+            "ws://127.0.0.1:9229/devtools/page/target-1"
+        );
     }
 }

--- a/crates/codex-plus-core/src/lib.rs
+++ b/crates/codex-plus-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod bridge;
 pub mod ccs_import;
 pub mod cdp;
 pub mod cli_wrapper;
+mod computer_use_guard;
 pub mod diagnostic_log;
 pub mod http_client;
 pub mod install;

--- a/crates/codex-plus-core/src/ports.rs
+++ b/crates/codex-plus-core/src/ports.rs
@@ -16,6 +16,28 @@ pub fn select_platform_loopback_port(requested: u16) -> u16 {
     )
 }
 
+pub fn select_packaged_codex_debug_port(requested: u16) -> u16 {
+    select_packaged_codex_debug_port_with(
+        requested,
+        cfg!(windows),
+        can_bind_loopback_port,
+        find_available_loopback_port,
+    )
+}
+
+pub fn select_packaged_codex_debug_port_with(
+    requested: u16,
+    is_windows: bool,
+    can_bind: impl Fn(u16) -> bool,
+    find_available: impl Fn() -> u16,
+) -> u16 {
+    if is_windows {
+        requested
+    } else {
+        select_platform_loopback_port_with(requested, is_windows, can_bind, find_available)
+    }
+}
+
 pub fn select_platform_loopback_port_with(
     requested: u16,
     is_windows: bool,

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -824,6 +824,27 @@ fn write_codex_live_atomic(
     std::fs::create_dir_all(home)?;
     let config_path = home.join("config.toml");
     let auth_path = home.join("auth.json");
+    #[cfg(windows)]
+    let guarded_config_text = match config_text {
+        Some(config_text) => {
+            let notify_exe = crate::computer_use_guard::find_computer_use_notify_exe(home);
+            let marketplace_path =
+                crate::computer_use_guard::ensure_openai_bundled_marketplace(home)?;
+            let guarded = if let Some(marketplace_path) = marketplace_path.as_deref() {
+                crate::computer_use_guard::guard_config_text_with_marketplace(
+                    config_text,
+                    notify_exe.as_deref(),
+                    Some(marketplace_path),
+                )?
+            } else {
+                crate::computer_use_guard::guard_config_text(config_text, notify_exe.as_deref())?
+            };
+            Some(guarded)
+        }
+        None => None,
+    };
+    #[cfg(windows)]
+    let config_text = guarded_config_text.as_deref();
 
     if let Some(config_text) = config_text {
         validate_toml_config(config_text, &config_path)?;

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -1,6 +1,9 @@
 use codex_plus_core::assets;
 use codex_plus_core::bridge::{self, BRIDGE_BINDING_NAME};
-use codex_plus_core::cdp::{CdpTarget, list_targets, pick_page_target};
+use codex_plus_core::cdp::{
+    CdpTarget, list_targets, pick_injectable_codex_page_target, pick_page_target,
+};
+
 use futures_util::{SinkExt, StreamExt};
 use serde_json::json;
 use std::future::Future;
@@ -797,7 +800,7 @@ fn pick_page_target_prefers_codex_title_or_url() {
 }
 
 #[test]
-fn pick_page_target_falls_back_to_first_injectable_page() {
+fn pick_page_target_leniently_falls_back_to_first_injectable_page() {
     let targets = vec![
         target(
             "browser",
@@ -842,11 +845,46 @@ fn pick_page_target_rejects_non_pages_and_pages_without_websocket() {
 
     let error = pick_page_target(&targets).expect_err("no injectable page should be selected");
 
+    assert!(error.to_string().contains("No injectable page target found"));
+}
+
+#[test]
+fn pick_injectable_codex_page_target_rejects_non_codex_pages() {
+    let targets = vec![
+        target(
+            "browser",
+            "browser",
+            "Codex",
+            "https://codex.test",
+            Some("ws://browser"),
+        ),
+        target(
+            "other-page",
+            "page",
+            "Other App",
+            "https://example.test",
+            Some("ws://other"),
+        ),
+    ];
+
+    let error = pick_injectable_codex_page_target(&targets)
+        .expect_err("non-Codex page must not be selected for injection");
+
     assert!(
         error
             .to_string()
             .contains("No injectable Codex page target found")
     );
+}
+
+#[test]
+fn pick_injectable_codex_page_target_requires_websocket() {
+    let targets = vec![target("codex", "page", "Codex", "https://codex.test", None)];
+
+    let error = pick_injectable_codex_page_target(&targets)
+        .expect_err("Codex page without websocket must not be selected for injection");
+
+    assert!(error.to_string().contains("No injectable Codex page target found"));
 }
 
 #[tokio::test]

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -13,7 +13,9 @@ use codex_plus_core::launcher::{
 };
 #[cfg(windows)]
 use codex_plus_core::launcher::{WindowsProcessControlStrategy, windows_process_control_strategy};
-use codex_plus_core::ports::select_platform_loopback_port_with;
+use codex_plus_core::ports::{
+    select_packaged_codex_debug_port_with, select_platform_loopback_port_with,
+};
 use codex_plus_core::settings::{BackendSettings, RelayProfile, RelayProtocol};
 use codex_plus_core::status::StatusStore;
 
@@ -327,6 +329,13 @@ fn ports_windows_falls_back_to_ephemeral_when_requested_is_busy() {
 }
 
 #[test]
+fn ports_windows_packaged_debug_keeps_requested_even_when_busy() {
+    let selected = select_packaged_codex_debug_port_with(9229, true, |_| false, || 43001);
+
+    assert_eq!(selected, 9229);
+}
+
+#[test]
 fn ports_non_windows_keeps_requested_even_when_busy() {
     let selected = select_platform_loopback_port_with(9229, false, |_| false, || 43001);
 
@@ -441,8 +450,11 @@ async fn launch_lifecycle_runs_sync_before_launch_writes_success_and_shutdowns_o
             "select-helper:57321",
             "load-settings",
             "provider-sync",
+            "apply-relay",
+            "computer-use-guard",
             "start-helper:57321",
             "launch:9229",
+            "computer-use-guard-watchdog",
             "inject:9229:57321",
             "status:running",
             "wait-codex",
@@ -525,8 +537,11 @@ async fn launch_lifecycle_keeps_js_injection_in_relay_mode() {
             "select-debug:9229",
             "select-helper:57321",
             "load-settings",
+            "apply-relay",
+            "computer-use-guard",
             "start-helper:57321",
             "launch:9229",
+            "computer-use-guard-watchdog",
             "inject:9229:57321",
             "status:running",
             "wait-codex",
@@ -566,7 +581,10 @@ async fn launch_lifecycle_skips_helper_and_injection_when_enhancements_disabled(
             "select-debug:9229",
             "select-helper:57321",
             "load-settings",
+            "apply-relay",
+            "computer-use-guard",
             "launch:9229",
+            "computer-use-guard-watchdog",
             "status:running",
             "wait-codex",
         ]
@@ -574,7 +592,8 @@ async fn launch_lifecycle_skips_helper_and_injection_when_enhancements_disabled(
 }
 
 #[tokio::test]
-async fn launch_lifecycle_does_not_apply_active_relay_profile_before_starting_codex() {
+async fn launch_lifecycle_applies_active_relay_profile_and_computer_use_guard_before_starting_codex()
+ {
     let temp = tempfile::tempdir().unwrap();
     let app_dir = temp.path().join("Codex.app");
     std::fs::create_dir_all(&app_dir).unwrap();
@@ -595,9 +614,23 @@ async fn launch_lifecycle_does_not_apply_active_relay_profile_before_starting_co
     .unwrap();
     handle.wait_for_codex_exit().await.unwrap();
 
-    let events = events.lock().unwrap().clone();
-    assert!(!events.contains(&"apply-relay".to_string()));
-    assert!(events.contains(&"launch:9229".to_string()));
+    assert_eq!(
+        *events.lock().unwrap(),
+        vec![
+            "select-debug:9229",
+            "select-helper:57321",
+            "load-settings",
+            "apply-relay",
+            "computer-use-guard",
+            "start-helper:57321",
+            "launch:9229",
+            "computer-use-guard-watchdog",
+            "inject:9229:57321",
+            "status:running",
+            "wait-codex",
+            "shutdown-helper:57321",
+        ]
+    );
 }
 
 #[tokio::test]
@@ -627,6 +660,7 @@ async fn launch_lifecycle_skips_active_relay_profile_when_supplier_config_disabl
 
     let events = events.lock().unwrap().clone();
     assert!(!events.contains(&"apply-relay".to_string()));
+    assert!(events.contains(&"computer-use-guard".to_string()));
     assert!(events.contains(&"launch:9229".to_string()));
 }
 
@@ -677,7 +711,8 @@ experimental_bearer_token = "sk-test"
     handle.wait_for_codex_exit().await.unwrap();
 
     let events = events.lock().unwrap().clone();
-    assert!(!events.contains(&"apply-relay".to_string()));
+    assert!(events.contains(&"apply-relay".to_string()));
+    assert!(events.contains(&"computer-use-guard".to_string()));
     assert!(events.contains(&"launch:9229".to_string()));
 }
 
@@ -708,8 +743,11 @@ async fn launch_lifecycle_enters_degraded_mode_and_retries_when_injection_fails(
             "select-debug:9229",
             "select-helper:57321",
             "load-settings",
+            "apply-relay",
+            "computer-use-guard",
             "start-helper:57321",
             "launch:9229",
+            "computer-use-guard-watchdog",
             "inject:9229:57321",
             "status:running_degraded",
         ]
@@ -753,6 +791,8 @@ async fn launch_lifecycle_cleans_helper_when_launch_fails_after_helper_started()
             "select-debug:9229",
             "select-helper:57321",
             "load-settings",
+            "apply-relay",
+            "computer-use-guard",
             "start-helper:57321",
             "launch:9229",
             "shutdown-helper:57321",
@@ -860,8 +900,11 @@ async fn launch_lifecycle_cleans_helper_and_codex_when_status_save_fails() {
             "select-debug:9229",
             "select-helper:57321",
             "load-settings",
+            "apply-relay",
+            "computer-use-guard",
             "start-helper:57321",
             "launch:9229",
+            "computer-use-guard-watchdog",
             "inject:9229:57321",
             "shutdown-helper:57321",
             "terminate-packaged:4242",
@@ -1055,6 +1098,11 @@ impl LaunchHooks for FakeHooks {
         Ok(())
     }
 
+    async fn ensure_computer_use_config(&self, _settings: &BackendSettings) -> anyhow::Result<()> {
+        self.event("computer-use-guard");
+        Ok(())
+    }
+
     async fn start_helper(&self, helper_port: u16) -> anyhow::Result<()> {
         self.event(format!("start-helper:{helper_port}"));
         Ok(())
@@ -1096,6 +1144,14 @@ impl LaunchHooks for FakeHooks {
         _debug_port: u16,
         _helper_port: u16,
     ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn start_computer_use_guard_watchdog(
+        &self,
+        _settings: &BackendSettings,
+    ) -> anyhow::Result<()> {
+        self.event("computer-use-guard-watchdog");
         Ok(())
     }
 

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -754,7 +754,7 @@ async fn launch_lifecycle_enters_degraded_mode_and_retries_when_injection_fails(
     );
     let status = status_store.load_latest().unwrap().unwrap();
     assert_eq!(status.status, "running_degraded");
-    assert!(status.message.contains("Codex 已启动"));
+    assert!(status.message.contains("Codex launched"));
 
     handle.wait_for_codex_exit().await.unwrap();
     let events = events.lock().unwrap().clone();

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -1929,7 +1929,8 @@ requires_openai_auth = true
 experimental_bearer_token = "22222222222222222222222222222222222"
 "#
         .to_string(),
-        auth_contents: r#"{"auth_mode":"chatgpt","tokens":{"access_token":"official"}}"#.to_string(),
+        auth_contents: r#"{"auth_mode":"chatgpt","tokens":{"access_token":"official"}}"#
+            .to_string(),
         ..RelayProfile::default()
     };
     let mut common = String::new();
@@ -1940,9 +1941,11 @@ experimental_bearer_token = "22222222222222222222222222222222222"
     assert_eq!(profile.relay_mode, RelayMode::Official);
     assert!(profile.official_mix_api_key);
     assert_eq!(profile.api_key, "333333333333333333333");
-    assert!(profile
-        .config_contents
-        .contains(r#"experimental_bearer_token = "333333333333333333333""#));
+    assert!(
+        profile
+            .config_contents
+            .contains(r#"experimental_bearer_token = "333333333333333333333""#)
+    );
     assert!(!profile.auth_contents.contains("OPENAI_API_KEY"));
 }
 
@@ -2059,6 +2062,56 @@ requires_openai_auth = true
     assert!(config.contains(r#"base_url = "https://max2.jojocode.com/v1""#));
     assert!(!config.contains("experimental_bearer_token"));
     assert!(!config.contains("[model_providers.custom]"));
+}
+
+#[cfg(windows)]
+#[test]
+fn apply_relay_profile_to_home_with_switch_rules_preserves_computer_use_guard_config() {
+    let temp = tempfile::tempdir().unwrap();
+    let helper = temp
+        .path()
+        .join("plugins")
+        .join("cache")
+        .join("openai-bundled")
+        .join("computer-use")
+        .join("26.608.12217")
+        .join("node_modules")
+        .join("@oai")
+        .join("sky")
+        .join("bin")
+        .join("windows")
+        .join("codex-computer-use.exe");
+    std::fs::create_dir_all(helper.parent().unwrap()).unwrap();
+    std::fs::write(&helper, "").unwrap();
+    let profile = RelayProfile {
+        id: "relay-a".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model_provider = "max_ai"
+model = "gpt-5.4"
+
+[features]
+js_repl = false
+
+[model_providers.max_ai]
+name = "max_ai"
+base_url = "https://max2.jojocode.com/v1"
+wire_api = "responses"
+requires_openai_auth = true
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_to_home_with_switch_rules(temp.path(), &profile, "").unwrap();
+
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(config.contains("js_repl = true"));
+    assert!(config.contains("[plugins.\"browser@openai-bundled\"]"));
+    assert!(config.contains("[plugins.\"chrome@openai-bundled\"]"));
+    assert!(config.contains("[plugins.\"computer-use@openai-bundled\"]"));
+    assert!(config.contains(r#"notify = ["#));
+    assert!(config.contains("codex-computer-use.exe"));
 }
 
 #[test]


### PR DESCRIPTION
## 摘要

这个 Draft PR 为 Codex++ 增加 Windows-only 的 Computer Use 启动前检查和启动链路加固，目标是让 Computer Use 在 Codex++ 中更稳定地可用。

修复范围集中在启动前配置修复、bundled 插件可用性、CDP 目标判定、已有实例复用路径，以及 bundled runtime 的兼容性兜底。

相关问题/讨论：

- https://github.com/BigPizzaV3/CodexPlusPlus/issues/498
- https://github.com/BigPizzaV3/CodexPlusPlus/issues/470
- https://github.com/BigPizzaV3/CodexPlusPlus/issues/442

## 主要改动

- 新增 Windows Computer Use 启动前 guard：
  - 修复 `~/.codex/config.toml` 的 UTF-8 BOM。
  - 保证 `[features] js_repl = true`。
  - 启用 `openai-bundled` 的 browser/chrome/computer-use 插件。
  - 保证 root `notify = ["...codex-computer-use.exe", "turn-ended"]`。

- 在 Codex++ 写入 live relay config 时保留 Computer Use 必需配置，避免切换供应商后覆盖 guard 结果。

- 增加 OpenAI bundled marketplace 的修复/复用逻辑。

- 加强 CDP readiness 判断：
  - 注入路径必须选择 Codex page target。
  - target 必须包含 websocket。
  - 拒绝无关 CDP page，避免误注入其他服务。
  - 避免把启动前已存在的旧 target 误判为本次启动成功。

- 整理 launcher 生命周期：
  - existing-instance 路径也执行 Computer Use guard。
  - helper/watchdog 生命周期更明确。
  - 常规启动路径不默认杀 Codex 进程。

- 增加 bundled `@oai/sky` runtime exports 兼容性兜底：
  - 仅当 Computer Use client 引用的 exact internal subpath 存在但未被 `package.json exports` 暴露时，补充该 exact export。
  - 不使用过宽的通配导出。
  - 已存在或官方后续修复时保持 no-op。

- 增加 post-launch retry：
  - runtime artifacts 启动后延迟出现时，仍可被后续 guard 发现并修复。

## 范围说明

这个 PR 刻意不包含：

- 私有 release 文档。
- 本机路径。
- 二进制文件或备份 exe。
- 私有仓库信息。
- 二维码图片清理。
- 与 Computer Use 无关的 Manager UI / provider preset 改动。

非 Windows 平台应保持 no-op，不改变现有行为。

## 验证

### 自动化验证

以下命令由 Codex 代理在本地 Windows 环境中执行，用户负责授权、复核执行范围和确认结果；不是 upstream CI 结果，也不代表维护者环境已经验证。

```powershell
git diff --check origin/main..HEAD
cargo +stable-x86_64-pc-windows-msvc test -p codex-plus-core launcher
cargo +stable-x86_64-pc-windows-msvc test -p codex-plus-core computer_use_guard
cargo +stable-x86_64-pc-windows-msvc test -p codex-plus-core relay_config
```

上述命令均通过。

### 运行时验证

运行时验证是在本地 Windows 安装版 Codex++ 上完成的，同等 Computer Use Guard / CDP / runtime exports 补丁已安装并验证通过。该结果用于说明方案在一个真实 Windows GUI 环境中可行，但仍建议维护者在自己的环境中复测。

已验证现象：

- `57321` helper backend 返回 OK。
- `9229/json` 返回 Codex page target，并包含 websocket。
- `~/.codex/config.toml` 无 BOM，`js_repl=true`，Computer Use 所需 bundled 插件启用，`notify` 指向有效的 `codex-computer-use.exe`。
- Computer Use 插件可以初始化。
- `list_apps` 成功。
- Calculator 无害点击测试 `1 + 2 = 3` 成功。

## 说明

这个 PR 的代码和验证过程主要由 Codex 代理协助完成，并由用户进行范围确认和结果复核。由于 Computer Use / CDP / bundled runtime 行为与本机运行环境相关，欢迎维护者进一步审查实现边界，并指出是否需要拆分 PR 或调整默认行为。

这是 Draft PR，主要用于让维护者评估方案方向、实现边界和是否需要拆分。当前实现避免在常规启动路径中强制杀进程；涉及清理残留进程的操作仍应保留给显式修复脚本或用户确认后的修复流程。
