### PR TITLE
[codex] Apply preferred Codex++ defaults

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -207,7 +207,7 @@ fn open_manager_with_update_prompt() -> anyhow::Result<()> {
     command
         .spawn()
         .map(|_| ())
-        .map_err(|error| anyhow::anyhow!("启动管理工具失败：{error}"))
+        .map_err(|error| anyhow::anyhow!("Failed to start manager: {error}"))
 }
 
 fn parse_launch_options<I, S>(args: I) -> LaunchOptions
@@ -511,13 +511,13 @@ impl BridgeRuntimeService for LauncherRuntimeService {
             std::process::Command::new(&manager_path)
                 .creation_flags(codex_plus_core::windows_create_no_window())
                 .spawn()
-                .map_err(|error| anyhow::anyhow!("启动管理工具失败：{error}"))?;
+                .map_err(|error| anyhow::anyhow!("Failed to start manager: {error}"))?;
         }
         #[cfg(not(windows))]
         {
             std::process::Command::new(&manager_path)
                 .spawn()
-                .map_err(|error| anyhow::anyhow!("启动管理工具失败：{error}"))?;
+                .map_err(|error| anyhow::anyhow!("Failed to start manager: {error}"))?;
         }
         Ok(json!({
             "status": "ok",
@@ -527,7 +527,7 @@ impl BridgeRuntimeService for LauncherRuntimeService {
 
     async fn backend_status(&self) -> anyhow::Result<Value> {
         Ok(
-            json!({"status": "ok", "message": "后端已连接", "version": codex_plus_core::version::VERSION}),
+            json!({"status": "ok", "message": "Backend connected", "version": codex_plus_core::version::VERSION}),
         )
     }
 

--- a/apps/codex-plus-manager/index.html
+++ b/apps/codex-plus-manager/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Codex++ 管理工具</title>
+    <title>Codex++ Manager</title>
   </head>
   <body>
     <div id="app"></div>

--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -258,7 +258,7 @@ pub struct StartupPayload {
 #[tauri::command]
 pub fn backend_version() -> CommandResult<VersionPayload> {
     ok(
-        "后端版本已读取。",
+        "Backend version read.",
         VersionPayload {
             version: codex_plus_core::version::VERSION.to_string(),
         },
@@ -268,7 +268,7 @@ pub fn backend_version() -> CommandResult<VersionPayload> {
 #[tauri::command]
 pub fn startup_options() -> CommandResult<StartupPayload> {
     ok(
-        "启动参数已读取。",
+        "Launch arguments loaded.",
         StartupPayload {
             show_update: startup_should_show_update(),
         },
@@ -295,7 +295,7 @@ pub async fn load_overview() -> CommandResult<OverviewPayload> {
     let payload = tauri::async_runtime::spawn_blocking(load_overview_payload).await;
     let Ok((codex_app_path, entrypoints, latest_launch)) = payload else {
         return failed(
-            "概览后台任务失败。",
+            "Overview background task failed.",
             OverviewPayload {
                 codex_app: path_state(None),
                 codex_version: None,
@@ -314,7 +314,7 @@ pub async fn load_overview() -> CommandResult<OverviewPayload> {
         );
     };
     ok(
-        "概览已加载。",
+        "Overview loaded.",
         OverviewPayload {
             codex_version: codex_app_path
                 .as_deref()
@@ -337,14 +337,14 @@ pub async fn load_overview() -> CommandResult<OverviewPayload> {
 
 #[tauri::command]
 pub fn launch_codex_plus(request: LaunchRequest) -> CommandResult<Value> {
-    spawn_codex_plus_launch(request, "启动任务已在后台开始，可稍后查看概览状态。")
+    spawn_codex_plus_launch(request, "Launch task started in the background. Check the overview status shortly.")
 }
 
 #[tauri::command]
 pub fn restart_codex_plus(request: LaunchRequest) -> CommandResult<Value> {
     codex_plus_core::watcher::stop_launcher_processes();
     codex_plus_core::watcher::stop_codex_processes();
-    spawn_codex_plus_launch(request, "Codex 已请求重启，启动任务正在后台运行。")
+    spawn_codex_plus_launch(request, "Codex restart requested. The launch task is running in the background.")
 }
 
 fn spawn_codex_plus_launch(request: LaunchRequest, accepted_message: &str) -> CommandResult<Value> {
@@ -368,7 +368,7 @@ fn spawn_codex_plus_launch(request: LaunchRequest, accepted_message: &str) -> Co
             }),
         },
         Err(error) => failed(
-            &format!("启动静默入口失败：{error}"),
+            &format!("Failed to start the silent launcher: {error}"),
             json!({
                 "debugPort": debug_port,
                 "helperPort": helper_port
@@ -396,12 +396,12 @@ fn spawn_silent_launcher(request: &LaunchRequest) -> anyhow::Result<()> {
     command
         .spawn()
         .map(|_| ())
-        .map_err(|error| anyhow::anyhow!("无法启动 {}：{error}", launcher.to_string_lossy()))
+        .map_err(|error| anyhow::anyhow!("Failed to launch {}: {error}", launcher.to_string_lossy()))
 }
 
 #[tauri::command]
 pub fn load_settings() -> CommandResult<SettingsPayload> {
-    settings_payload("设置已加载。", "设置读取失败")
+    settings_payload("Settings loaded.", "Failed to read settings")
 }
 
 #[tauri::command]
@@ -410,7 +410,7 @@ pub fn get_config_coordination_status()
     let settings =
         settings_with_live_ccs_profiles(SettingsStore::default().load().unwrap_or_default());
     ok(
-        "已读取配置协调状态。",
+        "Loaded config coordination status.",
         codex_plus_core::config_coordinator::coordination_status(&settings),
     )
 }
@@ -429,7 +429,7 @@ pub fn save_settings(settings: BackendSettings) -> CommandResult<SettingsPayload
                     .to_string(),
                 user_scripts: user_script_inventory(),
             };
-            return failed(&format!("写回 cc-switch 供应商配置失败：{error}"), payload);
+            return failed(&format!("Failed to write cc-switch provider config: {error}"), payload);
         }
         let active = settings.active_relay_profile();
         if !active.linked_ccs_provider_id.trim().is_empty() {
@@ -445,7 +445,7 @@ pub fn save_settings(settings: BackendSettings) -> CommandResult<SettingsPayload
                         .to_string(),
                     user_scripts: user_script_inventory(),
                 };
-                return failed(&format!("同步 cc-switch 当前供应商失败：{error}"), payload);
+                return failed(&format!("Failed to sync the current cc-switch provider: {error}"), payload);
             }
         }
     }
@@ -454,12 +454,12 @@ pub fn save_settings(settings: BackendSettings) -> CommandResult<SettingsPayload
         Ok(()) => {
             let wrapper_message = refresh_cli_wrapper_after_settings_save(&settings);
             settings_payload(
-                &format!("设置已保存。{wrapper_message}"),
-                "设置保存后重新读取失败",
+                &format!("Settings saved. {wrapper_message}"),
+                "Failed to reload settings after saving",
             )
         }
         Err(error) => failed(
-            &format!("保存设置失败：{error}"),
+            &format!("Failed to save settings: {error}"),
             SettingsPayload {
                 settings,
                 settings_path: codex_plus_core::paths::default_settings_path()
@@ -476,14 +476,14 @@ pub fn load_ccs_providers() -> CommandResult<CcsProvidersPayload> {
     let db_path = codex_plus_core::ccs_import::default_ccs_db_path();
     match codex_plus_core::ccs_import::list_codex_providers_from_db(&db_path) {
         Ok(providers) => ok(
-            &format!("已读取外部 Codex 供应商配置：{} 个。", providers.len()),
+            &format!("Loaded {} external Codex provider configs.", providers.len()),
             CcsProvidersPayload {
                 db_path: db_path.to_string_lossy().to_string(),
                 providers,
             },
         ),
         Err(error) => failed(
-            &format!("读取外部供应商配置失败：{error}"),
+            &format!("Failed to read external provider config: {error}"),
             CcsProvidersPayload {
                 db_path: db_path.to_string_lossy().to_string(),
                 providers: Vec::new(),
@@ -502,23 +502,23 @@ pub fn import_ccs_providers() -> CommandResult<SettingsPayload> {
             let payload = settings_payload_value()
                 .map(|payload| payload)
                 .unwrap_or_else(|(_, payload)| payload);
-            return failed(&format!("读取外部供应商配置失败：{error}"), payload);
+            return failed(&format!("Failed to read external provider config: {error}"), payload);
         }
     };
     settings.ccs_link_enabled = true;
     remove_linked_ccs_profiles_for_local_storage(&mut settings);
 
     if synced == 0 {
-        return settings_payload("没有可联动的 cc-switch Codex 供应商配置。", "设置读取失败");
+        return settings_payload("No linkable cc-switch Codex provider config was found.", "Failed to read settings");
     }
 
     match store.save(&settings) {
         Ok(()) => settings_payload(
-            &format!("已开启 cc-switch 联动：{synced} 个供应商将直接从 cc-switch 读取。"),
-            "联动供应商配置后重新读取设置失败",
+            &format!("cc-switch linking enabled: {synced} provider configs will be read directly from cc-switch."),
+            "Failed to reload settings after linking provider configs",
         ),
         Err(error) => failed(
-            &format!("保存外部供应商配置失败：{error}"),
+            &format!("Failed to save external provider config: {error}"),
             settings_payload_value()
                 .map(|payload| payload)
                 .unwrap_or_else(|(_, payload)| payload),
@@ -561,12 +561,12 @@ pub fn list_local_sessions() -> CommandResult<LocalSessionsPayload> {
     };
     if errors.is_empty() {
         ok(
-            &format!("已读取 {} 个本地会话。", payload.sessions.len()),
+            &format!("Loaded {} local sessions.", payload.sessions.len()),
             payload,
         )
     } else {
         failed(
-            &format!("读取部分本地会话失败：{}", errors.join("; ")),
+            &format!("Failed to load some local sessions: {}", errors.join("; ")),
             payload,
         )
     }
@@ -584,7 +584,7 @@ pub fn list_zed_remote_projects() -> CommandResult<ZedRemoteProjectsPayload> {
         )
         .unwrap_or_default();
         return ok(
-            &format!("已读取 {} 个 Zed 远程项目。", projects.len()),
+            &format!("Loaded {} Zed remote projects.", projects.len()),
             ZedRemoteProjectsPayload { projects },
         );
     }
@@ -592,7 +592,7 @@ pub fn list_zed_remote_projects() -> CommandResult<ZedRemoteProjectsPayload> {
         result
             .get("message")
             .and_then(Value::as_str)
-            .unwrap_or("读取 Zed 远程项目失败。"),
+            .unwrap_or("Failed to read Zed remote projects."),
         ZedRemoteProjectsPayload {
             projects: Vec::new(),
         },
@@ -614,7 +614,7 @@ pub fn open_zed_remote(payload: Value) -> CommandResult<ZedRemoteOpenPayload> {
         .to_string();
     if result.get("status").and_then(Value::as_str) == Some("ok") {
         return ok(
-            "已在 Zed Remote 打开项目。",
+            "Opened project in Zed Remote.",
             ZedRemoteOpenPayload { url, strategy },
         );
     }
@@ -622,7 +622,7 @@ pub fn open_zed_remote(payload: Value) -> CommandResult<ZedRemoteOpenPayload> {
         result
             .get("message")
             .and_then(Value::as_str)
-            .unwrap_or("无法在 Zed Remote 打开项目。"),
+            .unwrap_or("Unable to open project in Zed Remote."),
         ZedRemoteOpenPayload { url, strategy },
     )
 }
@@ -636,7 +636,7 @@ pub fn forget_zed_remote_project(id: String) -> CommandResult<ZedRemoteProjectsP
             result
                 .get("message")
                 .and_then(Value::as_str)
-                .unwrap_or("移除 Zed 远程项目失败。"),
+                .unwrap_or("Failed to remove Zed remote project."),
             ZedRemoteProjectsPayload {
                 projects: Vec::new(),
             },
@@ -650,11 +650,11 @@ pub fn delete_local_session(request: DeleteLocalSessionRequest) -> CommandResult
     let session_id = request.session_id.trim();
     if session_id.is_empty() {
         return failed(
-            "会话 ID 不能为空。",
+            "Session ID cannot be empty.",
             DeleteResult {
                 status: codex_plus_core::models::DeleteStatus::Failed,
                 session_id: String::new(),
-                message: "会话 ID 不能为空。".to_string(),
+                message: "Session ID cannot be empty.".to_string(),
                 undo_token: None,
                 backup_path: None,
             },
@@ -984,11 +984,11 @@ pub async fn load_provider_sync_targets() -> CommandResult<Value> {
                 .collect::<Vec<_>>();
             merge_manual_provider_sync_targets(&mut targets, &manual, &settings);
             ok(
-                "Provider 同步目标已加载。",
+                "Provider sync targets loaded.",
                 serde_json::to_value(targets).unwrap_or_else(|_| json!({})),
             )
         }
-        Err(error) => failed(&format!("Provider 同步目标加载失败：{error}"), json!({})),
+        Err(error) => failed(&format!("Failed to load provider sync targets: {error}"), json!({})),
     }
 }
 
@@ -1052,7 +1052,7 @@ pub async fn sync_providers_now(target_provider: Option<String>) -> CommandResul
             }
             ok(
                 &format!(
-                    "供应商已同步一次：{} 个会话文件，{} 行索引，跳过 {} 个占用文件。",
+                "Providers synced once: {} session files, {} index rows, skipped {} locked files.",
                     sync.changed_session_files,
                     sync.sqlite_rows_updated,
                     sync.skipped_locked_rollout_files.len()
@@ -1073,7 +1073,7 @@ pub async fn sync_providers_now(target_provider: Option<String>) -> CommandResul
                 }),
             )
         }
-        Err(error) => failed(&format!("供应商同步失败：{error}"), json!({})),
+        Err(error) => failed(&format!("Provider sync failed: {error}"), json!({})),
     }
 }
 
@@ -1106,9 +1106,9 @@ fn persist_provider_sync_selection(provider: &str) {
 #[tauri::command]
 pub async fn load_ads() -> CommandResult<AdsPayload> {
     match codex_plus_core::ads::fetch_ad_list().await {
-        Ok(payload) => ok("推荐内容已加载。", ads_payload(payload)),
+        Ok(payload) => ok("Recommendations loaded.", ads_payload(payload)),
         Err(error) => failed(
-            &format!("推荐内容加载失败：{error}"),
+            &format!("Failed to load recommendations: {error}"),
             AdsPayload {
                 version: 1,
                 ads: Vec::new(),
@@ -1121,12 +1121,12 @@ pub async fn load_ads() -> CommandResult<AdsPayload> {
 pub async fn refresh_script_market() -> CommandResult<ScriptMarketPayload> {
     match script_market::fetch_market_manifest(script_market::DEFAULT_MARKET_INDEX_URL).await {
         Ok(manifest) => ok(
-            "脚本市场已刷新。",
-            script_market_payload_from_manifest(&manifest, "ok", "脚本市场已刷新。"),
+            "Script market refreshed.",
+            script_market_payload_from_manifest(&manifest, "ok", "Script market refreshed."),
         ),
         Err(error) => failed(
-            &format!("脚本市场加载失败：{error}"),
-            failed_script_market_payload(&format!("脚本市场加载失败：{error}")),
+            &format!("Failed to load script market: {error}"),
+            failed_script_market_payload(&format!("Failed to load script market: {error}")),
         ),
     }
 }
@@ -1136,8 +1136,8 @@ pub async fn install_market_script(id: String) -> CommandResult<ScriptMarketPayl
     let trimmed = id.trim();
     if trimmed.is_empty() {
         return failed(
-            "脚本 id 不能为空。",
-            failed_script_market_payload("脚本 id 不能为空。"),
+            "Script id cannot be empty.",
+            failed_script_market_payload("Script id cannot be empty."),
         );
     }
     let manifest =
@@ -1145,29 +1145,29 @@ pub async fn install_market_script(id: String) -> CommandResult<ScriptMarketPayl
             Ok(manifest) => manifest,
             Err(error) => {
                 return failed(
-                    &format!("脚本市场加载失败：{error}"),
-                    failed_script_market_payload(&format!("脚本市场加载失败：{error}")),
+                    &format!("Failed to load script market: {error}"),
+                    failed_script_market_payload(&format!("Failed to load script market: {error}")),
                 );
             }
         };
     let Some(script) = manifest.scripts.iter().find(|script| script.id == trimmed) else {
         return failed(
-            "市场清单中未找到该脚本。",
-            script_market_payload_from_manifest(&manifest, "failed", "市场清单中未找到该脚本。"),
+            "Script was not found in the market manifest.",
+            script_market_payload_from_manifest(&manifest, "failed", "Script was not found in the market manifest."),
         );
     };
     let manager = default_user_script_manager();
     match script_market::install_market_script(&manager, script).await {
         Ok(()) => ok(
-            "脚本已安装。",
-            script_market_payload_from_manifest(&manifest, "ok", "脚本已安装。"),
+            "Script installed.",
+            script_market_payload_from_manifest(&manifest, "ok", "Script installed."),
         ),
         Err(error) => failed(
-            &format!("安装脚本失败：{error}"),
+            &format!("Failed to install script: {error}"),
             script_market_payload_from_manifest(
                 &manifest,
                 "failed",
-                &format!("安装脚本失败：{error}"),
+                &format!("Failed to install script: {error}"),
             ),
         ),
     }
@@ -1177,20 +1177,20 @@ pub async fn install_market_script(id: String) -> CommandResult<ScriptMarketPayl
 pub fn set_user_script_enabled(key: String, enabled: bool) -> CommandResult<SettingsPayload> {
     let trimmed = key.trim();
     if trimmed.is_empty() {
-        return failed("脚本 key 不能为空。", fallback_settings_payload());
+        return failed("Script key cannot be empty.", fallback_settings_payload());
     }
     let manager = default_user_script_manager();
     match manager.set_script_enabled(trimmed, enabled) {
         Ok(_) => settings_payload(
             if enabled {
-                "脚本已启用。"
+                "Script enabled."
             } else {
-                "脚本已禁用。"
+                "Script disabled."
             },
-            "脚本启停失败",
+            "Failed to toggle script",
         ),
         Err(error) => failed(
-            &format!("脚本启停失败：{error}"),
+            &format!("Failed to toggle script: {error}"),
             fallback_settings_payload(),
         ),
     }
@@ -1200,13 +1200,13 @@ pub fn set_user_script_enabled(key: String, enabled: bool) -> CommandResult<Sett
 pub fn delete_user_script(key: String) -> CommandResult<SettingsPayload> {
     let trimmed = key.trim();
     if trimmed.is_empty() {
-        return failed("脚本 key 不能为空。", fallback_settings_payload());
+        return failed("Script key cannot be empty.", fallback_settings_payload());
     }
     let manager = default_user_script_manager();
     match manager.delete_user_script(trimmed) {
-        Ok(_) => settings_payload("脚本已删除。", "脚本删除失败"),
+        Ok(_) => settings_payload("Script deleted.", "Failed to delete script"),
         Err(error) => failed(
-            &format!("脚本删除失败：{error}"),
+            &format!("Failed to delete script: {error}"),
             fallback_settings_payload(),
         ),
     }
@@ -1216,11 +1216,11 @@ pub fn delete_user_script(key: String) -> CommandResult<SettingsPayload> {
 pub fn open_external_url(url: String) -> CommandResult<Value> {
     let trimmed = url.trim();
     if !(trimmed.starts_with("https://") || trimmed.starts_with("http://")) {
-        return failed("只允许打开 http 或 https 链接。", json!({}));
+        return failed("Only http or https links can be opened.", json!({}));
     }
     match open_url(trimmed) {
-        Ok(()) => ok("已在系统浏览器打开链接。", json!({ "url": trimmed })),
-        Err(error) => failed(&format!("打开链接失败：{error}"), json!({ "url": trimmed })),
+        Ok(()) => ok("Opened link in the system browser.", json!({ "url": trimmed })),
+        Err(error) => failed(&format!("Failed to open link: {error}"), json!({ "url": trimmed })),
     }
 }
 
@@ -1228,21 +1228,21 @@ pub fn open_external_url(url: String) -> CommandResult<Value> {
 pub async fn install_entrypoints() -> InstallActionResult {
     tauri::async_runtime::spawn_blocking(install::install_entrypoints)
         .await
-        .unwrap_or_else(|error| install_background_failure("安装入口", error))
+        .unwrap_or_else(|error| install_background_failure("install entries", error))
 }
 
 #[tauri::command]
 pub async fn uninstall_entrypoints(options: InstallOptions) -> InstallActionResult {
     tauri::async_runtime::spawn_blocking(move || install::uninstall_entrypoints(options))
         .await
-        .unwrap_or_else(|error| install_background_failure("卸载入口", error))
+        .unwrap_or_else(|error| install_background_failure("uninstall entries", error))
 }
 
 #[tauri::command]
 pub async fn repair_shortcuts() -> InstallActionResult {
     tauri::async_runtime::spawn_blocking(install::repair_shortcuts)
         .await
-        .unwrap_or_else(|error| install_background_failure("修复快捷方式", error))
+        .unwrap_or_else(|error| install_background_failure("repair shortcuts", error))
 }
 
 #[tauri::command]
@@ -1251,13 +1251,13 @@ pub fn repair_backend() -> CommandResult<SettingsPayload> {
         settings_with_live_ccs_profiles(SettingsStore::default().load().unwrap_or_default());
     let message = match codex_plus_core::cli_wrapper::ensure_cli_wrapper(&settings) {
         Ok(Some(install)) => format!(
-            "后端已修复，命令包装器已指向 {}。",
+            "Backend repaired; command wrapper now points to {}.",
             install.real_codex.to_string_lossy()
         ),
-        Ok(None) => "后端已修复，命令包装器当前未启用。".to_string(),
-        Err(error) => format!("后端修复部分失败：{error}"),
+        Ok(None) => "Backend repaired; command wrapper is currently disabled.".to_string(),
+        Err(error) => format!("Backend repair partially failed: {error}"),
     };
-    settings_payload(&message, "修复后重新读取设置失败")
+    settings_payload(&message, "Failed to reload settings after repair")
 }
 
 #[tauri::command]
@@ -1272,9 +1272,9 @@ pub async fn check_update() -> CommandResult<Value> {
             CommandResult {
                 status: status.to_string(),
                 message: if update.update_available {
-                    "发现可用更新。".to_string()
+                    "Update available.".to_string()
                 } else {
-                    "当前已是最新版本。".to_string()
+                    "Already on the latest version.".to_string()
                 },
                 payload: json!({
                     "currentVersion": update.current_version,
@@ -1288,7 +1288,7 @@ pub async fn check_update() -> CommandResult<Value> {
             }
         }
         Err(error) => failed(
-            &format!("检查更新失败：{error}"),
+            &format!("Failed to check for updates: {error}"),
             json!({
                 "currentVersion": codex_plus_core::version::VERSION,
                 "latestVersion": Value::Null,
@@ -1308,7 +1308,7 @@ pub async fn perform_update(
 ) -> CommandResult<Value> {
     let Some(release) = release else {
         return failed(
-            "请先检查更新并选择可下载的 Release asset。",
+            "Check for updates first and choose a downloadable release asset.",
             json!({
                 "currentVersion": codex_plus_core::version::VERSION,
                 "progress": 0
@@ -1318,7 +1318,7 @@ pub async fn perform_update(
     let download_dir = codex_plus_core::paths::default_app_state_dir().join("updates");
     match codex_plus_core::update::perform_update(&release, &download_dir).await {
         Ok(result) => ok(
-            "安装包已下载并启动，请按安装向导完成更新。",
+            "Installer package downloaded and started. Follow the installer to finish updating.",
             json!({
                 "currentVersion": codex_plus_core::version::VERSION,
                 "latestVersion": result.release.version,
@@ -1329,7 +1329,7 @@ pub async fn perform_update(
             }),
         ),
         Err(error) => failed(
-            &format!("安装更新失败：{error}"),
+            &format!("Failed to install update: {error}"),
             json!({
                 "currentVersion": codex_plus_core::version::VERSION,
                 "latestVersion": release.version,
@@ -1342,7 +1342,7 @@ pub async fn perform_update(
 
 #[tauri::command]
 pub fn load_watcher_state() -> CommandResult<WatcherPayload> {
-    ok("watcher 状态已加载。", watcher_payload())
+    ok("Watcher status loaded.", watcher_payload())
 }
 
 #[tauri::command]
@@ -1350,32 +1350,32 @@ pub fn install_watcher() -> CommandResult<WatcherPayload> {
     let launcher_path =
         codex_plus_core::install::companion_binary_path(codex_plus_core::install::SILENT_BINARY);
     match codex_plus_core::watcher::install_watcher(&launcher_path, default_debug_port()) {
-        Ok(()) => ok("watcher 已安装。", watcher_payload()),
-        Err(error) => failed(&format!("安装 watcher 失败：{error}"), watcher_payload()),
+        Ok(()) => ok("Watcher installed.", watcher_payload()),
+        Err(error) => failed(&format!("Failed to install watcher: {error}"), watcher_payload()),
     }
 }
 
 #[tauri::command]
 pub fn uninstall_watcher() -> CommandResult<WatcherPayload> {
     match codex_plus_core::watcher::uninstall_watcher() {
-        Ok(()) => ok("watcher 已移除。", watcher_payload()),
-        Err(error) => failed(&format!("移除 watcher 失败：{error}"), watcher_payload()),
+        Ok(()) => ok("Watcher removed.", watcher_payload()),
+        Err(error) => failed(&format!("Failed to remove watcher: {error}"), watcher_payload()),
     }
 }
 
 #[tauri::command]
 pub fn enable_watcher() -> CommandResult<WatcherPayload> {
     match codex_plus_core::watcher::enable_watcher() {
-        Ok(()) => ok("watcher 已启用。", watcher_payload()),
-        Err(error) => failed(&format!("启用 watcher 失败：{error}"), watcher_payload()),
+        Ok(()) => ok("Watcher enabled.", watcher_payload()),
+        Err(error) => failed(&format!("Failed to enable watcher: {error}"), watcher_payload()),
     }
 }
 
 #[tauri::command]
 pub fn disable_watcher() -> CommandResult<WatcherPayload> {
     match codex_plus_core::watcher::disable_watcher() {
-        Ok(()) => ok("watcher 已禁用。", watcher_payload()),
-        Err(error) => failed(&format!("禁用 watcher 失败：{error}"), watcher_payload()),
+        Ok(()) => ok("Watcher disabled.", watcher_payload()),
+        Err(error) => failed(&format!("Failed to disable watcher: {error}"), watcher_payload()),
     }
 }
 
@@ -1384,7 +1384,7 @@ pub fn read_latest_logs(request: LogRequest) -> CommandResult<LogsPayload> {
     let path = codex_plus_core::paths::default_diagnostic_log_path();
     match read_tail(&path, request.lines) {
         Ok(text) => ok(
-            "日志已读取。",
+            "Logs read.",
             LogsPayload {
                 path: path.to_string_lossy().to_string(),
                 text,
@@ -1392,7 +1392,7 @@ pub fn read_latest_logs(request: LogRequest) -> CommandResult<LogsPayload> {
             },
         ),
         Err(error) => failed(
-            &format!("读取日志失败：{error}"),
+            &format!("Failed to read logs: {error}"),
             LogsPayload {
                 path: path.to_string_lossy().to_string(),
                 text: String::new(),
@@ -1405,7 +1405,7 @@ pub fn read_latest_logs(request: LogRequest) -> CommandResult<LogsPayload> {
 #[tauri::command]
 pub fn copy_diagnostics() -> CommandResult<DiagnosticsPayload> {
     ok(
-        "诊断报告已生成。",
+        "Diagnostics report generated.",
         DiagnosticsPayload {
             report: diagnostics_report(),
         },
@@ -1416,9 +1416,9 @@ pub fn copy_diagnostics() -> CommandResult<DiagnosticsPayload> {
 pub fn reset_settings() -> CommandResult<SettingsPayload> {
     let settings = BackendSettings::default();
     match SettingsStore::default().save(&settings) {
-        Ok(()) => settings_payload("设置已重置为默认值。", "设置重置后重新读取失败"),
+        Ok(()) => settings_payload("Settings reset to defaults.", "Failed to reload settings after reset"),
         Err(error) => failed(
-            &format!("重置设置失败：{error}"),
+            &format!("Failed to reset settings: {error}"),
             SettingsPayload {
                 settings,
                 settings_path: codex_plus_core::paths::default_settings_path()
@@ -1434,9 +1434,9 @@ pub fn reset_settings() -> CommandResult<SettingsPayload> {
 pub fn relay_status() -> CommandResult<RelayPayload> {
     let status = codex_plus_core::relay_config::default_relay_status();
     let message = if status.authenticated {
-        "已检测到 ChatGPT 登录状态。"
+        "ChatGPT login state detected."
     } else {
-        "未检测到 ChatGPT 登录状态，请先在 Codex/ChatGPT 中正常登录。"
+        "ChatGPT login state was not detected. Sign in normally through Codex/ChatGPT first."
     };
     ok(message, relay_payload(status, None))
 }
@@ -1445,9 +1445,9 @@ pub fn relay_status() -> CommandResult<RelayPayload> {
 pub fn read_relay_files() -> CommandResult<RelayFilesPayload> {
     let home = codex_plus_core::relay_config::default_codex_home_dir();
     match relay_files_payload_from_home(&home) {
-        Ok(payload) => ok("配置文件内容已读取。", payload),
+        Ok(payload) => ok("Config file contents read.", payload),
         Err(error) => failed(
-            &format!("读取配置文件失败：{error}"),
+            &format!("Failed to read config file: {error}"),
             RelayFilesPayload {
                 config_path: home.join("config.toml").to_string_lossy().to_string(),
                 auth_path: home.join("auth.json").to_string_lossy().to_string(),
@@ -1464,9 +1464,9 @@ pub fn save_relay_file(request: SaveRelayFileRequest) -> CommandResult<RelayFile
     match save_relay_file_in_home(&home, &request.kind, &request.contents)
         .and_then(|_| relay_files_payload_from_home(&home))
     {
-        Ok(payload) => ok("配置文件已保存。", payload),
+        Ok(payload) => ok("Config file saved.", payload),
         Err(error) => failed(
-            &format!("保存配置文件失败：{error}"),
+            &format!("Failed to save config file: {error}"),
             relay_files_payload_from_home(&home).unwrap_or_else(|_| RelayFilesPayload {
                 config_path: home.join("config.toml").to_string_lossy().to_string(),
                 auth_path: home.join("auth.json").to_string_lossy().to_string(),
@@ -1481,8 +1481,8 @@ pub fn save_relay_file(request: SaveRelayFileRequest) -> CommandResult<RelayFile
 pub fn write_diagnostic_event(event: String, detail: Value) -> CommandResult<Value> {
     let event = sanitize_manager_event(&event);
     match codex_plus_core::diagnostic_log::append_diagnostic_log(&event, detail) {
-        Ok(()) => ok("诊断日志已写入。", json!({})),
-        Err(error) => failed(&format!("写入诊断日志失败：{error}"), json!({})),
+        Ok(()) => ok("Diagnostic log written.", json!({})),
+        Err(error) => failed(&format!("Failed to write diagnostic log: {error}"), json!({})),
     }
 }
 
@@ -1512,7 +1512,7 @@ pub fn backfill_relay_profile_from_live(
             }),
         );
         return failed(
-            "当前供应商已不在配置列表中，已停止切换以避免覆盖用户改动。",
+            "The current provider is no longer in the config list, so switching stopped to avoid overwriting your changes.",
             SettingsBackfillPayload { settings },
         );
     };
@@ -1530,7 +1530,7 @@ pub fn backfill_relay_profile_from_live(
                 }),
             );
             ok(
-                "当前供应商配置已从 live 文件回填。",
+                "Current provider config was backfilled from live files.",
                 SettingsBackfillPayload { settings },
             )
         }
@@ -1543,7 +1543,7 @@ pub fn backfill_relay_profile_from_live(
                 }),
             );
             failed(
-                &format!("回填当前供应商配置失败：{error}"),
+                &format!("Failed to backfill current provider config: {error}"),
                 SettingsBackfillPayload { settings },
             )
         }
@@ -1558,14 +1558,14 @@ pub fn list_context_entries(
         &request.settings.relay_context_config_contents,
     ) {
         Ok(entries) => ok(
-            "工具与插件列表已读取。",
+            "Tool and plugin list read.",
             ContextEntriesPayload {
                 settings: request.settings,
                 entries,
             },
         ),
         Err(error) => failed(
-            &format!("读取工具与插件列表失败：{error}"),
+            &format!("Failed to read tool and plugin list: {error}"),
             ContextEntriesPayload {
                 settings: request.settings,
                 entries: empty_context_entries(),
@@ -1581,11 +1581,11 @@ pub fn read_live_context_entries() -> CommandResult<LiveContextEntriesPayload> {
     let config = read_optional_text_file(&config_path).unwrap_or_default();
     match codex_plus_core::relay_config::list_context_entries_from_common_config(&config) {
         Ok(entries) => ok(
-            "live 工具与插件已读取。",
+            "Live tools and plugins read.",
             LiveContextEntriesPayload { entries },
         ),
         Err(error) => failed(
-            &format!("读取 live 工具与插件失败：{error}"),
+            &format!("Failed to read live tools and plugins: {error}"),
             LiveContextEntriesPayload {
                 entries: empty_context_entries(),
             },
@@ -1607,7 +1607,7 @@ pub fn upsert_context_entry(request: ContextEntryRequest) -> CommandResult<Conte
             list_context_entries(ContextSettingsRequest { settings })
         }
         Err(error) => failed(
-            &format!("保存工具与插件失败：{error}"),
+            &format!("Failed to save tools and plugins: {error}"),
             ContextEntriesPayload {
                 settings,
                 entries: empty_context_entries(),
@@ -1626,7 +1626,7 @@ pub fn sync_live_context_entries(
         Ok(config) => config,
         Err(error) => {
             return failed(
-                &format!("读取 live config.toml 失败：{error}"),
+                &format!("Failed to read live config.toml: {error}"),
                 LiveContextEntriesPayload {
                     entries: empty_context_entries(),
                 },
@@ -1640,7 +1640,7 @@ pub fn sync_live_context_entries(
         Ok(config) => config,
         Err(error) => {
             return failed(
-                &format!("同步 live 工具与插件失败：{error}"),
+                &format!("Failed to sync live tools and plugins: {error}"),
                 LiveContextEntriesPayload {
                     entries: empty_context_entries(),
                 },
@@ -1650,7 +1650,7 @@ pub fn sync_live_context_entries(
     if let Some(parent) = config_path.parent() {
         if let Err(error) = std::fs::create_dir_all(parent) {
             return failed(
-                &format!("创建 Codex 配置目录失败：{error}"),
+                &format!("Failed to create Codex config directory: {error}"),
                 LiveContextEntriesPayload {
                     entries: empty_context_entries(),
                 },
@@ -1659,7 +1659,7 @@ pub fn sync_live_context_entries(
     }
     if let Err(error) = std::fs::write(&config_path, &updated_config) {
         return failed(
-            &format!("写入 live config.toml 失败：{error}"),
+            &format!("Failed to write live config.toml: {error}"),
             LiveContextEntriesPayload {
                 entries: empty_context_entries(),
             },
@@ -1667,11 +1667,11 @@ pub fn sync_live_context_entries(
     }
     match codex_plus_core::relay_config::list_context_entries_from_common_config(&updated_config) {
         Ok(entries) => ok(
-            "live 工具与插件已同步。",
+            "Live tools and plugins synced.",
             LiveContextEntriesPayload { entries },
         ),
         Err(error) => failed(
-            &format!("读取同步后的 live 工具与插件失败：{error}"),
+            &format!("Failed to read synced live tools and plugins: {error}"),
             LiveContextEntriesPayload {
                 entries: empty_context_entries(),
             },
@@ -1692,7 +1692,7 @@ pub fn delete_context_entry(request: ContextDeleteRequest) -> CommandResult<Cont
             list_context_entries(ContextSettingsRequest { settings })
         }
         Err(error) => failed(
-            &format!("删除工具与插件失败：{error}"),
+            &format!("Failed to delete tools and plugins: {error}"),
             ContextEntriesPayload {
                 settings,
                 entries: empty_context_entries(),
@@ -1717,9 +1717,9 @@ pub fn extract_relay_common_config(
                 profile_config_contents,
             })
         }) {
-        Ok(payload) => ok("通用配置已按兼容切换规则提取。", payload),
+        Ok(payload) => ok("Common config extracted using compatible switching rules.", payload),
         Err(error) => failed(
-            &format!("提取通用配置失败：{error}"),
+            &format!("Failed to extract common config: {error}"),
             ExtractRelayCommonConfigPayload {
                 common_config_contents: String::new(),
                 profile_config_contents: request.config_contents,
@@ -1731,20 +1731,20 @@ pub fn extract_relay_common_config(
 #[tauri::command]
 pub async fn test_relay_profile(profile: RelayProfile) -> CommandResult<RelayProfileTestPayload> {
     let profile_name = if profile.name.trim().is_empty() {
-        "未命名供应商"
+        "Unnamed provider"
     } else {
         profile.name.trim()
     };
     let settings =
         settings_with_live_ccs_profiles(SettingsStore::default().load().unwrap_or_default());
     let test_model: String = if !profile.test_model.trim().is_empty() {
-        // 1. 使用者在該供應商明確填的測試模型
+        // 1. Use the explicit test model set on this provider.
         profile.test_model.trim().to_string()
     } else {
-        // 2. 該供應商自己 config.toml 裡的 model（避免串味）
+        // 2. Fall back to this provider's own config.toml model to avoid cross-provider bleed.
         let from_profile = codex_plus_core::relay_config::relay_profile_model(&profile);
         if from_profile.trim().is_empty() {
-            // 3. 最後才用全域預設
+            // 3. Only then use the global default.
             settings.relay_test_model.trim().to_string()
         } else {
             from_profile
@@ -1759,14 +1759,14 @@ pub async fn test_relay_profile(profile: RelayProfile) -> CommandResult<RelayPro
             };
             let preview = result.response_preview.trim();
             let detail = if preview.is_empty() {
-                "响应内容为空".to_string()
+                "Response body is empty".to_string()
             } else {
-                format!("响应：{preview}")
+                format!("Response: {preview}")
             };
             CommandResult {
                 status: status.to_string(),
                 message: format!(
-                    "已向「{profile_name}」用模型「{test_model}」发送 hi，HTTP {}。{detail}",
+                    "Sent hi to \"{profile_name}\" using model \"{test_model}\", HTTP {}. {detail}",
                     result.http_status
                 ),
                 payload: RelayProfileTestPayload {
@@ -1777,7 +1777,7 @@ pub async fn test_relay_profile(profile: RelayProfile) -> CommandResult<RelayPro
             }
         }
         Err(error) => failed(
-            &format!("测试「{profile_name}」失败：{error}"),
+            &format!("Test for \"{profile_name}\" failed: {error}"),
             RelayProfileTestPayload {
                 http_status: 0,
                 endpoint: String::new(),
@@ -1792,17 +1792,17 @@ pub async fn fetch_relay_profile_models(
     profile: RelayProfile,
 ) -> CommandResult<RelayProfileModelsPayload> {
     let profile_name = if profile.name.trim().is_empty() {
-        "未命名供应商"
+        "Unnamed provider"
     } else {
         profile.name.trim()
     };
     match codex_plus_core::model_catalog::fetch_relay_profile_model_ids(&profile).await {
         Ok((models, endpoint)) => ok(
-            &format!("已从「{profile_name}」获取 {} 个模型。", models.len()),
+            &format!("Fetched {} models from \"{profile_name}\".", models.len()),
             RelayProfileModelsPayload { models, endpoint },
         ),
         Err(error) => failed(
-            &format!("从「{profile_name}」获取模型失败：{error}"),
+            &format!("Failed to fetch models from \"{profile_name}\": {error}"),
             RelayProfileModelsPayload {
                 models: Vec::new(),
                 endpoint: String::new(),
@@ -1819,7 +1819,7 @@ pub fn apply_relay_injection() -> CommandResult<RelayPayload> {
     if !settings.relay_profiles_enabled {
         let status = codex_plus_core::relay_config::relay_status_from_home(&home);
         return failed(
-            "供应商配置总开关已关闭，未写入 config.toml / auth.json。",
+            "Provider config master switch is off, so config.toml / auth.json were not written.",
             relay_payload(status, None),
         );
     }
@@ -1847,7 +1847,7 @@ pub fn apply_relay_injection() -> CommandResult<RelayPayload> {
                     None,
                 );
                 ok(
-                    "已按兼容切换规则切换供应商。",
+                    "Switched providers using compatible switching rules.",
                     relay_payload(status, result.backup_path),
                 )
             }
@@ -1861,7 +1861,7 @@ pub fn apply_relay_injection() -> CommandResult<RelayPayload> {
                     Some(error.to_string()),
                 );
                 failed(
-                    &format!("切换完整中转配置失败：{error}"),
+                    &format!("Failed to switch full relay config: {error}"),
                     relay_payload(status, None),
                 )
             }
@@ -1876,10 +1876,10 @@ pub fn apply_relay_injection() -> CommandResult<RelayPayload> {
             &relay,
             &status,
             None,
-            Some("未检测到 ChatGPT 登录状态".to_string()),
+            Some("ChatGPT login state was not detected".to_string()),
         );
         return failed(
-            "未检测到 ChatGPT 登录状态，已停止写入中转配置。",
+            "ChatGPT login state was not detected, so relay config writing stopped.",
             relay_payload(status, None),
         );
     }
@@ -1901,7 +1901,7 @@ pub fn apply_relay_injection() -> CommandResult<RelayPayload> {
                 None,
             );
             ok(
-                "中转配置已写入，密钥未在界面明文显示。",
+                "Relay config written; the key is not shown in plain text in the UI.",
                 relay_payload(status, result.backup_path),
             )
         }
@@ -1915,7 +1915,7 @@ pub fn apply_relay_injection() -> CommandResult<RelayPayload> {
                 Some(error.to_string()),
             );
             failed(
-                &format!("写入中转配置失败：{error}"),
+                &format!("Failed to write relay config: {error}"),
                 relay_payload(status, None),
             )
         }
@@ -1930,7 +1930,7 @@ pub fn apply_pure_api_injection() -> CommandResult<RelayPayload> {
     if !settings.relay_profiles_enabled {
         let status = codex_plus_core::relay_config::relay_status_from_home(&home);
         return failed(
-            "供应商配置总开关已关闭，未写入 config.toml / auth.json。",
+            "Provider config master switch is off, so config.toml / auth.json were not written.",
             relay_payload(status, None),
         );
     }
@@ -1959,12 +1959,12 @@ pub fn apply_pure_api_injection() -> CommandResult<RelayPayload> {
                 );
                 if !status.configured {
                     return failed(
-                        "纯 API 配置写入后未检测到完整 custom provider，请检查 config.toml 和供应商 API Key。",
+                        "Pure API config was written, but no complete custom provider was detected. Check config.toml and the provider API key.",
                         relay_payload(status, result.backup_path),
                     );
                 }
                 ok(
-                    "已按兼容切换规则切换供应商。",
+                    "Switched providers using compatible switching rules.",
                     relay_payload(status, result.backup_path),
                 )
             }
@@ -1978,7 +1978,7 @@ pub fn apply_pure_api_injection() -> CommandResult<RelayPayload> {
                     Some(error.to_string()),
                 );
                 failed(
-                    &format!("切换纯 API 配置失败：{error}"),
+                    &format!("Failed to switch Pure API config: {error}"),
                     relay_payload(status, None),
                 )
             }
@@ -2003,12 +2003,12 @@ pub fn apply_pure_api_injection() -> CommandResult<RelayPayload> {
             );
             if !status.configured {
                 return failed(
-                    "纯 API 配置写入后未检测到完整 custom provider，请检查 config.toml 和供应商 API Key。",
+                    "Pure API config was written, but no complete custom provider was detected. Check config.toml and the provider API key.",
                     relay_payload(status, result.backup_path),
                 );
             }
             ok(
-                "纯 API 模式已写入：config.toml 已写入 custom provider，auth.json 已切换为当前供应商。",
+                "Pure API mode written: config.toml now has the custom provider, and auth.json now points at the current provider.",
                 relay_payload(status, result.backup_path),
             )
         }
@@ -2022,7 +2022,7 @@ pub fn apply_pure_api_injection() -> CommandResult<RelayPayload> {
                 Some(error.to_string()),
             );
             failed(
-                &format!("写入纯 API 模式失败：{error}"),
+                &format!("Failed to write Pure API mode: {error}"),
                 relay_payload(status, None),
             )
         }
@@ -2058,7 +2058,7 @@ pub fn clear_relay_injection() -> CommandResult<RelayPayload> {
                 }),
             );
             ok(
-                "已清除 custom 中转 API 模式，并切换到官方 ChatGPT 登录模式。",
+                "Cleared custom relay API mode and switched back to official ChatGPT login mode.",
                 relay_payload(status, result.backup_path),
             )
         }
@@ -2072,7 +2072,7 @@ pub fn clear_relay_injection() -> CommandResult<RelayPayload> {
                 }),
             );
             failed(
-                &format!("清除中转配置失败：{error}"),
+                &format!("Failed to clear relay config: {error}"),
                 relay_payload(status, None),
             )
         }
@@ -2110,14 +2110,14 @@ fn try_apply_linked_ccs_provider(
                 None,
             );
             Some(ok(
-                "已通过 cc-switch 联动应用当前供应商配置，避免与 CC Switch 发生覆盖冲突。",
+                "Applied the current provider through cc-switch linking to avoid overwrite conflicts with CC Switch.",
                 relay_payload(status, result.backup_path),
             ))
         }
         Err(error) => {
             let status = codex_plus_core::relay_config::relay_status_from_home(&home);
             Some(failed(
-                &format!("通过 cc-switch 联动应用供应商失败：{error}"),
+                &format!("Failed to apply provider through cc-switch linking: {error}"),
                 relay_payload(status, None),
             ))
         }
@@ -2219,11 +2219,11 @@ fn sanitize_manager_event(event: &str) -> String {
 fn refresh_cli_wrapper_after_settings_save(settings: &BackendSettings) -> String {
     match codex_plus_core::cli_wrapper::ensure_cli_wrapper(settings) {
         Ok(Some(install)) => format!(
-            " 命令包装器已更新：{}。",
+            " Command wrapper updated: {}.",
             install.real_codex.to_string_lossy()
         ),
         Ok(None) => String::new(),
-        Err(error) => format!(" 但命令包装器更新失败：{error}。"),
+        Err(error) => format!(" But command wrapper update failed: {error}."),
     }
 }
 
@@ -2270,7 +2270,7 @@ fn save_relay_file_in_home(
     let path = match kind {
         "config" => home.join("config.toml"),
         "auth" => home.join("auth.json"),
-        other => anyhow::bail!("未知配置文件类型：{other}"),
+        other => anyhow::bail!("Unknown config file type: {other}"),
     };
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -2309,7 +2309,7 @@ fn open_url(url: &str) -> anyhow::Result<()> {
             .arg(url)
             .spawn()
             .map(|_| ())
-            .map_err(|error| anyhow::anyhow!("启动系统浏览器失败：{error}"))
+            .map_err(|error| anyhow::anyhow!("Failed to start system browser: {error}"))
     }
 }
 
@@ -2479,7 +2479,7 @@ fn builtin_user_scripts_dir() -> PathBuf {
 fn diagnostics_report() -> String {
     let (codex_app_path, entrypoints, latest_launch) = load_overview_payload();
     let overview = ok(
-        "概览已加载。",
+        "Overview loaded.",
         OverviewPayload {
             codex_version: codex_app_path
                 .as_deref()
@@ -2517,7 +2517,7 @@ fn diagnostics_report() -> String {
             "arch": std::env::consts::ARCH
         }
     }))
-    .unwrap_or_else(|error| format!("诊断报告序列化失败：{error}"))
+    .unwrap_or_else(|error| format!("Failed to serialize diagnostics report: {error}"))
 }
 
 fn load_overview_payload() -> (
@@ -2540,7 +2540,7 @@ fn install_background_failure(action: &str, error: impl std::fmt::Display) -> In
     let state = install::inspect_entrypoints();
     InstallActionResult {
         status: "failed".to_string(),
-        message: format!("{action}后台任务失败：{error}"),
+        message: format!("{action} background task failed: {error}"),
         silent_shortcut: state.silent_shortcut,
         management_shortcut: state.management_shortcut,
     }
@@ -2685,7 +2685,7 @@ mod tests {
         let result = tauri::async_runtime::block_on(perform_update(None));
 
         assert_eq!(result.status, "failed");
-        assert!(result.message.contains("请先检查更新"));
+        assert!(result.message.contains("Check for updates first"));
     }
 
     #[test]
@@ -3036,6 +3036,6 @@ model_reasoning_effort = "high"
         let result = open_external_url("file:///C:/Windows/win.ini".to_string());
 
         assert_eq!(result.status, "failed");
-        assert!(result.message.contains("只允许打开 http 或 https 链接"));
+        assert!(result.message.contains("Only http or https links can be opened"));
     }
 }

--- a/apps/codex-plus-manager/src-tauri/src/lib.rs
+++ b/apps/codex-plus-manager/src-tauri/src/lib.rs
@@ -22,7 +22,7 @@ pub fn run() {
                 "index.html"
             };
             tauri::WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::App(url.into()))
-                .title("Codex++ 管理工具")
+                .title("Codex++ Manager")
                 .inner_size(1180.0, 820.0)
                 .min_inner_size(960.0, 720.0)
                 .build()?;
@@ -101,7 +101,7 @@ fn install_panic_logger() {
             .downcast_ref::<&str>()
             .map(|message| (*message).to_string())
             .or_else(|| panic_info.payload().downcast_ref::<String>().cloned())
-            .unwrap_or_else(|| "非字符串 panic payload".to_string());
+            .unwrap_or_else(|| "non-string panic payload".to_string());
         let location = panic_info.location().map(|location| {
             serde_json::json!({
                 "file": location.file(),

--- a/apps/codex-plus-manager/src-tauri/tauri.conf.json
+++ b/apps/codex-plus-manager/src-tauri/tauri.conf.json
@@ -14,7 +14,7 @@
       {
         "create": false,
         "label": "main",
-        "title": "Codex++ 管理工具",
+        "title": "Codex++ Manager",
         "width": 1180,
         "height": 820,
         "minWidth": 960,

--- a/apps/codex-plus-manager/src-tauri/tests/windows_subsystem.rs
+++ b/apps/codex-plus-manager/src-tauri/tests/windows_subsystem.rs
@@ -104,7 +104,7 @@ fn macos_packager_hides_silent_launcher_but_not_manager() {
         "create_app \"Codex++\" \"CodexPlusPlus\" \"$BINARY_DIR/codex-plus-plus\" \"com.bigpizzav3.codexplusplus\" \"true\""
     ));
     assert!(script.contains(
-        "create_app \"Codex++ 管理工具\" \"CodexPlusPlusManager\" \"$BINARY_DIR/codex-plus-plus-manager\" \"com.bigpizzav3.codexplusplus.manager\" \"false\""
+        "create_app \"Codex++ Manager\" \"CodexPlusPlusManager\" \"$BINARY_DIR/codex-plus-plus-manager\" \"com.bigpizzav3.codexplusplus.manager\" \"false\""
     ));
 }
 

--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -456,23 +456,23 @@ type ScriptMarketResult = CommandResult<{
 function providerSyncProgressMessage(result: CommandResult<ProviderSyncPayload>): string {
   const changed = result.changedSessionFiles ?? 0;
   const rows = result.sqliteRowsUpdated ?? 0;
-  const target = result.targetProvider || "当前 provider";
+  const target = result.targetProvider || "current provider";
   const skipped = result.skippedLockedRolloutFiles?.length ?? 0;
-  const skippedText = skipped ? `，跳过 ${skipped} 个占用文件` : "";
-  return `已同步到 ${target}：修复 ${changed} 个会话文件，更新 ${rows} 行索引${skippedText}。`;
+  const skippedText = skipped ? `, skipped ${skipped} locked files` : "";
+  return `Synced to ${target}: repaired ${changed} session files, updated ${rows} index rows${skippedText}.`;
 }
 
 const providerSyncSourceLabels: Record<ProviderSyncTargetSource, string> = {
-  config: "配置",
-  rollout: "会话",
-  sqlite: "索引",
-  manual: "手动",
+  config: "Config",
+  rollout: "Sessions",
+  sqlite: "Index",
+  manual: "Manual",
 };
 
 function providerSyncTargetLabel(target: ProviderSyncTargetOption): string {
   const labels = target.sources.map((source) => providerSyncSourceLabels[source]).filter(Boolean);
-  const current = target.isCurrentProvider ? ["当前"] : [];
-  return [...labels, ...current].join(" / ") || "发现";
+  const current = target.isCurrentProvider ? ["Current"] : [];
+  return [...labels, ...current].join(" / ") || "Discovered";
 }
 
 function syncMarketInstalledState(current: ScriptMarketResult | null, userScripts: UserScriptInventory): ScriptMarketResult | null {
@@ -508,17 +508,17 @@ type Route = "overview" | "relay" | "sessions" | "context" | "enhance" | "zedRem
 type Theme = "dark" | "light";
 
 const routes: Array<{ id: Route; label: string; icon: LucideIcon }> = [
-  { id: "overview", label: "概览", icon: LayoutDashboard },
-  { id: "relay", label: "供应商配置", icon: KeyRound },
-  { id: "sessions", label: "会话管理", icon: MessageCircle },
-  { id: "context", label: "工具与插件", icon: Network },
-  { id: "enhance", label: "页面增强", icon: Hammer },
-  { id: "zedRemote", label: "Zed 远程项目", icon: ExternalLink },
-  { id: "userScripts", label: "脚本市场", icon: FileCode2 },
-  { id: "recommendations", label: "推荐内容", icon: ExternalLink },
-  { id: "maintenance", label: "安装维护", icon: Wrench },
-  { id: "about", label: "关于", icon: Info },
-  { id: "settings", label: "设置", icon: Settings },
+  { id: "overview", label: "Overview", icon: LayoutDashboard },
+  { id: "relay", label: "Providers", icon: KeyRound },
+  { id: "sessions", label: "Sessions", icon: MessageCircle },
+  { id: "context", label: "Tools & Plugins", icon: Network },
+  { id: "enhance", label: "Page Enhancements", icon: Hammer },
+  { id: "zedRemote", label: "Zed Remote Projects", icon: ExternalLink },
+  { id: "userScripts", label: "Script Market", icon: FileCode2 },
+  { id: "recommendations", label: "Recommendations", icon: ExternalLink },
+  { id: "maintenance", label: "Maintenance", icon: Wrench },
+  { id: "about", label: "About", icon: Info },
+  { id: "settings", label: "Settings", icon: Settings },
 ];
 
 const defaultSettings: BackendSettings = {
@@ -539,7 +539,7 @@ const defaultSettings: BackendSettings = {
   codexAppSessionDelete: true,
   codexAppMarkdownExport: true,
   codexAppProjectMove: true,
-  codexAppConversationTimeline: true,
+  codexAppConversationTimeline: false,
   codexAppConversationView: false,
   codexAppThreadScrollRestore: true,
   codexAppZedRemoteOpen: true,
@@ -557,7 +557,7 @@ const defaultSettings: BackendSettings = {
     {
       id: "default",
       linkedCcsProviderId: "",
-      name: "默认中转",
+      name: "Default Relay",
       model: "",
       baseUrl: "",
       upstreamBaseUrl: "",
@@ -614,7 +614,7 @@ export function App() {
   const [providerSyncProgress, setProviderSyncProgress] = useState<ProviderSyncProgress>({
     active: false,
     percent: 0,
-    message: "尚未运行历史会话修复。",
+    message: "Historical session repair has not run yet.",
     result: null,
   });
   const [providerSyncTargets, setProviderSyncTargets] = useState<ProviderSyncTargetsResult | null>(null);
@@ -631,7 +631,7 @@ export function App() {
     try {
       return await task();
     } catch (error) {
-      showNotice("调用失败", stringifyError(error), "failed");
+      showNotice("Call failed", stringifyError(error), "failed");
       return null;
     }
   };
@@ -639,15 +639,15 @@ export function App() {
   const refreshOverview = async (silent = false) => {
     const result = await run(() => call<OverviewResult>("load_overview"));
     if (result) {
-      // 崩溃检测：进程从运行状态变为停止/失败 → 弹出通知
+      // Crash detection: notify when the process leaves the running state.
       const prev = prevLaunchStatusRef.current;
       const current = result.latest_launch?.status;
       if (prev && prev === "running" && current && (current === "stopped" || current === "failed" || current === "crashed")) {
-        showNotice("Codex 意外停止", `进程状态：${current}。是否要重新启动？`, "failed");
+        showNotice("Codex stopped unexpectedly", `Process status: ${current}. Do you want to restart?`, "failed");
       }
       prevLaunchStatusRef.current = current ?? null;
       setOverview(result);
-      if (!silent) showResultNotice("概览已检查", result, { silentSuccess: true });
+      if (!silent) showResultNotice("Overview checked", result, { silentSuccess: true });
     }
   };
 
@@ -661,7 +661,7 @@ export function App() {
         ...current,
         appPath: current.appPath || result.settings.codexAppPath || "",
       }));
-      if (!silent) showResultNotice("设置已加载", result, { silentSuccess: true });
+      if (!silent) showResultNotice("Settings loaded", result, { silentSuccess: true });
       return normalized;
     }
     return null;
@@ -672,7 +672,7 @@ export function App() {
     if (result) {
       setScriptMarket(result);
       setSettings((current) => (current ? { ...current, user_scripts: result.user_scripts } : current));
-      if (!silent || !isSuccessStatus(result.status)) showResultNotice("脚本市场", result, { silentSuccess: true });
+      if (!silent || !isSuccessStatus(result.status)) showResultNotice("Script Market", result, { silentSuccess: true });
     }
   };
 
@@ -681,7 +681,7 @@ export function App() {
     if (result) {
       setScriptMarket(result);
       setSettings((current) => (current ? { ...current, user_scripts: result.user_scripts } : current));
-      showResultNotice("脚本市场", result);
+      showResultNotice("Script Market", result);
     }
   };
 
@@ -690,19 +690,19 @@ export function App() {
     if (result) {
       setSettings(result);
       setScriptMarket((current) => syncMarketInstalledState(current, result.user_scripts));
-      showResultNotice("本地脚本", result);
+      showResultNotice("Local Scripts", result);
     }
   };
 
   const deleteUserScript = async (key: string) => {
     const script = settings?.user_scripts?.scripts?.find((item) => item.key === key);
     const name = script?.name || key;
-    if (!window.confirm(`删除脚本“${name}”？此操作会移除本地脚本文件。`)) return;
+    if (!window.confirm(`Delete script "${name}"? This will remove the local script file.`)) return;
     const result = await run(() => call<SettingsResult>("delete_user_script", { key }));
     if (result) {
       setSettings(result);
       setScriptMarket((current) => syncMarketInstalledState(current, result.user_scripts));
-      showResultNotice("本地脚本", result);
+      showResultNotice("Local Scripts", result);
     }
   };
 
@@ -710,7 +710,7 @@ export function App() {
     const result = await run(() => call<RelayResult>("relay_status"));
     if (result) {
       setRelay(result);
-      if (!silent) showResultNotice("登录状态", result, { silentSuccess: true });
+      if (!silent) showResultNotice("Login Status", result, { silentSuccess: true });
     }
   };
 
@@ -718,7 +718,7 @@ export function App() {
     const result = await run(() => call<RelayFilesResult>("read_relay_files"));
     if (result) {
       setRelayFiles(result);
-      if (!silent) showResultNotice("配置文件", result, { silentSuccess: true });
+      if (!silent) showResultNotice("Config Files", result, { silentSuccess: true });
     }
     return result;
   };
@@ -727,7 +727,7 @@ export function App() {
     const result = await run(() => call<LocalSessionsResult>("list_local_sessions"));
     if (result) {
       setLocalSessions(result);
-      if (!silent || !isSuccessStatus(result.status)) showResultNotice("会话管理", result, { silentSuccess: true });
+      if (!silent || !isSuccessStatus(result.status)) showResultNotice("Session Management", result, { silentSuccess: true });
     }
     return result;
   };
@@ -736,7 +736,7 @@ export function App() {
     const result = await run(() => call<ZedRemoteProjectsResult>("list_zed_remote_projects"));
     if (result) {
       setZedRemoteProjects(result);
-      if (!silent || !isSuccessStatus(result.status)) showResultNotice("Zed 远程项目", result, { silentSuccess: true });
+      if (!silent || !isSuccessStatus(result.status)) showResultNotice("Zed Remote Projects", result, { silentSuccess: true });
     }
     return result;
   };
@@ -757,7 +757,7 @@ export function App() {
       }),
     );
     if (result) {
-      showResultNotice("Zed 远程打开", result);
+      showResultNotice("Zed Remote Open", result);
       await refreshZedRemoteProjects(true);
     }
   };
@@ -766,20 +766,20 @@ export function App() {
     const result = await run(() => call<ZedRemoteProjectsResult>("forget_zed_remote_project", { id: project.id }));
     if (result) {
       setZedRemoteProjects(result);
-      showResultNotice("Zed 远程项目", result);
+      showResultNotice("Zed Remote Projects", result);
     }
   };
 
   const deleteLocalSession = async (session: LocalSession) => {
     const title = session.title || session.id;
-    if (!window.confirm(`删除会话“${title}”？此操作会删除本地数据库记录和 rollout 文件，并创建备份。`)) return;
+    if (!window.confirm(`Delete session "${title}"? This will delete the local database record and rollout file, and create a backup.`)) return;
     const result = await run(() =>
       call<DeleteLocalSessionResult>("delete_local_session", {
         request: { sessionId: session.id, title: session.title, dbPath: session.dbPath },
       }),
     );
     if (result) {
-      showResultNotice("会话删除", result);
+      showResultNotice("Session Delete", result);
       await refreshLocalSessions(true);
     }
   };
@@ -788,7 +788,7 @@ export function App() {
     const result = await run(() => call<LiveContextEntriesResult>("read_live_context_entries"));
     if (result) {
       setLiveContextEntries(result.entries);
-      if (!silent || !isSuccessStatus(result.status)) showResultNotice("工具与插件", result, { silentSuccess: true });
+      if (!silent || !isSuccessStatus(result.status)) showResultNotice("Tools & Plugins", result, { silentSuccess: true });
     }
     return result;
   };
@@ -797,7 +797,7 @@ export function App() {
     const result = await run(() => call<LiveContextEntriesResult>("sync_live_context_entries", { request: { settings: next } }));
     if (result) {
       setLiveContextEntries(result.entries);
-      if (!silent || !isSuccessStatus(result.status)) showResultNotice("工具与插件", result, { silentSuccess: true });
+      if (!silent || !isSuccessStatus(result.status)) showResultNotice("Tools & Plugins", result, { silentSuccess: true });
     }
     return result;
   };
@@ -806,7 +806,7 @@ export function App() {
     const result = await run(() => call<LogsResult>("read_latest_logs", { request: { lines: 240 } }));
     if (result) {
       setLogs(result);
-      if (!silent) showResultNotice("日志已刷新", result, { silentSuccess: true });
+      if (!silent) showResultNotice("Logs refreshed", result, { silentSuccess: true });
     }
   };
 
@@ -814,7 +814,7 @@ export function App() {
     const result = await run(() => call<DiagnosticsResult>("copy_diagnostics"));
     if (result) {
       setDiagnostics(result);
-      if (!silent) showResultNotice("诊断已生成", result, { silentSuccess: true });
+      if (!silent) showResultNotice("Diagnostics generated", result, { silentSuccess: true });
     }
   };
 
@@ -822,7 +822,7 @@ export function App() {
     const result = await run(() => call<WatcherResult>("load_watcher_state"));
     if (result) {
       setWatcher(result);
-      if (!silent) showResultNotice("Watcher 状态", result, { silentSuccess: true });
+      if (!silent) showResultNotice("Watcher Status", result, { silentSuccess: true });
     }
   };
 
@@ -868,7 +868,7 @@ export function App() {
   const launch = async () => {
     const result = await launchCommand("launch_codex_plus");
     if (result) {
-      showNotice("启动任务", result.message, result.status);
+      showNotice("Launch Task", result.message, result.status);
       await refreshOverview(true);
     }
   };
@@ -876,7 +876,7 @@ export function App() {
   const restart = async () => {
     const result = await launchCommand("restart_codex_plus");
     if (result) {
-      showNotice("重启 Codex++", result.message, result.status);
+      showNotice("Restart Codex++", result.message, result.status);
       await refreshOverview(true);
     }
   };
@@ -899,14 +899,14 @@ export function App() {
     if (result) {
       setSettings(result);
       setSettingsForm(normalizeSettings(result.settings));
-      showNotice("后端修复", result.message, result.status);
+      showNotice("Backend Repair", result.message, result.status);
     }
   };
 
   const installEntrypoints = async () => {
     const result = await run(() => call<InstallResult>("install_entrypoints"));
     if (result) {
-      showNotice("入口安装", result.message, result.status);
+      showNotice("Entry Install", result.message, result.status);
       await refreshOverview(true);
     }
   };
@@ -918,7 +918,7 @@ export function App() {
       }),
     );
     if (result) {
-      showNotice("入口卸载", result.message, result.status);
+      showNotice("Entry Uninstall", result.message, result.status);
       await refreshOverview(true);
     }
   };
@@ -926,7 +926,7 @@ export function App() {
   const repairShortcuts = async () => {
     const result = await run(() => call<InstallResult>("repair_shortcuts"));
     if (result) {
-      showNotice("快捷方式修复", result.message, result.status);
+      showNotice("Shortcut Repair", result.message, result.status);
       await refreshOverview(true);
     }
   };
@@ -935,7 +935,7 @@ export function App() {
     const result = await run(() => call<WatcherResult>(command));
     if (result) {
       setWatcher(result);
-      showNotice("Watcher 操作", result.message, result.status);
+      showNotice("Watcher Operation", result.message, result.status);
     }
   };
 
@@ -944,7 +944,7 @@ export function App() {
     if (result) {
       setUpdate(result);
       if (!silent || result.updateAvailable) {
-        showNotice("GitHub Release 检查", result.message, result.status);
+        showNotice("GitHub Release Check", result.message, result.status);
       }
     }
   };
@@ -963,7 +963,7 @@ export function App() {
     const result = await run(() => call<UpdateResult>("perform_update", { release }));
     if (result) {
       setUpdate(result);
-      showNotice("更新安装", result.message, result.status);
+      showNotice("Update Install", result.message, result.status);
     }
   };
 
@@ -973,7 +973,7 @@ export function App() {
     if (result) {
       setSettings(result);
       setSettingsForm(normalizeSettings(result.settings));
-      showNotice("设置保存", result.message, result.status);
+      showNotice("Settings Saved", result.message, result.status);
     }
   };
 
@@ -985,7 +985,7 @@ export function App() {
     if (result) {
       setSettings(result);
       setSettingsForm(normalizeSettings(result.settings));
-      if (!silent || !isSuccessStatus(result.status)) showNotice("设置保存", result.message, result.status);
+      if (!silent || !isSuccessStatus(result.status)) showNotice("Settings Saved", result.message, result.status);
     }
   };
 
@@ -1002,7 +1002,7 @@ export function App() {
     if (result) {
       setSettings(result);
       setSettingsForm(normalizeSettings(result.settings));
-      showResultNotice("联动 cc-switch", result);
+      showResultNotice("cc-switch Link", result);
     }
   };
 
@@ -1011,7 +1011,7 @@ export function App() {
     if (result) {
       setSettings(result);
       setSettingsForm(normalizeSettings(result.settings));
-      showNotice("设置重置", result.message, result.status);
+      showNotice("Settings Reset", result.message, result.status);
     }
   };
 
@@ -1019,7 +1019,7 @@ export function App() {
     const result = await run(() => call<AdsResult>("load_ads"));
     if (result) {
       setAds(result);
-      if (!silent) showResultNotice("推荐内容", result, { silentSuccess: true });
+      if (!silent) showResultNotice("Recommendations", result, { silentSuccess: true });
     }
   };
 
@@ -1035,7 +1035,7 @@ export function App() {
         targets[0]?.id ||
         "openai";
       setSelectedProviderSyncTarget((current) => (targets.some((target) => target.id === current) ? current : preferred));
-      if (!silent && !isSuccessStatus(result.status)) showNotice("Provider 同步目标", result.message, result.status);
+      if (!silent && !isSuccessStatus(result.status)) showNotice("Provider Sync Targets", result.message, result.status);
     }
     return result;
   };
@@ -1045,7 +1045,7 @@ export function App() {
     setProviderSyncProgress({
       active: true,
       percent: 12,
-      message: selectedProviderSyncTarget ? `正在同步到 ${selectedProviderSyncTarget}…` : "正在扫描历史会话与索引…",
+      message: selectedProviderSyncTarget ? `Syncing to ${selectedProviderSyncTarget}...` : "Scanning historical sessions and indexes...",
       result: null,
     });
     const progressTimer = window.setInterval(() => {
@@ -1054,7 +1054,7 @@ export function App() {
         return {
           ...current,
           percent: Math.min(88, current.percent + 8),
-          message: current.percent < 40 ? "正在检查会话 provider 标记…" : "正在写入修复与备份…",
+          message: current.percent < 40 ? "Checking session provider markers..." : "Writing repairs and backups...",
         };
       });
     }, 350);
@@ -1081,12 +1081,12 @@ export function App() {
           setSettingsForm(next);
         }
         await refreshProviderSyncTargets(true);
-        showNotice("历史会话修复", result.message, result.status);
+        showNotice("Historical Session Repair", result.message, result.status);
       } else {
         setProviderSyncProgress({
           active: false,
           percent: 100,
-          message: "历史会话修复失败，请查看错误提示后重试。",
+          message: "Historical session repair failed. Review the error and try again.",
           result: null,
         });
       }
@@ -1101,7 +1101,7 @@ export function App() {
       setSettings(settingsResult);
       setSettingsForm(normalizeSettings(settingsResult.settings));
       if (!isSuccessStatus(settingsResult.status)) {
-        showNotice("设置保存", settingsResult.message, settingsResult.status);
+        showNotice("Settings Saved", settingsResult.message, settingsResult.status);
         return false;
       }
     } else {
@@ -1111,7 +1111,7 @@ export function App() {
     if (result) {
       setRelay(result);
       await refreshRelayFiles(true);
-      if (!silent || !isSuccessStatus(result.status)) showNotice("官方混入 API Key", result.message, result.status);
+      if (!silent || !isSuccessStatus(result.status)) showNotice("Official Login with API Key", result.message, result.status);
     }
     return !!result && isSuccessStatus(result.status) && result.configured;
   };
@@ -1123,7 +1123,7 @@ export function App() {
     if (result) {
       setSettings(result);
       setSettingsForm(normalizeSettings(result.settings));
-      if (!silent) showNotice("页面增强模式", result.message, result.status);
+      if (!silent) showNotice("Page Enhancement Mode", result.message, result.status);
     }
     return result;
   };
@@ -1134,7 +1134,7 @@ export function App() {
       setSettings(settingsResult);
       setSettingsForm(normalizeSettings(settingsResult.settings));
       if (!isSuccessStatus(settingsResult.status)) {
-        showNotice("设置保存", settingsResult.message, settingsResult.status);
+        showNotice("Settings Saved", settingsResult.message, settingsResult.status);
         return false;
       }
     } else {
@@ -1144,7 +1144,7 @@ export function App() {
     if (result) {
       setRelay(result);
       await refreshRelayFiles(true);
-      if (!silent || !isSuccessStatus(result.status)) showNotice("纯 API 模式", result.message, result.status);
+      if (!silent || !isSuccessStatus(result.status)) showNotice("Pure API Mode", result.message, result.status);
     }
     return !!result && isSuccessStatus(result.status) && result.configured;
   };
@@ -1154,7 +1154,7 @@ export function App() {
     if (result) {
       setRelay(result);
       await refreshRelayFiles(true);
-      if (!silent || !isSuccessStatus(result.status)) showNotice("官方登录模式", result.message, result.status);
+      if (!silent || !isSuccessStatus(result.status)) showNotice("Official Login Mode", result.message, result.status);
     }
     return !!result && isSuccessStatus(result.status) && !result.configured;
   };
@@ -1184,7 +1184,7 @@ export function App() {
       normalized = normalizeSettings(saveResult.settings);
     }
     setSettingsForm(normalized);
-    if (!isSuccessStatus(result.status)) showResultNotice("工具与插件", result);
+    if (!isSuccessStatus(result.status)) showResultNotice("Tools & Plugins", result);
     return normalized;
   };
 
@@ -1202,7 +1202,7 @@ export function App() {
       normalized = normalizeSettings(saveResult.settings);
     }
     setSettingsForm(normalized);
-    if (!isSuccessStatus(result.status)) showResultNotice("工具与插件", result);
+    if (!isSuccessStatus(result.status)) showResultNotice("Tools & Plugins", result);
     return normalized;
   };
 
@@ -1212,18 +1212,18 @@ export function App() {
         request: { configContents },
       }),
     );
-    if (result) showResultNotice("通用配置文件", result);
+    if (result) showResultNotice("Common Config", result);
     return result && isSuccessStatus(result.status) ? result : null;
   };
 
   const testRelayProfile = async (profile: RelayProfile) => {
     const result = await run(() => call<RelayProfileTestResult>("test_relay_profile", { profile }));
-    if (result) showNotice("供应商测试", result.message, result.status);
+    if (result) showNotice("Provider Test", result.message, result.status);
   };
 
   const fetchRelayProfileModels = async (profile: RelayProfile) => {
     const result = await run(() => call<RelayProfileModelsResult>("fetch_relay_profile_models", { profile }));
-    if (result) showNotice("模型列表", result.message, result.status);
+    if (result) showNotice("Model List", result.message, result.status);
     return result && isSuccessStatus(result.status) ? result.models : null;
   };
 
@@ -1231,14 +1231,14 @@ export function App() {
     const switched = await clearRelayInjection(true);
     if (!switched) return;
     const result = await saveLaunchMode("relay", true);
-    if (result) showNotice("官方登录模式", "已切回官方登录；页面增强已设为兼容增强。", result.status);
+    if (result) showNotice("Official Login Mode", "Switched back to official login; Page Enhancements are set to compatibility mode.", result.status);
   };
 
   const switchPureApiMode = async () => {
     const switched = await applyPureApiInjection(true);
     if (!switched) return;
     const result = await saveLaunchMode("patch", true);
-    if (result) showNotice("纯 API 模式", "已切换到纯 API；页面增强已设为完整增强。", result.status);
+    if (result) showNotice("Pure API Mode", "Switched to Pure API; Page Enhancements are set to full mode.", result.status);
   };
 
   const switchRelayProfile = async (next: BackendSettings, previousActiveRelayId = settingsForm.activeRelayId) => {
@@ -1249,13 +1249,13 @@ export function App() {
       if (!refreshed) return;
       const latest = normalizeSettings(refreshed);
       if (!latest.relayProfiles.some((profile) => profile.id === targetRelayId)) {
-        showNotice("供应商切换", "目标供应商已不在 cc-switch 或本地配置中，请刷新供应商列表后重试。", "failed");
+        showNotice("Provider Switch", "The target provider is no longer in cc-switch or local settings. Refresh the provider list and try again.", "failed");
         return;
       }
       switchSettings = syncLegacyRelayFields({ ...latest, activeRelayId: targetRelayId });
     }
     if (!switchSettings.relayProfilesEnabled) {
-      showNotice("供应商配置已关闭", "当前不会写入 Codex config.toml / auth.json。打开供应商配置总开关后再切换。", "failed");
+      showNotice("Provider configuration is off", "Codex config.toml / auth.json will not be written. Turn on provider switching before switching providers.", "failed");
       return;
     }
     const targetBeforeSnapshot = activeRelayProfile(switchSettings);
@@ -1283,7 +1283,7 @@ export function App() {
         targetRelayName: selectedBeforeSave.name,
         error: validationError,
       });
-      showNotice("供应商配置可能不正确", validationError, "failed");
+      showNotice("Provider configuration may be incorrect", validationError, "failed");
       return;
     }
 
@@ -1303,7 +1303,7 @@ export function App() {
           status: settingsResult.status,
           message: settingsResult.message,
         });
-        showNotice("供应商切换", settingsResult.message, settingsResult.status);
+        showNotice("Provider Switch", settingsResult.message, settingsResult.status);
         return;
       }
     } else {
@@ -1339,7 +1339,7 @@ export function App() {
         message: result.message,
         configured: result.configured,
       });
-      showNotice("供应商切换", relayProfileReadinessText(selectedAfterSave, result), result.status);
+      showNotice("Provider Switch", relayProfileReadinessText(selectedAfterSave, result), result.status);
       return;
     }
 
@@ -1356,7 +1356,7 @@ export function App() {
         launchMode,
         status: modeResult.status,
       });
-      showNotice("供应商切换", relayProfileModeSwitchedText(currentSelected), modeResult.status);
+      showNotice("Provider Switch", relayProfileModeSwitchedText(currentSelected), modeResult.status);
     } else {
       logDiagnostic("switchRelayProfile.launch_mode_no_result", {
         targetRelayId: currentSelected.id,
@@ -1388,7 +1388,7 @@ export function App() {
         status: result?.status,
         message: result?.message,
       });
-      showNotice("供应商切换", result?.message ?? "读取当前配置文件失败，已停止切换以避免覆盖用户改动。", result?.status ?? "failed");
+      showNotice("Provider Switch", result?.message ?? "Failed to read the current config files, so switching was stopped to avoid overwriting your changes.", result?.status ?? "failed");
       return null;
     }
 
@@ -1404,14 +1404,14 @@ export function App() {
     try {
       await navigator.clipboard.writeText(text);
     } catch (error) {
-      showNotice("复制失败", stringifyError(error), "failed");
+      showNotice("Copy failed", stringifyError(error), "failed");
     }
   };
 
   const openExternalUrl = async (url: string) => {
     const result = await run(() => call<CommandResult<Record<string, unknown>>>("open_external_url", { url }));
     if (result) {
-      showResultNotice("打开链接", result, { silentSuccess: true });
+      showResultNotice("Open Link", result, { silentSuccess: true });
     }
   };
 
@@ -1483,25 +1483,25 @@ export function App() {
         try {
           selected = await open(
             mode === "folder"
-              ? { directory: true, multiple: false, title: "选择 Codex 应用目录" }
+              ? { directory: true, multiple: false, title: "Choose Codex App Directory" }
               : {
                   directory: false,
                   multiple: false,
-                  title: "选择 Codex.exe 或 Codex.app",
-                  filters: [{ name: "Codex 应用", extensions: ["exe", "app"] }],
+                  title: "Choose Codex.exe or Codex.app",
+                  filters: [{ name: "Codex App", extensions: ["exe", "app"] }],
                 },
           );
         } catch (error) {
           // Surface plugin failures (e.g. missing capability permission) so the
           // buttons no longer appear unresponsive — see #345.
           const message = error instanceof Error ? error.message : String(error);
-          showNotice("Codex 应用路径", `打开选择器失败：${message}`, "failed");
+          showNotice("Codex App Path", `Failed to open picker: ${message}`, "failed");
           return;
         }
         if (typeof selected === "string" && selected.trim()) {
           const result = await saveCodexAppPath(selected.trim());
           if (result) {
-            showNotice("Codex 应用路径", "应用路径已保存，之后启动会自动复用。", result.status);
+            showNotice("Codex App Path", "App path saved and will be reused for future launches.", result.status);
           }
         }
       },
@@ -1512,19 +1512,19 @@ export function App() {
           setSettings(result);
           setSettingsForm(normalizeSettings(result.settings));
           setLaunchForm((current) => ({ ...current, appPath: "" }));
-          showNotice("Codex 应用路径", "已清除保存路径，后续启动会回到自动探测。", result.status);
+          showNotice("Codex App Path", "Saved path cleared; future launches will use auto-detection.", result.status);
           await refreshOverview(true);
         }
       },
       saveManualCodexAppPath: async () => {
         const appPath = launchForm.appPath.trim();
         if (!appPath) {
-          showNotice("Codex 应用路径", "请先填写或选择应用路径。", "failed");
+          showNotice("Codex App Path", "Please enter or choose an app path first.", "failed");
           return;
         }
         const result = await saveCodexAppPath(appPath);
         if (result) {
-          showNotice("Codex 应用路径", "应用路径已保存，之后启动会自动复用。", result.status);
+          showNotice("Codex App Path", "App path saved and will be reused for future launches.", result.status);
         }
       },
       syncProvidersNow,
@@ -1571,14 +1571,14 @@ export function App() {
       refreshLogs,
       refreshDiagnostics,
       showMessage: async (title: string, message: string, status?: Status) => showNotice(title, message, status),
-      copyLogs: () => copyText(logs?.text ?? "", "日志已复制。"),
-      copyDiagnostics: () => copyText(diagnostics?.report ?? "", "诊断报告已复制。"),
+      copyLogs: () => copyText(logs?.text ?? "", "Logs copied."),
+      copyDiagnostics: () => copyText(diagnostics?.report ?? "", "Diagnostics report copied."),
       goLogs: () => navigate("about"),
       checkHealth: async () => {
         await refreshOverview(true);
         await refreshRelay(true);
         await refreshWatcher(true);
-        showNotice("检查完成", "已刷新 Codex 应用、入口和 Watcher 状态。", "ok");
+        showNotice("Check complete", "Refreshed Codex app, entries, and watcher status.", "ok");
       },
       installWatcher: () => watcherAction("install_watcher"),
       uninstallWatcher: () => watcherAction("uninstall_watcher"),
@@ -1605,14 +1605,14 @@ export function App() {
                     setRoute("about");
                     void checkUpdate(false);
                   }}
-                  title={`发现新版本 ${update?.latestVersion ?? ""}`}
+                  title={`New version found ${update?.latestVersion ?? ""}`}
                   type="button"
                 >
                   <CircleArrowUp className="h-4 w-4" aria-hidden="true" />
                 </button>
               ) : null}
             </div>
-            <div className="brand-subtitle">管理控制台</div>
+            <div className="brand-subtitle">Manager Console</div>
           </div>
         </div>
         <nav className="nav">
@@ -1645,16 +1645,16 @@ export function App() {
             <Button
               onClick={actions.toggleTheme}
               size="icon"
-              title={theme === "dark" ? "切换到浅色" : "切换到深色"}
+              title={theme === "dark" ? "Switch to light" : "Switch to dark"}
               variant="outline"
             >
               {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
             </Button>
-            <Button onClick={() => void actions.restart()} title="重启 Codex++" variant="outline">
+            <Button onClick={() => void actions.restart()} title="Restart Codex++" variant="outline">
               <Rocket className="h-4 w-4" />
-              重启 Codex++
+              Restart Codex++
             </Button>
-            <Button onClick={() => void actions.refreshCurrent()} size="icon" title="刷新当前页面" variant="outline">
+            <Button onClick={() => void actions.refreshCurrent()} size="icon" title="Refresh current page" variant="outline">
               <RefreshCw className="h-4 w-4" />
             </Button>
           </div>
@@ -1820,10 +1820,10 @@ function OverviewScreen({
                 <Network className="h-5 w-5" />
               </div>
               <div>
-                <span className="eyebrow">官方中转站</span>
+                <span className="eyebrow">Official Relay</span>
                 <h2>JOJO Code</h2>
                 <p>
-                  Codex++ 官方中转站，主打稳定接入和划算价格，支持 GPT-5.5、GPT-5.4、Claude Opus 4.8、Claude Opus 4.7、gpt-image-2 等模型与图像能力。
+                  The official Codex++ relay, focused on stable access and fair pricing, with support for GPT-5.5, GPT-5.4, Claude Opus 4.8, Claude Opus 4.7, gpt-image-2, and image capabilities.
                 </p>
               </div>
             </div>
@@ -1837,21 +1837,21 @@ function OverviewScreen({
               </div>
               <Button onClick={() => void actions.openExternalUrl("https://jojocode.com/")}>
                 <ExternalLink className="h-4 w-4" />
-                打开 JOJO Code
+                Open JOJO Code
               </Button>
             </div>
           </div>
         </CardContent>
       </Panel>
       <Panel>
-        <CardHead title="健康检查" detail="概览只展示关键问题，具体配置在对应页面处理" />
+        <CardHead title="Health Check" detail="Overview shows key issues; detailed configuration lives in each section" />
         <CardContent>
           <div className="health-grid">
             <div className={`health-item ${overview?.codex_version ? "ok" : "needs-fix"}`}>
               {overview?.codex_version ? <CheckCircle2 className="h-4 w-4" /> : <Bell className="h-4 w-4" />}
               <div>
-                <strong>Codex 版本</strong>
-                <span>{overview?.codex_version ?? "未检测到 Codex 应用版本。"}</span>
+                <strong>Codex Version</strong>
+                <span>{overview?.codex_version ?? "Codex app version was not detected."}</span>
               </div>
               <Badge status={overview?.codex_version ? "ok" : "not_checked"} />
             </div>
@@ -1869,29 +1869,29 @@ function OverviewScreen({
           <Toolbar>
             <Button onClick={() => void actions.checkHealth()}>
               <RefreshCw className="h-4 w-4" />
-              检查
+              Check
             </Button>
             <Button variant="secondary" onClick={() => void actions.repairShortcuts()}>
               <Wrench className="h-4 w-4" />
-              修复入口
+              Repair Entries
             </Button>
             <Button variant="secondary" onClick={() => void actions.repairBackend()}>
-              修复后端
+              Repair Backend
             </Button>
           </Toolbar>
         </CardContent>
       </Panel>
       <Panel>
-        <CardHead title="最近启动" detail={overview?.logs_path ?? "暂无状态文件"} />
+        <CardHead title="Recent Launch" detail={overview?.logs_path ?? "No status file"} />
         <CardContent>
           <LatestLaunch status={overview?.latest_launch ?? null} />
           <Toolbar>
             <Button onClick={() => void actions.launch()}>
               <Rocket className="h-4 w-4" />
-              启动 Codex++
+              Launch Codex++
             </Button>
             <Button variant="secondary" onClick={() => void actions.goLogs()}>
-              打开关于
+              Open About
             </Button>
           </Toolbar>
         </CardContent>
@@ -1971,7 +1971,7 @@ function RelayScreen({
   return (
     <>
       <Panel>
-        <CardHead title="供应商列表" detail={`${normalized.relayProfiles.length} 个供应商配置；可拖动排序，点编辑进入详情`} />
+        <CardHead title="Provider List" detail={`${normalized.relayProfiles.length} provider configs; drag to sort, click edit for details`} />
         <CardContent>
           <label className="switch-row relay-master-switch">
             <input
@@ -1983,8 +1983,8 @@ function RelayScreen({
               type="checkbox"
             />
             <span>
-              <strong>启用供应商配置切换</strong>
-              <small>关闭后本工具不会在手动切换时写入 Codex 的 config.toml / auth.json；启动 Codex 时始终不会自动改这些文件。</small>
+              <strong>Enable Provider Switching</strong>
+              <small>When off, this tool will not write Codex config.toml / auth.json during manual switching; launching Codex never changes those files automatically.</small>
             </span>
           </label>
           <label className="switch-row relay-link-switch">
@@ -2001,14 +2001,14 @@ function RelayScreen({
               type="checkbox"
             />
             <span>
-              <strong>联动 cc-switch</strong>
-              <small>开启后读取 cc-switch Codex 供应商并保存时回写；建议配合“配置所有权”避免与 CC Switch 互相覆盖。</small>
+              <strong>Link cc-switch</strong>
+              <small>When on, reads cc-switch Codex providers and writes them back on save; pair it with Config Ownership to avoid overwrites with CC Switch.</small>
             </span>
           </label>
           <label className="switch-row relay-ownership-row">
             <span>
-              <strong>配置所有权</strong>
-              <small>决定由谁写入 ~/.codex/config.toml 与 auth.json。auto 在开启联动且检测到 CC Switch 时交由 CC Switch 管理。</small>
+              <strong>Config Ownership</strong>
+              <small>Controls who writes ~/.codex/config.toml and auth.json. Auto delegates to CC Switch when linking is on and CC Switch is detected.</small>
             </span>
             <select
               className="select-input relay-ownership-select"
@@ -2022,9 +2022,9 @@ function RelayScreen({
                 void saveRelaySettings(next);
               }}
             >
-              <option value="auto">自动（推荐）</option>
-              <option value="ccSwitch">CC Switch 管理</option>
-              <option value="codexPlusPlus">Codex++ 管理</option>
+              <option value="auto">Auto (recommended)</option>
+              <option value="ccSwitch">CC Switch managed</option>
+              <option value="codexPlusPlus">Codex++ managed</option>
             </select>
           </label>
           <CoordinationStatusBanner form={normalized} actions={actions} />
@@ -2037,7 +2037,7 @@ function RelayScreen({
               }}
             >
               <Plus className="h-4 w-4" />
-              添加供应商
+              Add Provider
             </Button>
           </div>
           <RelayProfileList
@@ -2068,7 +2068,7 @@ function EnhanceScreen({
   return (
     <>
       <Panel>
-        <CardHead title="页面功能增强" detail="会话删除、导出、项目移动、Timeline 和用户脚本等界面能力" />
+        <CardHead title="Page Enhancements" detail="Session delete, export, project move, Timeline, user scripts, and related page features" />
         <CardContent>
           <label className="switch-row">
             <input
@@ -2077,56 +2077,56 @@ function EnhanceScreen({
               type="checkbox"
             />
             <span>
-              <strong>启用 Codex++ 页面增强</strong>
-              <small>关闭后会停用删除、导出、项目移动、Timeline、插件相关和菜单位置增强。</small>
+              <strong>Enable Codex++ Page Enhancements</strong>
+              <small>When off, disables delete, export, project move, plugin-related features, menu placement, and other page enhancements.</small>
             </span>
           </label>
           <ModeSelector launchMode={form.launchMode} actions={actions} />
           {form.launchMode === "relay" ? (
             <div className="hint-line">
               <ShieldCheck className="h-4 w-4" />
-              <span>当前为兼容增强模式，插件市场解锁、强制解锁入口和特殊插件强制安装不会启用；其他页面功能仍可用。</span>
+              <span>Compatibility enhancement mode is active; marketplace unlock, entry unlock, and force install stay disabled, while other page features still work.</span>
             </div>
           ) : null}
           <div className="feature-switch-grid">
-            <FeatureToggle title="插件市场解锁" detail="API Key 模式下扩展插件市场请求，尽量显示完整插件列表；官方/混合模式通常不需要。" checked={form.codexAppPluginMarketplaceUnlock} disabled={!masterEnabled || !patchMode} onChange={(value) => setEnhanceFlag("codexAppPluginMarketplaceUnlock", value)} />
-            <FeatureToggle title="强制解锁入口" detail="恢复 1.1.9 的入口解锁方式，强制显示并启用插件入口。" checked={form.codexAppPluginEntryUnlock} disabled={!masterEnabled || !patchMode} onChange={(value) => setEnhanceFlag("codexAppPluginEntryUnlock", value)} />
-            <FeatureToggle title="特殊插件强制安装" detail="解除 App unavailable / 应用不可用导致的前端安装禁用。" checked={form.codexAppForcePluginInstall} disabled={!masterEnabled || !patchMode} onChange={(value) => setEnhanceFlag("codexAppForcePluginInstall", value)} />
-            <FeatureToggle title="模型白名单解锁" detail="从环境变量和 config.toml 的 /v1/models 拉取模型并补进模型列表。" checked={form.codexAppModelWhitelistUnlock} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppModelWhitelistUnlock", value)} />
-            <FeatureToggle title="Fast 按钮" detail="显示服务模式切换按钮；Fast 仅支持 gpt-5.4 / gpt-5.5，其他模型按 Standard 发送。" checked={form.codexAppServiceTierControls} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppServiceTierControls", value)} />
-            <FeatureToggle title="会话删除" detail="在会话列表悬停显示删除按钮，并支持撤销。" checked={form.codexAppSessionDelete} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppSessionDelete", value)} />
-            <FeatureToggle title="Markdown 导出" detail="在会话列表显示导出按钮，导出带时间戳的 Markdown。" checked={form.codexAppMarkdownExport} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppMarkdownExport", value)} />
-            <FeatureToggle title="会话项目移动" detail="把会话移动到普通对话或其他本地项目。" checked={form.codexAppProjectMove} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppProjectMove", value)} />
-            <FeatureToggle title="对话 Timeline" detail="在对话右侧显示用户提问时间线，支持摘要和跳转。" checked={form.codexAppConversationTimeline} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppConversationTimeline", value)} />
-            <FeatureToggle title="对话居中宽度" detail="把主对话和输入框限制到固定最大宽度，适合大屏阅读。" checked={form.codexAppConversationView} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppConversationView", value)} />
-            <FeatureToggle title="切换对话保留位置" detail="切换 thread 时恢复上一次浏览位置。" checked={form.codexAppThreadScrollRestore} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppThreadScrollRestore", value)} />
-            <FeatureToggle title="Zed Remote open" detail="远程 SSH 文件引用可直接用 Zed Remote Development 打开。" checked={form.codexAppZedRemoteOpen} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppZedRemoteOpen", value)} />
-            <FeatureToggle title="Zed 项目记录" detail="维护 Codex++ 自己的远程项目最近列表。" checked={form.zedRemoteProjectRegistryEnabled} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("zedRemoteProjectRegistryEnabled", value)} />
-            <FeatureToggle title="同步 Zed settings" detail="高级选项，默认关闭；当前实现不主动改写 Zed settings。" checked={form.zedRemoteSyncToZedSettings} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("zedRemoteSyncToZedSettings", value)} />
-            <FeatureToggle title="Upstream worktree" detail="从最新 upstream 分支创建 Git worktree。" checked={form.codexAppUpstreamWorktreeCreate} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppUpstreamWorktreeCreate", value)} />
-            <FeatureToggle title="原生菜单栏位置" detail="把 Codex++ 菜单插入 Codex 顶部原生菜单栏。" checked={form.codexAppNativeMenuPlacement} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppNativeMenuPlacement", value)} />
+            <FeatureToggle title="Plugin Marketplace Unlock" detail="Extends plugin marketplace requests in API key mode so the full plugin list can be shown; official and mixed modes usually do not need this." checked={form.codexAppPluginMarketplaceUnlock} disabled={!masterEnabled || !patchMode} onChange={(value) => setEnhanceFlag("codexAppPluginMarketplaceUnlock", value)} />
+            <FeatureToggle title="Force Entry Unlock" detail="Restores the 1.1.9 entry unlock path to force-show and enable the plugin entry." checked={form.codexAppPluginEntryUnlock} disabled={!masterEnabled || !patchMode} onChange={(value) => setEnhanceFlag("codexAppPluginEntryUnlock", value)} />
+            <FeatureToggle title="Force Plugin Install" detail="Removes frontend install blocking caused by App unavailable states." checked={form.codexAppForcePluginInstall} disabled={!masterEnabled || !patchMode} onChange={(value) => setEnhanceFlag("codexAppForcePluginInstall", value)} />
+            <FeatureToggle title="Model Whitelist Unlock" detail="Pulls models from environment variables and config.toml /v1/models, then adds them to the model list." checked={form.codexAppModelWhitelistUnlock} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppModelWhitelistUnlock", value)} />
+            <FeatureToggle title="Fast Button" detail="Shows service mode controls; Fast only supports gpt-5.4 / gpt-5.5, and other models are sent as Standard." checked={form.codexAppServiceTierControls} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppServiceTierControls", value)} />
+            <FeatureToggle title="Session Delete" detail="Shows a delete button on session hover, with undo support." checked={form.codexAppSessionDelete} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppSessionDelete", value)} />
+            <FeatureToggle title="Markdown Export" detail="Shows an export button in the session list and exports timestamped Markdown." checked={form.codexAppMarkdownExport} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppMarkdownExport", value)} />
+            <FeatureToggle title="Session Project Move" detail="Moves sessions to Chats or another local project." checked={form.codexAppProjectMove} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppProjectMove", value)} />
+            <FeatureToggle title="Conversation Timeline" detail="Disabled in this patched build to remove the right-side line and circles." checked={false} disabled={true} onChange={() => {}} />
+            <FeatureToggle title="Centered Conversation Width" detail="Limits the main conversation and input to a fixed max width for large-screen reading." checked={form.codexAppConversationView} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppConversationView", value)} />
+            <FeatureToggle title="Preserve Position When Switching Conversations" detail="Restores the last viewed position when switching threads." checked={form.codexAppThreadScrollRestore} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppThreadScrollRestore", value)} />
+            <FeatureToggle title="Zed Remote open" detail="Opens remote SSH file references directly in Zed Remote Development." checked={form.codexAppZedRemoteOpen} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppZedRemoteOpen", value)} />
+            <FeatureToggle title="Zed Project Registry" detail="Maintains Codex++'s own recent list of remote projects." checked={form.zedRemoteProjectRegistryEnabled} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("zedRemoteProjectRegistryEnabled", value)} />
+            <FeatureToggle title="Sync Zed settings" detail="Advanced option, off by default; the current implementation does not actively rewrite Zed settings." checked={form.zedRemoteSyncToZedSettings} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("zedRemoteSyncToZedSettings", value)} />
+            <FeatureToggle title="Upstream worktree" detail="Creates a Git worktree from the latest upstream branch." checked={form.codexAppUpstreamWorktreeCreate} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppUpstreamWorktreeCreate", value)} />
+            <FeatureToggle title="Native Menu Bar Placement" detail="Inserts the Codex++ menu into the top native menu bar." checked={form.codexAppNativeMenuPlacement} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppNativeMenuPlacement", value)} />
           </div>
           <div className="zed-remote-settings">
-            <Field label="Zed 默认打开策略">
+            <Field label="Default Zed Open Strategy">
               <select
                 className="select-input"
                 disabled={!masterEnabled}
                 onChange={(event) => onFormChange({ ...form, zedRemoteOpenStrategy: event.currentTarget.value as ZedOpenStrategy })}
                 value={form.zedRemoteOpenStrategy}
               >
-                <option value="addToFocusedWorkspace">加入当前工作区</option>
-                <option value="reuseWindow">复用窗口</option>
-                <option value="newWindow">新窗口</option>
-                <option value="default">Zed 默认行为</option>
+                <option value="addToFocusedWorkspace">Add to Focused Workspace</option>
+                <option value="reuseWindow">Reuse Window</option>
+                <option value="newWindow">New Window</option>
+                <option value="default">Zed Default Behavior</option>
               </select>
             </Field>
           </div>
           <div className="hint-line">
             <Info className="h-4 w-4" />
-            <span>如果使用官方模式或官方混入 API 模式，通常不需要开启插件市场解锁、强制解锁入口和特殊插件强制安装。</span>
+            <span>Official mode and official mixed API mode usually do not need Plugin Marketplace Unlock, Force Entry Unlock, or Force Plugin Install.</span>
           </div>
           <Toolbar>
-            <Button onClick={() => void actions.saveSettings()}>保存增强设置</Button>
+            <Button onClick={() => void actions.saveSettings()}>Save Enhancement Settings</Button>
           </Toolbar>
         </CardContent>
       </Panel>
@@ -2154,15 +2154,15 @@ function ZedRemoteScreen({
   const copyUrl = async (project: ZedRemoteProject) => {
     try {
       await navigator.clipboard.writeText(project.url);
-      await actions.showMessage("Zed Remote URL", "ssh:// URL 已复制。", "ok");
+      await actions.showMessage("Zed Remote URL", "ssh:// URL copied.", "ok");
     } catch (error) {
-      await actions.showMessage("复制失败", stringifyError(error), "failed");
+      await actions.showMessage("Copy failed", stringifyError(error), "failed");
     }
   };
   return (
     <>
       <Panel>
-        <CardHead title="Zed 远程项目" detail={`${allProjects.length} 个 Codex++ 可识别项目，默认策略：${zedStrategyLabel(form.zedRemoteOpenStrategy)}`} />
+        <CardHead title="Zed Remote Projects" detail={`${allProjects.length} Codex++ recognizable projects, default strategy: ${zedStrategyLabel(form.zedRemoteOpenStrategy)}`} />
         <CardContent>
           <div className="metric-list">
             <Metric label="Current" value={String(currentProjects.length)} />
@@ -2170,16 +2170,16 @@ function ZedRemoteScreen({
             <Metric label="Discovered" value={String(discoveredProjects.length)} />
           </div>
           <div className="zed-remote-settings">
-            <Field label="默认打开策略">
+            <Field label="Default Open Strategy">
               <select
                 className="select-input"
                 onChange={(event) => onFormChange({ ...form, zedRemoteOpenStrategy: event.currentTarget.value as ZedOpenStrategy })}
                 value={form.zedRemoteOpenStrategy}
               >
-                <option value="addToFocusedWorkspace">加入当前工作区</option>
-                <option value="reuseWindow">复用窗口</option>
-                <option value="newWindow">新窗口</option>
-                <option value="default">Zed 默认行为</option>
+                <option value="addToFocusedWorkspace">Add to Focused Workspace</option>
+                <option value="reuseWindow">Reuse Window</option>
+                <option value="newWindow">New Window</option>
+                <option value="default">Zed Default Behavior</option>
               </select>
             </Field>
             <label className="switch-row compact">
@@ -2189,19 +2189,19 @@ function ZedRemoteScreen({
                 type="checkbox"
               />
               <span>
-                <strong>记录最近打开</strong>
-                <small>保存到 Codex++ state，不改写 Zed settings。</small>
+                <strong>Remember Recent Opens</strong>
+                <small>Saves to Codex++ state without rewriting Zed settings.</small>
               </span>
             </label>
           </div>
           <Toolbar>
             <Button onClick={() => void actions.refreshZedRemoteProjects()}>
               <RefreshCw className="h-4 w-4" />
-              刷新项目
+              Refresh Projects
             </Button>
             <Button variant="secondary" onClick={() => void actions.saveSettingsValue(form, false)}>
               <Save className="h-4 w-4" />
-              保存策略
+              Save Strategy
             </Button>
           </Toolbar>
         </CardContent>
@@ -2226,7 +2226,7 @@ function ZedRemoteProjectSection({
 }) {
   return (
     <Panel>
-      <CardHead title={title} detail={`${projects.length} 个项目`} />
+      <CardHead title={title} detail={`${projects.length} projects`} />
       <CardContent>
         {projects.length ? (
           <div className="zed-remote-project-list">
@@ -2246,19 +2246,19 @@ function ZedRemoteProjectSection({
                 <div className="zed-remote-project-actions">
                   <Button onClick={() => void actions.openZedRemoteProject(project, "addToFocusedWorkspace")} size="sm">
                     <ExternalLink className="h-4 w-4" />
-                    加入当前工作区
+                    Add to Focused Workspace
                   </Button>
                   <Button onClick={() => void actions.openZedRemoteProject(project, "reuseWindow")} size="sm" variant="outline">
-                    复用窗口
+                    Reuse Window
                   </Button>
                   <Button onClick={() => void actions.openZedRemoteProject(project, "newWindow")} size="sm" variant="outline">
-                    新窗口
+                    New Window
                   </Button>
-                  <Button onClick={() => void onCopyUrl(project)} size="icon" title="复制 ssh:// URL" variant="ghost">
+                  <Button onClick={() => void onCopyUrl(project)} size="icon" title="Copy ssh:// URL" variant="ghost">
                     <Copy className="h-4 w-4" />
                   </Button>
                   {project.source === "recent" ? (
-                    <Button onClick={() => void actions.forgetZedRemoteProject(project)} size="icon" title="移除最近记录" variant="ghost">
+                    <Button onClick={() => void actions.forgetZedRemoteProject(project)} size="icon" title="Remove recent record" variant="ghost">
                       <Trash2 className="h-4 w-4" />
                     </Button>
                   ) : null}
@@ -2267,7 +2267,7 @@ function ZedRemoteProjectSection({
             ))}
           </div>
         ) : (
-          <div className="empty">暂无项目。</div>
+          <div className="empty">No projects.</div>
         )}
       </CardContent>
     </Panel>
@@ -2282,32 +2282,32 @@ function UserScriptsScreen({ settings, market, actions }: { settings: SettingsRe
   return (
     <>
       <Panel>
-        <CardHead title="脚本市场" detail={`${marketScripts.length} 个市场脚本，已安装 ${installedCount} 个，本地整体 ${inventory?.enabled === false ? "关闭" : "开启"}`} />
+        <CardHead title="Script Market" detail={`${marketScripts.length}  market scripts, installed  ${installedCount} , local scripts  ${inventory?.enabled === false ? "Off" : "On"}`} />
         <CardContent>
           <div className="metric-list">
-            <Metric label="市场状态" value={market?.market.message ?? "尚未刷新"} />
-            <Metric label="远程脚本" value={`${marketScripts.length} 个`} />
-            <Metric label="已安装" value={`${installedCount} 个`} />
-            <Metric label="本地整体" value={inventory?.enabled === false ? "关闭" : "开启"} />
+            <Metric label="Market Status" value={market?.market.message ?? "Not refreshed yet"} />
+            <Metric label="Remote Scripts" value={`${marketScripts.length}`} />
+            <Metric label="Installed" value={`${installedCount}`} />
+            <Metric label="Local Scripts" value={inventory?.enabled === false ? "Off" : "On"} />
           </div>
           <Toolbar>
             <Button onClick={() => void actions.refreshScriptMarket()}>
               <RefreshCw className="h-4 w-4" />
-              刷新市场
+              Refresh Market
             </Button>
             <Button onClick={() => void actions.openExternalUrl(SCRIPT_MARKET_REPOSITORY_URL)} variant="secondary">
               <ExternalLink className="h-4 w-4" />
-              投稿
+              Submit
             </Button>
             <Button onClick={() => void actions.refreshCurrent()} variant="secondary">
               <RefreshCw className="h-4 w-4" />
-              刷新本地
+              Refresh Local
             </Button>
           </Toolbar>
         </CardContent>
       </Panel>
       <Panel>
-        <CardHead title="市场脚本" detail={market?.market.updatedAt ? `清单更新时间：${market.market.updatedAt}` : "从 GitHub 静态清单加载"} />
+        <CardHead title="Market Scripts" detail={market?.market.updatedAt ? `Manifest updated: ${market.market.updatedAt}` : "Loaded from GitHub static manifest"} />
         <CardContent>
           {marketScripts.length ? (
             <div className="script-market-grid">
@@ -2316,15 +2316,15 @@ function UserScriptsScreen({ settings, market, actions }: { settings: SettingsRe
               ))}
             </div>
           ) : (
-            <div className="empty">{market?.status === "failed" ? market.message : "点击刷新市场加载远程脚本。"}</div>
+            <div className="empty">{market?.status === "failed" ? market.message : "Click Refresh Market to load remote scripts."}</div>
           )}
         </CardContent>
       </Panel>
       <Panel>
-        <CardHead title="本地脚本" detail="内置、手动和市场安装脚本；可在这里启停或删除用户脚本" />
+        <CardHead title="Local Scripts" detail="Built-in, manual, and market-installed scripts; enable, disable, or delete user scripts here" />
         <CardContent>
           <div className="table">
-            {scripts.length ? scripts.map((script) => <ScriptRow key={script.key} script={script} actions={actions} />) : <div className="empty">未发现用户脚本。</div>}
+            {scripts.length ? scripts.map((script) => <ScriptRow key={script.key} script={script} actions={actions} />) : <div className="empty">No user scripts found.</div>}
           </div>
         </CardContent>
       </Panel>
@@ -2357,16 +2357,16 @@ function SessionsScreen({
   return (
     <>
       <Panel>
-        <CardHead title="会话管理" detail="读取 Codex 本地 SQLite 会话库，会删除数据库记录和对应 rollout 文件" />
+        <CardHead title="Session Management" detail="Reads Codex local SQLite session stores and can delete database records plus matching rollout files" />
         <CardContent>
           <div className="metric-list">
-            <Metric label="会话总数" value={`${items.length} 个`} />
-            <Metric label="未归档" value={`${activeCount} 个`} />
-            <Metric label="已归档" value={`${archivedCount} 个`} />
-            <Metric label="数据库" value={sessions?.dbPath ?? "~/.codex/sqlite/*.db"} />
+            <Metric label="Total Sessions" value={`${items.length}`} />
+            <Metric label="Active" value={`${activeCount}`} />
+            <Metric label="Archived" value={`${archivedCount}`} />
+            <Metric label="Database" value={sessions?.dbPath ?? "~/.codex/sqlite/*.db"} />
           </div>
           <div className="form-row">
-            <Field label="同步目标">
+            <Field label="Sync Target">
               <select
                 className="select-input"
                 disabled={providerSyncProgress.active || !(providerSyncTargets?.targets ?? []).length}
@@ -2375,26 +2375,26 @@ function SessionsScreen({
               >
                 {(providerSyncTargets?.targets ?? []).map((target) => (
                   <option key={target.id} value={target.id}>
-                    {target.id}（{providerSyncTargetLabel(target)}）
+                    {target.id} ({providerSyncTargetLabel(target)})
                   </option>
                 ))}
-                {!(providerSyncTargets?.targets ?? []).length ? <option value="">当前配置 provider</option> : null}
+                {!(providerSyncTargets?.targets ?? []).length ? <option value="">Current configured provider</option> : null}
               </select>
             </Field>
           </div>
           <Toolbar>
             <Button onClick={() => void actions.refreshLocalSessions()}>
               <RefreshCw className="h-4 w-4" />
-              刷新会话
+              Refresh Sessions
             </Button>
             <Button disabled={providerSyncProgress.active} onClick={() => void actions.syncProvidersNow()} variant="outline">
               <RefreshCw className="h-4 w-4" />
-              {providerSyncProgress.active ? "正在修复…" : "立刻修复历史会话"}
+              {providerSyncProgress.active ? "Repairing..." : "Repair Historical Sessions Now"}
             </Button>
           </Toolbar>
           <div className="provider-sync-progress" data-active={providerSyncProgress.active}>
             <div className="provider-sync-progress-head">
-              <strong>{providerSyncProgress.active ? "正在修复历史会话" : "历史会话修复进度"}</strong>
+              <strong>{providerSyncProgress.active ? "Repairing Historical Sessions" : "Historical Session Repair Progress"}</strong>
               <span>{providerSyncProgress.percent}%</span>
             </div>
             <div
@@ -2410,7 +2410,7 @@ function SessionsScreen({
           </div>
           <div className="hint-line">
             <Info className="h-4 w-4" />
-            <span>删除会创建本地备份；如果 Codex App 正在使用该会话，建议先关闭对应会话窗口再操作。</span>
+            <span>Delete creates a local backup. If Codex App is using that session, close the matching session window before deleting it.</span>
           </div>
           <label className="switch-row">
             <input
@@ -2419,41 +2419,41 @@ function SessionsScreen({
               type="checkbox"
             />
             <span>
-              <strong>启动前自动修复历史会话</strong>
-              <small>开启后，通过 Codex++ 启动 Codex 前自动整理一次旧对话的归属标记。</small>
+              <strong>Automatically Repair Historical Sessions Before Launch</strong>
+              <small>When on, Codex++ repairs old conversation ownership markers once before launching Codex.</small>
             </span>
           </label>
           <Toolbar>
-            <Button onClick={() => void actions.saveSettings()}>保存自动修复设置</Button>
+            <Button onClick={() => void actions.saveSettings()}>Save Auto Repair Settings</Button>
           </Toolbar>
         </CardContent>
       </Panel>
       <Panel>
-        <CardHead title="本地会话" detail={items.length ? "按更新时间倒序显示" : "点击刷新会话读取本地数据库"} />
+        <CardHead title="Local Sessions" detail={items.length ? "Sorted by latest update" : "Click Refresh Sessions to read the local database"} />
         <CardContent>
           {items.length ? (
             <div className="session-list">
               {items.map((session) => (
                 <div className="session-row" key={session.id}>
                   <div className="session-main">
-                    <strong>{session.title || "未命名会话"}</strong>
+                    <strong>{session.title || "Untitled session"}</strong>
                     <span>{session.id}</span>
-                    <small>{session.cwd || "未记录项目路径"}</small>
+                    <small>{session.cwd || "No project path recorded"}</small>
                   </div>
                   <div className="session-meta">
                     <Badge status={session.archived ? "archived" : "ok"} />
-                    <span>{session.modelProvider || "provider 未记录"}</span>
+                    <span>{session.modelProvider || "Provider not recorded"}</span>
                     <span>{formatTime(session.updatedAtMs ?? 0)}</span>
                   </div>
                   <Button variant="outline" onClick={() => void actions.deleteLocalSession(session)}>
                     <Trash2 className="h-4 w-4" />
-                    删除
+                    Delete
                   </Button>
                 </div>
               ))}
             </div>
           ) : (
-            <div className="empty">未读取到本地会话，或当前 SQLite 会话库不存在。</div>
+            <div className="empty">No local sessions were read, or the current SQLite session store does not exist.</div>
           )}
         </CardContent>
       </Panel>
@@ -2468,30 +2468,30 @@ function RecommendationsScreen({ ads, actions }: { ads: AdsResult | null; action
   return (
     <>
       <Panel>
-        <CardHead title="推荐内容" detail="与 Codex 内插件菜单使用同一个远端广告源" />
+        <CardHead title="Recommendations" detail="Uses the same remote recommendation source as the in-Codex plugin menu" />
         <CardContent>
           <div className="recommend-hero">
             <div>
-              <strong>{ads ? `已加载 ${items.length} 条推荐` : "尚未加载推荐内容"}</strong>
-              <span>内容来自 BigPizzaV3/Ad-List，分为赞助商推荐和普通推荐。</span>
+              <strong>{ads ? `Loaded ${items.length}  recommendations` : "Recommendations not loaded yet"}</strong>
+              <span>Content comes from BigPizzaV3/Ad-List and is split between sponsored and regular recommendations.</span>
             </div>
             <Button onClick={() => void actions.refreshAds()}>
               <RefreshCw className="h-4 w-4" />
-              刷新推荐
+              Refresh Recommendations
             </Button>
           </div>
         </CardContent>
       </Panel>
       <Panel>
-        <CardHead title="赞助商推荐" detail={`${sponsors.length} 条`} />
+        <CardHead title="Sponsored Recommendations" detail={`${sponsors.length}`} />
         <CardContent>
-          <AdGrid actions={actions} ads={sponsors} empty="暂无赞助商推荐。" />
+          <AdGrid actions={actions} ads={sponsors} empty="No sponsored recommendations." />
         </CardContent>
       </Panel>
       <Panel>
-        <CardHead title="普通推荐" detail={`${normal.length} 条`} />
+        <CardHead title="Recommendations" detail={`${normal.length}`} />
         <CardContent>
-          <AdGrid actions={actions} ads={normal} empty="暂无普通推荐。" />
+          <AdGrid actions={actions} ads={normal} empty="No recommendations." />
         </CardContent>
       </Panel>
     </>
@@ -2521,85 +2521,85 @@ function MaintenanceScreen({
   return (
     <>
       <Panel>
-        <CardHead title="检查与修复" detail="检查入口、Codex 应用和 Watcher 状态" />
+        <CardHead title="Check & Repair" detail="Checks entries, Codex App, and Watcher status" />
         <CardContent>
           <div className="status-table">
-            <StatusRow title="Codex 应用" status={overview?.codex_app.status} path={overview?.codex_app.path} />
-            <StatusRow title="静默启动入口" status={overview?.silent_shortcut.status} path={overview?.silent_shortcut.path} />
-            <StatusRow title="管理控制台入口" status={overview?.management_shortcut.status} path={overview?.management_shortcut.path} />
-            <StatusRow title="Watcher 自动接管" status={watcher?.enabled ? "ok" : "disabled"} path={watcher?.disabled_flag} />
+            <StatusRow title="Codex App" status={overview?.codex_app.status} path={overview?.codex_app.path} />
+            <StatusRow title="Silent Launcher Entry" status={overview?.silent_shortcut.status} path={overview?.silent_shortcut.path} />
+            <StatusRow title="Manager Entry" status={overview?.management_shortcut.status} path={overview?.management_shortcut.path} />
+            <StatusRow title="Watcher Auto Takeover" status={watcher?.enabled ? "ok" : "disabled"} path={watcher?.disabled_flag} />
           </div>
           <Toolbar>
-            <Button onClick={() => void actions.checkHealth()}>检查</Button>
-            <Button variant="secondary" onClick={() => void actions.repairShortcuts()}>修复快捷方式</Button>
-            <Button variant="secondary" onClick={() => void actions.repairBackend()}>修复后端</Button>
+            <Button onClick={() => void actions.checkHealth()}>Check</Button>
+            <Button variant="secondary" onClick={() => void actions.repairShortcuts()}>Repair Shortcuts</Button>
+            <Button variant="secondary" onClick={() => void actions.repairBackend()}>Repair Backend</Button>
           </Toolbar>
         </CardContent>
       </Panel>
       <Panel>
-        <CardHead title="入口管理" detail="快捷方式写入系统实际桌面位置，不使用写死桌面路径" />
+        <CardHead title="Entry Management" detail="Entries are written to the actual system desktop location instead of a hard-coded desktop path" />
         <CardContent>
           <label className="check-row">
             <input checked={removeOwnedData} onChange={(event) => onRemoveOwnedDataChange(event.currentTarget.checked)} type="checkbox" />
-            <span>卸载时移除 Codex++ 托管数据</span>
+            <span>Remove Codex++ managed data during uninstall</span>
           </label>
           <Toolbar>
-            <Button onClick={() => void actions.installEntrypoints()}>安装入口</Button>
-            <Button variant="secondary" onClick={() => void actions.uninstallEntrypoints()}>卸载入口</Button>
-            <Button variant="secondary" onClick={() => void actions.repairShortcuts()}>修复入口</Button>
+            <Button onClick={() => void actions.installEntrypoints()}>Install Entries</Button>
+            <Button variant="secondary" onClick={() => void actions.uninstallEntrypoints()}>Uninstall Entries</Button>
+            <Button variant="secondary" onClick={() => void actions.repairShortcuts()}>Repair Entries</Button>
           </Toolbar>
         </CardContent>
       </Panel>
       <Panel>
-        <CardHead title="自动接管" detail="Watcher 用于保持 Codex++ 接管状态" />
+        <CardHead title="Auto Takeover" detail="Watcher keeps Codex++ takeover active" />
         <CardContent>
           <Toolbar>
-            <Button variant="secondary" onClick={() => void actions.installWatcher()}>安装 watcher</Button>
-            <Button variant="secondary" onClick={() => void actions.uninstallWatcher()}>移除 watcher</Button>
-            <Button variant="secondary" onClick={() => void actions.enableWatcher()}>启用</Button>
-            <Button variant="secondary" onClick={() => void actions.disableWatcher()}>禁用</Button>
+            <Button variant="secondary" onClick={() => void actions.installWatcher()}>Install Watcher</Button>
+            <Button variant="secondary" onClick={() => void actions.uninstallWatcher()}>Remove Watcher</Button>
+            <Button variant="secondary" onClick={() => void actions.enableWatcher()}>Enable</Button>
+            <Button variant="secondary" onClick={() => void actions.disableWatcher()}>Disable</Button>
           </Toolbar>
         </CardContent>
       </Panel>
       <Panel>
-        <CardHead title="Codex 应用路径" detail="免安装版或解包版只需要选择一次，之后静默启动会自动复用" />
+        <CardHead title="Codex App Path" detail="Portable or unpacked installs only need to be selected once; silent launch reuses it later" />
         <CardContent>
           <div className="status-table">
-            <StatusRow title="保存路径" status={savedCodexAppPath ? "ok" : "not_checked"} path={savedCodexAppPath || null} />
-            <StatusRow title="当前识别" status={overview?.codex_app.status} path={overview?.codex_app.path} />
+            <StatusRow title="Saved Path" status={savedCodexAppPath ? "ok" : "not_checked"} path={savedCodexAppPath || null} />
+            <StatusRow title="Current Detection" status={overview?.codex_app.status} path={overview?.codex_app.path} />
           </div>
-          <Field label="保存的应用路径">
+          <Field label="Saved App Path">
             <Input
               value={settings?.settings.codexAppPath ?? ""}
-              placeholder="选择 Codex.exe、Codex.app、app 目录或解包目录"
+              placeholder="Choose Codex.exe, Codex.app, the app directory, or an unpacked directory"
               readOnly
             />
           </Field>
           <Toolbar>
-            <Button onClick={() => void actions.chooseCodexAppPath("folder")}>选择应用目录</Button>
-            <Button variant="secondary" onClick={() => void actions.chooseCodexAppPath("file")}>选择 Codex.exe</Button>
-            <Button variant="secondary" onClick={() => void actions.clearCodexAppPath()}>清除保存路径</Button>
+            <Button onClick={() => void actions.chooseCodexAppPath("folder")}>Choose App Directory</Button>
+            <Button variant="secondary" onClick={() => void actions.chooseCodexAppPath("file")}>Choose Codex.exe</Button>
+            <Button variant="secondary" onClick={() => void actions.clearCodexAppPath()}>Clear Saved Path</Button>
           </Toolbar>
         </CardContent>
       </Panel>
       <Panel>
-        <CardHead title="手动启动" detail="应用路径留空时使用已保存路径；没有保存路径时使用自动探测" />
+        <CardHead title="Manual Launch" detail="When app path is empty, uses the saved path; without one, uses auto-detection" />
         <CardContent>
-          <Field label="应用路径覆盖">
+          <Field label="App Path Override">
             <Input
               value={launchForm.appPath}
               onChange={(event) => onLaunchFormChange({ ...launchForm, appPath: event.currentTarget.value })}
-              placeholder={savedCodexAppPath || "例如 C:\\Program Files\\WindowsApps\\OpenAI.Codex...\\app"}
+              placeholder={savedCodexAppPath || "Example: C:\\Program Files\\WindowsApps\\OpenAI.Codex...\\app"}
             />
           </Field>
           <div className="form-row">
-            <Field label="Debug 端口">
+            <Field label="Debug Port">
               <Input
                 value={launchForm.debugPort}
                 onChange={(event) => onLaunchFormChange({ ...launchForm, debugPort: event.currentTarget.value })}
               />
             </Field>
-            <Field label="Helper 端口">
+            <Field label="Helper Port">
               <Input
                 value={launchForm.helperPort}
                 onChange={(event) => onLaunchFormChange({ ...launchForm, helperPort: event.currentTarget.value })}
@@ -2607,9 +2607,9 @@ function MaintenanceScreen({
             </Field>
           </div>
           <Toolbar>
-            <Button onClick={() => void actions.launch()}>启动 Codex++</Button>
+            <Button onClick={() => void actions.launch()}>Launch Codex++</Button>
             <Button variant="secondary" onClick={() => void actions.saveManualCodexAppPath()}>
-              保存为默认路径
+              Save as Default Path
             </Button>
           </Toolbar>
         </CardContent>
@@ -2634,21 +2634,21 @@ function AboutScreen({
   return (
     <>
       <Panel>
-        <CardHead title="关于 Codex++" detail="本地 Codex 增强、管理工具和安装包维护" />
+        <CardHead title="About Codex++" detail="Local Codex enhancements, manager, and package maintenance" />
         <CardContent>
           <div className="metric-list">
-            <Metric label="Codex++ 版本" value={overview?.current_version ?? update?.currentVersion ?? "-"} />
-            <Metric label="Codex 版本" value={overview?.codex_version ?? "未检测到"} />
-            <Metric label="项目地址" value="github.com/BigPizzaV3/CodexPlusPlus" />
+            <Metric label="Codex++ Version" value={overview?.current_version ?? update?.currentVersion ?? "-"} />
+            <Metric label="Codex Version" value={overview?.codex_version ?? "Not detected"} />
+            <Metric label="Project URL" value="github.com/BigPizzaV3/CodexPlusPlus" />
           </div>
           <Toolbar>
             <Button onClick={() => void actions.openExternalUrl("https://github.com/BigPizzaV3/CodexPlusPlus")} variant="secondary">
               <ExternalLink className="h-4 w-4" />
-              打开项目主页
+              Open Project Home
             </Button>
             <Button onClick={() => void actions.openExternalUrl("https://github.com/BigPizzaV3/CodexPlusPlus/issues")} variant="secondary">
               <ExternalLink className="h-4 w-4" />
-              反馈问题
+              Report Issue
             </Button>
             <Button onClick={() => void actions.openExternalUrl("https://discord.gg/y96kX7A76v")} variant="secondary">
               <MessageCircle className="h-4 w-4" />
@@ -2662,18 +2662,18 @@ function AboutScreen({
         </CardContent>
       </Panel>
       <Panel>
-        <CardHead title="GitHub Release 更新" detail={`当前版本 ${overview?.current_version ?? update?.currentVersion ?? "-"}`} />
+        <CardHead title="GitHub Release Updates" detail={`Current Version ${overview?.current_version ?? update?.currentVersion ?? "-"}`} />
         <CardContent>
           <div className="metric-list">
-            <Metric label="状态" value={update?.status ?? "not_checked"} />
-            <Metric label="最新版本" value={update?.latestVersion ?? "未检查"} />
-            <Metric label="资源" value={update?.assetName ?? "-"} />
-            <Metric label="进度" value={`${update?.progress ?? 0}%`} />
+            <Metric label="Status" value={update?.status ?? "not_checked"} />
+            <Metric label="Latest Version" value={update?.latestVersion ?? "Not checked"} />
+            <Metric label="Asset" value={update?.assetName ?? "-"} />
+            <Metric label="Progress" value={`${update?.progress ?? 0}%`} />
           </div>
-          <Textarea className="log-view" readOnly value={update?.releaseSummary || update?.message || "尚未检查 GitHub Release；更新会下载并启动安装包。"} />
+          <Textarea className="log-view" readOnly value={update?.releaseSummary || update?.message || "GitHub releases have not been checked yet. Updating downloads and starts the installer package."} />
           <Toolbar>
-            <Button onClick={() => void actions.checkUpdate()}>检查更新</Button>
-            <Button variant="secondary" onClick={() => void actions.performUpdate()}>下载并运行安装包</Button>
+            <Button onClick={() => void actions.checkUpdate()}>Check for Updates</Button>
+            <Button variant="secondary" onClick={() => void actions.performUpdate()}>Download and Run Installer</Button>
           </Toolbar>
         </CardContent>
       </Panel>
@@ -2699,20 +2699,20 @@ function SettingsScreen({
   return (
     <>
       <Panel>
-        <CardHead title="基础设置" detail={settings?.settings_path ?? ""} />
+        <CardHead title="Basic Settings" detail={settings?.settings_path ?? ""} />
         <CardContent>
           <div className="theme-row">
             <div>
-              <strong>界面主题</strong>
-              <span>当前为{theme === "dark" ? "深色" : "浅色"}模式。</span>
+              <strong>Theme</strong>
+              <span>Current: {theme === "dark" ? "dark" : "light"} mode.</span>
             </div>
-            <Button variant="secondary" onClick={actions.toggleTheme}>切换主题</Button>
+            <Button variant="secondary" onClick={actions.toggleTheme}>Toggle Theme</Button>
           </div>
-          <Field label="供应商测试模型">
+          <Field label="Provider Test Model">
             <Input
               value={form.relayTestModel}
               onChange={(event) => onFormChange({ ...form, relayTestModel: event.currentTarget.value })}
-              placeholder="例如 gpt-5.4-mini"
+              placeholder="Example: gpt-5.4-mini"
             />
           </Field>
           <label className="check-row">
@@ -2721,16 +2721,16 @@ function SettingsScreen({
               onChange={(event) => onFormChange({ ...form, cliWrapperEnabled: event.currentTarget.checked })}
               type="checkbox"
             />
-            <span>启用 Codex 命令包装器</span>
+            <span>Enable Codex Command Wrapper</span>
           </label>
           <div className="form-row">
-            <Field label="包装器 Base URL">
+            <Field label="Wrapper Base URL">
               <Input
                 value={form.cliWrapperBaseUrl}
                 onChange={(event) => onFormChange({ ...form, cliWrapperBaseUrl: event.currentTarget.value })}
               />
             </Field>
-            <Field label="API Key 环境变量">
+            <Field label="API Key Environment Variable">
               <Input
                 value={form.cliWrapperApiKeyEnv}
                 onChange={(event) => onFormChange({ ...form, cliWrapperApiKeyEnv: event.currentTarget.value })}
@@ -2745,17 +2745,17 @@ function SettingsScreen({
             />
           </Field>
           <Toolbar>
-            <Button onClick={() => void actions.saveSettings()}>保存设置</Button>
+            <Button onClick={() => void actions.saveSettings()}>Save Settings</Button>
             <Button variant="secondary" onClick={() => void actions.resetSettings()}>
-              重置设置
+              Reset Settings
             </Button>
           </Toolbar>
         </CardContent>
       </Panel>
       <Panel>
-        <CardHead title="Codex 启动参数" detail="启动 Codex App 时追加到默认 CDP 参数后。留空则保持默认启动行为。" />
+        <CardHead title="Codex Launch Arguments" detail="Appended after the default CDP arguments when launching Codex App. Leave empty to keep default launch behavior." />
         <CardContent>
-          <Field label="额外参数">
+          <Field label="Extra Arguments">
             <Textarea
               className="launch-args-input"
               placeholder="--force_high_performance_gpu"
@@ -2769,9 +2769,9 @@ function SettingsScreen({
               }
             />
           </Field>
-          <p className="field-hint">每行一个参数，例如 --force_high_performance_gpu。不需要填写 open 或 --args。</p>
+          <p className="field-hint">One argument per line, for example --force_high_performance_gpu. Do not include open or --args.</p>
           <Toolbar>
-            <Button onClick={() => void actions.saveSettings()}>保存设置</Button>
+            <Button onClick={() => void actions.saveSettings()}>Save Settings</Button>
           </Toolbar>
         </CardContent>
       </Panel>
@@ -2783,7 +2783,7 @@ function LogsPanel({ logs, actions }: { logs: LogsResult | null; actions: Action
   const lines = splitLogLines(logs?.text ?? "");
   return (
     <Panel>
-      <CardHead title="最近日志" detail={logs?.path ?? ""} />
+      <CardHead title="Recent Logs" detail={logs?.path ?? ""} />
       <CardContent>
         <div className="log-lines">
           {lines.length ? (
@@ -2794,13 +2794,13 @@ function LogsPanel({ logs, actions }: { logs: LogsResult | null; actions: Action
               </div>
             ))
           ) : (
-            <div className="empty">暂无日志。</div>
+            <div className="empty">No logs.</div>
           )}
         </div>
         <Toolbar>
-          <Button onClick={() => void actions.refreshLogs()}>刷新</Button>
+          <Button onClick={() => void actions.refreshLogs()}>Refresh</Button>
           <Button variant="secondary" onClick={() => void actions.copyLogs()}>
-            复制
+            Copy
           </Button>
         </Toolbar>
       </CardContent>
@@ -2811,13 +2811,13 @@ function LogsPanel({ logs, actions }: { logs: LogsResult | null; actions: Action
 function DiagnosticsPanel({ diagnostics, actions }: { diagnostics: DiagnosticsResult | null; actions: Actions }) {
   return (
     <Panel>
-      <CardHead title="诊断报告" detail="包含版本、路径、设置和平台信息" />
+      <CardHead title="Diagnostics Report" detail="Includes version, paths, settings, and platform information" />
       <CardContent>
-        <Textarea className="log-view tall" readOnly value={diagnostics?.report ?? "尚未生成诊断报告。"} />
+        <Textarea className="log-view tall" readOnly value={diagnostics?.report ?? "No diagnostics report has been generated yet."} />
         <Toolbar>
-          <Button onClick={() => void actions.refreshDiagnostics()}>重新生成</Button>
+          <Button onClick={() => void actions.refreshDiagnostics()}>Regenerate</Button>
           <Button variant="secondary" onClick={() => void actions.copyDiagnostics()}>
-            复制报告
+            Copy Report
           </Button>
         </Toolbar>
       </CardContent>
@@ -2911,20 +2911,20 @@ function SortableRelayProfileCard({
       tabIndex={0}
     >
       <button
-        aria-label="拖动排序"
+        aria-label="Drag to sort"
         className="relay-drag"
-        title="拖动排序"
+        title="Drag to sort"
         type="button"
         {...attributes}
         {...listeners}
       >
         <GripVertical className="h-4 w-4" />
       </button>
-      <span className="relay-index" title={profile.name || "未命名供应商"}>
+      <span className="relay-index" title={profile.name || "Unnamed Provider"}>
         {providerInitial(profile.name)}
       </span>
       <span className="relay-summary">
-        <strong>{profile.name || "未命名供应商"}</strong>
+        <strong>{profile.name || "Unnamed Provider"}</strong>
         <small>{relayProfileSourceLabel(profile)} · {relayModeLabel(profile.relayMode)} · {relayProtocolLabel(profile.protocol)} · {relayProfileConfigBrief(profile)}</small>
       </span>
       <span className="relay-card-actions">
@@ -2939,11 +2939,11 @@ function SortableRelayProfileCard({
             void actions.switchRelayProfile(next, previousActiveRelayId);
           }}
           size="sm"
-          title={disabled ? "供应商配置总开关已关闭" : active ? "当前正在使用" : "设为当前"}
+          title={disabled ? "Provider switching is off" : active ? "Currently active" : "Set current"}
           variant={active ? "secondary" : "outline"}
         >
           <CheckCircle2 className="h-4 w-4" />
-          {active ? "使用中" : "使用"}
+          {active ? "Active" : "Use"}
         </Button>
         <span className="relay-card-extra">
           <Button
@@ -2952,7 +2952,7 @@ function SortableRelayProfileCard({
               void actions.testRelayProfile(profile);
             }}
             size="icon"
-            title="发送 hi 测试"
+            title="Send hi test"
             variant="ghost"
           >
             <TestTube className="h-4 w-4" />
@@ -2963,7 +2963,7 @@ function SortableRelayProfileCard({
               onEdit(profile.id);
             }}
             size="icon"
-            title="编辑"
+            title="Edit"
             variant="ghost"
           >
             <Edit3 className="h-4 w-4" />
@@ -2974,7 +2974,7 @@ function SortableRelayProfileCard({
               onFormChange(duplicateRelayProfile(form, profile.id));
             }}
             size="icon"
-            title="复制"
+            title="Copy"
             variant="ghost"
           >
             <Copy className="h-4 w-4" />
@@ -2986,7 +2986,7 @@ function SortableRelayProfileCard({
               onFormChange(removeRelayProfile(form, profile.id));
             }}
             size="icon"
-            title="删除供应商"
+            title="Delete Provider"
             variant="ghost"
           >
             <Trash2 className="h-4 w-4" />
@@ -2998,17 +2998,17 @@ function SortableRelayProfileCard({
 }
 
 function MarketScriptCard({ script, actions }: { script: ScriptMarketItem; actions: Actions }) {
-  const status = script.updateAvailable ? "可更新" : script.installed ? `已安装 ${script.installedVersion}` : "未安装";
+  const status = script.updateAvailable ? "Update available" : script.installed ? `Installed ${script.installedVersion}` : "Not installed";
   return (
     <div className="script-market-card">
       <div className="script-market-title">
         <div>
           <strong>{script.name}</strong>
-          <span>{script.author || "未知作者"}</span>
+          <span>{script.author || "Unknown author"}</span>
         </div>
         <UiBadge variant={script.updateAvailable ? "default" : script.installed ? "secondary" : "outline"}>{status}</UiBadge>
       </div>
-      <p className="script-market-description">{script.description || "暂无描述。"}</p>
+      <p className="script-market-description">{script.description || "No description."}</p>
       <div className="script-market-tags">
         <span className="script-market-tag">v{script.version}</span>
         {script.tags.map((tag) => (
@@ -3018,12 +3018,12 @@ function MarketScriptCard({ script, actions }: { script: ScriptMarketItem; actio
       <div className="script-market-actions">
         <Button onClick={() => void actions.installMarketScript(script.id)} size="sm">
           <Download className="h-4 w-4" />
-          {script.updateAvailable ? "更新" : script.installed ? "重新安装" : "安装"}
+          {script.updateAvailable ? "Update" : script.installed ? "Reinstall" : "Install"}
         </Button>
         {script.homepage ? (
           <Button onClick={() => void actions.openExternalUrl(script.homepage)} size="sm" variant="secondary">
             <ExternalLink className="h-4 w-4" />
-            主页
+            Home
           </Button>
         ) : null}
       </div>
@@ -3098,11 +3098,11 @@ function RelayProfileDetail({
         <Toolbar>
           <Button onClick={onBack} variant="secondary">
             <ArrowLeft className="h-4 w-4" />
-            返回列表
+            Back to list
           </Button>
           <Button onClick={() => void saveDraft()}>
             <Save className="h-4 w-4" />
-            保存
+            Save
           </Button>
         </Toolbar>
       </div>
@@ -3136,7 +3136,7 @@ function ContextScreen({
 }) {
   return (
     <Panel fill>
-      <CardHead title="Codex 工具与插件" detail="独立管理 Codex 的 MCP、Skills、Plugins；切换任意供应商都会带上。" />
+      <CardHead title="Codex Tools & Plugins" detail="Manage MCP, Skills, and Plugins separately; every provider switch includes them." />
       <CardContent>
         <RelayContextManager
           form={normalizeSettings(form)}
@@ -3174,17 +3174,17 @@ function RelayProfileEditor({
     <div className="relay-profile-editor">
       <div className="relay-editor-head">
         <div>
-          <strong>{profile.name || "未命名供应商"}</strong>
+          <strong>{profile.name || "Unnamed Provider"}</strong>
           <span>{relayProfileEditorStatus(profile, form, isNew)}</span>
         </div>
         {isNew ? null : (
           <Button
             disabled={!form.relayProfilesEnabled}
             onClick={onSwitch}
-            title={!form.relayProfilesEnabled ? "供应商配置总开关已关闭" : undefined}
+            title={!form.relayProfilesEnabled ? "Provider switching is off" : undefined}
             variant={profile.id === form.activeRelayId ? "secondary" : "default"}
           >
-            {profile.id === form.activeRelayId ? "使用中" : "设为当前"}
+            {profile.id === form.activeRelayId ? "Active" : "Set current"}
           </Button>
         )}
       </div>
@@ -3196,13 +3196,13 @@ function RelayProfileEditor({
         />
       ) : null}
       <div className="relay-fields">
-        <Field className="relay-field-name" label="名称">
+        <Field className="relay-field-name" label="Name">
           <Input
             value={profile.name}
             onChange={(event) => updateDraft({ name: event.currentTarget.value })}
           />
         </Field>
-        <Field className="relay-field-mode" label="接入模式">
+        <Field className="relay-field-mode" label="Access Mode">
           <select
             className="field-select"
             value={profile.relayMode}
@@ -3211,18 +3211,18 @@ function RelayProfileEditor({
               updateDraft(relayMode === "official" ? { relayMode, officialMixApiKey: false } : { relayMode });
             }}
           >
-            <option value="official">官方登录</option>
-            <option value="pureApi">纯 API</option>
+            <option value="official">Official Login</option>
+            <option value="pureApi">Pure API</option>
           </select>
         </Field>
-        <Field className="relay-field-config-model" label="配置模型">
+        <Field className="relay-field-config-model" label="Config Model">
           <Input
             value={profile.model}
             onChange={(event) => updateDraft({ model: event.currentTarget.value })}
-            placeholder="写入 config.toml 的 model 字段，例如 gpt-5"
+            placeholder="Model field written to config.toml, for example gpt-5"
           />
         </Field>
-        <Field className="relay-field-goals" label="Codex 目标">
+        <Field className="relay-field-goals" label="Codex Goals">
           <label className="inline-check">
             <input
               checked={configHasCodexGoalsFeature(profile.configContents)}
@@ -3233,7 +3233,7 @@ function RelayProfileEditor({
               }
               type="checkbox"
             />
-            <span>启用目标功能</span>
+            <span>Enable goals</span>
           </label>
         </Field>
         <div className="relay-advanced-toggle">
@@ -3245,32 +3245,32 @@ function RelayProfileEditor({
             variant="secondary"
           >
             <Settings className="h-4 w-4" />
-            更多选项
+            More Options
           </Button>
         </div>
         {showAdvanced ? (
           <div className="relay-advanced-fields">
-            <Field className="relay-field-test-model" label="测试模型">
+            <Field className="relay-field-test-model" label="Test Model">
               <Input
                 value={profile.testModel}
                 onChange={(event) => updateDraft({ testModel: event.currentTarget.value })}
-                placeholder={`留空使用默认：${form.relayTestModel || defaultSettings.relayTestModel}`}
+                placeholder={`Leave empty to use the default: ${form.relayTestModel || defaultSettings.relayTestModel}`}
               />
             </Field>
-            <Field className="relay-field-context-window" label="上下文大小">
+            <Field className="relay-field-context-window" label="Context Window">
               <Input
                 inputMode="numeric"
                 value={profile.contextWindow}
                 onChange={(event) => updateDraft({ contextWindow: event.currentTarget.value.replace(/[^\d]/g, "") })}
-                placeholder="留空不改写，例如 200000"
+                placeholder="Leave empty to keep unchanged, for example 200000"
               />
             </Field>
-            <Field className="relay-field-auto-compact" label="压缩上下文大小">
+            <Field className="relay-field-auto-compact" label="Auto Compact Limit">
               <Input
                 inputMode="numeric"
                 value={profile.autoCompactLimit}
                 onChange={(event) => updateDraft({ autoCompactLimit: event.currentTarget.value.replace(/[^\d]/g, "") })}
-                placeholder="留空不改写，例如 160000"
+                placeholder="Leave empty to keep unchanged, for example 160000"
               />
             </Field>
           </div>
@@ -3283,7 +3283,7 @@ function RelayProfileEditor({
                 onChange={(event) => updateDraft({ officialMixApiKey: event.currentTarget.checked })}
                 type="checkbox"
               />
-              <span>混入 API KEY</span>
+              <span>Mix in API Key</span>
             </label>
           </Field>
         ) : null}
@@ -3293,7 +3293,7 @@ function RelayProfileEditor({
               <Input
                 value={profile.baseUrl}
                 onChange={(event) => updateDraft({ baseUrl: event.currentTarget.value })}
-                placeholder="填写中转服务 Base URL"
+                placeholder="Enter relay service Base URL"
               />
             </Field>
             <Field className="relay-field-key" label="Key">
@@ -3301,10 +3301,10 @@ function RelayProfileEditor({
                 type="password"
                 value={profile.apiKey}
                 onChange={(event) => updateDraft({ apiKey: event.currentTarget.value })}
-                placeholder="输入中转服务的 API Key"
+                placeholder="Enter relay service API Key"
               />
             </Field>
-            <Field className="relay-field-protocol" label="上游协议">
+            <Field className="relay-field-protocol" label="Upstream Protocol">
               <div className="protocol-options">
                 <button
                   className={`protocol-option ${profile.protocol === "responses" ? "active" : ""}`}
@@ -3325,12 +3325,12 @@ function RelayProfileEditor({
           </div>
         ) : null}
         {showApiFields ? (
-          <Field className="relay-field-model-list" label="模型列表">
+          <Field className="relay-field-model-list" label="Model List">
             <div className="relay-model-list-tools">
               <Textarea
                 value={profile.modelList}
                 onChange={(event) => updateDraft({ modelList: event.currentTarget.value })}
-                placeholder="每行一个模型，例如 qwen3-coder"
+                placeholder="One model per line, for example qwen3-coder"
               />
               <Button
                 onClick={async () => {
@@ -3342,7 +3342,7 @@ function RelayProfileEditor({
                 variant="secondary"
               >
                 <Download className="h-4 w-4" />
-                从上游获取
+                Fetch from Upstream
               </Button>
             </div>
           </Field>
@@ -3352,7 +3352,7 @@ function RelayProfileEditor({
             <Input
               value={profile.userAgent}
               onChange={(event) => updateDraft({ userAgent: event.currentTarget.value })}
-              placeholder="留空使用默认值"
+              placeholder="Leave blank to use the default"
             />
           </Field>
         ) : null}
@@ -3360,7 +3360,7 @@ function RelayProfileEditor({
       {showApiFields && profile.protocol === "chatCompletions" ? (
         <div className="hint-line relay-protocol-hint">
           <MessageCircle className="h-4 w-4" />
-          <span>此上游会通过本地 127.0.0.1:57321 转成 Responses API，需要从 Codex++ 启动 Codex。</span>
+          <span>This upstream is converted to the Responses API through local 127.0.0.1:57321 and requires launching Codex from Codex++.</span>
         </div>
       ) : null}
       <div className="hint-line relay-protocol-hint">
@@ -3371,7 +3371,7 @@ function RelayProfileEditor({
         <div className="hint-line relay-protocol-hint">
           <Link2 className="h-4 w-4" />
           <span>
-            此供应商联动自 cc-switch：{profile.linkedCcsProviderId}。开启“保存时回写 cc-switch”后，本页保存会同步修改 cc-switch 数据库中的同一供应商。
+            This provider is linked from cc-switch: {profile.linkedCcsProviderId}. When cc-switch writeback is enabled, saving here updates the same provider in the cc-switch database.
           </span>
         </div>
       ) : null}
@@ -3426,13 +3426,13 @@ function RelayContextManager({
     <div className="relay-context-panel">
       <div className="relay-context-head">
         <div>
-          <strong>Codex 工具与插件</strong>
-          <span>MCP、Skills、Plugins 作为全局配置独立管理，切换任意供应商都会合并。</span>
+          <strong>Codex Tools & Plugins</strong>
+          <span>MCP, Skills, and Plugins are managed as global configuration and merged into every provider switch.</span>
         </div>
         <div className="relay-context-head-actions">
           <Button onClick={() => setEditor({ kind: activeKind })} size="sm" variant="secondary">
             <Plus className="h-4 w-4" />
-            新增{label}
+            Add {label}
           </Button>
         </div>
       </div>
@@ -3450,7 +3450,7 @@ function RelayContextManager({
         ))}
       </div>
       <div className="relay-context-summary">
-        当前共有 {visibleEntries.length} 个{label}；这些条目独立于供应商保存，会写入所有供应商切换后的 config.toml。
+        {visibleEntries.length} {label} entries are saved independently from providers and written into config.toml after every provider switch.
       </div>
       <div className="relay-context-list">
         {visibleEntries.length ? (
@@ -3464,21 +3464,21 @@ function RelayContextManager({
                   className={`context-enabled-switch ${entry.enabled ? "active" : ""}`}
                   onClick={() => void toggleContextEntryEnabled(entry)}
                   role="switch"
-                  title={entry.enabled ? "禁用此扩展项" : "启用此扩展项"}
+                  title={entry.enabled ? "Disable this extension" : "Enable this extension"}
                   type="button"
                 >
                   <span className="context-switch-track" aria-hidden="true">
                     <span className="context-switch-thumb" />
                   </span>
                 </button>
-                <Button onClick={() => setEditor({ kind: entry.kind, entry })} size="icon" title="编辑扩展项" variant="ghost">
+                <Button onClick={() => setEditor({ kind: entry.kind, entry })} size="icon" title="Edit extension" variant="ghost">
                   <Edit3 className="h-4 w-4" />
                 </Button>
                 <Button
                   className="relay-context-delete"
                   onClick={() => void deleteEntry(entry)}
                   size="icon"
-                  title="删除扩展项"
+                  title="Delete extension"
                   variant="ghost"
                 >
                   <Trash2 className="h-4 w-4" />
@@ -3487,7 +3487,7 @@ function RelayContextManager({
             </div>
           ))
         ) : (
-          <div className="empty">暂无{label}，可以从通用配置文件或这里新增。</div>
+          <div className="empty">No {label} entries yet. Add one here or extract it from the common config.</div>
         )}
       </div>
       {editor ? (
@@ -3521,7 +3521,7 @@ function ContextEntryEditor({
   return (
     <div className="context-editor">
       <div className="context-editor-fields">
-        <Field label="类型">
+        <Field label="Type">
           <select
             className="field-select"
             disabled={!!entry}
@@ -3538,25 +3538,25 @@ function ContextEntryEditor({
             disabled={!!entry}
             value={id}
             onChange={(event) => setId(event.currentTarget.value.trim())}
-            placeholder="例如 context7"
+            placeholder="Example: context7"
           />
         </Field>
       </div>
-      <Field label="TOML 配置体">
+      <Field label="TOML Body">
         <Textarea
           className="context-editor-textarea"
           value={tomlBody}
           onChange={(event) => setTomlBody(event.currentTarget.value)}
-          placeholder={'只填写表头下面的内容，例如：\ncommand = "npx"\nargs = ["-y", "@upstash/context7-mcp"]'}
+          placeholder={'Only enter the content under the table header, for example:\ncommand = "npx"\nargs = ["-y", "@upstash/context7-mcp"]'}
           spellCheck={false}
         />
       </Field>
       <Toolbar>
         <Button disabled={!canSave} onClick={() => onSave(draftKind, id.trim(), tomlBody)} size="sm">
           <Save className="h-4 w-4" />
-          保存扩展项
+          Save Extension
         </Button>
-        <Button onClick={onCancel} size="sm" variant="secondary">取消</Button>
+        <Button onClick={onCancel} size="sm" variant="secondary">Cancel</Button>
       </Toolbar>
     </div>
   );
@@ -3629,8 +3629,8 @@ function RelayFileEditors({
       <div className="relay-file-panel">
         <div className="relay-file-head">
           <div>
-            <strong>config.toml 预览</strong>
-            <span>{isActive ? "当前供应商切换后会写入的预览；上下文开关变化会立即反映" : "切换到此供应商时会写入的预览；上下文开关变化会立即反映"}</span>
+            <strong>config.toml Preview</strong>
+            <span>{isActive ? "Preview written after switching the current provider; tool/plugin toggle changes appear immediately" : "Preview written when switching to this provider; tool/plugin toggle changes appear immediately"}</span>
           </div>
         </div>
         <SyncedTextarea
@@ -3652,8 +3652,8 @@ function RelayFileEditors({
       <div className="relay-file-panel">
         <div className="relay-file-head">
           <div>
-            <strong>通用配置文件</strong>
-            <span>只保留非 MCP、Skills、Plugins 的跨供应商配置；工具与插件在独立页面管理。</span>
+            <strong>Common Config</strong>
+            <span>Keeps cross-provider config that is not MCP, Skills, or Plugins; tools and plugins are managed on their own page.</span>
           </div>
           <Button
             onClick={async () => {
@@ -3661,7 +3661,7 @@ function RelayFileEditors({
               if (!extracted) return;
               const split = splitContextConfigText(extracted.commonConfigContents || "");
               if (!split.common.trim() && !split.context.trim()) {
-                await actions.showMessage("通用配置文件", "当前供应商 config.toml 里没有可提取的通用配置。", "failed");
+                await actions.showMessage("Common Config", "The current provider config.toml has no common config to extract.", "failed");
                 return;
               }
               const promotedProfile = {
@@ -3683,7 +3683,7 @@ function RelayFileEditors({
             variant="secondary"
           >
             <Download className="h-4 w-4" />
-            提取当前供应商配置
+            Extract Current Provider Config
           </Button>
         </div>
         <SyncedTextarea
@@ -3696,7 +3696,7 @@ function RelayFileEditors({
         <div className="relay-file-head">
           <div>
             <strong>auth.json</strong>
-            <span>{isActive ? "当前使用中：打开时从 ~/.codex/auth.json 回填，保存后会作为此供应商 auth 存档" : "切换到此供应商时会写入 ~/.codex/auth.json"}</span>
+            <span>{isActive ? "Currently active: loaded from ~/.codex/auth.json when opened and saved as this provider's auth archive" : "Written to ~/.codex/auth.json when switching to this provider"}</span>
           </div>
         </div>
         <SyncedTextarea
@@ -3717,16 +3717,16 @@ function ModeSelector({ launchMode, actions }: { launchMode: LaunchMode; actions
         onClick={() => void actions.setLaunchMode("relay")}
         type="button"
       >
-        <strong>兼容增强</strong>
-        <span>适合官方登录或官方混入 API Key；保留会话删除、导出、项目移动、Timeline 和用户脚本，关闭插件入口相关增强。</span>
+        <strong>Compatibility Enhancement</strong>
+        <span>Best for Official Login or Official Login with API Key; keeps Session Delete, export, Project Move, Timeline, and user scripts while disabling plugin-entry enhancements.</span>
       </button>
       <button
         className={`mode-option ${launchMode === "patch" ? "active" : ""}`}
         onClick={() => void actions.setLaunchMode("patch")}
         type="button"
       >
-        <strong>完整增强</strong>
-        <span>适合纯 API；启用插件入口、强制安装、会话删除导出、项目移动等全部页面能力。</span>
+        <strong>Full Enhancement</strong>
+        <span>Best for Pure API; enables plugin entry, force install, Session Delete, export, Project Move, and the full set of page features.</span>
       </button>
     </div>
   );
@@ -3851,7 +3851,7 @@ function StatusRow({ title, status = "unknown", path }: { title: string; status?
     <div className="status-row">
       <span>{title}</span>
       <Badge status={status} />
-      <code>{path || "未记录路径"}</code>
+      <code>{path || "No path recorded"}</code>
     </div>
   );
 }
@@ -3861,14 +3861,14 @@ function Badge({ status }: { status: string }) {
 }
 
 function LatestLaunch({ status }: { status: LaunchStatus | null }) {
-  if (!status) return <div className="empty">暂无启动状态。</div>;
+  if (!status) return <div className="empty">No launch status.</div>;
   return (
     <div className="metric-list">
-      <Metric label="状态" value={status.status} />
-      <Metric label="消息" value={status.message} />
+      <Metric label="Status" value={status.status} />
+      <Metric label="Message" value={status.message} />
       <Metric label="Debug" value={String(status.debug_port ?? "-")} />
       <Metric label="Helper" value={String(status.helper_port ?? "-")} />
-      <Metric label="时间" value={formatTime(status.started_at_ms)} />
+      <Metric label="Time" value={formatTime(status.started_at_ms)} />
     </div>
   );
 }
@@ -3883,23 +3883,23 @@ function Metric({ label, value }: { label: string; value: string }) {
 }
 
 function ScriptRow({ script, actions }: { script: NonNullable<UserScriptInventory["scripts"]>[number]; actions: Actions }) {
-  const source = script.market_id ? `市场 · ${script.version || "未知版本"}` : script.source === "builtin" ? "内置" : "用户";
+  const source = script.market_id ? `Market · ${script.version || "Unknown version"}` : script.source === "builtin" ? "Built-in" : "User";
   const canDelete = script.source === "user";
   return (
     <div className="table-row">
       <span>{script.name}</span>
       <span>{source}</span>
-      <span>{script.enabled ? "启用" : "关闭"}</span>
+      <span>{script.enabled ? "Enable" : "Off"}</span>
       <span>{script.status}</span>
       <div className="script-row-actions">
         <Button onClick={() => void actions.setUserScriptEnabled(script.key, !script.enabled)} size="sm" variant="secondary">
           {script.enabled ? <PowerOff className="h-4 w-4" /> : <Power className="h-4 w-4" />}
-          {script.enabled ? "禁用" : "启用"}
+          {script.enabled ? "Disable" : "Enable"}
         </Button>
         {canDelete ? (
           <Button onClick={() => void actions.deleteUserScript(script.key)} size="sm" variant="outline">
             <Trash2 className="h-4 w-4" />
-            删除
+            Delete
           </Button>
         ) : null}
       </div>
@@ -3925,7 +3925,7 @@ function AdGrid({ ads, empty, actions }: { ads: AdItem[]; empty: string; actions
             </div>
           ) : null}
           <span className="ad-link">
-            打开
+            Open
             <ExternalLink className="h-4 w-4" />
           </span>
         </button>
@@ -3941,22 +3941,22 @@ function isExpiredAd(ad: AdItem) {
 }
 
 function routeTitle(route: Route) {
-  return routes.find((item) => item.id === route)?.label ?? "概览";
+  return routes.find((item) => item.id === route)?.label ?? "Overview";
 }
 
 function routeSubtitle(route: Route) {
   const subtitles: Record<Route, string> = {
-    overview: "检查问题、启动与快速修复",
-    relay: "管理 API 供应商、协议、Key 与配置文件",
-    sessions: "查看、删除和修复 Codex 本地会话",
-    context: "独立管理 MCP、Skills、Plugins",
-    enhance: "会话删除、导出、项目移动和脚本能力",
-    zedRemote: "管理 Codex SSH 项目并加入 Zed workspace",
-    userScripts: "内置和用户自定义脚本清单",
-    recommendations: "赞助商推荐与普通推荐",
-    maintenance: "入口安装、修复、Watcher 与手动启动",
-    about: "版本信息、项目链接、GitHub Release 更新、日志与诊断",
-    settings: "主题、命令包装器和启动参数",
+    overview: "Check issues, launch, and quick repair",
+    relay: "Manage API providers, protocols, keys, and config files",
+    sessions: "View, delete, and repair local Codex sessions",
+    context: "Manage MCP, Skills, and Plugins separately",
+    enhance: "Session Delete, Export, Project Move, and script features",
+    zedRemote: "Manage Codex SSH projects and add them to Zed workspaces",
+    userScripts: "Built-in and custom user script inventory",
+    recommendations: "Sponsored and regular recommendations",
+    maintenance: "Entry install, repair, watcher, and manual launch",
+    about: "Version info, project links, GitHub Release updates, logs, and diagnostics",
+    settings: "Theme, command wrapper, and launch arguments",
   };
   return subtitles[route];
 }
@@ -3964,11 +3964,11 @@ function routeSubtitle(route: Route) {
 const contextKindOptions: Array<{ kind: ContextKind; label: string; tableName: string }> = [
   { kind: "mcp", label: "MCP", tableName: "mcp_servers" },
   { kind: "skill", label: "Skills", tableName: "skills" },
-  { kind: "plugin", label: "插件", tableName: "plugins" },
+  { kind: "plugin", label: "Plugins", tableName: "plugins" },
 ];
 
 function contextKindLabel(kind: ContextKind) {
-  return contextKindOptions.find((option) => option.kind === kind)?.label ?? "扩展项";
+  return contextKindOptions.find((option) => option.kind === kind)?.label ?? "Extension";
 }
 
 function contextEntriesFromSettings(settings: BackendSettings): CodexContextEntries {
@@ -4568,7 +4568,7 @@ function normalizeConfigOwnership(value: ConfigOwnership | undefined): ConfigOwn
 function configOwnershipLabel(value: ConfigOwnership): string {
   if (value === "codexPlusPlus") return "Codex++";
   if (value === "ccSwitch") return "CC Switch";
-  return "自动";
+  return "Auto";
 }
 
 function CoordinationStatusBanner({
@@ -4586,13 +4586,13 @@ function CoordinationStatusBanner({
   const tone = status.conflictDetected ? "failed" : status.effectiveOwnership === "ccSwitch" ? "success" : "info";
   return (
     <div className={`relay-coordination-banner relay-coordination-${tone}`}>
-      <strong>配置协调状态</strong>
+      <strong>Config Coordination Status</strong>
       <p>{status.guidance}</p>
       {status.ccswitchDetected ? (
         <small>
-          有效所有权：{configOwnershipLabel(status.effectiveOwnership)}；live model_provider：{status.liveModelProvider || "（空）"}
-          {status.ccswitchCurrentProviderName ? `；CC Switch 当前：${status.ccswitchCurrentProviderName}` : ""}
-          {status.lastWriter ? `；上次写入方：${status.lastWriter}` : ""}
+          Effective ownership: {configOwnershipLabel(status.effectiveOwnership)}; live model_provider: {status.liveModelProvider || "(empty)"}
+          {status.ccswitchCurrentProviderName ? `; CC Switch current: ${status.ccswitchCurrentProviderName}` : ""}
+          {status.lastWriter ? `; Last writer: ${status.lastWriter}` : ""}
         </small>
       ) : null}
       {status.conflictDetected ? <small>{status.conflictMessage}</small> : null}
@@ -4601,39 +4601,39 @@ function CoordinationStatusBanner({
 }
 
 function relayProfileSourceLabel(profile: RelayProfile) {
-  return profile.linkedCcsProviderId ? "cc-switch 联动" : "本地";
+  return profile.linkedCcsProviderId ? "cc-switch linked" : "Local";
 }
 
 function relayProfileEditorStatus(profile: RelayProfile, form: BackendSettings, isNew: boolean) {
-  if (isNew) return "新建供应商需要先保存到列表";
-  if (!form.relayProfilesEnabled) return "供应商配置总开关已关闭；当前只保存配置，不写入 Codex live 文件";
+  if (isNew) return "Save the new provider to the list first";
+  if (!form.relayProfilesEnabled) return "Provider switching is off; this only saves settings and does not write live Codex files";
   if (profile.linkedCcsProviderId && form.ccsLinkEnabled && form.configOwnership !== "codexPlusPlus") {
-    return "联动 cc-switch；切换时从 cc-switch 数据库应用配置，避免覆盖冲突";
+    return "Linked to cc-switch; switching applies the cc-switch database config to avoid overwrite conflicts";
   }
-  if (profile.linkedCcsProviderId && form.ccsLinkEnabled) return "联动 cc-switch；保存后会回写外部供应商数据库";
-  if (profile.linkedCcsProviderId) return "联动 cc-switch；当前未开启保存回写";
-  return profile.id === form.activeRelayId ? "当前正在使用" : "编辑后保存列表，再切换模式时会使用新配置";
+  if (profile.linkedCcsProviderId && form.ccsLinkEnabled) return "Linked to cc-switch; saving writes back to the external provider database";
+  if (profile.linkedCcsProviderId) return "Linked to cc-switch; writeback is currently off";
+  return profile.id === form.activeRelayId ? "Currently active" : "Edit and save the list, then switch modes to use the new configuration";
 }
 
 function providerInitial(name: string) {
-  const trimmed = (name || "供应商").trim();
-  return Array.from(trimmed)[0]?.toUpperCase() || "供";
+  const trimmed = (name || "Provider").trim();
+  return Array.from(trimmed)[0]?.toUpperCase() || "P";
 }
 
 function statusLabel(status: string) {
   const labels: Record<string, string> = {
-    found: "已找到",
-    missing: "缺失",
-    installed: "已安装",
-    ok: "正常",
-    running: "运行中",
-    failed: "失败",
-    archived: "已归档",
-    accepted: "已受理",
-    not_checked: "未检查",
-    not_implemented: "未实现",
-    disabled: "已禁用",
-    unknown: "未知",
+    found: "Found",
+    missing: "Missing",
+    installed: "Installed",
+    ok: "OK",
+    running: "Running",
+    failed: "Failed",
+    archived: "Archived",
+    accepted: "Accepted",
+    not_checked: "Not checked",
+    not_implemented: "Not implemented",
+    disabled: "Disabled",
+    unknown: "Unknown",
   };
   return labels[status] ?? status;
 }
@@ -4651,22 +4651,22 @@ function isSuccessStatus(status?: Status) {
 function healthItems(overview: OverviewResult | null) {
   return [
     {
-      title: "Codex 应用",
+      title: "Codex App",
       status: overview?.codex_app.status ?? "not_checked",
       ok: overview?.codex_app.status === "found",
-      detail: overview?.codex_app.path || "尚未检查 Codex 应用路径。",
+      detail: overview?.codex_app.path || "Codex app path has not been checked yet.",
     },
     {
-      title: "静默启动入口",
+      title: "Silent Launcher Entry",
       status: overview?.silent_shortcut.status ?? "not_checked",
       ok: overview?.silent_shortcut.status === "installed",
-      detail: overview?.silent_shortcut.path || "缺少 Codex++ 静默启动快捷方式时可在安装维护页修复。",
+      detail: overview?.silent_shortcut.path || "Repair it from Install & Maintenance if the Codex++ silent launcher shortcut is missing.",
     },
     {
-      title: "管理工具入口",
+      title: "Manager Entry",
       status: overview?.management_shortcut.status ?? "not_checked",
       ok: overview?.management_shortcut.status === "installed",
-      detail: overview?.management_shortcut.path || "缺少管理工具快捷方式时可在安装维护页修复。",
+      detail: overview?.management_shortcut.path || "Repair it from Install & Maintenance if the manager shortcut is missing.",
     },
   ];
 }
@@ -4690,7 +4690,7 @@ function normalizeSettings(settings: BackendSettings): BackendSettings {
           {
             id: settings.activeRelayId || "default",
             linkedCcsProviderId: "",
-            name: "默认中转",
+            name: "Default Relay",
             model: "",
             baseUrl: settings.relayBaseUrl || defaultSettings.relayBaseUrl,
             upstreamBaseUrl: settings.relayBaseUrl || defaultSettings.relayBaseUrl,
@@ -4771,7 +4771,7 @@ function activeRelayProfile(settings: BackendSettings): RelayProfile {
 }
 
 function relayProtocolLabel(protocol: RelayProtocol): string {
-  return protocol === "chatCompletions" ? "Chat Completions 转 Responses" : "Responses API";
+  return protocol === "chatCompletions" ? "Chat Completions to Responses" : "Responses API";
 }
 
 function normalizeRelayMode(mode: RelayMode | undefined): RelayMode {
@@ -4798,45 +4798,45 @@ function normalizeContextSelection(
 }
 
 function relayModeLabel(mode: RelayMode): string {
-  if (mode === "pureApi") return "纯 API";
-  return "官方登录";
+  if (mode === "pureApi") return "Pure API";
+  return "Official Login";
 }
 
 function relayProfileConfigBrief(profile: RelayProfile): string {
-  if (profile.relayMode === "official") return profile.officialMixApiKey ? "混入 API Key" : "不写 API 文件";
-  return profile.baseUrl || "未填写 URL";
+  if (profile.relayMode === "official") return profile.officialMixApiKey ? "Mix in API Key" : "Do not write API files";
+  return profile.baseUrl || "URL not filled";
 }
 
 function relayProfileModeHelp(profile: RelayProfile): string {
   if (profile.relayMode === "official") {
     if (profile.officialMixApiKey) {
-      return "此供应商会保留官方登录模式，并把请求混入当前 API Key；页面增强仍使用兼容模式。";
+      return "This provider keeps Official Login Mode and mixes requests with the current API key; Page Enhancements remain in Compatibility Mode.";
     }
-    return "此供应商会切回官方登录模式，使用 ChatGPT 官方账号，不写入 API Key。";
+    return "This provider switches back to Official Login Mode, uses the ChatGPT official account, and does not write an API key.";
   }
   if (profile.relayMode === "pureApi") {
-    return "此供应商会同时写入 config.toml 和 auth.json；API Key 也会注入到 provider bearer token。";
+    return "This provider writes both config.toml and auth.json; the API key is also injected into the provider bearer token.";
   }
-  return "此供应商会保留官方登录模式，并把请求混入当前 API Key；页面增强仍使用兼容模式。";
+  return "This provider keeps Official Login Mode and mixes requests with the current API key; Page Enhancements remain in Compatibility Mode.";
 }
 
 function relayProfileReadinessText(profile: RelayProfile, relay: RelayResult | null): string {
   if (profile.relayMode === "official") {
     if (profile.officialMixApiKey) {
       const hasApiFields = profile.baseUrl.trim() && profile.apiKey.trim();
-      if (!relay?.authenticated && !hasApiFields) return "当前未登录官方账号，也未配置混入 API 的 Base URL / Key。";
-      if (!relay?.authenticated) return "当前未登录官方账号；官方登录混入 API Key 需要先登录官方账号。";
-      if (!hasApiFields) return "当前还没有填写混入 API 的 Base URL / Key。";
-      return `官方登录已就绪：${relay.accountLabel || "已登录"}，会混入当前 API Key。`;
+      if (!relay?.authenticated && !hasApiFields) return "No official account is logged in, and no Base URL / Key is configured for API mixing.";
+      if (!relay?.authenticated) return "No official account is logged in. Official Login with API Key requires signing in first.";
+      if (!hasApiFields) return "Base URL / Key for API mixing has not been filled in yet.";
+      return `Official Login is ready: ${relay.accountLabel || "Logged in"}. Requests will mix in the current API key.`;
     }
     return relay?.authenticated
-      ? `官方账号已登录：${relay.accountLabel || relay.authSource || "已检测"}。`
-      : "当前未登录官方账号；切到官方登录模式后仍需要先在 Codex/ChatGPT 登录。";
+      ? `Official account logged in: ${relay.accountLabel || relay.authSource || "Detected"}.`
+      : "No official account is logged in. After switching to Official Login Mode, sign in through Codex/ChatGPT first.";
   }
   const hasFiles = profile.configContents.trim() && profile.authContents.trim();
-  if (!hasFiles) return "当前供应商还没有完整 config.toml / API Key 存档。";
-  if (relay && !relay.configured) return "纯 API 配置未完整写入：请检查此供应商是否有 OPENAI_API_KEY，且 config.toml 是否包含 model_provider / provider / base_url。";
-  return "纯 API 就绪：会同时写入 config.toml 和 auth.json。";
+  if (!hasFiles) return "Current provider does not yet have a complete config.toml / API key archive.";
+  if (relay && !relay.configured) return "Pure API config was not fully written. Check whether this provider has OPENAI_API_KEY and whether config.toml contains model_provider / provider / base_url.";
+  return "Pure API is ready. config.toml and auth.json will both be written.";
 }
 
 function relayProfileSwitchCommand(profile: RelayProfile): "clear_relay_injection" | "apply_relay_injection" | "apply_pure_api_injection" {
@@ -4847,9 +4847,9 @@ function relayProfileSwitchCommand(profile: RelayProfile): "clear_relay_injectio
 }
 
 function relayProfileModeSwitchedText(profile: RelayProfile): string {
-  if (profile.relayMode === "pureApi") return "已按此供应商切换到纯 API；页面增强已设为完整增强。";
-  if (profile.officialMixApiKey) return "已按此供应商使用官方登录，并混入 API Key；页面增强已设为兼容增强。";
-  return "已按此供应商切回官方登录；页面增强已设为兼容增强。";
+  if (profile.relayMode === "pureApi") return "Switched this provider to Pure API; Page Enhancements are set to Full Enhancement.";
+  if (profile.officialMixApiKey) return "Switched this provider to Official Login with API Key; Page Enhancements are set to Compatibility Enhancement.";
+  return "Switched this provider back to Official Login; Page Enhancements are set to Compatibility Enhancement.";
 }
 
 function withGeneratedRelayFiles(profile: RelayProfile): RelayProfile {
@@ -5198,10 +5198,10 @@ function removeTomlSectionKey(contents: string, sectionName: string, key: string
 function relayProfileSwitchValidation(profile: RelayProfile): string | null {
   if (profile.relayMode === "official" && !profile.officialMixApiKey) return null;
   if (!profile.configContents.trim()) {
-    return `供应商「${profile.name || profile.id}」缺少独立 config.toml，已停止切换，避免继续显示上一套配置文件。请先在该供应商详情里保存 config.toml。`;
+    return `Provider "${profile.name || profile.id}" is missing its own config.toml. Switching was stopped to avoid continuing to show the previous config files. Save config.toml in this provider's details first.`;
   }
   if (profile.relayMode !== "official" || !authJsonHasOpenAiApiKey(profile.authContents)) return null;
-  return "官方混合 API 不应在 auth.json 中保存 OPENAI_API_KEY。请清理此供应商的 auth.json 后再切换。";
+  return "Official mixed API should not store OPENAI_API_KEY in auth.json. Clean this provider's auth.json before switching.";
 }
 
 function authJsonHasOpenAiApiKey(contents: string): boolean {
@@ -5268,7 +5268,7 @@ function createRelayProfile(settings: BackendSettings): RelayProfile {
   const next = {
     id,
     linkedCcsProviderId: "",
-    name: `供应商 ${settings.relayProfiles.length + 1}`,
+    name: `Provider ${settings.relayProfiles.length + 1}`,
     model: "",
     baseUrl: defaultSettings.relayBaseUrl,
     upstreamBaseUrl: defaultSettings.relayBaseUrl,
@@ -5312,7 +5312,7 @@ function duplicateRelayProfile(settings: BackendSettings, id: string): BackendSe
     ...source,
     id: nextId,
     linkedCcsProviderId: "",
-    name: `${source.name || "未命名供应商"} 副本`,
+    name: `${source.name || "Unnamed Provider"} Copy`,
   };
   const relayProfiles = [...settings.relayProfiles];
   relayProfiles.splice(sourceIndex >= 0 ? sourceIndex + 1 : relayProfiles.length, 0, next);
@@ -5355,10 +5355,10 @@ function splitLogLines(text: string) {
 }
 
 function zedStrategyLabel(strategy: ZedOpenStrategy) {
-  if (strategy === "reuseWindow") return "复用窗口";
-  if (strategy === "newWindow") return "新窗口";
-  if (strategy === "default") return "Zed 默认行为";
-  return "加入当前工作区";
+  if (strategy === "reuseWindow") return "Reuse Window";
+  if (strategy === "newWindow") return "New Window";
+  if (strategy === "default") return "Zed Default Behavior";
+  return "Add to Focused Workspace";
 }
 
 function zedRemoteHostLabel(project: ZedRemoteProject) {
@@ -5368,12 +5368,12 @@ function zedRemoteHostLabel(project: ZedRemoteProject) {
 }
 
 function zedRemoteSourceLabel(source: string) {
-  if (source === "currentThread") return "当前会话";
+  if (source === "currentThread") return "Current Thread";
   if (source === "codexRemoteProject") return "Codex remote project";
   if (source === "threadWorkspaceHint") return "Thread workspace hint";
   if (source === "sqliteThreadCwd") return "SQLite cwd";
-  if (source === "recent") return "最近打开";
-  return source || "未知来源";
+  if (source === "recent") return "Recent";
+  return source || "Unknown Source";
 }
 
 function formatTime(value: number) {
@@ -5386,11 +5386,11 @@ function formatDuration(startedAtMs: number): string {
   const elapsed = Date.now() - startedAtMs;
   if (elapsed < 0) return formatTime(startedAtMs);
   const mins = Math.floor(elapsed / 60000);
-  if (mins < 1) return "刚刚启动";
-  if (mins < 60) return `已运行 ${mins} 分钟`;
+  if (mins < 1) return "Just started";
+  if (mins < 60) return `Running for ${mins} min`;
   const hours = Math.floor(mins / 60);
   const remainMins = mins % 60;
-  return `已运行 ${hours} 小时 ${remainMins} 分钟`;
+  return `Running for ${hours} hr ${remainMins} min`;
 }
 
 function stringifyError(error: unknown) {

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -117,6 +117,17 @@
     pluginSvgPath: 'svg path[d^="M7.94562 14.0277"]',
   };
 
+  function codexDomRoot() {
+    return document.body || document.documentElement || null;
+  }
+
+  function appendToCodexDomRoot(node) {
+    const root = document.head || document.body || document.documentElement;
+    if (!root) return false;
+    root.appendChild(node);
+    return true;
+  }
+
   function installStyle() {
     const existingStyle = document.getElementById(styleId);
     if (existingStyle?.dataset.codexDeleteStyleVersion === codexDeleteStyleVersion) return;
@@ -684,7 +695,7 @@
       .codex-plus-toggle[data-enabled="true"] span { transform: translateX(18px); }
       .codex-plus-toggle[data-relay-unneeded="true"] { width: 72px; cursor: default; background: rgba(16,163,127,.16); color: #6ee7b7; }
       .codex-plus-toggle[data-relay-unneeded="true"] span { display: none; }
-      .codex-plus-toggle[data-relay-unneeded="true"]::after { content: "无需开启"; font-size: 12px; font-weight: 650; line-height: 1; }
+      .codex-plus-toggle[data-relay-unneeded="true"]::after { content: "Not needed"; font-size: 12px; font-weight: 650; line-height: 1; }
       .codex-plus-width-control { display: flex; align-items: center; justify-content: flex-end; gap: 8px; min-width: 176px; align-self: center; }
       .codex-plus-width-input {
         width: 78px;
@@ -878,11 +889,11 @@
         100% { box-shadow: 0 0 0 14px rgba(16, 163, 127, 0); }
       }
     `;
-    document.documentElement.appendChild(style);
+    appendToCodexDomRoot(style);
   }
 
   function defaultCodexPlusSettings() {
-    return { pluginEntryUnlock: true, pluginMarketplaceUnlock: true, forcePluginInstall: true, modelWhitelistUnlock: true, sessionDelete: true, markdownExport: true, projectMove: true, conversationTimeline: true, conversationView: false, conversationViewMaxWidth: conversationViewDefaultWidth, threadScrollRestore: true, zedRemoteOpen: true, upstreamWorktreeCreate: true, nativeMenuPlacement: true, serviceTierControls: false };
+    return { pluginEntryUnlock: true, pluginMarketplaceUnlock: true, forcePluginInstall: true, modelWhitelistUnlock: true, sessionDelete: true, markdownExport: true, projectMove: true, conversationTimeline: false, conversationView: false, conversationViewMaxWidth: conversationViewDefaultWidth, threadScrollRestore: true, zedRemoteOpen: true, upstreamWorktreeCreate: true, nativeMenuPlacement: true, serviceTierControls: false };
   }
 
   const codexPlusBackendSettingMap = {
@@ -934,12 +945,13 @@
       };
     }
     try {
-      const settings = { ...defaultCodexPlusSettings(), ...JSON.parse(localStorage.getItem(codexPlusSettingsKey) || "{}"), ...backendCodexPlusSettings() };
+      const settings = { ...defaultCodexPlusSettings(), ...JSON.parse(localStorage.getItem(codexPlusSettingsKey) || "{}"), ...backendCodexPlusSettings(), conversationTimeline: false };
       if (relayPatchDisabled) {
         settings.pluginEntryUnlock = false;
         settings.pluginMarketplaceUnlock = false;
         settings.forcePluginInstall = false;
       }
+      settings.conversationTimeline = false;
       return settings;
     } catch {
       const settings = { ...defaultCodexPlusSettings(), ...backendCodexPlusSettings() };
@@ -948,6 +960,7 @@
         settings.pluginMarketplaceUnlock = false;
         settings.forcePluginInstall = false;
       }
+      settings.conversationTimeline = false;
       return settings;
     }
   }
@@ -1076,7 +1089,7 @@
   let codexServiceTierState = {
     status: "loading",
     serviceTier: null,
-    message: "正在读取…",
+    message: "Reading...",
     fastTierValue: "priority",
     controlMode: "inherit",
     defaultMode: "inherit",
@@ -1107,7 +1120,7 @@
     if (!codexServiceTierModulePromises.has(namePart)) {
       const promise = Promise.resolve().then(async () => {
         const url = codexAppAssetUrl(namePart);
-        if (!url) throw new Error(`未找到 Codex App asset: ${namePart}`);
+        if (!url) throw new Error(`Codex App asset not found: ${namePart}`);
         return await import(url);
       }).catch((error) => {
         codexServiceTierModulePromises.delete(namePart);
@@ -1121,7 +1134,7 @@
   async function codexSettingStorageModule() {
     const module = await loadCodexAppModule("setting-storage-");
     if (typeof module.n !== "function" || typeof module.s !== "function") {
-      throw new Error("Codex setting-storage 接口不可用");
+      throw new Error("Codex setting-storage API is unavailable");
     }
     return module;
   }
@@ -1184,8 +1197,8 @@
   }
 
   function codexServiceTierFastUnsupportedMessage(modelName = codexServiceTierCurrentModelName()) {
-    const modelText = modelName ? `当前模型 ${modelName} 不支持` : "当前模型未读取";
-    return `Fast 仅支持 ${codexServiceTierFastModelListLabel()}，${modelText}`;
+    const modelText = modelName ? `Current model ${modelName} is not supported` : "Current model not read";
+    return `Fast only supports ${codexServiceTierFastModelListLabel()}; ${modelText}`;
   }
 
   function codexServiceTierMaybeLoadModelCatalog(force = false) {
@@ -1254,9 +1267,9 @@
   }
 
   function serviceTierGlobalStatusMessage(serviceTier) {
-    if (isFastServiceTierValue(serviceTier)) return "Fast 已开启";
-    if (!serviceTier) return "默认服务模式";
-    return `当前：${serviceTier}`;
+    if (isFastServiceTierValue(serviceTier)) return "Fast enabled";
+    if (!serviceTier) return "Default service mode";
+    return `Current: ${serviceTier}`;
   }
 
   function serviceTierStatusMessage(
@@ -1265,13 +1278,13 @@
     effectiveMode = codexServiceTierState.effectiveMode || "standard",
     defaultMode = codexServiceTierState.defaultMode || "inherit"
   ) {
-    if (codexServiceTierState.status === "loading") return "正在读取…";
-    if (codexServiceTierState.status === "failed") return "读取失败";
-    if (controlMode === "inherit") return `继承 config.toml：${effectiveMode}`;
-    if (controlMode === "global-standard") return "全局 Standard";
-    if (controlMode === "global-fast") return "全局 Fast";
-    if (threadMode === "inherit") return `自定义：默认 ${defaultMode}`;
-    return `自定义：当前 thread ${threadMode}`;
+    if (codexServiceTierState.status === "loading") return "Reading...";
+    if (codexServiceTierState.status === "failed") return "Read failed";
+    if (controlMode === "inherit") return `Inherit config.toml: ${effectiveMode}`;
+    if (controlMode === "global-standard") return "Global Standard";
+    if (controlMode === "global-fast") return "Global Fast";
+    if (threadMode === "inherit") return `Custom: default ${defaultMode}`;
+    return `Custom: current thread ${threadMode}`;
   }
 
   function readThreadServiceTierState() {
@@ -1389,7 +1402,7 @@
 
   function setCodexServiceTierControlMode(mode) {
     if (codexPlusBackendStatus.status !== "ok") {
-      showToast("后端未连接，无法切换服务模式", null);
+      showToast("Backend disconnected; cannot switch service mode", null);
       refreshCodexServiceTierControls();
       return;
     }
@@ -1415,12 +1428,12 @@
     writeThreadServiceTierState(state);
     refreshCodexServiceTierControls();
     const labels = {
-      inherit: "继承 config.toml",
-      "global-standard": "全局 Standard",
-      "global-fast": "全局 Fast",
-      custom: "自定义",
+      inherit: "Inherit config.toml",
+      "global-standard": "Global Standard",
+      "global-fast": "Global Fast",
+      custom: "Custom",
     };
-    showToast(`服务模式：${labels[normalizedMode] || normalizedMode}`, null);
+    showToast(`Service mode: ${labels[normalizedMode] || normalizedMode}`, null);
   }
 
   function syncCodexServiceTierEffectiveState() {
@@ -1431,7 +1444,7 @@
         threadMode: "inherit",
         effectiveServiceTier: codexServiceTierState.serviceTier || null,
         effectiveMode: codexServiceTierEffectiveMode(codexServiceTierState.serviceTier),
-        message: "未启用",
+        message: "Disabled",
       };
       return;
     }
@@ -1463,22 +1476,22 @@
   }
 
   function codexServiceTierBadgeState() {
-    if (codexPlusBackendStatus.status === "checking") return { tier: "loading", label: "...", disabled: true, title: "服务模式：正在检查后端连接" };
-    if (codexPlusBackendStatus.status && codexPlusBackendStatus.status !== "ok") return { tier: "failed", label: "未连接", disabled: true, title: "服务模式：后端未连接，无法切换" };
-    if (codexServiceTierState.status === "loading") return { tier: "loading", label: "...", title: "服务模式：正在读取" };
-    if (codexServiceTierState.status === "failed") return { tier: "failed", label: "?", title: "服务模式：读取失败" };
+    if (codexPlusBackendStatus.status === "checking") return { tier: "loading", label: "...", disabled: true, title: "Service mode: checking backend connection" };
+    if (codexPlusBackendStatus.status && codexPlusBackendStatus.status !== "ok") return { tier: "failed", label: "Disconnected", disabled: true, title: "Service mode: backend disconnected; cannot switch" };
+    if (codexServiceTierState.status === "loading") return { tier: "loading", label: "...", title: "Service mode: reading" };
+    if (codexServiceTierState.status === "failed") return { tier: "failed", label: "?", title: "Service mode: read failed" };
     const fastAvailability = codexServiceTierFastAvailability();
     const effectiveMode = codexServiceTierState.effectiveMode || "standard";
     const scope = codexServiceTierState.controlMode === "custom" && codexServiceTierState.threadMode !== "inherit"
-      ? `当前 thread：${codexServiceTierState.threadMode}`
+      ? `Current thread: ${codexServiceTierState.threadMode}`
       : serviceTierStatusMessage(codexServiceTierState.controlMode, codexServiceTierState.threadMode, effectiveMode, codexServiceTierState.defaultMode);
     const title = [
-      `服务模式：${scope}`,
-      "Standard：使用标准处理；不在请求上设置 priority。",
-      `Fast：仅支持 ${codexServiceTierFastModelListLabel()}；对支持模型使用 service_tier=\"priority\"，官方说明其延迟更低且更一致，但会按更高价格计费；rate limit 与 Standard 共享，流量快速上涨时可能回落到 Standard。`,
+      `Service mode: ${scope}`,
+      "Standard: uses standard processing and does not set priority on requests.",
+      `Fast: only supports ${codexServiceTierFastModelListLabel()}; for supported models it uses service_tier=\"priority\". Official docs describe lower, more consistent latency, but at higher cost. Rate limits are shared with Standard and may fall back to Standard under rapid traffic growth.`,
     ].join("\n");
     if (effectiveMode === "fast" && !fastAvailability.supported) {
-      return { tier: "unsupported", label: "不支持", title: `${title}\n${codexServiceTierFastUnsupportedMessage(fastAvailability.modelName)}；当前请求会按 Standard 发送。` };
+      return { tier: "unsupported", label: "Unsupported", title: `${title}\n${codexServiceTierFastUnsupportedMessage(fastAvailability.modelName)}; current requests will be sent as Standard.` };
     }
     if (effectiveMode === "fast") return { tier: "fast", label: "fast", title };
     return { tier: "standard", label: "standard", title };
@@ -1504,7 +1517,7 @@
     const fastAvailability = codexServiceTierFastAvailability();
     const fastDisabled = !featureEnabled || !backendConnected || codexServiceTierState.status === "loading" || !fastAvailability.supported;
     const fastTitle = fastAvailability.supported
-      ? "Fast：使用 service_tier=\"priority\""
+      ? "Fast: use service_tier=\"priority\""
       : codexServiceTierFastUnsupportedMessage(fastAvailability.modelName);
     const fastUnsupportedActive = codexServiceTierState.effectiveMode === "fast" && !fastAvailability.supported;
     document.querySelectorAll("[data-codex-service-tier-controls]").forEach((node) => {
@@ -1513,8 +1526,8 @@
     document.querySelectorAll("[data-codex-service-tier-status]").forEach((node) => {
       node.dataset.status = fastUnsupportedActive ? "unsupported" : (featureEnabled && backendConnected ? (codexServiceTierState.status || "loading") : (backendChecking ? "loading" : "failed"));
       node.textContent = featureEnabled
-        ? (backendConnected ? (codexServiceTierState.message || "未读取") : (backendChecking ? "正在检查后端…" : "未连接"))
-        : "未启用";
+        ? (backendConnected ? (codexServiceTierState.message || "Not read") : (backendChecking ? "Checking backend..." : "Disconnected"))
+        : "Disabled";
     });
     document.querySelectorAll("[data-codex-service-tier-inherit]").forEach((button) => {
       button.disabled = !featureEnabled || !backendConnected || codexServiceTierState.status === "loading";
@@ -1536,7 +1549,7 @@
     document.querySelectorAll("[data-codex-service-tier-thread-inherit]").forEach((button) => {
       button.disabled = !featureEnabled || !backendConnected || codexServiceTierState.status === "loading";
       button.dataset.active = String(codexServiceTierState.controlMode === "custom" && codexServiceTierState.threadMode === "inherit");
-      button.title = `当前 thread 不单独覆盖，继承自定义默认 ${codexServiceTierState.defaultMode || "inherit"}`;
+      button.title = `Current thread has no separate override; inheriting custom default ${codexServiceTierState.defaultMode || "inherit"}`;
     });
     document.querySelectorAll("[data-codex-service-tier-thread-standard]").forEach((button) => {
       button.disabled = !featureEnabled || !backendConnected || codexServiceTierState.status === "loading";
@@ -1552,11 +1565,11 @@
 
   async function loadCodexServiceTierState() {
     if (!codexPlusSettings().serviceTierControls) {
-      codexServiceTierState = { ...codexServiceTierState, status: "idle", message: "未启用" };
+      codexServiceTierState = { ...codexServiceTierState, status: "idle", message: "Disabled" };
       refreshCodexServiceTierControls();
       return;
     }
-    codexServiceTierState = { ...codexServiceTierState, status: "loading", message: "正在读取…" };
+    codexServiceTierState = { ...codexServiceTierState, status: "loading", message: "Reading..." };
     refreshCodexServiceTierControls();
     try {
       const serviceTier = await getCodexServiceTierSetting();
@@ -1570,7 +1583,7 @@
       codexServiceTierState = {
         ...codexServiceTierState,
         status: "failed",
-        message: "读取失败",
+        message: "Read failed",
       };
       sendCodexPlusDiagnostic("service_tier_read_failed", {
         errorName: error?.name || "",
@@ -1583,7 +1596,7 @@
 
   function setCodexThreadServiceTierMode(mode) {
     if (codexPlusBackendStatus.status !== "ok") {
-      showToast("后端未连接，无法切换服务模式", null);
+      showToast("Backend disconnected; cannot switch service mode", null);
       refreshCodexServiceTierControls();
       return;
     }
@@ -1600,13 +1613,13 @@
     const threadId = validThreadScrollSessionKey(currentSessionRef().session_id);
     setCodexThreadServiceTierOverride(threadId, normalizedMode);
     refreshCodexServiceTierControls();
-    const target = threadId ? "当前 thread" : "新 thread 草稿";
-    showToast(`${target}服务模式：${normalizedMode === "inherit" ? "继承" : normalizedMode}`, null);
+    const target = threadId ? "Current thread" : "New thread draft";
+    showToast(`${target} service mode: ${normalizedMode === "inherit" ? "inherit" : normalizedMode}`, null);
   }
 
   function toggleCodexServiceTierFromBadge() {
     if (codexPlusBackendStatus.status !== "ok") {
-      showToast("后端未连接，无法切换服务模式", null);
+      showToast("Backend disconnected; cannot switch service mode", null);
       refreshCodexServiceTierControls();
       return;
     }
@@ -1827,7 +1840,7 @@
   }
 
   let codexPlusUserScripts = { enabled: true, builtin_dir: "", user_dir: "", scripts: [] };
-  let codexPlusBackendStatus = { status: "checking", message: "正在检查后端…" };
+  let codexPlusBackendStatus = { status: "checking", message: "Checking backend..." };
   let codexPlusBackendCheckSeq = 0;
 
   function setCodexPlusTriggerLabel(trigger) {
@@ -1858,11 +1871,11 @@
     const label = document.querySelector("[data-codex-backend-status]");
     if (label) {
       label.dataset.status = status;
-      label.textContent = codexPlusBackendStatus.message || (status === "ok" ? "后端已连接" : "未连接");
+      label.textContent = codexPlusBackendStatus.message || (status === "ok" ? "Backend connected" : "Disconnected");
     }
     document.querySelectorAll("[data-codex-backend-indicator]").forEach((indicator) => {
       indicator.dataset.status = status;
-      indicator.title = status === "ok" ? "后端已连接" : status === "checking" ? "正在检查后端" : "未连接";
+      indicator.title = status === "ok" ? "Backend connected" : status === "checking" ? "Checking backend" : "Disconnected";
     });
     const repair = document.querySelector("[data-codex-backend-repair]");
     if (repair) repair.hidden = status === "ok" || status === "checking";
@@ -1872,7 +1885,7 @@
   function withBackendTimeout(request) {
     return Promise.race([
       request,
-      new Promise((resolve) => setTimeout(() => resolve({ status: "failed", message: "后端检查超时", timeout: true }), 2000)),
+      new Promise((resolve) => setTimeout(() => resolve({ status: "failed", message: "Backend check timed out", timeout: true }), 2000)),
     ]);
   }
 
@@ -1892,12 +1905,12 @@
   }
 
   async function repairBackend() {
-    codexPlusBackendStatus = { status: "checking", message: "正在修复后端…" };
+    codexPlusBackendStatus = { status: "checking", message: "Repairing backend..." };
     renderBackendStatus();
     try {
       codexPlusBackendStatus = await postJson("/backend/repair", {});
     } catch (error) {
-      codexPlusBackendStatus = { status: "failed", message: "后端修复失败" };
+      codexPlusBackendStatus = { status: "failed", message: "Backend repair failed" };
     }
     renderBackendStatus();
   }
@@ -1905,9 +1918,9 @@
   async function openManagerFromCodex() {
     const result = await postJson("/manager/open", {});
     if (result.status === "ok") {
-      showToast("管理工具已打开", null);
+      showToast("Manager opened", null);
     } else {
-      showToast(result.message || "打开管理工具失败", null);
+      showToast(result.message || "Failed to open manager", null);
     }
   }
 
@@ -1918,25 +1931,25 @@
   }
 
   function userScriptStatusLabel(status) {
-    return { loaded: "已加载", failed: "失败", disabled: "已禁用", not_loaded: "未加载", loading: "加载中" }[status] || status || "未知";
+    return { loaded: "Loaded", failed: "Failed", disabled: "Disabled", not_loaded: "Not loaded", loading: "Loading" }[status] || status || "Unknown";
   }
 
   function renderUserScripts() {
     const enabledToggle = document.querySelector("[data-codex-user-scripts-enabled]");
     if (enabledToggle) enabledToggle.dataset.enabled = String(!!codexPlusUserScripts.enabled);
     const dirs = document.querySelector("[data-codex-user-script-dirs]");
-    if (dirs) dirs.textContent = `内置：${codexPlusUserScripts.builtin_dir || "未找到"}  用户：${codexPlusUserScripts.user_dir || "未找到"}`;
+    if (dirs) dirs.textContent = `Built-in: ${codexPlusUserScripts.builtin_dir || "Not found"}  User: ${codexPlusUserScripts.user_dir || "Not found"}`;
     const list = document.querySelector("[data-codex-user-script-list]");
     if (!list) return;
     if (!codexPlusUserScripts.scripts?.length) {
-      list.textContent = "未发现用户脚本。";
+      list.textContent = "No user scripts found.";
       return;
     }
     list.innerHTML = codexPlusUserScripts.scripts.map((script) => `
       <div class="codex-plus-user-script-item">
         <div>
           <div class="codex-plus-user-script-name">${escapeHtml(script.name || script.key)}</div>
-          <div class="codex-plus-user-script-meta">${script.source === "builtin" ? "内置" : "用户"} · ${userScriptStatusLabel(script.status)}</div>
+          <div class="codex-plus-user-script-meta">${script.source === "builtin" ? "Built-in" : "User"} · ${userScriptStatusLabel(script.status)}</div>
           ${script.error ? `<div class="codex-plus-user-script-error">${escapeHtml(script.error)}</div>` : ""}
         </div>
         <button type="button" class="codex-plus-toggle" data-codex-user-script-key="${escapeHtml(script.key)}" data-enabled="${String(!!script.enabled)}"><span></span></button>
@@ -1988,23 +2001,23 @@
           <div class="codex-plus-ad-highlights">
             ${ad.highlights.map((item) => `<span>${escapeHtml(item)}</span>`).join("")}
           </div>
-          <a class="codex-plus-ad-link" href="${escapeHtml(ad.url)}" target="_blank" rel="noreferrer">访问 ${escapeHtml(new URL(ad.url).hostname)}</a>
+          <a class="codex-plus-ad-link" href="${escapeHtml(ad.url)}" target="_blank" rel="noreferrer">Visit ${escapeHtml(new URL(ad.url).hostname)}</a>
         </div>
       </article>
     `).join("");
   }
 
   function renderCodexPlusAds() {
-    if (!codexPlusAdsLoaded) return `<div class="codex-plus-ad-empty">推荐内容加载中…</div>`;
-    if (!codexPlusAds.length) return `<div class="codex-plus-ad-empty">暂无推荐内容。</div>`;
+    if (!codexPlusAdsLoaded) return `<div class="codex-plus-ad-empty">Loading recommendations...</div>`;
+    if (!codexPlusAds.length) return `<div class="codex-plus-ad-empty">No recommendations available.</div>`;
     return `
       <section class="codex-plus-ad-section">
-        <h3 class="codex-plus-ad-section-title">赞助商推荐</h3>
-        <div class="codex-plus-ad-list">${renderCodexPlusAdGroup("sponsor", "暂无赞助商推荐。")}</div>
+        <h3 class="codex-plus-ad-section-title">Sponsored Recommendations</h3>
+        <div class="codex-plus-ad-list">${renderCodexPlusAdGroup("sponsor", "No sponsored recommendations.")}</div>
       </section>
       <section class="codex-plus-ad-section">
-        <h3 class="codex-plus-ad-section-title">普通推荐</h3>
-        <div class="codex-plus-ad-list">${renderCodexPlusAdGroup("normal", "暂无普通推荐。")}</div>
+        <h3 class="codex-plus-ad-section-title">Recommendations</h3>
+        <div class="codex-plus-ad-list">${renderCodexPlusAdGroup("normal", "No recommendations.")}</div>
       </section>
     `;
   }
@@ -2073,90 +2086,90 @@
       <div class="codex-plus-modal-content" role="dialog" aria-modal="true" aria-label="Codex++">
         <div class="codex-plus-modal-header">
           <div class="codex-plus-modal-title"><span class="codex-plus-backend-indicator" data-codex-backend-indicator="true" data-status="checking"></span><span data-codex-plus-version="true">Codex++ ${codexPlusVersion}</span></div>
-          <button type="button" class="codex-plus-modal-close" aria-label="关闭">×</button>
+          <button type="button" class="codex-plus-modal-close" aria-label="Close">×</button>
         </div>
         <div class="codex-plus-tabs" role="tablist" aria-label="Codex++">
-          <button type="button" class="codex-plus-tab-button" data-codex-plus-tab="home" data-active="true">主页</button>
-          <button type="button" class="codex-plus-tab-button" data-codex-plus-tab="userScripts" data-active="false">用户脚本</button>
-          <button type="button" class="codex-plus-tab-button" data-codex-plus-tab="sponsor" data-active="false">推荐内容</button>
-          <button type="button" class="codex-plus-tab-button" data-codex-plus-tab="support" data-active="false">请作者喝咖啡</button>
+          <button type="button" class="codex-plus-tab-button" data-codex-plus-tab="home" data-active="true">Home</button>
+          <button type="button" class="codex-plus-tab-button" data-codex-plus-tab="userScripts" data-active="false">User Scripts</button>
+          <button type="button" class="codex-plus-tab-button" data-codex-plus-tab="sponsor" data-active="false">Recommendations</button>
+          <button type="button" class="codex-plus-tab-button" data-codex-plus-tab="support" data-active="false">Support</button>
         </div>
         <div class="codex-plus-modal-body">
           <div class="codex-plus-panel" data-codex-plus-panel="home">
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">后端连接</div><div class="codex-plus-row-description">每 5 秒检查一次 launcher 后端状态；断开时可尝试修复后端运行。</div></div>
+              <div><div class="codex-plus-row-title">Backend Connection</div><div class="codex-plus-row-description">Checks the launcher backend every 5 seconds; if it disconnects, you can try to repair it.</div></div>
               <div class="codex-plus-backend-status">
-                <div class="codex-plus-backend-label" data-codex-backend-status="true" data-status="checking">正在检查后端…</div>
-                <button type="button" class="codex-plus-backend-repair" data-codex-backend-repair="true" hidden>修复后端运行</button>
+                <div class="codex-plus-backend-label" data-codex-backend-status="true" data-status="checking">Checking backend...</div>
+                <button type="button" class="codex-plus-backend-repair" data-codex-backend-repair="true" hidden>Repair Backend</button>
               </div>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">页面功能增强</div><div class="codex-plus-row-description">关闭后停用删除、导出、移动、Timeline、插件相关和菜单位置增强。</div></div>
+              <div><div class="codex-plus-row-title">Page Enhancements</div><div class="codex-plus-row-description">When off, disables delete, export, move, plugin-related features, menu placement, and other page enhancements.</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-backend-setting="enhancementsEnabled"><span></span></button>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">插件市场解锁</div><div class="codex-plus-row-description">${codexPlusBackendSettings.launchMode === "relay" ? "兼容增强模式下无需开启；ChatGPT 登录态会保留官方插件市场。" : "API Key 模式下扩展插件市场请求，尽量显示完整插件列表。"}</div></div>
+              <div><div class="codex-plus-row-title">Plugin Marketplace Unlock</div><div class="codex-plus-row-description">${codexPlusBackendSettings.launchMode === "relay" ? "Not needed in compatibility enhancement mode; ChatGPT login keeps the official plugin marketplace." : "Extends plugin marketplace requests in API key mode so the full plugin list can be shown."}</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="pluginMarketplaceUnlock" ${codexPlusBackendSettings.launchMode === "relay" ? 'disabled data-relay-unneeded="true"' : ""}><span></span></button>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">强制解锁入口</div><div class="codex-plus-row-description">${codexPlusBackendSettings.launchMode === "relay" ? "兼容增强模式下无需开启；官方登录态会保留插件入口。" : "恢复 1.1.9 的入口解锁方式，强制显示并启用插件入口。"}</div></div>
+              <div><div class="codex-plus-row-title">Force Entry Unlock</div><div class="codex-plus-row-description">${codexPlusBackendSettings.launchMode === "relay" ? "Not needed in compatibility enhancement mode; official login keeps the plugin entry." : "Restores the 1.1.9 entry unlock path to force-show and enable the plugin entry."}</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="pluginEntryUnlock" ${codexPlusBackendSettings.launchMode === "relay" ? 'disabled data-relay-unneeded="true"' : ""}><span></span></button>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">特殊插件强制安装</div><div class="codex-plus-row-description">${codexPlusBackendSettings.launchMode === "relay" ? "兼容增强模式下无需开启；不会改插件安装入口。" : "解除 App unavailable / 应用不可用导致的前端安装禁用。"}</div></div>
+              <div><div class="codex-plus-row-title">Force Plugin Install</div><div class="codex-plus-row-description">${codexPlusBackendSettings.launchMode === "relay" ? "Not needed in compatibility enhancement mode; plugin install entries are left untouched." : "Enables install buttons blocked by App unavailable states."}</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="forcePluginInstall" ${codexPlusBackendSettings.launchMode === "relay" ? 'disabled data-relay-unneeded="true"' : ""}><span></span></button>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">模型白名单解锁</div><div class="codex-plus-row-description">从环境变量和 Codex config.toml 中的中转站 /v1/models 拉取模型，并补进模型选择列表。</div></div>
+              <div><div class="codex-plus-row-title">Model Whitelist Unlock</div><div class="codex-plus-row-description">Fetches models from relay /v1/models endpoints in environment variables and Codex config.toml, then adds them to the model picker.</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="modelWhitelistUnlock"><span></span></button>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">Fast 按钮</div><div class="codex-plus-row-description">显示服务模式切换按钮；Fast 仅支持 ${codexServiceTierFastModelListLabel()}，其他模型按 Standard 发送。</div></div>
+              <div><div class="codex-plus-row-title">Fast Button</div><div class="codex-plus-row-description">Shows the service mode switch; Fast only supports ${codexServiceTierFastModelListLabel()}, and other models are sent as Standard.</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="serviceTierControls"><span></span></button>
             </div>
             <div class="codex-plus-row" data-codex-service-tier-controls="true">
-              <div><div class="codex-plus-row-title">服务模式</div><div class="codex-plus-row-description">继承使用 config.toml 的 service tier；全局模式覆盖全部 thread；自定义允许按 thread 覆盖。</div></div>
+              <div><div class="codex-plus-row-title">Service Mode</div><div class="codex-plus-row-description">Inherit uses config.toml service tier; global modes override all threads; custom allows per-thread overrides.</div></div>
               <div class="codex-plus-service-tier-control">
-                <div class="codex-plus-service-tier-status" data-codex-service-tier-status="true" data-status="loading">正在读取…</div>
+                <div class="codex-plus-service-tier-status" data-codex-service-tier-status="true" data-status="loading">Reading...</div>
                 <div class="codex-plus-service-tier-actions">
-                  <button type="button" class="codex-plus-service-tier-button" data-codex-service-tier-inherit="true">继承</button>
-                  <button type="button" class="codex-plus-service-tier-button" data-codex-service-tier-standard="true">全局 Standard</button>
-                  <button type="button" class="codex-plus-service-tier-button" data-codex-service-tier-fast="true">全局 Fast</button>
-                  <button type="button" class="codex-plus-service-tier-button" data-codex-service-tier-custom="true">自定义</button>
+                  <button type="button" class="codex-plus-service-tier-button" data-codex-service-tier-inherit="true">Inherit</button>
+                  <button type="button" class="codex-plus-service-tier-button" data-codex-service-tier-standard="true">Global Standard</button>
+                  <button type="button" class="codex-plus-service-tier-button" data-codex-service-tier-fast="true">Global Fast</button>
+                  <button type="button" class="codex-plus-service-tier-button" data-codex-service-tier-custom="true">Custom</button>
                 </div>
                 <div class="codex-plus-service-tier-actions codex-plus-service-tier-thread-actions">
-                  <span class="codex-plus-service-tier-thread-label">当前 thread 覆盖</span>
-                  <button type="button" class="codex-plus-service-tier-button" data-codex-service-tier-thread-inherit="true" title="当前 thread 不单独覆盖，继承 config.toml">继承</button>
-                  <button type="button" class="codex-plus-service-tier-button" data-codex-service-tier-thread-standard="true" title="仅当前 thread 使用 Standard，并切到自定义模式">Standard</button>
-                  <button type="button" class="codex-plus-service-tier-button" data-codex-service-tier-thread-fast="true" title="仅当前 thread 使用 Fast，并切到自定义模式">Fast</button>
+                  <span class="codex-plus-service-tier-thread-label">Current thread override</span>
+                  <button type="button" class="codex-plus-service-tier-button" data-codex-service-tier-thread-inherit="true" title="The current thread has no separate override and inherits config.toml">Inherit</button>
+                  <button type="button" class="codex-plus-service-tier-button" data-codex-service-tier-thread-standard="true" title="Use Standard only for the current thread and switch to custom mode">Standard</button>
+                  <button type="button" class="codex-plus-service-tier-button" data-codex-service-tier-thread-fast="true" title="Use Fast only for the current thread and switch to custom mode">Fast</button>
                 </div>
               </div>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">会话删除</div><div class="codex-plus-row-description">在会话列表悬停显示删除按钮，并支持撤销。</div></div>
+              <div><div class="codex-plus-row-title">Session Delete</div><div class="codex-plus-row-description">Shows a delete button on session hover, with undo support.</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="sessionDelete"><span></span></button>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">Markdown 导出</div><div class="codex-plus-row-description">在会话列表显示导出按钮，按本地 rollout 导出带时间戳的 Markdown。</div></div>
+              <div><div class="codex-plus-row-title">Markdown Export</div><div class="codex-plus-row-description">Shows an export button in the session list and exports timestamped Markdown from local rollouts.</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="markdownExport"><span></span></button>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">会话项目移动</div><div class="codex-plus-row-description">在会话列表悬停显示移动按钮，可移动到普通对话或其他本地项目。</div></div>
+              <div><div class="codex-plus-row-title">Project Move</div><div class="codex-plus-row-description">Shows a move button on session hover so sessions can move to Chats or another local project.</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="projectMove"><span></span></button>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">对话 Timeline</div><div class="codex-plus-row-description">在对话右侧显示用户提问时间线，悬停查看摘要，点击跳转。</div></div>
-              <button type="button" class="codex-plus-toggle" data-codex-plus-setting="conversationTimeline"><span></span></button>
+              <div><div class="codex-plus-row-title">Conversation Timeline</div><div class="codex-plus-row-description">Disabled in this patched build to remove the right-side line and circles.</div></div>
+              <button type="button" class="codex-plus-toggle" disabled><span></span></button>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">对话居中宽度</div><div class="codex-plus-row-description">开启后把主对话和输入框限制到固定最大宽度，适合大屏阅读。</div></div>
+              <div><div class="codex-plus-row-title">Centered Conversation Width</div><div class="codex-plus-row-description">Limits the main conversation and input to a fixed max width for large-screen reading.</div></div>
               <div class="codex-plus-width-control">
                 <input class="codex-plus-width-input" data-codex-plus-conversation-view-width="true" min="${conversationViewMinWidth}" max="${conversationViewMaxAllowedWidth}" step="10" type="number" value="${conversationViewWidth()}">
                 <button type="button" class="codex-plus-toggle" data-codex-plus-setting="conversationView"><span></span></button>
               </div>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">切换对话保留位置</div><div class="codex-plus-row-description">开启后在不同 thread 之间切换时恢复到上一次浏览位置，不再自动跳到底部。</div></div>
+              <div><div class="codex-plus-row-title">Preserve Position When Switching Conversations</div><div class="codex-plus-row-description">Restores the last viewed position when switching threads instead of jumping to the bottom.</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="threadScrollRestore"><span></span></button>
             </div>
             <div class="codex-plus-row">
@@ -2166,73 +2179,73 @@
             <div class="codex-plus-row">
               <div><div class="codex-plus-row-title">Upstream worktree</div><div class="codex-plus-row-description">Create a Git worktree from a fresh upstream branch, equivalent to git worktree add -b branch path upstream/base.</div></div>
               <div class="codex-plus-worktree-actions">
-                <button type="button" class="codex-plus-action-button" data-codex-upstream-worktree-open="true">创建</button>
+                <button type="button" class="codex-plus-action-button" data-codex-upstream-worktree-open="true">Create</button>
                 <button type="button" class="codex-plus-toggle" data-codex-plus-setting="upstreamWorktreeCreate"><span></span></button>
               </div>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">历史会话修复</div><div class="codex-plus-row-description">切换官方登录、混合 API 或纯 API 后，让旧对话重新显示在当前模式下。</div></div>
+              <div><div class="codex-plus-row-title">Historical Session Repair</div><div class="codex-plus-row-description">Keeps old conversations visible in the current mode after switching official login, mixed API, or pure API modes.</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-backend-setting="providerSyncEnabled"><span></span></button>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">页面增强模式</div><div class="codex-plus-row-description">${codexPlusBackendSettings.launchMode === "relay" ? "兼容增强：保留会话删除、导出、项目移动、Timeline 和用户脚本，仅关闭插件入口相关增强。" : "完整增强：加载插件入口、强制安装、项目路径移动等全部页面能力。"}</div></div>
-              <button type="button" class="codex-plus-action-button" data-codex-open-manager="true">打开管理工具</button>
+              <div><div class="codex-plus-row-title">Page Enhancement Mode</div><div class="codex-plus-row-description">${codexPlusBackendSettings.launchMode === "relay" ? "Compatibility enhancement: keeps session delete, export, project move, and user scripts, while disabling plugin-entry enhancements." : "Full enhancement: loads plugin entry, force install, project path move, and the full page feature set."}</div></div>
+              <button type="button" class="codex-plus-action-button" data-codex-open-manager="true">Open Manager</button>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">原生菜单栏位置</div><div class="codex-plus-row-description">把 Codex++ 菜单插入顶部原生菜单栏；默认关闭以避免页面重渲染冲突。</div></div>
+              <div><div class="codex-plus-row-title">Native Menu Bar Placement</div><div class="codex-plus-row-description">Insert the Codex++ menu into the top native menu bar; off by default to avoid page re-render conflicts.</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="nativeMenuPlacement"><span></span></button>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">打开 DevTools</div><div class="codex-plus-row-description">打开当前 Codex 页面开发者工具，方便查看用户脚本报错。</div></div>
-              <button type="button" class="codex-plus-action-button" data-codex-open-devtools="true">打开 DevTools</button>
+              <div><div class="codex-plus-row-title">Open DevTools</div><div class="codex-plus-row-description">Open developer tools for the current Codex page to inspect user script errors.</div></div>
+              <button type="button" class="codex-plus-action-button" data-codex-open-devtools="true">Open DevTools</button>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">关于 Codex++</div><div class="codex-plus-about">Codex++ 是通过外部 launcher 注入的增强菜单，不修改 Codex App 原始安装文件。<br>Build: <span data-codex-plus-build="true">${codexPlusBuild}</span><br>GitHub: <a href="https://github.com/BigPizzaV3/CodexPlusPlus" target="_blank" rel="noreferrer">https://github.com/BigPizzaV3/CodexPlusPlus</a><br>Discord: <a href="https://discord.gg/y96kX7A76v" target="_blank" rel="noreferrer">https://discord.gg/y96kX7A76v</a><br>Telegram: <a href="https://t.me/CodexPlusPlus" target="_blank" rel="noreferrer">https://t.me/CodexPlusPlus</a></div></div>
+              <div><div class="codex-plus-row-title">About Codex++</div><div class="codex-plus-about">Codex++ is an enhancement menu injected by an external launcher. It does not modify the original Codex App installation files.<br>Build: <span data-codex-plus-build="true">${codexPlusBuild}</span><br>GitHub: <a href="https://github.com/BigPizzaV3/CodexPlusPlus" target="_blank" rel="noreferrer">https://github.com/BigPizzaV3/CodexPlusPlus</a><br>Discord: <a href="https://discord.gg/y96kX7A76v" target="_blank" rel="noreferrer">https://discord.gg/y96kX7A76v</a><br>Telegram: <a href="https://t.me/CodexPlusPlus" target="_blank" rel="noreferrer">https://t.me/CodexPlusPlus</a></div></div>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">Discord 社区</div><div class="codex-plus-row-description">加入 Discord 获取更新消息、反馈问题或交流使用体验。</div></div>
-              <button type="button" class="codex-plus-action-button" data-codex-plus-discord="true">打开 Discord</button>
+              <div><div class="codex-plus-row-title">Discord Community</div><div class="codex-plus-row-description">Join Discord for update news, issue reports, and usage discussion.</div></div>
+              <button type="button" class="codex-plus-action-button" data-codex-plus-discord="true">Open Discord</button>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">Telegram 频道</div><div class="codex-plus-row-description">加入 Telegram 获取更新消息和交流使用体验。</div></div>
-              <button type="button" class="codex-plus-action-button" data-codex-plus-telegram="true">打开 Telegram</button>
+              <div><div class="codex-plus-row-title">Telegram Channel</div><div class="codex-plus-row-description">Join Telegram for update news and usage discussion.</div></div>
+              <button type="button" class="codex-plus-action-button" data-codex-plus-telegram="true">Open Telegram</button>
             </div>
             <div class="codex-plus-row">
-              <div><div class="codex-plus-row-title">提出问题</div><div class="codex-plus-row-description">打开 GitHub Issues 反馈问题或建议。</div></div>
-              <button type="button" class="codex-plus-issue-button" data-codex-plus-issue="true">提出问题</button>
+              <div><div class="codex-plus-row-title">Report Issue</div><div class="codex-plus-row-description">Open GitHub Issues to report problems or suggestions.</div></div>
+              <button type="button" class="codex-plus-issue-button" data-codex-plus-issue="true">Report Issue</button>
             </div>
           </div>
           <div class="codex-plus-panel" data-codex-plus-panel="userScripts" hidden>
             <div class="codex-plus-row" data-codex-user-scripts-section="true">
               <div>
-                <div class="codex-plus-row-title">用户脚本</div>
-                <div class="codex-plus-row-description">启用用户脚本：自动加载内置目录和用户配置目录中的 .js 文件。</div>
-                <div class="codex-plus-user-script-warning">禁用后需重载页面或重启 Codex++ 才能完全移除已执行效果。</div>
-                <div class="codex-plus-user-script-dirs" data-codex-user-script-dirs="true">正在读取脚本目录…</div>
-                <div class="codex-plus-user-script-list" data-codex-user-script-list="true">正在读取用户脚本…</div>
+                <div class="codex-plus-row-title">User Scripts</div>
+                <div class="codex-plus-row-description">Enable user scripts: automatically load .js files from built-in and user config directories.</div>
+                <div class="codex-plus-user-script-warning">After disabling, reload the page or restart Codex++ to fully remove effects from already-run scripts.</div>
+                <div class="codex-plus-user-script-dirs" data-codex-user-script-dirs="true">Reading script directories...</div>
+                <div class="codex-plus-user-script-list" data-codex-user-script-list="true">Reading user scripts...</div>
               </div>
               <div class="codex-plus-user-script-actions">
                 <button type="button" class="codex-plus-toggle" data-codex-user-scripts-enabled="true"><span></span></button>
-                <button type="button" class="codex-plus-user-script-reload" data-codex-user-scripts-reload="true">重新加载用户脚本</button>
+                <button type="button" class="codex-plus-user-script-reload" data-codex-user-scripts-reload="true">Reload User Scripts</button>
               </div>
             </div>
           </div>
           <div class="codex-plus-panel" data-codex-plus-panel="sponsor" hidden>
-            <div class="codex-plus-sponsor-text">推荐内容分为赞助商推荐和普通推荐。赞助商推荐来自支持 Codex++ 继续维护的合作方；普通推荐用于展示适合 Codex 用户的服务与信息。</div>
+            <div class="codex-plus-sponsor-text">Recommendations are split between sponsored and regular items. Sponsored recommendations come from partners who support ongoing Codex++ maintenance; regular recommendations show services and information useful to Codex users.</div>
             <div class="codex-plus-ad-remote">
               ${renderCodexPlusAds()}
             </div>
           </div>
           <div class="codex-plus-panel" data-codex-plus-panel="support" hidden>
-            <div class="codex-plus-sponsor-text">如果 Codex++ 帮到了你，可以请我喝杯咖啡，或者随手赞赏支持一下继续维护。</div>
+            <div class="codex-plus-sponsor-text">If Codex++ helped you, you can support ongoing maintenance here.</div>
             <div class="codex-plus-sponsor-grid">
               <div class="codex-plus-sponsor-card">
-                <div class="codex-plus-sponsor-card-title">支付宝</div>
-                <img class="codex-plus-sponsor-qr" src="${window.__CODEX_PLUS_SPONSOR_IMAGES__?.alipay || `${helperBase}/assets/sponsor-alipay.jpg`}" alt="支付宝赞赏码">
+                <div class="codex-plus-sponsor-card-title">Alipay</div>
+                <img class="codex-plus-sponsor-qr" src="${window.__CODEX_PLUS_SPONSOR_IMAGES__?.alipay || `${helperBase}/assets/sponsor-alipay.jpg`}" alt="Alipay support QR code">
               </div>
               <div class="codex-plus-sponsor-card">
-                <div class="codex-plus-sponsor-card-title">微信</div>
-                <img class="codex-plus-sponsor-qr" src="${window.__CODEX_PLUS_SPONSOR_IMAGES__?.wechat || `${helperBase}/assets/sponsor-wechat.jpg`}" alt="微信赞赏码">
+                <div class="codex-plus-sponsor-card-title">WeChat</div>
+                <img class="codex-plus-sponsor-qr" src="${window.__CODEX_PLUS_SPONSOR_IMAGES__?.wechat || `${helperBase}/assets/sponsor-wechat.jpg`}" alt="WeChat support QR code">
               </div>
             </div>
           </div>
@@ -2547,9 +2560,9 @@
   }
 
   function displayNameForPluginMarketplaceName(name, fallback) {
-    if (name === "openai-bundled" || name === "codex-plus-openai-bundled") return "OpenAI插件1(Codex++)";
-    if (name === "openai-curated" || name === "codex-plus-openai-curated") return "OpenAI插件2(Codex++)";
-    if (name === "openai-primary-runtime" || name === "codex-plus-openai-primary-runtime") return "OpenAI插件3(Codex++)";
+    if (name === "openai-bundled" || name === "codex-plus-openai-bundled") return "OpenAI Plugin 1 (Codex++)";
+    if (name === "openai-curated" || name === "codex-plus-openai-curated") return "OpenAI Plugin 2 (Codex++)";
+    if (name === "openai-primary-runtime" || name === "codex-plus-openai-primary-runtime") return "OpenAI Plugin 3 (Codex++)";
     return fallback;
   }
 
@@ -2825,8 +2838,7 @@
       .flatMap((node) => Array.from(node.childNodes))
       .find((node) => node.nodeType === 3 && /^(插件|Plugins)( - 已解锁| - Unlocked)?$/i.test((node.nodeValue || "").trim()));
     if (!labelTextNode) return;
-    const current = (labelTextNode.nodeValue || "").trim();
-    labelTextNode.nodeValue = /^Plugins/i.test(current) ? "Plugins - Unlocked" : "插件 - 已解锁";
+    labelTextNode.nodeValue = "Plugins - Unlocked";
   }
 
   function clearPluginEntryUnlockLabel(button) {
@@ -2834,7 +2846,7 @@
       .flatMap((node) => Array.from(node.childNodes))
       .find((node) => node.nodeType === 3 && /^(插件 - 已解锁|Plugins - Unlocked)$/i.test((node.nodeValue || "").trim()));
     if (!labelTextNode) return;
-    labelTextNode.nodeValue = /^Plugins/i.test((labelTextNode.nodeValue || "").trim()) ? "Plugins" : "插件";
+    labelTextNode.nodeValue = "Plugins";
   }
 
   function enablePluginEntry() {
@@ -2877,7 +2889,7 @@
   }
 
   function isInstallButtonLabel(text) {
-    return /^安装\s*/.test(text) || /^Install\s*/i.test(text) || text === "强制安装";
+    return /^安装\s*/.test(text) || /^Install\s*/i.test(text) || text === "强制安装" || text === "Force install";
   }
 
   function patchReactDisabledProps(element) {
@@ -2943,7 +2955,7 @@
       if (isInstallButtonLabel((node.nodeValue || "").trim())) textNode = node;
     }
     if (textNode) {
-      textNode.nodeValue = "强制安装";
+      textNode.nodeValue = "Force install";
     }
   }
 
@@ -2952,10 +2964,10 @@
     let textNode = null;
     while (!textNode && walker.nextNode()) {
       const node = walker.currentNode;
-      if ((node.nodeValue || "").trim() === "强制安装") textNode = node;
+      if (["强制安装", "Force install"].includes((node.nodeValue || "").trim())) textNode = node;
     }
     if (textNode) {
-      textNode.nodeValue = "安装";
+      textNode.nodeValue = "Install";
     }
   }
 
@@ -3059,7 +3071,7 @@
     const sessionId = codexThreadId || (idMatch && idMatch[1]) || fallbackId;
     const titleNode = row.querySelector(`${selectors.threadTitle}, .truncate.select-none, .truncate.text-base`);
     const rawTitle = (titleNode?.textContent || (titleNode ? "" : (row.textContent || "Untitled session")));
-    const title = (titleNode ? rawTitle : rawTitle.replace(/\s*(导出|删除|移动|移出项目)(\s*(导出|删除|移动|移出项目))*$/g, "")).trim().slice(0, 160);
+    const title = (titleNode ? rawTitle : rawTitle.replace(/\s*(导出|删除|移动|移出项目|Export|Delete|Move|Remove from project)(\s*(导出|删除|移动|移出项目|Export|Delete|Move|Remove from project))*$/gi, "")).trim().slice(0, 160);
     return { session_id: sessionId, title };
   }
 
@@ -3735,16 +3747,16 @@
           });
           return await response.json();
         } catch (error) {
-          return { status: "failed", message: "未连接" };
+          return { status: "failed", message: "Disconnected" };
         }
       }
       sendCodexPlusDiagnostic("bridge_missing_for_route", { path });
-      return { status: "failed", message: "桥接不可用，请重启启动器" };
+      return { status: "failed", message: "Bridge unavailable; please restart the launcher" };
     }
     function bridgeWithBackendTimeout(path, payload) {
       return Promise.race([
         window.__codexSessionDeleteBridge(path, payload),
-        new Promise((resolve) => setTimeout(() => resolve({ status: "failed", message: "后端检查超时", timeout: true }), 2000)),
+        new Promise((resolve) => setTimeout(() => resolve({ status: "failed", message: "Backend check timed out", timeout: true }), 2000)),
       ]);
     }
     async function fetchBackendStatusFromHelper(path, payload) {
@@ -3756,7 +3768,7 @@
         });
         return await response.json();
       } catch (error) {
-        return { status: "failed", message: "未连接" };
+        return { status: "failed", message: "Disconnected" };
       }
     }
     try {
@@ -3810,7 +3822,7 @@
 
   function downloadMarkdown(filename, markdown) {
     if (!filename || typeof markdown !== "string") {
-      throw new Error("导出结果不完整");
+      throw new Error("Export result is incomplete");
     }
     const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
     const url = URL.createObjectURL(blob);
@@ -3831,7 +3843,7 @@
   async function codexStateApi() {
     codexStateApiPromise = codexStateApiPromise || import("./assets/vscode-api-Dc9pX2Bc.js");
     const api = await codexStateApiPromise;
-    if (typeof api.n !== "function") throw new Error("Codex 状态 API 不可用");
+    if (typeof api.n !== "function") throw new Error("Codex state API is unavailable");
     return api.n;
   }
 
@@ -4346,18 +4358,18 @@
     const timestamp = numericTimestamp(timestampMs);
     if (!timestamp) return "";
     const elapsedSeconds = Math.max(0, Math.floor((nowMs - timestamp) / 1000));
-    if (elapsedSeconds < 60) return "刚刚";
+    if (elapsedSeconds < 60) return "just now";
     const elapsedMinutes = Math.floor(elapsedSeconds / 60);
-    if (elapsedMinutes < 60) return `${elapsedMinutes} 分`;
+    if (elapsedMinutes < 60) return `${elapsedMinutes} min`;
     const elapsedHours = Math.floor(elapsedMinutes / 60);
-    if (elapsedHours < 24) return `${elapsedHours} 小时`;
+    if (elapsedHours < 24) return `${elapsedHours} hr`;
     const elapsedDays = Math.floor(elapsedHours / 24);
-    if (elapsedDays < 7) return `${elapsedDays} 天`;
+    if (elapsedDays < 7) return `${elapsedDays} d`;
     const elapsedWeeks = Math.floor(elapsedDays / 7);
-    if (elapsedWeeks < 5) return `${elapsedWeeks} 周`;
+    if (elapsedWeeks < 5) return `${elapsedWeeks} wk`;
     const elapsedMonths = Math.floor(elapsedDays / 30);
-    if (elapsedMonths < 12) return `${Math.max(1, elapsedMonths)} 月`;
-    return `${Math.floor(elapsedDays / 365)} 年`;
+    if (elapsedMonths < 12) return `${Math.max(1, elapsedMonths)} mo`;
+    return `${Math.floor(elapsedDays / 365)} yr`;
   }
 
   function normalizeWorkspacePath(path) {
@@ -4373,7 +4385,7 @@
 
   function displayProjectName(path) {
     const trimmed = String(path || "").replace(/\/+$/, "");
-    return trimmed.split(/[\\/]+/).filter(Boolean).pop() || trimmed || "未命名项目";
+    return trimmed.split(/[\\/]+/).filter(Boolean).pop() || trimmed || "Unnamed project";
   }
 
   function normalizeProjectLabel(value) {
@@ -4414,7 +4426,7 @@
 
   function projectMoveTargets() {
     return [
-      { kind: "projectless", label: "普通对话", description: "不属于任何项目", path: "", normalizedPath: "" },
+      { kind: "projectless", label: "Chats", description: "Does not belong to any project", path: "", normalizedPath: "" },
       ...nativeProjectTargets().map(serializableProjectTarget),
     ];
   }
@@ -4465,7 +4477,7 @@
           sessionId,
           targetKind,
           targetCwd,
-          targetLabel: String(value.targetLabel || value.label || (targetKind === "projectless" ? "普通对话" : displayProjectName(targetCwd))),
+          targetLabel: String(value.targetLabel || value.label || (targetKind === "projectless" ? "Chats" : displayProjectName(targetCwd))),
           title: String(value.title || ""),
           sortMs: sortMsForSession(sessionId, value.sortMs || value.updatedAtMs || value.updated_at_ms),
           sortMsTrusted: value.sortMsTrusted === true,
@@ -4496,7 +4508,7 @@
       sessionId: id,
       targetKind: target.kind === "projectless" ? "projectless" : "project",
       targetCwd: target.path || "",
-      targetLabel: target.label || (target.kind === "projectless" ? "普通对话" : displayProjectName(target.path)),
+      targetLabel: target.label || (target.kind === "projectless" ? "Chats" : displayProjectName(target.path)),
       title: ref.title || "",
       sortMs: sortMsForSession(ref.session_id, sortMs || target.sortMs),
       sortMsTrusted: target.sortMsTrusted === true,
@@ -5047,7 +5059,7 @@
 
   async function setProjectlessThreadIds(ref, mode) {
     const variants = threadIdVariants(ref.session_id);
-    if (variants.length === 0) throw new Error("未找到会话 ID");
+    if (variants.length === 0) throw new Error("Session ID not found");
     const existingIds = await getCodexGlobalState("projectless-thread-ids").catch(() => []);
     const ids = Array.isArray(existingIds) ? existingIds : [];
     const variantSet = new Set(variants);
@@ -5067,7 +5079,7 @@
   }
 
   async function moveSessionToProjectless(ref) {
-    if (!ref.session_id) throw new Error("未找到会话 ID");
+    if (!ref.session_id) throw new Error("Session ID not found");
     await setProjectlessThreadIds(ref, "add");
     await clearThreadWorkspaceHints(ref);
     const sortKey = await postJson("/thread-sort-key", ref).catch(() => ({}));
@@ -5079,11 +5091,11 @@
   }
 
   async function moveSessionToProject(ref, target) {
-    if (!ref.session_id) throw new Error("未找到会话 ID");
-    if (!target?.path) throw new Error("目标项目路径为空");
-    if (!isNativeProjectTarget(target)) throw new Error("目标项目不在 Codex 项目列表中");
+    if (!ref.session_id) throw new Error("Session ID not found");
+    if (!target?.path) throw new Error("Target project path is empty");
+    if (!isNativeProjectTarget(target)) throw new Error("Target project is not in the Codex project list");
     const result = await postJson("/move-thread-workspace", { ...ref, target_cwd: target.path });
-    if (result.status !== "moved") throw new Error(result.message || "移动项目失败");
+    if (result.status !== "moved") throw new Error(result.message || "Move failed");
     await setProjectlessThreadIds(ref, "remove");
     await clearThreadWorkspaceHints(ref);
     return result;
@@ -5096,10 +5108,10 @@
     toast.textContent = message;
     if (undoToken) {
       const undo = document.createElement("button");
-      undo.textContent = "撤销";
+      undo.textContent = "Undo";
       undo.addEventListener("click", async () => {
         const result = await postJson("/undo", { undo_token: undoToken });
-        toast.textContent = result.message || "撤销完成";
+        toast.textContent = result.message || "Undo complete";
         setTimeout(() => toast.remove(), 5000);
       });
       toast.appendChild(undo);
@@ -5458,7 +5470,7 @@
       const worktreePath = usedBranches.get(branchMenuItemLabel(item));
       if (!worktreePath) continue;
       item.setAttribute(branchWorktreePathAttribute, worktreePath);
-      item.setAttribute("title", `该分支已在另一个 worktree 使用：${worktreePath}`);
+      item.setAttribute("title", `This branch is already used by another worktree: ${worktreePath}`);
     }
   }
 
@@ -5623,7 +5635,7 @@
       event.preventDefault();
       event.stopPropagation();
       event.stopImmediatePropagation?.();
-      showToast(`该分支已在另一个 worktree 使用：${usedWorktreePath}`, null);
+      showToast(`This branch is already used by another worktree: ${usedWorktreePath}`, null);
     }
   }
 
@@ -5702,7 +5714,7 @@
       prepareUpstreamBranchSelection(selection);
       syncUpstreamBranchTriggerLabel();
       syncUpstreamBranchMenuSelection(option.closest?.('[role="menu"], [data-radix-menu-content], [cmdk-list]'));
-      showToast(`将从 ${upstreamBranchOptionLabel(option) || "upstream/main"} 创建新 worktree`, null);
+      showToast(`Will create a new worktree from ${upstreamBranchOptionLabel(option) || "upstream/main"}`, null);
     }, true);
     let upstreamBranchInjectTimer = null;
     const schedule = () => {
@@ -5711,8 +5723,16 @@
         injectUpstreamBranchOptions().catch((error) => reportDiagnostic("upstream_branch_inject_failed", { error: error?.message || String(error) }));
       }, 80);
     };
-    new MutationObserver(schedule).observe(document.body || document.documentElement, { childList: true, subtree: true });
-    schedule();
+    const installMainScanObserver = () => {
+      const root = codexDomRoot();
+      if (!root) {
+        setTimeout(installMainScanObserver, 80);
+        return;
+      }
+      new MutationObserver(schedule).observe(root, { childList: true, subtree: true });
+      schedule();
+    };
+    installMainScanObserver();
   }
 
   function upstreamQualifiedSourceRef(selection) {
@@ -5869,7 +5889,7 @@
     if (!trigger) return false;
     const payload = upstreamWorktreePayloadFromSelection(trigger) || upstreamWorktreeNativePayloadFromElement(trigger);
     if (!payload) {
-      showToast("无法安全识别 Codex 原生 worktree 表单，请使用 Codex++ 菜单创建。", null);
+      showToast("Could not safely read Codex's native worktree form. Use the Codex++ menu to create it.", null);
       return false;
     }
     event.preventDefault();
@@ -5879,12 +5899,12 @@
       if (result?.status === "ok") {
         writeUpstreamBranchSelection(null);
         syncUpstreamBranchTriggerLabel();
-        showToast(`已从 ${result.sourceRef} 创建 worktree`, null);
+        showToast(`Created worktree from ${result.sourceRef}`, null);
       } else {
-        showToast(result?.message || "创建 upstream worktree 失败", null);
+        showToast(result?.message || "Failed to create upstream worktree", null);
       }
     } catch (error) {
-      showToast(error?.message || "创建 upstream worktree 失败", null);
+      showToast(error?.message || "Failed to create upstream worktree", null);
     }
     return true;
   }
@@ -5909,43 +5929,43 @@
   async function loadUpstreamWorktreeDefaults(dialog) {
     const repoPath = upstreamWorktreeField(dialog, "repoPath")?.value?.trim() || "";
     if (!repoPath) {
-      setUpstreamWorktreeMessage(dialog, "填写仓库路径后会自动读取 remote 和当前分支。", "idle");
+      setUpstreamWorktreeMessage(dialog, "Enter a repository path to read the remote and current branch automatically.", "idle");
       return;
     }
-    setUpstreamWorktreeMessage(dialog, "正在读取仓库默认值…", "loading");
+    setUpstreamWorktreeMessage(dialog, "Reading repository defaults...", "loading");
     try {
       const result = await postJson("/upstream-worktree/defaults", { repoPath });
       if (result?.status !== "ok") {
-        setUpstreamWorktreeMessage(dialog, result?.message || "读取仓库默认值失败", "failed");
+        setUpstreamWorktreeMessage(dialog, result?.message || "Failed to read repository defaults", "failed");
         return;
       }
       const remote = upstreamWorktreeField(dialog, "remote");
       const baseBranch = upstreamWorktreeField(dialog, "baseBranch");
       if (remote && !remote.value) remote.value = result.defaultRemote || "upstream";
       if (baseBranch && (!baseBranch.value || baseBranch.value === "main")) baseBranch.value = result.defaultBaseBranch || "main";
-      setUpstreamWorktreeMessage(dialog, `将从 ${remote?.value || "upstream"}/${baseBranch?.value || "main"} 创建 worktree。`, "ok");
+      setUpstreamWorktreeMessage(dialog, `Will create a worktree from ${remote?.value || "upstream"}/${baseBranch?.value || "main"}.`, "ok");
     } catch (error) {
-      setUpstreamWorktreeMessage(dialog, error?.message || "读取仓库默认值失败", "failed");
+      setUpstreamWorktreeMessage(dialog, error?.message || "Failed to read repository defaults", "failed");
     }
   }
 
   async function submitUpstreamWorktree(dialog) {
     const payload = upstreamWorktreePayload(dialog);
     if (!payload.repoPath || !payload.branchName || !payload.worktreePath || !payload.remote || !payload.baseBranch) {
-      setUpstreamWorktreeMessage(dialog, "仓库路径、分支名、worktree 路径、remote 和 base branch 都必须填写。", "failed");
+      setUpstreamWorktreeMessage(dialog, "Repository path, branch name, worktree path, remote, and base branch are all required.", "failed");
       return;
     }
-    setUpstreamWorktreeMessage(dialog, "正在 fetch 并创建 worktree…", "loading");
+    setUpstreamWorktreeMessage(dialog, "Fetching and creating worktree...", "loading");
     try {
       const result = await postJson("/upstream-worktree/create", payload);
       if (result?.status === "ok") {
-        setUpstreamWorktreeMessage(dialog, `已从 ${result.sourceRef} 创建：${result.worktreePath}`, "ok");
-        showToast(`已创建 upstream worktree：${result.branchName}`, null);
+        setUpstreamWorktreeMessage(dialog, `Created from ${result.sourceRef}: ${result.worktreePath}`, "ok");
+        showToast(`Created upstream worktree: ${result.branchName}`, null);
       } else {
-        setUpstreamWorktreeMessage(dialog, result?.message || "创建 upstream worktree 失败", "failed");
+        setUpstreamWorktreeMessage(dialog, result?.message || "Failed to create upstream worktree", "failed");
       }
     } catch (error) {
-      setUpstreamWorktreeMessage(dialog, error?.message || "创建 upstream worktree 失败", "failed");
+      setUpstreamWorktreeMessage(dialog, error?.message || "Failed to create upstream worktree", "failed");
     }
   }
 
@@ -5956,16 +5976,16 @@
     overlay.innerHTML = `
       <div class="codex-delete-confirm-content" role="dialog" aria-modal="true" aria-label="Create upstream worktree">
         <div class="codex-delete-confirm-title">Create from upstream</div>
-        <div class="codex-delete-confirm-message">等价于 git worktree add -b branch path upstream/base。创建前会先 fetch 远端分支。</div>
-        <label class="codex-plus-form-field">仓库路径<input data-codex-upstream-worktree-field="repoPath" type="text" placeholder="/path/to/repo"></label>
-        <label class="codex-plus-form-field">新分支名<input data-codex-upstream-worktree-field="branchName" type="text" placeholder="feature/my-task"></label>
-        <label class="codex-plus-form-field">Worktree 路径<input data-codex-upstream-worktree-field="worktreePath" type="text" placeholder="/path/to/worktrees/my-task"></label>
+        <div class="codex-delete-confirm-message">Equivalent to git worktree add -b branch path upstream/base. The remote branch is fetched first.</div>
+        <label class="codex-plus-form-field">Repository path<input data-codex-upstream-worktree-field="repoPath" type="text" placeholder="/path/to/repo"></label>
+        <label class="codex-plus-form-field">New branch name<input data-codex-upstream-worktree-field="branchName" type="text" placeholder="feature/my-task"></label>
+        <label class="codex-plus-form-field">Worktree path<input data-codex-upstream-worktree-field="worktreePath" type="text" placeholder="/path/to/worktrees/my-task"></label>
         <label class="codex-plus-form-field">Remote<input data-codex-upstream-worktree-field="remote" type="text" value="upstream"></label>
         <label class="codex-plus-form-field">Base branch<input data-codex-upstream-worktree-field="baseBranch" type="text" value="main"></label>
-        <div class="codex-plus-form-message" data-codex-upstream-worktree-message>填写仓库路径后会自动读取 remote 和当前分支。</div>
+        <div class="codex-plus-form-message" data-codex-upstream-worktree-message>Enter a repository path to read the remote and current branch automatically.</div>
         <div class="codex-delete-confirm-actions">
-          <button type="button" data-codex-upstream-worktree-cancel="true">取消</button>
-          <button type="button" data-codex-upstream-worktree-defaults="true">读取默认值</button>
+          <button type="button" data-codex-upstream-worktree-cancel="true">Cancel</button>
+          <button type="button" data-codex-upstream-worktree-defaults="true">Read defaults</button>
           <button type="button" data-codex-upstream-worktree-submit="true">Create from upstream</button>
         </div>
       </div>
@@ -6004,12 +6024,12 @@
       const overlay = document.createElement("div");
       overlay.className = "codex-delete-confirm-overlay";
       overlay.innerHTML = `
-        <div class="codex-delete-confirm-content" role="dialog" aria-modal="true" aria-label="删除会话">
-          <div class="codex-delete-confirm-title">删除会话</div>
-          <div class="codex-delete-confirm-message">删除“${escapeHtml(title)}”？</div>
+        <div class="codex-delete-confirm-content" role="dialog" aria-modal="true" aria-label="Delete conversation">
+          <div class="codex-delete-confirm-title">Delete Conversation</div>
+          <div class="codex-delete-confirm-message">Delete "${escapeHtml(title)}"?</div>
           <div class="codex-delete-confirm-actions">
-            <button type="button" data-codex-delete-cancel="true">取消</button>
-            <button type="button" data-codex-delete-confirm="true">删除</button>
+            <button type="button" data-codex-delete-cancel="true">Cancel</button>
+            <button type="button" data-codex-delete-confirm="true">Delete</button>
           </div>
         </div>
       `;
@@ -6077,8 +6097,8 @@
         const rect = button.getBoundingClientRect();
         const label = button.getAttribute("aria-label") || "";
         const text = (button.textContent || "").trim();
-        if (button.classList.contains(buttonClass) || button.classList.contains(exportButtonClass) || label === "归档对话" || label === "置顶对话") return false;
-        return text === "确认" || (text.length > 0 && rect.width > 0 && rect.width <= 36 && rect.x > row.getBoundingClientRect().right - 50);
+        if (button.classList.contains(buttonClass) || button.classList.contains(exportButtonClass) || ["归档对话", "Archive conversation", "置顶对话", "Pin conversation"].includes(label)) return false;
+        return ["确认", "Confirm"].includes(text) || (text.length > 0 && rect.width > 0 && rect.width <= 36 && rect.x > row.getBoundingClientRect().right - 50);
       });
       row.classList.toggle("codex-archive-confirm-visible", hasArchiveConfirm);
     });
@@ -6095,9 +6115,9 @@
       const result = await postJson("/delete", ref);
       if (result.status === "server_deleted" || result.status === "local_deleted") {
         removeDeletedRow(row, button, ref);
-        showToast(result.message || "删除成功", result.undo_token);
+        showToast(result.message || "Deleted", result.undo_token);
       } else {
-        showToast(result.message || "删除失败", null);
+        showToast(result.message || "Delete failed", null);
       }
     });
   }
@@ -6106,10 +6126,10 @@
     const result = await postJson("/export-markdown", ref);
     if (result.status === "exported" && result.filename && typeof result.markdown === "string") {
       downloadMarkdown(result.filename, result.markdown);
-      showToast(result.message || "导出成功", null);
+      showToast(result.message || "Exported", null);
       return;
     }
-    showToast(result.message || "导出失败", null);
+    showToast(result.message || "Export failed", null);
   }
 
   function sortStateFromMoveResult(result, ref, row) {
@@ -6120,7 +6140,7 @@
   function finishProjectMove(row, button, ref, target, message) {
     releaseDeleteFocus(row, button);
     button.disabled = false;
-    button.textContent = "移动";
+    button.textContent = "Move";
     saveProjectMoveProjection(ref, target, target.sortMs || rowSortMs(row, ref, target));
     if (target.kind === "projectless") moveRowToChats(row, target);
     refreshAfterProjectMove();
@@ -6129,19 +6149,19 @@
 
   async function applyProjectMove(row, button, ref, target) {
     button.disabled = true;
-    button.textContent = "移动中";
+    button.textContent = "Moving";
     try {
       if (target.kind === "projectless") {
         const result = await moveSessionToProjectless(ref);
-        finishProjectMove(row, button, ref, { ...target, ...sortStateFromMoveResult(result, ref, row) }, `已移动到普通对话：“${ref.title || ref.session_id}”`);
+        finishProjectMove(row, button, ref, { ...target, ...sortStateFromMoveResult(result, ref, row) }, `Moved to Chats: "${ref.title || ref.session_id}"`);
       } else {
         const result = await moveSessionToProject(ref, target);
-        finishProjectMove(row, button, ref, { ...target, ...sortStateFromMoveResult(result, ref, row) }, `已移动到“${target.label}”：“${ref.title || ref.session_id}”`);
+        finishProjectMove(row, button, ref, { ...target, ...sortStateFromMoveResult(result, ref, row) }, `Moved to "${target.label}": "${ref.title || ref.session_id}"`);
       }
     } catch (error) {
       button.disabled = false;
-      button.textContent = "移动";
-      showToast(`移动失败：${error?.message || error}`, null);
+      button.textContent = "Move";
+      showToast(`Move failed: ${error?.message || error}`, null);
     }
   }
 
@@ -6154,11 +6174,11 @@
     const overlay = document.createElement("div");
     overlay.className = projectMoveOverlayClass;
     overlay.innerHTML = `
-      <div class="codex-project-move-panel" role="dialog" aria-modal="true" aria-label="移动对话">
+      <div class="codex-project-move-panel" role="dialog" aria-modal="true" aria-label="Move conversation">
         <div class="codex-project-move-header">
-          <div class="codex-project-move-title">移动“${escapeHtml(ref.title || ref.session_id)}”</div>
+          <div class="codex-project-move-title">Move "${escapeHtml(ref.title || ref.session_id)}"</div>
         </div>
-        <div class="codex-project-move-list"><div class="codex-project-move-empty">加载项目中...</div></div>
+        <div class="codex-project-move-list"><div class="codex-project-move-empty">Loading projects...</div></div>
       </div>
     `;
     const panel = overlay.querySelector(".codex-project-move-panel");
@@ -6183,7 +6203,7 @@
       if (!list) return;
       list.innerHTML = "";
       if (targets.length === 0) {
-        list.innerHTML = `<div class="codex-project-move-empty">没有可用目标</div>`;
+        list.innerHTML = `<div class="codex-project-move-empty">No available targets</div>`;
         return;
       }
       for (const target of targets) {
@@ -6205,7 +6225,7 @@
       list.querySelector("button")?.focus();
     } catch (error) {
       close();
-      showToast(`加载项目失败：${error?.message || error}`, null);
+      showToast(`Failed to load projects: ${error?.message || error}`, null);
     }
   }
 
@@ -6485,20 +6505,20 @@
       moreButton.className = `${actionButtonClass} ${moreButtonClass}`;
       moreButton.setAttribute("aria-haspopup", "menu");
       moreButton.setAttribute("aria-expanded", "false");
-      configureActionButton(moreButton, "更多操作", "…");
+      configureActionButton(moreButton, "More Actions", "…");
       const moreMenu = document.createElement("div");
       moreMenu.className = moreMenuClass;
       moreMenu.setAttribute("role", "menu");
       moreMenu.hidden = true;
       if (settings.markdownExport) {
-        moreMenu.appendChild(createSessionMoreMenuItem("导出", "⇩", (event) => {
+        moreMenu.appendChild(createSessionMoreMenuItem("Export", "⇩", (event) => {
           stopActionButtonEvent(row, moreButton, event);
           closeSessionMoreMenus();
           exportMarkdown(ref);
         }));
       }
       if (settings.projectMove) {
-        moreMenu.appendChild(createSessionMoreMenuItem("移动", "↗", (event) => {
+        moreMenu.appendChild(createSessionMoreMenuItem("Move", "↗", (event) => {
           stopActionButtonEvent(row, moreButton, event);
           closeSessionMoreMenus();
           openProjectMoveMenuForRow(row, moreButton, ref, event);
@@ -6525,7 +6545,7 @@
       deleteButton.type = "button";
       deleteButton.className = `${actionButtonClass} ${buttonClass}`;
       deleteButton.dataset.codexDeleteVersion = codexDeleteVersion;
-      configureSvgActionButton(deleteButton, "删除", trashIconSvg());
+      configureSvgActionButton(deleteButton, "Delete", trashIconSvg());
       const openDeleteConfirm = (event) => openDeleteConfirmForRow(row, deleteButton, ref, event);
       installActionButtonEvents(row, deleteButton, openDeleteConfirm);
       group.appendChild(deleteButton);
@@ -6622,7 +6642,7 @@
       exportButton.type = "button";
       exportButton.className = `codex-archive-delete-all codex-archive-row-button ${exportButtonClass}`;
       exportButton.dataset.codexArchiveRowAction = "export";
-      exportButton.textContent = "导出";
+      exportButton.textContent = "Export";
       ["pointerdown", "mousedown", "mouseup", "touchstart"].forEach((eventName) => {
         exportButton.addEventListener(eventName, stopArchivedButtonEvent, true);
       });
@@ -6630,7 +6650,7 @@
         stopArchivedButtonEvent(event);
         const ref = await resolveArchivedThread(row);
         if (!ref.session_id) {
-          showToast("导出失败：未找到归档会话 ID", null);
+          showToast("Export failed: archived session ID not found", null);
           return;
         }
         await exportMarkdown(ref);
@@ -6796,7 +6816,7 @@
     marker.type = "button";
     marker.className = timelineMarkerClass;
     marker.style.top = `${question.markerTop}%`;
-    marker.setAttribute("aria-label", `跳转到：${truncateTimelineQuestion(question.text)}`);
+    marker.setAttribute("aria-label", `Jump to: ${truncateTimelineQuestion(question.text)}`);
     const tooltip = document.createElement("span");
     tooltip.className = timelineTooltipClass;
     tooltip.id = `codex-conversation-timeline-tooltip-${question.nodeId}`;

--- a/crates/codex-plus-core/src/ccs_import.rs
+++ b/crates/codex-plus-core/src/ccs_import.rs
@@ -285,7 +285,7 @@ fn profile_to_ccs_settings_config(profile: &RelayProfile) -> anyhow::Result<Valu
         json!({})
     } else {
         serde_json::from_str::<Value>(&profile.auth_contents)
-            .with_context(|| format!("{} 的 auth.json JSON 解析失败", profile.name))?
+            .with_context(|| format!("Failed to parse {} auth.json as JSON", profile.name))?
     };
     Ok(json!({
         "auth": auth,

--- a/crates/codex-plus-core/src/cli_wrapper.rs
+++ b/crates/codex-plus-core/src/cli_wrapper.rs
@@ -23,7 +23,7 @@ pub fn ensure_cli_wrapper(settings: &BackendSettings) -> anyhow::Result<Option<W
         return Ok(None);
     }
     let real_codex = resolve_real_codex_for_settings(settings).ok_or_else(|| {
-        anyhow::anyhow!("未找到系统 Codex CLI，可先启动一次系统 Codex 或重新安装 Codex")
+        anyhow::anyhow!("System Codex CLI was not found. Start the system Codex once or reinstall Codex.")
     })?;
     let codex_home = cli_home_dir();
     let wrapper_settings = wrapper_settings_for_refresh(settings, &wrapper_dir);
@@ -248,7 +248,7 @@ class CodexWrapper
 
 fn compile_wrapper(source_path: &Path, wrapper_path: &Path) -> anyhow::Result<()> {
     let csc =
-        find_csc().ok_or_else(|| anyhow::anyhow!("未找到 csc.exe，无法编译 Codex++ wrapper"))?;
+        find_csc().ok_or_else(|| anyhow::anyhow!("csc.exe was not found, so the Codex++ wrapper cannot be compiled"))?;
     let output_arg = format!("/out:{}", wrapper_path.display());
     let mut command = Command::new(&csc);
     command

--- a/crates/codex-plus-core/src/config_coordinator.rs
+++ b/crates/codex-plus-core/src/config_coordinator.rs
@@ -119,20 +119,19 @@ pub fn detect_external_modification(home: &std::path::Path) -> Option<String> {
     let writer = marker.writer.trim();
     if writer == WRITER_CODEX_PLUS_PLUS {
         Some(
-            "检测到 config.toml / auth.json 在 Codex++ 上次写入后被外部修改。\
-             这通常由 CC Switch 切换供应商引起。"
+            "config.toml / auth.json changed after the last Codex++ write.\
+             This is usually caused by CC Switch changing providers."
                 .to_string(),
         )
     } else if writer == WRITER_CC_SWITCH {
         Some(
-            "检测到 live 配置与 CC Switch 上次写入记录不一致。\
-             请先在 CC Switch 中重新启用当前供应商，或刷新 Codex++ 联动状态。"
+            "The live config no longer matches the last CC Switch write marker.\
+             Re-enable the current provider in CC Switch first, or refresh Codex++ linking status."
                 .to_string(),
         )
     } else {
         Some(
-            "检测到 config.toml / auth.json 与 Codex++ 记录不一致，\
-             可能已被其他工具改写。"
+            "config.toml / auth.json no longer matches the Codex++ marker and may have been changed by another tool."
                 .to_string(),
         )
     }
@@ -177,7 +176,7 @@ pub fn evaluate_live_write(settings: &BackendSettings, force: bool) -> LiveConfi
     if !settings.relay_profiles_enabled {
         return LiveConfigWriteDecision {
             allowed: false,
-            message: "供应商配置总开关已关闭，Codex++ 不会写入 config.toml / auth.json。".to_string(),
+            message: "Provider switching is off; Codex++ will not write config.toml / auth.json.".to_string(),
         };
     }
 
@@ -185,8 +184,8 @@ pub fn evaluate_live_write(settings: &BackendSettings, force: bool) -> LiveConfi
     if effective == ConfigOwnership::CcSwitch && !settings.ccs_link_enabled {
         return LiveConfigWriteDecision {
             allowed: false,
-            message: "当前配置所有权为 CC Switch，但未开启联动 cc-switch。\
-                      请开启联动，或将配置所有权改为 Codex++。"
+            message: "Config ownership is currently CC Switch, but cc-switch linking is off.\
+                      Enable linking or change Config Ownership to Codex++."
                 .to_string(),
         };
     }
@@ -194,8 +193,8 @@ pub fn evaluate_live_write(settings: &BackendSettings, force: bool) -> LiveConfi
     if effective == ConfigOwnership::CcSwitch && !force {
         return LiveConfigWriteDecision {
             allowed: false,
-            message: "当前由 CC Switch 管理 Codex 供应商配置。\
-                      Codex++ 不会直接覆盖 live 配置；请通过联动供应商切换，或在 CC Switch 中切换后刷新。"
+            message: "CC Switch currently owns Codex provider config.\
+                      Codex++ will not overwrite live config directly; switch through a linked provider, or switch in CC Switch and refresh."
                 .to_string(),
         };
     }
@@ -208,7 +207,7 @@ pub fn evaluate_live_write(settings: &BackendSettings, force: bool) -> LiveConfi
         return LiveConfigWriteDecision {
             allowed: false,
             message: format!(
-                "{conflict} 若确认由 Codex++ 接管，请先将“配置所有权”设为 Codex++ 并强制切换。"
+                "{conflict} To let Codex++ take over, set Config Ownership to Codex++ first and force the switch."
             ),
         };
     }
@@ -224,7 +223,7 @@ pub fn apply_linked_ccs_provider_to_home(
     common_config_contents: &str,
 ) -> anyhow::Result<RelayApplyResult> {
     let provider = current_ccs_codex_provider_by_id(source_id)
-        .with_context(|| format!("未在 cc-switch 中找到 Codex 供应商 {source_id}"))?;
+        .with_context(|| format!("Codex provider {source_id} was not found in cc-switch"))?;
     apply_ccs_provider_import_to_home(&provider, common_config_contents)
 }
 
@@ -232,7 +231,7 @@ pub fn apply_current_ccs_provider_to_home(
     common_config_contents: &str,
 ) -> anyhow::Result<RelayApplyResult> {
     let provider = current_ccs_codex_provider()
-        .ok_or_else(|| anyhow::anyhow!("cc-switch 中未找到当前启用的 Codex 供应商"))?;
+        .ok_or_else(|| anyhow::anyhow!("No currently enabled Codex provider was found in cc-switch"))?;
     apply_ccs_provider_import_to_home(&provider, common_config_contents)
 }
 
@@ -308,33 +307,32 @@ fn coordination_guidance(
     live_model_provider: &str,
 ) -> String {
     if !ccswitch_detected {
-        return "未检测到 CC Switch，Codex++ 将独立管理 ~/.codex/config.toml。".to_string();
+        return "CC Switch was not detected; Codex++ will manage ~/.codex/config.toml independently.".to_string();
     }
     if conflict_detected {
-        return "检测到配置冲突：请统一只在一个工具中切换供应商，或明确设置“配置所有权”。".to_string();
+        return "A config conflict was detected: switch providers from only one tool, or set Config Ownership explicitly.".to_string();
     }
     match effective {
         ConfigOwnership::CcSwitch => {
             let provider = current_ccs
                 .as_ref()
                 .map(|value| value.name.as_str())
-                .unwrap_or("未知");
+                .unwrap_or("Unknown");
             format!(
-                "当前由 CC Switch 管理供应商配置。Codex++ 会通过联动读取/回写 cc-switch 数据库，\
-                 不会直接覆盖 live 配置。CC Switch 当前供应商：{provider}；live model_provider：{live_model_provider}。"
+                "CC Switch currently manages provider config. Codex++ reads and writes the cc-switch database through linking,\
+                 and will not directly overwrite live config. Current CC Switch provider: {provider}; live model_provider: {live_model_provider}."
             )
         }
         ConfigOwnership::CodexPlusPlus => {
             if settings.ccs_link_enabled {
-                "已开启 cc-switch 联动，但配置所有权仍为 Codex++。切换供应商时 Codex++ 会写入 live 配置，\
-                 可能覆盖 CC Switch 的选择。"
+                "cc-switch linking is on, but Config Ownership is still Codex++. When switching providers, Codex++ writes live config and may overwrite CC Switch's selection."
                     .to_string()
             } else {
-                "Codex++ 独立管理 live 配置。若同时使用 CC Switch，建议开启联动并设为 auto/ccswitch 所有权。"
+                "Codex++ manages live config independently. If you also use CC Switch, enable linking and set ownership to auto or ccSwitch."
                     .to_string()
             }
         }
-        ConfigOwnership::Auto => "自动模式会根据联动开关和 CC Switch 是否存在选择所有权。".to_string(),
+        ConfigOwnership::Auto => "Auto mode chooses ownership based on the linking toggle and whether CC Switch is present.".to_string(),
     }
 }
 

--- a/crates/codex-plus-core/src/install/mod.rs
+++ b/crates/codex-plus-core/src/install/mod.rs
@@ -6,7 +6,7 @@ pub mod macos;
 pub mod windows;
 
 pub const SILENT_NAME: &str = "Codex++";
-pub const MANAGER_NAME: &str = "Codex++ 管理工具";
+pub const MANAGER_NAME: &str = "Codex++ Manager";
 pub const SILENT_BINARY: &str = "codex-plus-plus";
 pub const MANAGER_BINARY: &str = "codex-plus-plus-manager";
 
@@ -72,11 +72,11 @@ impl ShortcutState {
 }
 
 pub fn shortcut_names() -> (&'static str, &'static str) {
-    ("Codex++.lnk", "Codex++ 管理工具.lnk")
+    ("Codex++.lnk", "Codex++ Manager.lnk")
 }
 
 pub fn app_bundle_names() -> (&'static str, &'static str) {
-    ("Codex++.app", "Codex++ 管理工具.app")
+    ("Codex++.app", "Codex++ Manager.app")
 }
 
 pub fn inspect_entrypoints() -> EntryPointState {
@@ -89,7 +89,7 @@ pub fn inspect_entrypoints() -> EntryPointState {
 
 pub fn install_entrypoints(options: &InstallOptions) -> InstallActionResult {
     let result = platform_install(options);
-    action_result(result, "入口已安装。")
+    action_result(result, "Entries installed.")
 }
 
 pub fn uninstall_entrypoints(options: &InstallOptions) -> InstallActionResult {
@@ -97,12 +97,12 @@ pub fn uninstall_entrypoints(options: &InstallOptions) -> InstallActionResult {
     if result.is_ok() && options.remove_owned_data {
         let _ = remove_owned_data();
     }
-    action_result(result, "入口已卸载。")
+    action_result(result, "Entries uninstalled.")
 }
 
 pub fn repair_entrypoints(options: &InstallOptions) -> InstallActionResult {
     let result = platform_install(options);
-    action_result(result, "入口已修复。")
+    action_result(result, "Entries repaired.")
 }
 
 pub fn build_windows_entrypoint_plan(options: &InstallOptions) -> windows::WindowsEntrypointPlan {
@@ -164,7 +164,7 @@ fn platform_install(options: &InstallOptions) -> anyhow::Result<()> {
     #[cfg(not(any(windows, target_os = "macos")))]
     {
         let _ = options;
-        anyhow::bail!("当前平台暂不支持安装 Codex++ 入口")
+        anyhow::bail!("Installing Codex++ entries is not supported on this platform yet")
     }
 }
 
@@ -182,7 +182,7 @@ fn platform_uninstall(options: &InstallOptions) -> anyhow::Result<()> {
     #[cfg(not(any(windows, target_os = "macos")))]
     {
         let _ = options;
-        anyhow::bail!("当前平台暂不支持卸载 Codex++ 入口")
+        anyhow::bail!("Uninstalling Codex++ entries is not supported on this platform yet")
     }
 }
 

--- a/crates/codex-plus-core/src/install/windows.rs
+++ b/crates/codex-plus-core/src/install/windows.rs
@@ -35,7 +35,7 @@ pub fn build_windows_entrypoint_plan(options: &InstallOptions) -> WindowsEntrypo
             .to_string_lossy()
             .to_string(),
         manager_shortcut: install_root
-            .join("Codex++ 管理工具.lnk")
+            .join("Codex++ Manager.lnk")
             .to_string_lossy()
             .to_string(),
         install_root: install_root.to_string_lossy().to_string(),

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -254,7 +254,7 @@ where
             } else {
                 let degraded = launch_status(
                     "running_degraded",
-                    "Codex 已启动，Codex++ 增强仍在等待页面就绪。",
+                    "Codex launched; Codex++ enhancements are still waiting for the page to be ready.",
                     debug_port,
                     helper_port,
                     &app_dir,
@@ -704,7 +704,7 @@ async fn handle_helper_connection(
                 "200 OK".to_string(),
                 serde_json::to_vec(&serde_json::json!({
                     "status": "ok",
-                    "message": "后端已连接",
+                    "message": "Backend connected",
                     "version": crate::version::VERSION,
                     "transport": "http-helper"
                 }))?,
@@ -738,7 +738,7 @@ async fn handle_helper_connection(
                 "200 OK".to_string(),
                 serde_json::to_vec(&serde_json::json!({
                     "status": "ok",
-                    "message": "日志已记录"
+                    "message": "Log recorded"
                 }))?,
                 "application/json; charset=utf-8".to_string(),
                 "helper.diagnostics_log_ok",
@@ -748,7 +748,7 @@ async fn handle_helper_connection(
                 "404 Not Found".to_string(),
                 serde_json::to_vec(&serde_json::json!({
                     "status": "failed",
-                    "message": "未知后端路径"
+                    "message": "Unknown backend path"
                 }))?,
                 "application/json; charset=utf-8".to_string(),
                 "helper.unknown_path",
@@ -1118,7 +1118,7 @@ async fn read_http_request(stream: &mut tokio::net::TcpStream) -> anyhow::Result
             }
         }
         if buffer.len() > 32 * 1024 * 1024 {
-            anyhow::bail!("HTTP 请求过大");
+            anyhow::bail!("HTTP request is too large");
         }
     }
 

--- a/crates/codex-plus-core/src/model_catalog.rs
+++ b/crates/codex-plus-core/src/model_catalog.rs
@@ -526,7 +526,7 @@ pub async fn fetch_relay_profile_model_ids(
         api_key: profile.api_key.trim().to_string(),
     };
     if source.base_url.is_empty() {
-        anyhow::bail!("Base URL 不能为空");
+        anyhow::bail!("Base URL cannot be empty");
     }
     let endpoint = models_endpoint(&source.base_url);
     let client = crate::http_client::proxied_client(&profile.user_agent)?;
@@ -535,7 +535,7 @@ pub async fn fetch_relay_profile_model_ids(
         let message = status
             .get("message")
             .and_then(Value::as_str)
-            .unwrap_or("上游没有返回可用模型");
+            .unwrap_or("Upstream did not return any available models");
         anyhow::bail!("{message}");
     }
     Ok((models, endpoint))

--- a/crates/codex-plus-core/src/ports.rs
+++ b/crates/codex-plus-core/src/ports.rs
@@ -18,11 +18,11 @@ pub fn select_platform_loopback_port(requested: u16) -> u16 {
 
 pub fn select_platform_loopback_port_with(
     requested: u16,
-    is_windows: bool,
+    _is_windows: bool,
     can_bind: impl Fn(u16) -> bool,
     find_available: impl Fn() -> u16,
 ) -> u16 {
-    if !is_windows || can_bind(requested) {
+    if can_bind(requested) {
         requested
     } else {
         find_available()
@@ -33,7 +33,16 @@ pub fn can_bind_loopback_port(port: u16) -> bool {
     if port == 0 {
         return true;
     }
-    TcpListener::bind(("127.0.0.1", port)).is_ok()
+    if TcpListener::bind(("127.0.0.1", port)).is_err() {
+        return false;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        if TcpListener::bind(("::1", port)).is_err() {
+            return false;
+        }
+    }
+    true
 }
 
 pub fn find_available_loopback_port() -> u16 {

--- a/crates/codex-plus-core/src/protocol_proxy.rs
+++ b/crates/codex-plus-core/src/protocol_proxy.rs
@@ -1,6 +1,6 @@
-//! Codex Responses API 与 OpenAI Chat Completions 的本地协议转换。
+//! Local protocol conversion between the Codex Responses API and OpenAI Chat Completions.
 //!
-//! Codex Chat 与 Responses 协议之间的转换实现。
+//! Conversion implementation for Codex Chat and Responses protocols.
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
@@ -427,13 +427,13 @@ pub async fn open_responses_proxy_request(body: &str) -> anyhow::Result<Upstream
     let settings = SettingsStore::default().load().unwrap_or_default();
     let relay = settings.active_relay_profile();
     if relay.protocol != RelayProtocol::ChatCompletions {
-        anyhow::bail!("当前中转未启用 Chat Completions 协议代理");
+        anyhow::bail!("The current provider has not enabled the Chat Completions protocol proxy");
     }
     if relay.base_url.trim().is_empty() {
-        anyhow::bail!("Chat Completions 上游 Base URL 不能为空");
+        anyhow::bail!("Chat Completions upstream Base URL cannot be empty");
     }
     if relay.api_key.trim().is_empty() {
-        anyhow::bail!("Chat Completions 上游 Key 不能为空");
+        anyhow::bail!("Chat Completions upstream key cannot be empty");
     }
 
     let request_json: Value = serde_json::from_str(body)?;
@@ -470,13 +470,13 @@ pub async fn open_models_proxy_request() -> anyhow::Result<UpstreamProxyResponse
     let settings = SettingsStore::default().load().unwrap_or_default();
     let relay = settings.active_relay_profile();
     if relay.protocol != RelayProtocol::ChatCompletions {
-        anyhow::bail!("当前中转未启用 Chat Completions 协议代理");
+        anyhow::bail!("The current provider has not enabled the Chat Completions protocol proxy");
     }
     if relay.base_url.trim().is_empty() {
-        anyhow::bail!("Chat Completions 上游 Base URL 不能为空");
+        anyhow::bail!("Chat Completions upstream Base URL cannot be empty");
     }
     if relay.api_key.trim().is_empty() {
-        anyhow::bail!("Chat Completions 上游 Key 不能为空");
+        anyhow::bail!("Chat Completions upstream key cannot be empty");
     }
 
     let client = crate::http_client::proxied_client(&relay.user_agent)?;
@@ -507,13 +507,13 @@ pub async fn open_chat_completions_proxy_request(
     let settings = SettingsStore::default().load().unwrap_or_default();
     let relay = settings.active_relay_profile();
     if relay.protocol != RelayProtocol::ChatCompletions {
-        anyhow::bail!("当前中转未启用 Chat Completions 协议代理");
+        anyhow::bail!("The current provider has not enabled the Chat Completions protocol proxy");
     }
     if relay.base_url.trim().is_empty() {
-        anyhow::bail!("Chat Completions 上游 Base URL 不能为空");
+        anyhow::bail!("Chat Completions upstream Base URL cannot be empty");
     }
     if relay.api_key.trim().is_empty() {
-        anyhow::bail!("Chat Completions 上游 Key 不能为空");
+        anyhow::bail!("Chat Completions upstream key cannot be empty");
     }
 
     let request_json: Value = serde_json::from_str(body)?;

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -153,7 +153,7 @@ fn table_mut_or_insert<'a>(doc: &'a mut DocumentMut, key: &str) -> anyhow::Resul
     }
     doc.get_mut(key)
         .and_then(Item::as_table_mut)
-        .ok_or_else(|| anyhow::anyhow!("{key} 必须是 TOML table"))
+        .ok_or_else(|| anyhow::anyhow!("{key} must be a TOML table"))
 }
 
 fn table_mut_if_exists<'a>(doc: &'a mut DocumentMut, key: &str) -> Option<&'a mut Table> {
@@ -181,7 +181,7 @@ pub fn chatgpt_auth_status_from_home(home: &Path) -> ChatGptAuthStatus {
             authenticated: true,
             source: auth_path.to_string_lossy().to_string(),
             account_label,
-            message: "已通过 auth.json 和 config.toml 检测到 ChatGPT 登录。".to_string(),
+            message: "Detected ChatGPT login through auth.json and config.toml.".to_string(),
         };
     }
 
@@ -189,7 +189,7 @@ pub fn chatgpt_auth_status_from_home(home: &Path) -> ChatGptAuthStatus {
         authenticated: false,
         source: String::new(),
         account_label: None,
-        message: "未检测到 ChatGPT 登录账号。".to_string(),
+        message: "No ChatGPT login account detected.".to_string(),
     }
 }
 
@@ -251,11 +251,11 @@ pub fn apply_relay_config_to_home_with_protocol(
 ) -> anyhow::Result<RelayApplyResult> {
     let base_url = base_url.trim();
     if base_url.is_empty() {
-        anyhow::bail!("中转 Base URL 不能为空");
+        anyhow::bail!("Relay Base URL cannot be empty");
     }
     let bearer_token = bearer_token.trim();
     if bearer_token.is_empty() {
-        anyhow::bail!("中转 Key 不能为空");
+        anyhow::bail!("Relay key cannot be empty");
     }
     let codex_base_url = codex_base_url_for_protocol(base_url, protocol, proxy_port);
     let updated = upsert_model_provider_config("", &codex_base_url, bearer_token)?;
@@ -292,7 +292,7 @@ pub fn apply_relay_files_to_home(
     auth_contents: &str,
 ) -> anyhow::Result<RelayApplyResult> {
     if config_contents.trim().is_empty() {
-        anyhow::bail!("config.toml 内容不能为空");
+        anyhow::bail!("config.toml contents cannot be empty");
     }
     std::fs::create_dir_all(home)?;
 
@@ -404,7 +404,7 @@ pub fn apply_relay_config_file_to_home(
     config_contents: &str,
 ) -> anyhow::Result<RelayApplyResult> {
     if config_contents.trim().is_empty() {
-        anyhow::bail!("config.toml 内容不能为空");
+        anyhow::bail!("config.toml contents cannot be empty");
     }
     std::fs::create_dir_all(home)?;
 
@@ -427,11 +427,11 @@ pub fn apply_pure_api_config_to_home_with_protocol(
 ) -> anyhow::Result<RelayApplyResult> {
     let base_url = base_url.trim();
     if base_url.is_empty() {
-        anyhow::bail!("中转 Base URL 不能为空");
+        anyhow::bail!("Relay Base URL cannot be empty");
     }
     let bearer_token = bearer_token.trim();
     if bearer_token.is_empty() {
-        anyhow::bail!("中转 Key 不能为空");
+        anyhow::bail!("Relay key cannot be empty");
     }
     let codex_base_url = codex_base_url_for_protocol(base_url, protocol, proxy_port);
     let updated = upsert_model_provider_config("", &codex_base_url, bearer_token)?;
@@ -455,12 +455,12 @@ pub async fn test_relay_profile(
     let base_url = relay_profile_base_url(profile);
     let base_url = base_url.trim().trim_end_matches('/');
     if base_url.is_empty() {
-        anyhow::bail!("Base URL 不能为空");
+        anyhow::bail!("Base URL cannot be empty");
     }
     let api_key = relay_profile_api_key(profile);
     let api_key = api_key.trim();
     if api_key.is_empty() {
-        anyhow::bail!("API Key 不能为空");
+        anyhow::bail!("API key cannot be empty");
     }
 
     let client = crate::http_client::proxied_client("CodexPlusPlus/RelayTest")?;
@@ -470,7 +470,7 @@ pub async fn test_relay_profile(
     };
     let test_model = model.trim();
     if test_model.is_empty() {
-        anyhow::bail!("测试模型不能为空");
+        anyhow::bail!("Test model cannot be empty");
     }
 
     let payload = relay_profile_test_payload(profile.protocol, test_model);
@@ -483,9 +483,9 @@ pub async fn test_relay_profile(
         .await?;
     let http_status = response.status().as_u16();
 
-    // 如果 404 且 base_url 末尾没有 /v1，尝试自动补 /v1 后再发一次。
-    // 许多上游（中转站、自建代理）暴露的路径以 /v1/ 开头，
-    // 用户容易遗漏这个前缀，导致 /responses 或 /chat/completions 404。
+    // If a base URL without /v1 returns 404, retry once with the /v1 prefix.
+    // Many relays and self-hosted proxies expose paths below /v1/, and users
+    // often miss that prefix when /responses or /chat/completions returns 404.
     if http_status == 404 && !base_url.ends_with("/v1") {
         let v1_url = format!("{base_url}/v1");
         let v1_endpoint = match profile.protocol {
@@ -506,7 +506,7 @@ pub async fn test_relay_profile(
                 http_status: v1_status,
                 endpoint: v1_endpoint,
                 response_preview: format!(
-                    "（Base URL 建议加上 /v1 前缀）{}",
+                    "Base URL likely needs the /v1 prefix. {}",
                     response_text.chars().take(280).collect::<String>()
                 ),
             });
@@ -729,7 +729,7 @@ pub fn upsert_context_entry_in_common_config(
 ) -> anyhow::Result<String> {
     let id = id.trim();
     if id.is_empty() {
-        anyhow::bail!("上下文 id 不能为空");
+        anyhow::bail!("Context id cannot be empty");
     }
     let table_name = context_table_name(kind)?;
     let body_doc = parse_toml_document(toml_body)?;
@@ -739,7 +739,7 @@ pub fn upsert_context_entry_in_common_config(
         doc[table_name] = toml_edit::table();
     }
     if doc[table_name].as_table().is_none() {
-        anyhow::bail!("{table_name} 必须是 TOML 表");
+        anyhow::bail!("{table_name} must be a TOML table");
     }
     doc[table_name][id] = Item::Table(body_doc.as_table().clone());
     Ok(normalize_optional_toml(doc))
@@ -839,7 +839,7 @@ fn write_codex_live_atomic(
 
     if let Some(auth_bytes) = auth_bytes {
         if let Err(error) = crate::settings::atomic_write(&auth_path, auth_bytes) {
-            return Err(error.context("写入 auth.json 失败"));
+            return Err(error.context("Failed to write auth.json"));
         }
         auth_written = true;
     }
@@ -850,7 +850,7 @@ fn write_codex_live_atomic(
                 let _ = restore_optional_file(&auth_path, old_auth.as_deref());
             }
             let _ = restore_optional_file(&config_path, old_config.as_deref());
-            return Err(error.context("写入 config.toml 失败"));
+            return Err(error.context("Failed to write config.toml"));
         }
     }
 
@@ -894,7 +894,7 @@ fn parse_toml_document(contents: &str) -> anyhow::Result<DocumentMut> {
     } else {
         contents
             .parse::<DocumentMut>()
-            .with_context(|| "config.toml TOML 解析失败")
+            .with_context(|| "Failed to parse config.toml as TOML")
     }
 }
 
@@ -1085,7 +1085,7 @@ fn validate_toml_config(config_text: &str, path: &Path) -> anyhow::Result<()> {
     }
     config_text
         .parse::<toml::Table>()
-        .with_context(|| format!("{} 不是有效 TOML", path.display()))?;
+        .with_context(|| format!("{} is not valid TOML", path.display()))?;
     Ok(())
 }
 
@@ -1094,7 +1094,7 @@ fn validate_auth_json(auth_bytes: &[u8], path: &Path) -> anyhow::Result<()> {
         return Ok(());
     }
     serde_json::from_slice::<Value>(auth_bytes)
-        .with_context(|| format!("{} 不是有效 JSON", path.display()))?;
+        .with_context(|| format!("{} is not valid JSON", path.display()))?;
     Ok(())
 }
 
@@ -1105,9 +1105,9 @@ fn parse_optional_positive_u64(value: &str, label: &str) -> anyhow::Result<Optio
     }
     let parsed = trimmed
         .parse::<u64>()
-        .with_context(|| format!("{label}必须是正整数"))?;
+        .with_context(|| format!("{label} must be a positive integer"))?;
     if parsed == 0 {
-        anyhow::bail!("{label}必须大于 0");
+        anyhow::bail!("{label} must be greater than 0");
     }
     Ok(Some(parsed))
 }
@@ -1118,10 +1118,10 @@ fn apply_context_limits_to_config(
     auto_compact_limit: &str,
 ) -> anyhow::Result<String> {
     let mut doc = parse_toml_document(config_text)?;
-    if let Some(value) = parse_optional_positive_u64(context_window, "上下文大小")? {
+    if let Some(value) = parse_optional_positive_u64(context_window, "context window")? {
         doc["model_context_window"] = toml_edit::value(value as i64);
     }
-    if let Some(value) = parse_optional_positive_u64(auto_compact_limit, "压缩上下文大小")? {
+    if let Some(value) = parse_optional_positive_u64(auto_compact_limit, "auto compact context size")? {
         doc["model_auto_compact_token_limit"] = toml_edit::value(value as i64);
     }
     Ok(normalize_optional_toml(doc))
@@ -1312,7 +1312,7 @@ fn context_table_name(kind: &str) -> anyhow::Result<&'static str> {
         "mcp" | "mcpServer" | "mcpServers" => Ok("mcp_servers"),
         "skill" | "skills" => Ok("skills"),
         "plugin" | "plugins" => Ok("plugins"),
-        other => anyhow::bail!("未知上下文类型：{other}"),
+        other => anyhow::bail!("Unknown context type: {other}"),
     }
 }
 
@@ -1428,7 +1428,7 @@ fn restore_profile_auth_from_live_config(
     let mut auth = if template_auth.trim().is_empty() {
         json!({})
     } else {
-        serde_json::from_str::<Value>(template_auth).with_context(|| "auth.json JSON 解析失败")?
+        serde_json::from_str::<Value>(template_auth).with_context(|| "Failed to parse auth.json as JSON")?
     };
     if !auth.is_object() {
         auth = json!({});
@@ -1436,7 +1436,7 @@ fn restore_profile_auth_from_live_config(
     if let Some(auth_object) = auth.as_object_mut() {
         auth_object.insert("OPENAI_API_KEY".to_string(), Value::String(token));
     } else {
-        anyhow::bail!("auth.json 必须是 JSON 对象");
+        anyhow::bail!("auth.json must be a JSON object");
     }
     profile.auth_contents = serde_json::to_string_pretty(&auth)?;
     Ok(())
@@ -1479,8 +1479,9 @@ fn codex_auth_api_key(auth_contents: &str) -> Option<String> {
         .map(ToString::to_string)
 }
 
-/// 解析 profile 實際使用的模型：優先取 config.toml 裡的 `model =`，
-/// 否則退回 profile.model 欄位。供應商測試用它做回退，避免串到別家供應商的模型名。
+/// Resolve the model actually used by a profile: prefer `model =` from
+/// config.toml, otherwise fall back to profile.model. Provider tests use this
+/// to avoid accidentally borrowing another provider's model name.
 pub fn relay_profile_model(profile: &RelayProfile) -> String {
     root_key_string(&profile.config_contents, "model")
         .filter(|value| !value.trim().is_empty())
@@ -1639,9 +1640,9 @@ fn remove_openai_api_key_from_auth_contents(auth_contents: &str) -> anyhow::Resu
         return Ok(String::new());
     }
     let mut value =
-        serde_json::from_str::<Value>(auth_contents).with_context(|| "auth.json JSON 解析失败")?;
+        serde_json::from_str::<Value>(auth_contents).with_context(|| "Failed to parse auth.json as JSON")?;
     let Some(object) = value.as_object_mut() else {
-        anyhow::bail!("auth.json 必须是 JSON 对象");
+        anyhow::bail!("auth.json must be a JSON object");
     };
     object.remove("OPENAI_API_KEY");
     if object.is_empty() {
@@ -1740,7 +1741,7 @@ fn ensure_provider_table<'a>(
     providers
         .get_mut(provider_id)
         .and_then(Item::as_table_mut)
-        .ok_or_else(|| anyhow::anyhow!("model_providers.{provider_id} 必须是 TOML table"))
+        .ok_or_else(|| anyhow::anyhow!("model_providers.{provider_id} must be a TOML table"))
 }
 
 fn remove_provider_table(doc: &mut DocumentMut, provider_id: &str) {
@@ -1988,7 +1989,7 @@ mod tests {
 
     #[test]
     fn relay_profile_model_prefers_config_then_field_then_empty() {
-        // 1. 供應商測試的回退第一級：config.toml 的 model = 優先
+        // 1. Provider tests first fall back to model = from config.toml.
         let from_config = RelayProfile {
             config_contents: "model = \"deepseek-v4-flash\"\nmodel_provider = \"custom\"\n"
                 .to_string(),
@@ -1997,7 +1998,7 @@ mod tests {
         };
         assert_eq!(relay_profile_model(&from_config), "deepseek-v4-flash");
 
-        // 2. config 沒寫 model 時退回 profile.model 欄位
+        // 2. If config has no model, fall back to profile.model.
         let from_field = RelayProfile {
             config_contents: "model_provider = \"custom\"\n".to_string(),
             model: "deepseek-v4-pro".to_string(),
@@ -2005,7 +2006,7 @@ mod tests {
         };
         assert_eq!(relay_profile_model(&from_field), "deepseek-v4-pro");
 
-        // 3. 兩者皆空 → 空字串；呼叫端據此才回退到全域 relayTestModel
+        // 3. If both are empty, return an empty string so callers can fall back to the global relayTestModel.
         let empty = RelayProfile {
             config_contents: String::new(),
             model: String::new(),

--- a/crates/codex-plus-core/src/routes.rs
+++ b/crates/codex-plus-core/src/routes.rs
@@ -437,7 +437,7 @@ impl BridgeRuntimeService for CoreRuntimeService {
     async fn open_manager(&self) -> anyhow::Result<Value> {
         let manager_path = manager_exe_path();
         if !manager_path.exists() {
-            anyhow::bail!("未找到管理工具：{}", manager_path.display());
+            anyhow::bail!("Manager not found: {}", manager_path.display());
         }
         spawn_manager(&manager_path)?;
         Ok(json!({
@@ -455,7 +455,7 @@ impl BridgeRuntimeService for CoreRuntimeService {
                 "version": crate::version::VERSION
             }),
         );
-        Ok(json!({"status": "ok", "message": "后端已连接", "version": crate::version::VERSION}))
+        Ok(json!({"status": "ok", "message": "Backend connected", "version": crate::version::VERSION}))
     }
 
     async fn repair_backend(&self) -> anyhow::Result<Value> {
@@ -614,7 +614,7 @@ fn spawn_manager(manager_path: &Path) -> anyhow::Result<()> {
     command
         .spawn()
         .map(|_| ())
-        .map_err(|error| anyhow::anyhow!("启动管理工具失败：{error}"))
+        .map_err(|error| anyhow::anyhow!("Failed to start manager: {error}"))
 }
 
 fn settings_payload_value(
@@ -656,7 +656,7 @@ fn diagnostic_log_value(payload: Value) -> anyhow::Result<Value> {
     crate::diagnostic_log::append_diagnostic_log(&format!("renderer.{event}"), payload)?;
     Ok(json!({
         "status": "ok",
-        "message": "日志已记录"
+        "message": "Log recorded"
     }))
 }
 

--- a/crates/codex-plus-core/src/settings.rs
+++ b/crates/codex-plus-core/src/settings.rs
@@ -101,7 +101,7 @@ impl Default for RelayProfile {
         Self {
             id: "default".to_string(),
             linked_ccs_provider_id: String::new(),
-            name: "默认中转".to_string(),
+            name: "Default Relay".to_string(),
             model: String::new(),
             base_url: default_relay_base_url(),
             upstream_base_url: String::new(),
@@ -185,7 +185,7 @@ pub struct BackendSettings {
     pub codex_app_markdown_export: bool,
     #[serde(rename = "codexAppProjectMove", default = "default_true")]
     pub codex_app_project_move: bool,
-    #[serde(rename = "codexAppConversationTimeline", default = "default_true")]
+    #[serde(rename = "codexAppConversationTimeline", default)]
     pub codex_app_conversation_timeline: bool,
     #[serde(rename = "codexAppConversationView", default)]
     pub codex_app_conversation_view: bool,
@@ -257,7 +257,7 @@ impl Default for BackendSettings {
             codex_app_session_delete: true,
             codex_app_markdown_export: true,
             codex_app_project_move: true,
-            codex_app_conversation_timeline: true,
+            codex_app_conversation_timeline: false,
             codex_app_conversation_view: false,
             codex_app_thread_scroll_restore: true,
             codex_app_zed_remote_open: true,
@@ -294,7 +294,7 @@ impl BackendSettings {
             return RelayProfile {
                 id: default_active_relay_id(),
                 linked_ccs_provider_id: String::new(),
-                name: "默认中转".to_string(),
+                name: "Default Relay".to_string(),
                 model: String::new(),
                 base_url: if self.relay_base_url.is_empty() {
                     default_relay_base_url()
@@ -339,7 +339,7 @@ impl BackendSettings {
                 self.active_relay_id.clone()
             },
             linked_ccs_provider_id: String::new(),
-            name: "默认中转".to_string(),
+            name: "Default Relay".to_string(),
             model: String::new(),
             base_url: if self.relay_base_url.is_empty() {
                 default_relay_base_url()
@@ -732,7 +732,7 @@ fn parse_toml_document(contents: &str) -> anyhow::Result<DocumentMut> {
     } else {
         contents
             .parse::<DocumentMut>()
-            .with_context(|| "config.toml TOML 解析失败")
+            .with_context(|| "Failed to parse config.toml as TOML")
     }
 }
 
@@ -946,7 +946,7 @@ mod tests {
     #[test]
     fn relay_profile_official_mix_api_key_defaults_to_false() {
         let profile: RelayProfile =
-            serde_json::from_str(r#"{"id":"official","name":"官方","relayMode":"official"}"#)
+            serde_json::from_str(r#"{"id":"official","name":"Official","relayMode":"official"}"#)
                 .unwrap();
 
         assert_eq!(profile.relay_mode, RelayMode::Official);
@@ -974,7 +974,7 @@ mod tests {
         let profile: RelayProfile = serde_json::from_str(
             r#"{
                 "id":"relay-a",
-                "name":"供应商 A",
+                "name":"Provider A",
                 "contextSelection":{
                     "mcpServers":["context7"],
                     "skills":["writer"],
@@ -1006,7 +1006,7 @@ mod tests {
         let profile: RelayProfile = serde_json::from_str(
             r#"{
                 "id":"relay-a",
-                "name":"供应商 A",
+                "name":"Provider A",
                 "model":"gpt-5.4",
                 "baseUrl":"https://relay.example/v1",
                 "apiKey":"sk-test",
@@ -1086,7 +1086,7 @@ base_url = "http://127.0.0.1:57321/v1"
         let settings = BackendSettings {
             relay_profiles: vec![RelayProfile {
                 id: "official".to_string(),
-                name: "官方".to_string(),
+                name: "Official".to_string(),
                 relay_mode: RelayMode::Official,
                 official_mix_api_key: false,
                 model: "gpt-5.5".to_string(),
@@ -1124,7 +1124,7 @@ requires_openai_auth = true
         let settings = BackendSettings {
             relay_profiles: vec![RelayProfile {
                 id: "official-mix".to_string(),
-                name: "官方混入".to_string(),
+                name: "Official Mixed".to_string(),
                 relay_mode: RelayMode::Official,
                 official_mix_api_key: true,
                 model: "gpt-5.5".to_string(),
@@ -1180,7 +1180,7 @@ experimental_bearer_token = "sk-mix"
             .save(&BackendSettings {
                 relay_profiles: vec![RelayProfile {
                     id: "official-mix".to_string(),
-                    name: "官方混入".to_string(),
+                    name: "Official Mixed".to_string(),
                     relay_mode: RelayMode::Official,
                     official_mix_api_key: true,
                     config_contents: r#"model_provider = "custom"
@@ -1205,7 +1205,7 @@ experimental_bearer_token = "sk-existing"
             .update(json!({
                 "relayProfiles": [{
                     "id": "official-mix",
-                    "name": "官方混入",
+                    "name": "Official Mixed",
                     "relayMode": "official",
                     "officialMixApiKey": true,
                     "configContents": "model_provider = \"custom\"\n\n[model_providers.other]\nbase_url = \"https://other.example/v1\"\nexperimental_bearer_token = \"sk-other\"\n\n[model_providers.custom]\nbase_url = \"https://relay.example/v1\"\nexperimental_bearer_token = \"\"\n",
@@ -1234,7 +1234,7 @@ experimental_bearer_token = "sk-existing""#));
             .update(json!({
                 "relayProfiles": [{
                     "id": "official-mix",
-                    "name": "官方混入",
+                    "name": "Official Mixed",
                     "relayMode": "official",
                     "officialMixApiKey": true,
                     "baseUrl": "https://relay.example/v1",
@@ -1263,7 +1263,7 @@ experimental_bearer_token = "sk-existing""#));
             .update(json!({
                 "relayProfiles": [{
                     "id": "official-mix",
-                    "name": "官方混入",
+                    "name": "Official Mixed",
                     "relayMode": "official",
                     "officialMixApiKey": true,
                     "configContents": "model_provider = \"custom\"\n\n[model_providers.custom]\nbase_url = \"https://relay.example/v1\"\nexperimental_bearer_token = \"22222222222222222222222222222222222\"\n",
@@ -1400,13 +1400,13 @@ experimental_bearer_token = "sk-existing""#));
                 "relayProfiles": [
                     {
                         "id": "relay-a",
-                        "name": "中转 A",
+                        "name": "Relay A",
                         "baseUrl": "https://relay-a.example/v1",
                         "apiKey": "sk-a"
                     },
                     {
                         "id": "relay-b",
-                        "name": "中转 B",
+                        "name": "Relay B",
                         "baseUrl": "https://relay-b.example/v1",
                         "apiKey": "sk-b"
                     }
@@ -1419,7 +1419,7 @@ experimental_bearer_token = "sk-existing""#));
         let active = updated.active_relay_profile();
         assert_eq!(updated.relay_profiles.len(), 2);
         assert_eq!(active.id, "relay-b");
-        assert_eq!(active.name, "中转 B");
+        assert_eq!(active.name, "Relay B");
         assert_eq!(updated.relay_test_model, "claude-sonnet-4");
 
         let saved: Value =
@@ -1439,7 +1439,7 @@ experimental_bearer_token = "sk-existing""#));
                 "relayProfiles": [
                     {
                         "id": "relay-a",
-                        "name": "供应商 A",
+                        "name": "Provider A",
                         "model": "gpt-5.4",
                         "baseUrl": "https://relay.example/v1",
                         "apiKey": "sk-a",
@@ -1452,7 +1452,7 @@ experimental_bearer_token = "sk-existing""#));
             .unwrap();
 
         assert_eq!(updated.relay_profiles[0].id, "relay-a");
-        assert_eq!(updated.relay_profiles[0].name, "供应商 A");
+        assert_eq!(updated.relay_profiles[0].name, "Provider A");
 
         let saved: Value =
             serde_json::from_str(&std::fs::read_to_string(dir.join("settings.json")).unwrap())
@@ -1526,7 +1526,7 @@ experimental_bearer_token = "sk-existing""#));
         let active = settings.active_relay_profile();
 
         assert_eq!(active.id, "default");
-        assert_eq!(active.name, "默认中转");
+        assert_eq!(active.name, "Default Relay");
         assert_eq!(active.base_url, "https://legacy.example/v1");
         assert_eq!(active.api_key, "sk-legacy");
         assert_eq!(active.relay_mode, RelayMode::MixedApi);

--- a/crates/codex-plus-core/src/update.rs
+++ b/crates/codex-plus-core/src/update.rs
@@ -197,7 +197,7 @@ pub async fn perform_update(
     let url = release
         .asset_url
         .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("没有可下载的 Release asset"))?;
+        .ok_or_else(|| anyhow::anyhow!("No downloadable release asset found"))?;
     let bytes =
         crate::http_client::proxied_client(&format!("Codex++/{}", crate::version::VERSION))?
             .get(url)
@@ -223,7 +223,7 @@ pub fn download_asset_to(
     let name = release
         .asset_name
         .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("没有可下载的 Release asset"))?;
+        .ok_or_else(|| anyhow::anyhow!("No downloadable release asset found"))?;
     let safe = safe_asset_name(name)?;
     std::fs::create_dir_all(download_dir)?;
     let path = download_dir.join(safe);
@@ -233,18 +233,18 @@ pub fn download_asset_to(
 
 pub fn safe_asset_name(name: &str) -> anyhow::Result<String> {
     if name.trim().is_empty() {
-        anyhow::bail!("非法 Release asset 文件名: {name}");
+        anyhow::bail!("Invalid release asset filename: {name}");
     }
     let path = Path::new(name);
     if path.components().count() != 1 {
-        anyhow::bail!("非法 Release asset 文件名: {name}");
+        anyhow::bail!("Invalid release asset filename: {name}");
     }
     let file_name = path
         .file_name()
         .and_then(|name| name.to_str())
-        .ok_or_else(|| anyhow::anyhow!("非法 Release asset 文件名: {name}"))?;
+        .ok_or_else(|| anyhow::anyhow!("Invalid release asset filename: {name}"))?;
     if file_name == "." || file_name == ".." {
-        anyhow::bail!("非法 Release asset 文件名: {name}");
+        anyhow::bail!("Invalid release asset filename: {name}");
     }
     Ok(file_name.to_string())
 }
@@ -281,7 +281,7 @@ pub fn launch_installer(path: &Path) -> anyhow::Result<()> {
             .creation_flags(crate::windows_integration::CREATE_NO_WINDOW)
             .spawn()
             .map(|_| ())
-            .map_err(|error| anyhow::anyhow!("启动安装包失败：{error}"))
+            .map_err(|error| anyhow::anyhow!("Failed to start installer package: {error}"))
     }
 
     #[cfg(target_os = "macos")]
@@ -290,12 +290,12 @@ pub fn launch_installer(path: &Path) -> anyhow::Result<()> {
             .arg(path)
             .spawn()
             .map(|_| ())
-            .map_err(|error| anyhow::anyhow!("打开 DMG 失败：{error}"))
+            .map_err(|error| anyhow::anyhow!("Failed to open DMG: {error}"))
     }
 
     #[cfg(all(not(windows), not(target_os = "macos")))]
     {
         let _ = path;
-        anyhow::bail!("当前平台不支持启动安装包")
+        anyhow::bail!("Starting installer packages is not supported on this platform")
     }
 }

--- a/crates/codex-plus-core/src/watcher.rs
+++ b/crates/codex-plus-core/src/watcher.rs
@@ -212,7 +212,7 @@ pub fn stop_codex_processes() {}
 #[cfg(windows)]
 fn create_startup_shortcut(launcher_path: &Path, arguments: &str) -> anyhow::Result<()> {
     let Some(shortcut_path) = startup_shortcut_path() else {
-        anyhow::bail!("无法定位 Windows 启动目录")
+        anyhow::bail!("Could not locate the Windows startup directory")
     };
     crate::windows_integration::create_shortcut(&crate::windows_integration::ShortcutSpec {
         path: shortcut_path,

--- a/crates/codex-plus-core/src/windows_integration.rs
+++ b/crates/codex-plus-core/src/windows_integration.rs
@@ -95,38 +95,38 @@ pub fn create_shortcut(spec: &ShortcutSpec) -> anyhow::Result<()> {
     if let Some(parent) = spec.path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let _com = ComApartment::init().context("初始化 COM 失败")?;
+    let _com = ComApartment::init().context("Failed to initialize COM")?;
     unsafe {
         let shell_link: IShellLinkW = CoCreateInstance(&ShellLink, None, CLSCTX_INPROC_SERVER)
-            .context("创建 ShellLink COM 对象失败")?;
+            .context("Failed to create ShellLink COM object")?;
         shell_link
             .SetPath(PCWSTR(wide_null(spec.target.as_os_str()).as_ptr()))
-            .context("设置快捷方式目标失败")?;
+            .context("Failed to set shortcut target")?;
         shell_link
             .SetArguments(PCWSTR(wide_null(spec.arguments.as_str()).as_ptr()))
-            .context("设置快捷方式参数失败")?;
+            .context("Failed to set shortcut arguments")?;
         if let Some(working_directory) = &spec.working_directory {
             shell_link
                 .SetWorkingDirectory(PCWSTR(wide_null(working_directory.as_os_str()).as_ptr()))
-                .context("设置快捷方式工作目录失败")?;
+                .context("Failed to set shortcut working directory")?;
         }
         shell_link
             .SetDescription(PCWSTR(wide_null(spec.description.as_str()).as_ptr()))
-            .context("设置快捷方式描述失败")?;
+            .context("Failed to set shortcut description")?;
         if let Some(icon) = &spec.icon {
             shell_link
                 .SetIconLocation(PCWSTR(wide_null(icon.as_os_str()).as_ptr()), 0)
-                .context("设置快捷方式图标失败")?;
+                .context("Failed to set shortcut icon")?;
         }
         if spec.show_minimized {
             shell_link
                 .SetShowCmd(SW_SHOWMINNOACTIVE)
-                .context("设置快捷方式窗口模式失败")?;
+                .context("Failed to set shortcut window mode")?;
         }
-        let persist_file: IPersistFile = shell_link.cast().context("获取 IPersistFile 失败")?;
+        let persist_file: IPersistFile = shell_link.cast().context("Failed to get IPersistFile")?;
         persist_file
             .Save(PCWSTR(wide_null(spec.path.as_os_str()).as_ptr()), true)
-            .context("保存快捷方式失败")?;
+            .context("Failed to save shortcut")?;
     }
     Ok(())
 }
@@ -177,7 +177,7 @@ pub fn set_current_user_string_value(subkey: &str, name: &str, value: &str) -> a
             )
         }
         .ok()
-        .with_context(|| format!("写入注册表值 {subkey}\\{name} 失败"))
+        .with_context(|| format!("Failed to write registry value {subkey}\\{name}"))
     })
 }
 
@@ -344,7 +344,7 @@ fn with_created_current_user_key<T>(
         )
     }
     .ok()
-    .with_context(|| format!("打开注册表键 HKCU\\{subkey} 失败"))?;
+    .with_context(|| format!("Failed to open registry key HKCU\\{subkey}"))?;
     let _guard = RegistryKeyGuard(key);
     f(key)
 }

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -87,20 +87,20 @@ fn injection_script_times_out_backend_bridge_calls_and_falls_back_to_helper() {
 fn injection_script_explains_plugin_patch_is_unneeded_in_relay_mode() {
     let script = assets::injection_script(57321);
 
-    assert!(script.contains("兼容增强模式下无需开启"));
+    assert!(script.contains("Not needed in compatibility enhancement mode"));
 }
 
 #[test]
 fn injection_script_menu_exposes_three_independent_plugin_switches() {
     let script = assets::injection_script(57321);
 
-    assert!(script.contains("插件市场解锁"));
+    assert!(script.contains("Plugin Marketplace Unlock"));
     assert!(script.contains("data-codex-plus-setting=\"pluginMarketplaceUnlock\""));
-    assert!(script.contains("强制解锁入口"));
+    assert!(script.contains("Force Entry Unlock"));
     assert!(script.contains("data-codex-plus-setting=\"pluginEntryUnlock\""));
-    assert!(script.contains("特殊插件强制安装"));
+    assert!(script.contains("Force Plugin Install"));
     assert!(script.contains("data-codex-plus-setting=\"forcePluginInstall\""));
-    assert!(script.contains("恢复 1.1.9 的入口解锁方式"));
+    assert!(script.contains("Restores the 1.1.9 entry unlock path"));
 }
 
 #[test]
@@ -186,7 +186,7 @@ fn injection_script_keeps_bundled_marketplace_name_for_default_filter() {
     assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"10\""));
     assert!(script.contains("if (name === \"openai-bundled\") return \"\""));
     assert!(!script.contains("if (name === \"openai-bundled\") return \"codex-plus-openai-bundled\""));
-    assert!(script.contains("if (name === \"openai-bundled\" || name === \"codex-plus-openai-bundled\") return \"OpenAI插件1(Codex++)\""));
+    assert!(script.contains("if (name === \"openai-bundled\" || name === \"codex-plus-openai-bundled\") return \"OpenAI Plugin 1 (Codex++)\""));
 }
 
 #[test]
@@ -225,9 +225,9 @@ fn injection_script_expands_api_key_plugin_marketplace_requests() {
     assert!(script.contains("if (name === \"openai-bundled\") return \"\""));
     assert!(script.contains("if (name === \"openai-curated\") return \"codex-plus-openai-curated\""));
     assert!(script.contains("if (name === \"openai-primary-runtime\") return \"codex-plus-openai-primary-runtime\""));
-    assert!(script.contains("OpenAI插件1(Codex++)"));
-    assert!(script.contains("OpenAI插件2(Codex++)"));
-    assert!(script.contains("OpenAI插件3(Codex++)"));
+    assert!(script.contains("OpenAI Plugin 1 (Codex++)"));
+    assert!(script.contains("OpenAI Plugin 2 (Codex++)"));
+    assert!(script.contains("OpenAI Plugin 3 (Codex++)"));
     assert!(script.contains("method === \"install-plugin\""));
     assert!(script.contains("plugin_marketplace_response_expanded"));
     assert!(script.contains("plugin_build_flavor_filter_bypassed"));
@@ -294,7 +294,7 @@ fn injection_script_exposes_conversation_view_width_control() {
     assert!(script.contains("conversationView: false"));
     assert!(script.contains("conversationView"));
     assert!(script.contains("conversationViewMaxWidth"));
-    assert!(script.contains("对话居中宽度"));
+    assert!(script.contains("Centered Conversation Width"));
     assert!(script.contains("data-codex-plus-conversation-view-width"));
     assert!(script.contains("conversationViewWidth()"));
     assert!(script.contains("normalizeConversationViewWidth"));
@@ -316,9 +316,9 @@ fn injection_script_moves_export_and_project_move_into_more_menu() {
 
     assert!(script.contains("moreButtonClass = \"codex-session-more-button\""));
     assert!(script.contains("moreMenuClass = \"codex-session-more-menu\""));
-    assert!(script.contains("configureActionButton(moreButton, \"更多操作\", \"…\")"));
-    assert!(script.contains("createSessionMoreMenuItem(\"导出\""));
-    assert!(script.contains("createSessionMoreMenuItem(\"移动\""));
+    assert!(script.contains("configureActionButton(moreButton, \"More Actions\", \"…\")"));
+    assert!(script.contains("createSessionMoreMenuItem(\"Export\""));
+    assert!(script.contains("createSessionMoreMenuItem(\"Move\""));
     assert!(script.contains("group.appendChild(moreButton)"));
     assert!(script.contains("installMoreButtonEvents(row, moreButton, openMoreMenu)"));
     assert!(script.contains("installSessionMoreMenuAutoClose(row, moreMenu)"));
@@ -394,7 +394,7 @@ fn injection_script_exposes_fast_service_tier_control() {
     assert!(script.contains("data-codex-service-tier-controls"));
     assert!(script.contains("removeCodexServiceTierBadges"));
     assert!(script.contains("installCodexServiceTierDispatcherPatch"));
-    assert!(script.contains("服务模式"));
+    assert!(script.contains("Service Mode"));
     assert!(script.contains("data-codex-service-tier-status"));
     assert!(script.contains("data-codex-service-tier-inherit"));
     assert!(script.contains("data-codex-service-tier-standard"));
@@ -410,8 +410,8 @@ fn injection_script_exposes_fast_service_tier_control() {
     assert!(script.contains("codexServiceTierDefaultModeForControlMode"));
     assert!(script.contains("normalizeCodexServiceTierControlMode(state.mode) !== \"custom\""));
     assert!(script.contains("state.draft = null"));
-    assert!(script.contains("后端未连接，无法切换服务模式"));
-    assert!(script.contains("未连接"));
+    assert!(script.contains("Backend disconnected; cannot switch service mode"));
+    assert!(script.contains("Disconnected"));
     assert!(script.contains("thread/start"));
     assert!(script.contains("thread/resume"));
     assert!(script.contains("turn/start"));
@@ -433,10 +433,10 @@ fn injection_script_exposes_fast_service_tier_control() {
     assert!(script.contains("codexServiceTierBadgeWired"));
     assert!(script.contains("setAttribute(\"role\", \"button\")"));
     assert!(script.contains("setAttribute(\"tabindex\", \"0\")"));
-    assert!(script.contains("继承 config.toml"));
+    assert!(script.contains("Inherit config.toml"));
     assert!(script.contains("service_tier=\\\"priority\\\""));
-    assert!(script.contains("Fast 仅支持"));
-    assert!(script.contains("当前 thread"));
+    assert!(script.contains("Fast only supports"));
+    assert!(script.contains("current thread"));
     assert!(script.contains("standard"));
     assert!(script.contains("fast"));
 }
@@ -670,7 +670,7 @@ fn injection_script_prevents_switching_to_branches_used_by_other_worktrees() {
     assert!(script.contains("data-codex-branch-worktree-path"));
     assert!(script.contains("annotateBranchMenuWorktreeUsage"));
     assert!(script.contains("branchWorktreePathFromMenuItem"));
-    assert!(script.contains("该分支已在另一个 worktree 使用"));
+    assert!(script.contains("This branch is already used by another worktree"));
     assert!(script.contains("event.stopImmediatePropagation?.()"));
 }
 
@@ -696,8 +696,8 @@ fn manager_ui_exposes_pure_api_relay_mode_button() {
     let commands =
         std::fs::read_to_string(repo.join("apps/codex-plus-manager/src-tauri/src/lib.rs")).unwrap();
 
-    assert!(source.contains("官方混入 API Key"));
-    assert!(source.contains("纯 API"));
+    assert!(source.contains("Mix in API Key"));
+    assert!(source.contains("Pure API"));
     assert!(source.contains("apply_pure_api_injection"));
     assert!(commands.contains("commands::apply_pure_api_injection"));
 }

--- a/crates/codex-plus-core/tests/installers.rs
+++ b/crates/codex-plus-core/tests/installers.rs
@@ -16,7 +16,7 @@ fn windows_entrypoint_plan_contains_silent_and_manager_entrypoints() {
     let plan = build_windows_entrypoint_plan(&options);
 
     assert!(plan.silent_shortcut.ends_with("Codex++.lnk"));
-    assert!(plan.manager_shortcut.ends_with("Codex++ 管理工具.lnk"));
+    assert!(plan.manager_shortcut.ends_with("Codex++ Manager.lnk"));
     assert_eq!(plan.launcher_path, "C:/Tools/codex-plus-plus.exe");
     assert_eq!(plan.manager_path, "C:/Tools/codex-plus-plus-manager.exe");
     assert_eq!(plan.silent_icon_path, "C:/Tools/codex-plus-plus.exe");
@@ -40,7 +40,7 @@ fn windows_entrypoint_plan_can_request_owned_data_removal_without_shell_script()
     let plan = build_windows_entrypoint_plan(&options);
 
     assert!(plan.silent_shortcut.ends_with("Codex++.lnk"));
-    assert!(plan.manager_shortcut.ends_with("Codex++ 管理工具.lnk"));
+    assert!(plan.manager_shortcut.ends_with("Codex++ Manager.lnk"));
     assert!(plan.remove_owned_data);
 }
 
@@ -57,12 +57,12 @@ fn macos_bundle_metadata_contains_silent_and_manager_apps() {
     let manager = build_macos_app_bundle(&options, true);
 
     assert!(silent.app_path.ends_with("Codex++.app"));
-    assert!(manager.app_path.ends_with("Codex++ 管理工具.app"));
+    assert!(manager.app_path.ends_with("Codex++ Manager.app"));
     assert!(silent.info_plist.contains("<string>Codex++</string>"));
     assert!(
         manager
             .info_plist
-            .contains("<string>Codex++ 管理工具</string>")
+            .contains("<string>Codex++ Manager</string>")
     );
     assert!(silent.launch_script.contains("codex-plus-plus"));
     assert!(manager.launch_script.contains("codex-plus-plus-manager"));
@@ -70,14 +70,14 @@ fn macos_bundle_metadata_contains_silent_and_manager_apps() {
 
 #[test]
 fn installer_exports_expected_two_entrypoint_names() {
-    assert_eq!(shortcut_names(), ("Codex++.lnk", "Codex++ 管理工具.lnk"));
-    assert_eq!(app_bundle_names(), ("Codex++.app", "Codex++ 管理工具.app"));
+    assert_eq!(shortcut_names(), ("Codex++.lnk", "Codex++ Manager.lnk"));
+    assert_eq!(app_bundle_names(), ("Codex++.app", "Codex++ Manager.app"));
 }
 
 #[test]
 fn companion_binary_path_resolves_macos_silent_app_next_to_manager_app() {
     let manager_exe = std::path::Path::new(
-        "/Applications/Codex++ 管理工具.app/Contents/MacOS/CodexPlusPlusManager",
+        "/Applications/Codex++ Manager.app/Contents/MacOS/CodexPlusPlusManager",
     );
 
     let companion = companion_binary_path_from_exe(manager_exe, SILENT_BINARY);
@@ -89,7 +89,7 @@ fn companion_binary_path_resolves_macos_silent_app_next_to_manager_app() {
     assert_ne!(
         companion,
         std::path::PathBuf::from(
-            "/Applications/Codex++ 管理工具.app/Contents/MacOS/codex-plus-plus"
+            "/Applications/Codex++ Manager.app/Contents/MacOS/codex-plus-plus"
         )
     );
 }
@@ -100,7 +100,7 @@ fn macos_bundle_does_not_wrap_the_bundle_executable_in_itself() {
         install_root: Some("/Applications".into()),
         launcher_path: Some("/Applications/Codex++.app/Contents/MacOS/CodexPlusPlus".into()),
         manager_path: Some(
-            "/Applications/Codex++ 管理工具.app/Contents/MacOS/CodexPlusPlusManager".into(),
+            "/Applications/Codex++ Manager.app/Contents/MacOS/CodexPlusPlusManager".into(),
         ),
         remove_owned_data: false,
     };

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -327,10 +327,10 @@ fn ports_windows_falls_back_to_ephemeral_when_requested_is_busy() {
 }
 
 #[test]
-fn ports_non_windows_keeps_requested_even_when_busy() {
+fn ports_non_windows_falls_back_to_ephemeral_when_requested_is_busy() {
     let selected = select_platform_loopback_port_with(9229, false, |_| false, || 43001);
 
-    assert_eq!(selected, 9229);
+    assert_eq!(selected, 43001);
 }
 
 #[tokio::test]
@@ -716,7 +716,7 @@ async fn launch_lifecycle_enters_degraded_mode_and_retries_when_injection_fails(
     );
     let status = status_store.load_latest().unwrap().unwrap();
     assert_eq!(status.status, "running_degraded");
-    assert!(status.message.contains("Codex 已启动"));
+    assert!(status.message.contains("Codex launched"));
 
     handle.wait_for_codex_exit().await.unwrap();
     let events = events.lock().unwrap().clone();

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -1089,7 +1089,7 @@ fn apply_relay_files_with_context_rejects_invalid_context_token_values() {
     )
     .unwrap_err();
 
-    assert!(error.to_string().contains("上下文大小"));
+    assert!(error.to_string().contains("context window"));
 }
 
 #[test]

--- a/crates/codex-plus-data/src/markdown.rs
+++ b/crates/codex-plus-data/src/markdown.rs
@@ -18,19 +18,19 @@ impl MarkdownExportService {
 
     pub fn export(&self, session: &SessionRef) -> ExportResult {
         let Some(db_path) = &self.db_path else {
-            return failed(&session.session_id, "未配置本地 Codex 数据库");
+            return failed(&session.session_id, "Local Codex database is not configured");
         };
         if !db_path.exists() {
             return failed(
                 &session.session_id,
-                format!("数据库不存在：{}", db_path.to_string_lossy()),
+                format!("Database does not exist: {}", db_path.to_string_lossy()),
             );
         }
         let thread_id = normalize_session_id(&session.session_id);
         let result = (|| -> anyhow::Result<ExportResult> {
             let db = Connection::open(db_path)?;
             if !supports_codex_threads(&db)? {
-                return Ok(failed(&thread_id, "不支持当前本地存储结构"));
+                return Ok(failed(&thread_id, "Unsupported local storage schema"));
             }
             let row = db.query_row(
                 "SELECT id, title, rollout_path FROM threads WHERE id = ?1",
@@ -46,35 +46,35 @@ impl MarkdownExportService {
             let (_, title, rollout_path) = match row {
                 Ok(row) => row,
                 Err(rusqlite::Error::QueryReturnedNoRows) => {
-                    return Ok(failed(&thread_id, "未找到对应会话"));
+                    return Ok(failed(&thread_id, "Matching conversation was not found"));
                 }
                 Err(err) => return Err(err.into()),
             };
             let title = display_title(title.as_deref().unwrap_or(&session.title));
             let Some(rollout_path) = rollout_path.filter(|path| !path.is_empty()) else {
-                return Ok(failed(&thread_id, "会话缺少 rollout 文件路径"));
+                return Ok(failed(&thread_id, "Conversation is missing its rollout file path"));
             };
             if !Path::new(&rollout_path).is_file() {
                 return Ok(failed(
                     &thread_id,
-                    format!("rollout 文件不存在：{rollout_path}"),
+                    format!("Rollout file does not exist: {rollout_path}"),
                 ));
             }
             let messages = load_messages(Path::new(&rollout_path))?;
             if messages.is_empty() {
-                return Ok(failed(&thread_id, "未找到可导出的用户或助手消息"));
+                return Ok(failed(&thread_id, "No exportable user or assistant messages were found"));
             }
             let filename = build_filename(&title, &thread_id);
             let markdown = render_markdown(&title, &messages);
             Ok(ExportResult {
                 status: ExportStatus::Exported,
                 session_id: thread_id.clone(),
-                message: format!("已导出为 Markdown：{filename}"),
+                message: format!("Exported as Markdown: {filename}"),
                 filename: Some(filename),
                 markdown: Some(markdown),
             })
         })();
-        result.unwrap_or_else(|err| failed(&thread_id, format!("读取 rollout 失败：{err}")))
+        result.unwrap_or_else(|err| failed(&thread_id, format!("Failed to read rollout: {err}")))
     }
 }
 

--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -683,7 +683,7 @@ fn build_encrypted_content_warning(
     }
     let total = encrypted_content_counts.values().sum::<usize>();
     Some(format!(
-        "检测到 {total} 个会话文件包含来自 {} 的 encrypted_content。可见会话元数据已同步到 {target_provider}，但继续或压缩这些历史可能出现 invalid_encrypted_content；需要可靠续聊时请切回原供应商/账号或开启新会话。",
+        "Detected {total} session files containing encrypted_content from {}. Visible session metadata was synced to {target_provider}, but continuing or compacting these historical sessions may produce invalid_encrypted_content. Switch back to the original provider/account or start a new session when reliable continuation matters.",
         risky_providers.join(", ")
     ))
 }

--- a/crates/codex-plus-data/src/storage.rs
+++ b/crates/codex-plus-data/src/storage.rs
@@ -252,7 +252,7 @@ impl SQLiteStorageAdapter {
     ) -> serde_json::Value {
         let target = target_cwd.trim();
         if target.is_empty() {
-            return json!({"status": "failed", "session_id": session.session_id, "message": "目标项目路径为空"});
+            return json!({"status": "failed", "session_id": session.session_id, "message": "Target project path is empty"});
         }
         if !self.db_path.exists() {
             return json!({"status": "failed", "session_id": session.session_id, "message": format!("Database not found: {}", self.db_path.to_string_lossy())});
@@ -311,7 +311,7 @@ impl SQLiteStorageAdapter {
             let mut payload = json!({
                 "status": "moved",
                 "session_id": thread_id,
-                "message": "已移动对话",
+                "message": "Conversation moved",
                 "previous_cwd": previous_cwd,
                 "target_cwd": target,
                 "rollout_updated": rollout.0,
@@ -611,7 +611,7 @@ impl SQLiteStorageAdapter {
                 status: DeleteStatus::Failed,
                 session_id: thread_id,
                 message: format!(
-                    "本地数据库已删除，但文件删除失败：{}",
+                    "Local database entry was deleted, but file deletion failed: {}",
                     file_errors.join("; ")
                 ),
                 undo_token: Some(token.clone()),
@@ -701,7 +701,7 @@ fn local_deleted(session_id: &str, token: &str, backup_path: &Path) -> DeleteRes
     DeleteResult {
         status: DeleteStatus::LocalDeleted,
         session_id: session_id.to_string(),
-        message: "已从本地存储删除".to_string(),
+        message: "Deleted from local storage".to_string(),
         undo_token: Some(token.to_string()),
         backup_path: Some(backup_path.to_string_lossy().to_string()),
     }

--- a/crates/codex-plus-data/tests/storage_adapter.rs
+++ b/crates/codex-plus-data/tests/storage_adapter.rs
@@ -117,7 +117,7 @@ fn delete_local_session_creates_backup_and_undo_restores_rows() {
     let deleted = adapter.delete_local(&session("s1", "First"));
 
     assert_eq!(deleted.status, DeleteStatus::LocalDeleted);
-    assert_eq!(deleted.message, "已从本地存储删除");
+    assert_eq!(deleted.message, "Deleted from local storage");
     let db = Connection::open(&db_path).unwrap();
     assert_eq!(
         db.query_row("SELECT COUNT(*) FROM sessions", [], |row| row

--- a/scripts/installer/macos/package-dmg.sh
+++ b/scripts/installer/macos/package-dmg.sh
@@ -119,14 +119,14 @@ verify_app() {
 
 prepare_icon
 create_app "Codex++" "CodexPlusPlus" "$BINARY_DIR/codex-plus-plus" "com.bigpizzav3.codexplusplus" "true"
-create_app "Codex++ 管理工具" "CodexPlusPlusManager" "$BINARY_DIR/codex-plus-plus-manager" "com.bigpizzav3.codexplusplus.manager" "false"
+create_app "Codex++ Manager" "CodexPlusPlusManager" "$BINARY_DIR/codex-plus-plus-manager" "com.bigpizzav3.codexplusplus.manager" "false"
 ln -s /Applications "$STAGE/Applications"
 
 sign_app "$STAGE/Codex++.app"
-sign_app "$STAGE/Codex++ 管理工具.app"
+sign_app "$STAGE/Codex++ Manager.app"
 
 verify_app "$STAGE/Codex++.app"
-verify_app "$STAGE/Codex++ 管理工具.app"
+verify_app "$STAGE/Codex++ Manager.app"
 
 hdiutil create -volname "Codex++" -srcfolder "$STAGE" -ov -format UDZO "$DMG"
 echo "$DMG"


### PR DESCRIPTION
## Summary
- Switch Codex++ manager, injected UI, backend notices, and installer naming to English-facing copy.
- Keep Conversation Timeline disabled by default and force it off in the injected renderer, including saved/backend settings overrides.
- Preserve the session-proven reliability tweaks: macOS DevTools port fallback when the requested port is busy and the DOM-root guard for injected UI mounting.
- Update tests and macOS packaging names to match the English `Codex++ Manager` behavior.

## Validation
- `node --check assets/inject/renderer-inject.js`
- `git diff --check`
- `npm run check`
- `target/debug/deps/launcher-baefab9214d7638f ports_ --nocapture` (`2 passed`)
- `target/debug/deps/cdp_bridge-3ae95d85fe9ac652 --nocapture` (`48 passed`)
- `BINARY_DIR="$PWD/target/release" bash scripts/installer/macos/package-dmg.sh 1.2.6 arm64`
- `codesign --verify --deep --strict` for both staged macOS apps

## Notes
This PR carries forward the settings/preferences from a local Codex++ install session: English UI, no right-side Conversation Timeline line/circles, and more resilient startup/injection behavior on macOS.
