### PR TITLE
fix: 修复第一次打开右边栏并选择 Files / Browser / Terminal 会触发错误

### DIFF
--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -4162,9 +4162,43 @@
     return Object.keys(element).filter((key) => key.startsWith("__reactFiber") || key.startsWith("__reactInternalInstance") || key.startsWith("__reactProps"));
   }
 
+  function isWorkspaceChromeNode(node) {
+    if (!node || node.nodeType !== 1) return false;
+    if (node.closest?.('[data-app-action-sidebar-section-heading="Chats"], [data-app-action-sidebar-section-heading="Projects"], [data-app-action-sidebar-thread-id], [data-app-action-sidebar-project-row], [data-app-action-sidebar-project-id]')) {
+      return false;
+    }
+    return !!node.closest?.("main aside");
+  }
+
+  function patchReactModelStateNodes() {
+    const selector = "[role='menu'], [role='dialog'], [role='listbox'], [data-radix-popper-content-wrapper]";
+    return [document.body, ...document.querySelectorAll(selector)].filter((node) => node && !isWorkspaceChromeNode(node));
+  }
+
+  function shouldScheduleReactModelStatePatch(mutations) {
+    if (!codexPlusModelUnlockEnabled() || !codexPlusModelNames().length) return false;
+    if (!mutations) return false;
+    const selector = "[role='menu'], [role='dialog'], [role='listbox'], [data-radix-popper-content-wrapper]";
+    return mutations.some((mutation) => [...mutation.addedNodes].some((node) => {
+      if (node.nodeType !== 1 || isWorkspaceChromeNode(node)) return false;
+      return !!node.matches?.(selector) || !!node.querySelector?.(selector);
+    }));
+  }
+
+  function schedulePatchReactModelState() {
+    if (window.__codexPlusReactModelStatePatchPending) return;
+    window.__codexPlusReactModelStatePatchPending = true;
+    clearTimeout(window.__codexPlusReactModelStatePatchTimer);
+    window.__codexPlusReactModelStatePatchTimer = setTimeout(() => {
+      window.__codexPlusReactModelStatePatchPending = false;
+      window.__codexPlusReactModelStatePatchTimer = null;
+      patchReactModelState();
+    }, 120);
+  }
+
   function patchReactModelState() {
     const visited = new WeakSet();
-    const nodes = [document.body, ...document.querySelectorAll("button, [role='menu'], [role='dialog'], [data-radix-popper-content-wrapper]")].filter(Boolean);
+    const nodes = patchReactModelStateNodes();
     let changed = false;
     for (const node of nodes.slice(0, 220)) {
       for (const key of reactFiberKeys(node)) {
@@ -4290,17 +4324,31 @@
     void patch();
   }
 
-  function patchCodexModelWhitelist() {
+  function ensureCodexModelWhitelistInstalls() {
     if (!codexPlusModelUnlockEnabled()) return;
     installModelJsonResponsePatch();
     patchAppServerModelMessages();
     installAppServerModelRequestPatch();
+  }
+
+  function patchCodexModelWhitelist() {
+    ensureCodexModelWhitelistInstalls();
     if (!codexPlusModelNames().length) {
       loadCodexModelCatalog();
       return;
     }
     patchStatsigModelWhitelist();
     patchReactModelState();
+  }
+
+  function refreshCodexModelWhitelistFromScan(mutations) {
+    ensureCodexModelWhitelistInstalls();
+    if (!codexPlusModelNames().length) {
+      loadCodexModelCatalog();
+      return;
+    }
+    patchStatsigModelWhitelist();
+    if (shouldScheduleReactModelStatePatch(mutations)) schedulePatchReactModelState();
   }
 
   function threadIdVariants(sessionId) {
@@ -7939,7 +7987,7 @@
     refreshConversationView();
     installCodexServiceTierBadge();
     scheduleThreadScrollSync();
-    patchCodexModelWhitelist();
+    refreshCodexModelWhitelistFromScan(window.__codexSessionDeleteLastMutations);
   }
 
   function runScanStep(step) {
@@ -8024,6 +8072,7 @@
   }
 
   function scheduleScan(mutations) {
+    window.__codexSessionDeleteLastMutations = mutations;
     scheduleZedRemoteMenuRefresh(mutations);
     if (!shouldScheduleScan(mutations)) return;
     if (window.__codexSessionDeleteScanPending) return;

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -368,6 +368,9 @@ fn injection_script_unlocks_custom_model_catalog() {
     assert!(script.contains("Response.prototype.json"));
     assert!(script.contains("available_models"));
     assert!(script.contains("modelWhitelistUnlock"));
+    assert!(script.contains("isWorkspaceChromeNode"));
+    assert!(script.contains("refreshCodexModelWhitelistFromScan"));
+    assert!(!script.contains("querySelectorAll(\"button, [role='menu']"));
 }
 
 #[test]


### PR DESCRIPTION
- 问题描述 - Issue #900 
在开启「页面增强」和「模型白名单解锁」后，启动程序并第一次点击 Codex 右侧工作区侧栏的 **Files / Browser / Terminal** 会触发错误页：
> Oops, an error has occurred

DevTools 中的核心报错为：TypeError: this.events[e].clear is not a function at Oi.unmount (single-value-*.js) at app-shell-tab-controller / thread-app-shell-chrome

关闭「模型白名单解锁」或「页面增强」后问题消失。

- 根因
是 `patchReactModelState()` 在每次 scan 时扫描并修改所有 button 的 React fiber 状态，与工作区 Tab 切换动画的组件卸载冲突。

- 修复方案
1. 移除对全页 `button` 的扫描，仅针对模型选择相关 UI（`menu` / `dialog` / `listbox` 等）
2. 新增 `isWorkspaceChromeNode()`，排除右侧工作区（`main aside` 中的 Files/Browser/Terminal）
3. 将 `scan()` 中的模型白名单逻辑改为 `refreshCodexModelWhitelistFromScan()`，仅在模型相关 UI 出现时 debounce 触发 `patchReactModelState()`
4. 补充 `cdp_bridge` 注入脚本测试断言

- 修改文件
- assets/inject/renderer-inject.js
- crates/codex-plus-core/tests/cdp_bridge.rs