### PR TITLE
fix: 支持 Windows 商店 Codex Beta 包检测

### DIFF
--- a/crates/codex-plus-core/src/app_paths.rs
+++ b/crates/codex-plus-core/src/app_paths.rs
@@ -1,6 +1,8 @@
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
+const CODEX_PACKAGE_PREFIXES: &[&str] = &["OpenAI.Codex_", "OpenAI.CodexBeta_"];
+
 pub fn find_latest_codex_app_dir(root: &Path) -> Option<PathBuf> {
     let mut matches = std::fs::read_dir(root)
         .ok()?
@@ -219,9 +221,7 @@ pub fn codex_app_version(app_dir: &Path) -> Option<String> {
 
 pub fn packaged_app_user_model_id(app_dir: &Path) -> Option<String> {
     let package_name = package_name_from_app_dir(app_dir)?;
-    if !package_name.starts_with("OpenAI.Codex_") || !package_name.contains("__") {
-        return None;
-    }
+    strip_codex_prefix(&package_name)?;
     let identity_name = package_name.split_once('_')?.0;
     let publisher_id = package_name.rsplit_once("__")?.1;
     if publisher_id.is_empty() {
@@ -245,8 +245,8 @@ fn codex_package_version(package_dir: &Path) -> Option<String> {
     let name = path
         .split('/')
         .rev()
-        .find(|part| part.starts_with("OpenAI.Codex_"))?;
-    let rest = name.strip_prefix("OpenAI.Codex_")?;
+        .find(|part| strip_codex_prefix(part).is_some())?;
+    let rest = strip_codex_prefix(name)?;
     let version = rest.split_once('_')?.0;
     if version.is_empty() {
         None
@@ -291,7 +291,7 @@ fn macos_app_candidates(root: &Path) -> Vec<PathBuf> {
 
 fn version_tuple(path: &Path) -> Option<Vec<u32>> {
     let name = path.file_name()?.to_str()?;
-    let rest = name.strip_prefix("OpenAI.Codex_")?;
+    let rest = strip_codex_prefix(name)?;
     let version = rest.split_once('_')?.0;
     let parts = version
         .split('.')
@@ -299,4 +299,10 @@ fn version_tuple(path: &Path) -> Option<Vec<u32>> {
         .collect::<Result<Vec<_>, _>>()
         .ok()?;
     if parts.is_empty() { None } else { Some(parts) }
+}
+
+fn strip_codex_prefix(name: &str) -> Option<&str> {
+    CODEX_PACKAGE_PREFIXES
+        .iter()
+        .find_map(|prefix| name.strip_prefix(prefix))
 }

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -42,6 +42,25 @@ fn app_paths_find_latest_windows_package_returns_package_when_app_dir_missing() 
 }
 
 #[test]
+fn app_paths_find_latest_windows_package_includes_beta() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(temp.path().join("OpenAI.Codex_26.429.8261.0_x64__abc/app")).unwrap();
+    std::fs::create_dir_all(
+        temp.path()
+            .join("OpenAI.CodexBeta_26.527.7698.0_x64__abc/app"),
+    )
+    .unwrap();
+
+    let latest = find_latest_codex_app_dir(temp.path()).unwrap();
+
+    assert_eq!(
+        latest,
+        temp.path()
+            .join("OpenAI.CodexBeta_26.527.7698.0_x64__abc/app")
+    );
+}
+
+#[test]
 fn app_paths_find_latest_windows_package_checks_roots_before_fallback() {
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path().join("WindowsApps");
@@ -61,6 +80,17 @@ fn app_paths_extracts_codex_version_from_windows_package_app_dir() {
     assert_eq!(
         codex_app_version(&app_dir).as_deref(),
         Some("26.513.3673.0")
+    );
+}
+
+#[test]
+fn app_paths_extracts_codex_beta_version_from_windows_package_app_dir() {
+    let app_dir =
+        PathBuf::from(r"C:\Program Files\WindowsApps\OpenAI.CodexBeta_26.527.7698.0_x64__abc\app");
+
+    assert_eq!(
+        codex_app_version(&app_dir).as_deref(),
+        Some("26.527.7698.0")
     );
 }
 
@@ -243,6 +273,27 @@ fn launcher_constructs_windows_packaged_activation_without_real_app() {
         build_packaged_activation(&app_dir, 9229, &[]).unwrap(),
         CodexLaunch::PackagedActivation {
             app_user_model_id: "OpenAI.Codex_2p2nqsd0c76g0!App".to_string(),
+            arguments: "--remote-debugging-port=9229 --remote-allow-origins=http://127.0.0.1:9229"
+                .to_string(),
+            process_id: None,
+        }
+    );
+}
+
+#[test]
+fn launcher_constructs_windows_beta_packaged_activation_without_real_app() {
+    let app_dir = PathBuf::from(
+        r"C:\Program Files\WindowsApps\OpenAI.CodexBeta_26.527.7698.0_x64__2p2nqsd0c76g0\app",
+    );
+
+    assert_eq!(
+        packaged_app_user_model_id(&app_dir).unwrap(),
+        "OpenAI.CodexBeta_2p2nqsd0c76g0!App"
+    );
+    assert_eq!(
+        build_packaged_activation(&app_dir, 9229, &[]).unwrap(),
+        CodexLaunch::PackagedActivation {
+            app_user_model_id: "OpenAI.CodexBeta_2p2nqsd0c76g0!App".to_string(),
             arguments: "--remote-debugging-port=9229 --remote-allow-origins=http://127.0.0.1:9229"
                 .to_string(),
             process_id: None,


### PR DESCRIPTION
## 概述

支持 Windows 下 Microsoft Store 版 Codex Beta 的包名识别。

之前 Windows 商店应用路径检测逻辑只匹配 `OpenAI.Codex_` 前缀。  
但 Codex Beta 的包名前缀是 `OpenAI.CodexBeta_`，因此会被自动发现逻辑过滤掉，并导致后续无法正确生成用于启动商店应用的 AUMID。

## 修改内容

- 集中维护支持的 Codex 包名前缀
- 同时支持 `OpenAI.Codex_` 和 `OpenAI.CodexBeta_`
- 版本解析和 AUMID 生成复用同一套前缀判断逻辑
- 增加 Codex Beta 的回归测试，覆盖：
  - Beta 包目录发现
  - Beta 版本号解析
  - Beta packaged activation / AUMID 生成

## 验证

已执行：

- `cargo fmt --check -p codex-plus-core`
- `cargo test -p codex-plus-core --test launcher`
- `cargo clippy -p codex-plus-core --all-targets`

说明：  
`cargo test --all-features` 当前会在一个无关的 `cdp_bridge` Node 测试中失败，原因是该测试的 mock `document` 对象缺少 `getElementById`，与本次 Windows 包名检测修改无关。