### PR TITLE
[codex] Add optional sidebar thread ID badge

### DIFF
--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -110,6 +110,7 @@ type BackendSettings = {
   codexAppMarkdownExport: boolean;
   codexAppProjectMove: boolean;
   codexAppConversationTimeline: boolean;
+  codexAppThreadIdBadge: boolean;
   codexAppConversationView: boolean;
   codexAppThreadScrollRestore: boolean;
   codexAppZedRemoteOpen: boolean;
@@ -517,6 +518,7 @@ const defaultSettings: BackendSettings = {
   codexAppMarkdownExport: true,
   codexAppProjectMove: true,
   codexAppConversationTimeline: true,
+  codexAppThreadIdBadge: false,
   codexAppConversationView: false,
   codexAppThreadScrollRestore: true,
   codexAppZedRemoteOpen: true,
@@ -1967,6 +1969,7 @@ function EnhanceScreen({
             <FeatureToggle title="Markdown 导出" detail="在会话列表显示导出按钮，导出带时间戳的 Markdown。" checked={form.codexAppMarkdownExport} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppMarkdownExport", value)} />
             <FeatureToggle title="会话项目移动" detail="把会话移动到普通对话或其他本地项目。" checked={form.codexAppProjectMove} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppProjectMove", value)} />
             <FeatureToggle title="对话 Timeline" detail="在对话右侧显示用户提问时间线，支持摘要和跳转。" checked={form.codexAppConversationTimeline} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppConversationTimeline", value)} />
+            <FeatureToggle title="会话 ID 标识" detail="在侧边栏会话标题前显示短 ID 和 UUIDv7 创建时间，方便定位历史会话。" checked={form.codexAppThreadIdBadge} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppThreadIdBadge", value)} />
             <FeatureToggle title="对话居中宽度" detail="把主对话和输入框限制到固定最大宽度，适合大屏阅读。" checked={form.codexAppConversationView} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppConversationView", value)} />
             <FeatureToggle title="切换对话保留位置" detail="切换 thread 时恢复上一次浏览位置。" checked={form.codexAppThreadScrollRestore} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppThreadScrollRestore", value)} />
             <FeatureToggle title="Zed Remote open" detail="远程 SSH 文件引用可直接用 Zed Remote Development 打开。" checked={form.codexAppZedRemoteOpen} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppZedRemoteOpen", value)} />

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -9,6 +9,7 @@
   const moreButtonClass = "codex-session-more-button";
   const moreMenuClass = "codex-session-more-menu";
   const actionTooltipClass = "codex-session-action-tooltip";
+  const threadIdBadgeClass = "codex-thread-id-badge";
   const timelineClass = "codex-conversation-timeline";
   const timelineTrackClass = "codex-conversation-timeline-track";
   const timelineMarkerClass = "codex-conversation-timeline-marker";
@@ -40,7 +41,7 @@
   const chatsSortRefreshIntervalMs = 1500;
   const chatsSortDbRefreshIntervalMs = 5000;
   const styleId = "codex-delete-style";
-  const codexDeleteStyleVersion = "13";
+  const codexDeleteStyleVersion = "14";
   const codexPlusMenuId = "codex-plus-menu";
   const codexPlusMenuFloatingClass = "codex-plus-menu-floating";
   const codexDeleteVersion = "7";
@@ -52,6 +53,7 @@
   const codexConversationTimelineVersion = "2";
   const codexConversationViewVersion = "1";
   const codexThreadScrollVersion = "1";
+  const codexThreadIdBadgeVersion = "1";
   const codexThreadServiceTierVersion = "1";
   const codexServiceTierBadgeClass = "codex-service-tier-badge";
   const codexServiceTierBadgeVersion = "3";
@@ -250,6 +252,30 @@
       .codex-session-more-menu-icon {
         width: 16px;
         text-align: center;
+      }
+      .${threadIdBadgeClass} {
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        max-width: 152px;
+        margin-right: 8px;
+        color: var(--text-secondary, var(--token-text-secondary, rgba(142,142,160,.95)));
+        font: 11px/1.1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+        letter-spacing: .01em;
+        opacity: .9;
+        white-space: nowrap;
+        user-select: text;
+      }
+      ${selectors.sidebarThread} [data-codex-thread-id-badge-wrap="true"] {
+        display: inline-flex;
+        align-items: center;
+        min-width: 0;
+        max-width: 100%;
+      }
+      ${selectors.sidebarThread} [data-codex-thread-id-badge-wrap="true"] ${selectors.threadTitle},
+      ${selectors.sidebarThread} [data-codex-thread-id-badge-wrap="true"] .truncate.select-none,
+      ${selectors.sidebarThread} [data-codex-thread-id-badge-wrap="true"] .truncate.text-base {
+        min-width: 0;
       }
       .codex-archive-row-button {
         border: 1px solid #ef4444;
@@ -931,7 +957,7 @@
   }
 
   function defaultCodexPlusSettings() {
-    return { pluginEntryUnlock: true, pluginMarketplaceUnlock: true, forcePluginInstall: true, modelWhitelistUnlock: true, sessionDelete: true, markdownExport: true, projectMove: true, conversationTimeline: true, conversationView: false, conversationViewMaxWidth: conversationViewDefaultWidth, threadScrollRestore: true, zedRemoteOpen: true, upstreamWorktreeCreate: true, nativeMenuPlacement: true, serviceTierControls: false };
+    return { pluginEntryUnlock: true, pluginMarketplaceUnlock: true, forcePluginInstall: true, modelWhitelistUnlock: true, sessionDelete: true, markdownExport: true, projectMove: true, conversationTimeline: true, threadIdBadge: false, conversationView: false, conversationViewMaxWidth: conversationViewDefaultWidth, threadScrollRestore: true, zedRemoteOpen: true, upstreamWorktreeCreate: true, nativeMenuPlacement: true, serviceTierControls: false };
   }
 
   const codexPlusBackendSettingMap = {
@@ -943,6 +969,7 @@
     markdownExport: "codexAppMarkdownExport",
     projectMove: "codexAppProjectMove",
     conversationTimeline: "codexAppConversationTimeline",
+    threadIdBadge: "codexAppThreadIdBadge",
     conversationView: "codexAppConversationView",
     threadScrollRestore: "codexAppThreadScrollRestore",
     zedRemoteOpen: "codexAppZedRemoteOpen",
@@ -973,6 +1000,7 @@
         markdownExport: false,
         projectMove: false,
         conversationTimeline: false,
+        threadIdBadge: false,
         conversationView: false,
         conversationViewMaxWidth: conversationViewDefaultWidth,
         threadScrollRestore: false,
@@ -2198,6 +2226,10 @@
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="conversationTimeline"><span></span></button>
             </div>
             <div class="codex-plus-row">
+              <div><div class="codex-plus-row-title">会话 ID 标识</div><div class="codex-plus-row-description">在侧边栏会话标题前显示短 ID 和 UUIDv7 创建时间，方便定位历史会话。</div></div>
+              <button type="button" class="codex-plus-toggle" data-codex-plus-setting="threadIdBadge"><span></span></button>
+            </div>
+            <div class="codex-plus-row">
               <div><div class="codex-plus-row-title">对话居中宽度</div><div class="codex-plus-row-description">开启后把主对话和输入框限制到固定最大宽度，适合大屏阅读。</div></div>
               <div class="codex-plus-width-control">
                 <input class="codex-plus-width-input" data-codex-plus-conversation-view-width="true" min="${conversationViewMinWidth}" max="${conversationViewMaxAllowedWidth}" step="10" type="number" value="${conversationViewWidth()}">
@@ -3048,6 +3080,7 @@
 
   let cachedSessionRows = [];
   let cachedSessionRowsAt = 0;
+  let threadIdBadgeActive = false;
 
   function sessionRows(forceRefresh = false) {
     const now = Date.now();
@@ -3110,6 +3143,113 @@
     const rawTitle = (titleNode?.textContent || (titleNode ? "" : (row.textContent || "Untitled session")));
     const title = (titleNode ? rawTitle : rawTitle.replace(/\s*(导出|删除|移动|移出项目)(\s*(导出|删除|移动|移出项目))*$/g, "")).trim().slice(0, 160);
     return { session_id: sessionId, title };
+  }
+
+  function threadIdBadgeTitleNode(row) {
+    return row.querySelector(`${selectors.threadTitle}, .truncate.select-none, .truncate.text-base`);
+  }
+
+  function padThreadIdBadgePart(value) {
+    return String(value).padStart(2, "0");
+  }
+
+  function threadIdBadgeCreatedAt(sessionId) {
+    const timestampMs = uuidV7TimestampMs(sessionId);
+    const minReasonableMs = Date.UTC(2020, 0, 1);
+    const maxReasonableMs = Date.now() + 366 * 24 * 60 * 60 * 1000;
+    if (!timestampMs || timestampMs < minReasonableMs || timestampMs > maxReasonableMs) return null;
+    return new Date(timestampMs);
+  }
+
+  function formatThreadIdBadgeCreatedAt(date) {
+    if (!(date instanceof Date) || Number.isNaN(date.getTime())) return "";
+    return `${padThreadIdBadgePart(date.getMonth() + 1)}-${padThreadIdBadgePart(date.getDate())} ${padThreadIdBadgePart(date.getHours())}:${padThreadIdBadgePart(date.getMinutes())}`;
+  }
+
+  function threadIdBadgeMeta(sessionId) {
+    const id = projectMoveSessionKey(sessionId);
+    const compact = id.replaceAll("-", "");
+    const shortId = compact.slice(0, 8);
+    const createdAt = threadIdBadgeCreatedAt(sessionId);
+    const createdLabel = formatThreadIdBadgeCreatedAt(createdAt);
+    return {
+      id,
+      shortId,
+      createdAt,
+      label: shortId ? `[${shortId}${createdLabel ? ` ${createdLabel}` : ""}]` : "",
+    };
+  }
+
+  function wrapThreadTitleForBadge(row, titleNode) {
+    const parent = titleNode?.parentElement;
+    if (!parent) return null;
+    if (parent.dataset?.codexThreadIdBadgeWrap === "true") return parent;
+    const wrapper = document.createElement("span");
+    wrapper.dataset.codexThreadIdBadgeWrap = "true";
+    parent.insertBefore(wrapper, titleNode);
+    wrapper.appendChild(titleNode);
+    return wrapper;
+  }
+
+  function removeThreadIdBadges(root = document) {
+    root.querySelectorAll?.(`.${threadIdBadgeClass}`).forEach((badge) => badge.remove());
+    root.querySelectorAll?.('[data-codex-thread-id-badge-wrap="true"]').forEach((wrapper) => {
+      const parent = wrapper.parentElement;
+      if (!parent) return;
+      while (wrapper.firstChild) parent.insertBefore(wrapper.firstChild, wrapper);
+      wrapper.remove();
+    });
+    const rows = root.matches?.(selectors.sidebarThread) ? [root] : Array.from(root.querySelectorAll?.(selectors.sidebarThread) || []);
+    rows.forEach((row) => {
+      delete row.dataset.codexThreadIdBadge;
+      delete row.dataset.codexThreadIdBadgeVersion;
+    });
+  }
+
+  function installThreadIdBadge(row) {
+    const ref = sessionRefFromRow(row);
+    if (!ref.session_id) {
+      removeThreadIdBadges(row);
+      return;
+    }
+    const meta = threadIdBadgeMeta(ref.session_id);
+    const titleNode = threadIdBadgeTitleNode(row);
+    if (!meta.label || !titleNode) {
+      removeThreadIdBadges(row);
+      return;
+    }
+
+    const wrapper = wrapThreadTitleForBadge(row, titleNode);
+    if (!wrapper) return;
+
+    let badge = wrapper.querySelector(`.${threadIdBadgeClass}`);
+    if (!badge) {
+      badge = document.createElement("span");
+      badge.className = threadIdBadgeClass;
+      wrapper.insertBefore(badge, titleNode);
+    }
+
+    badge.dataset.codexThreadIdBadgeVersion = codexThreadIdBadgeVersion;
+    if (badge.textContent !== meta.label) badge.textContent = meta.label;
+    const fullTitle = meta.createdAt
+      ? `${meta.label}\nSession ID: ${meta.id}\nCreated: ${meta.createdAt.toLocaleString()}`
+      : `${meta.label}\nSession ID: ${meta.id}`;
+    badge.setAttribute("title", fullTitle);
+    badge.setAttribute("aria-label", fullTitle);
+    row.dataset.codexThreadIdBadge = meta.label;
+    row.dataset.codexThreadIdBadgeVersion = codexThreadIdBadgeVersion;
+  }
+
+  function refreshThreadIdBadges() {
+    if (!codexPlusSettings().threadIdBadge) {
+      if (threadIdBadgeActive) {
+        removeThreadIdBadges();
+        threadIdBadgeActive = false;
+      }
+      return;
+    }
+    threadIdBadgeActive = true;
+    sessionRows().forEach(installThreadIdBadge);
   }
 
   function codexPlusDiagnosticPayload(event, detail) {
@@ -7978,6 +8118,7 @@
       unblockPluginInstallButtons();
       refreshForcePluginInstallUnlockLoop();
     }
+    refreshThreadIdBadges();
     sessionRows().forEach(tryAttachButton);
     syncActionGroupsLayout();
     updateDeleteButtonOffsets();

--- a/crates/codex-plus-core/src/settings.rs
+++ b/crates/codex-plus-core/src/settings.rs
@@ -177,6 +177,8 @@ pub struct BackendSettings {
     pub codex_app_project_move: bool,
     #[serde(rename = "codexAppConversationTimeline", default = "default_true")]
     pub codex_app_conversation_timeline: bool,
+    #[serde(rename = "codexAppThreadIdBadge", default)]
+    pub codex_app_thread_id_badge: bool,
     #[serde(rename = "codexAppConversationView", default)]
     pub codex_app_conversation_view: bool,
     #[serde(rename = "codexAppThreadScrollRestore", default = "default_true")]
@@ -257,6 +259,7 @@ impl Default for BackendSettings {
             codex_app_markdown_export: true,
             codex_app_project_move: true,
             codex_app_conversation_timeline: true,
+            codex_app_thread_id_badge: false,
             codex_app_conversation_view: false,
             codex_app_thread_scroll_restore: true,
             codex_app_zed_remote_open: true,
@@ -561,6 +564,7 @@ fn merge_known_setting_fields(target: &mut Map<String, Value>, source: &Map<Stri
     merge_bool_setting(target, source, "codexAppMarkdownExport");
     merge_bool_setting(target, source, "codexAppProjectMove");
     merge_bool_setting(target, source, "codexAppConversationTimeline");
+    merge_bool_setting(target, source, "codexAppThreadIdBadge");
     merge_bool_setting(target, source, "codexAppConversationView");
     merge_bool_setting(target, source, "codexAppThreadScrollRestore");
     merge_bool_setting(target, source, "codexAppZedRemoteOpen");
@@ -900,6 +904,7 @@ mod tests {
         assert!(settings.codex_app_plugin_entry_unlock);
         assert!(settings.codex_app_plugin_marketplace_unlock);
         assert!(settings.codex_app_force_plugin_install);
+        assert!(!settings.codex_app_thread_id_badge);
         assert!(!settings.codex_goals_enabled);
         assert!(settings.codex_app_path.is_empty());
         assert!(settings.codex_extra_args.is_empty());
@@ -1389,6 +1394,7 @@ experimental_bearer_token = "sk-existing""#
             "codexAppPluginEntryUnlock": false,
             "codexAppSessionDelete": false,
             "codexAppConversationView": true,
+            "codexAppThreadIdBadge": true,
             "codexAppServiceTierControls": true,
             "codexGoalsEnabled": true,
             "relayBaseUrl": "https://relay.example.test/v1",
@@ -1405,6 +1411,7 @@ experimental_bearer_token = "sk-existing""#
         assert!(!updated.codex_app_plugin_entry_unlock);
         assert!(!updated.codex_app_session_delete);
         assert!(updated.codex_app_conversation_view);
+        assert!(updated.codex_app_thread_id_badge);
         assert!(updated.codex_app_service_tier_controls);
         assert!(updated.codex_goals_enabled);
         assert_eq!(updated.relay_base_url, "https://relay.example.test/v1");

--- a/crates/codex-plus-core/tests/bridge_routes.rs
+++ b/crates/codex-plus-core/tests/bridge_routes.rs
@@ -116,6 +116,7 @@ async fn settings_get_includes_runtime_codex_app_version() {
     assert_eq!(result["codexAppPluginEntryUnlock"], json!(true));
     assert_eq!(result["codexAppPluginMarketplaceUnlock"], json!(true));
     assert_eq!(result["codexAppForcePluginInstall"], json!(true));
+    assert_eq!(result["codexAppThreadIdBadge"], json!(false));
 }
 
 #[tokio::test]
@@ -963,6 +964,7 @@ impl BridgeSettingsService for FakeSettings {
             "codexAppMarkdownExport",
             "codexAppProjectMove",
             "codexAppConversationTimeline",
+            "codexAppThreadIdBadge",
             "codexAppConversationView",
             "codexAppThreadScrollRestore",
             "codexAppZedRemoteOpen",

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -352,6 +352,23 @@ fn injection_script_exposes_conversation_view_width_control() {
 }
 
 #[test]
+fn injection_script_exposes_sidebar_thread_id_badge_control() {
+    let script = assets::injection_script(57321);
+
+    assert!(script.contains("threadIdBadge: false"));
+    assert!(script.contains("threadIdBadge: \"codexAppThreadIdBadge\""));
+    assert!(script.contains("会话 ID 标识"));
+    assert!(script.contains("data-codex-plus-setting=\"threadIdBadge\""));
+    assert!(script.contains("codex-thread-id-badge"));
+    assert!(script.contains("data-codex-thread-id-badge-wrap=\"true\""));
+    assert!(script.contains("let threadIdBadgeActive = false"));
+    assert!(script.contains("if (threadIdBadgeActive)"));
+    assert!(script.contains("function refreshThreadIdBadges()"));
+    assert!(script.contains("uuidV7TimestampMs(sessionId)"));
+    assert!(script.contains("refreshThreadIdBadges();"));
+}
+
+#[test]
 fn injection_script_keeps_session_action_buttons_in_pr_style() {
     let script = assets::injection_script(57321);
 


### PR DESCRIPTION
## Summary

Adds an optional sidebar thread ID badge for Codex++ enhancements.

When enabled, thread rows show a compact badge before the title:

- short session ID derived from the local thread/session ID
- UUIDv7-created timestamp formatted as `MM-DD HH:mm` when available
- full session ID and full timestamp in the badge tooltip

The setting is default-off as `codexAppThreadIdBadge`, exposed in both the manager app and the injected Codex++ menu.

## Why

Local Codex histories can contain similarly titled or duplicated conversations. A compact, opt-in ID badge makes it easier to identify and debug a specific local session without opening every thread or relying on relative timestamps.

## Implementation Notes

- Keeps the feature default-off.
- Avoids work on the disabled path unless badges were previously installed and need cleanup.
- Does not modify the thread row title text or override the row tooltip.
- Reuses existing UUIDv7 timestamp and session-key helpers in the injected renderer script.

## Validation

- `node --check assets/inject/renderer-inject.js`
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo test -p codex-plus-core settings --lib`
- `cargo test -p codex-plus-core injection_script_exposes_sidebar_thread_id_badge_control --test cdp_bridge`
- `cargo test -p codex-plus-core settings_get_includes_runtime_codex_app_version --test bridge_routes`
- local release build/install smoke test using a separately named `Codex--` app

Existing Rust warnings in unrelated files remain unchanged.
