### PR TITLE
fix: reduce sidebar hover ghosting in the conversation list

### DIFF
--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -328,14 +328,6 @@
         pointer-events: auto;
         z-index: 2147483201;
       }
-      [data-codex-delete-row="true"]:hover [data-thread-title] {
-        display: block;
-        max-width: var(--codex-session-title-max-width, 100%);
-        min-width: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
       [data-codex-delete-row="true"].codex-archive-confirm-visible .${actionGroupClass} {
         right: max(66px, var(--codex-session-actions-right, 28px));
       }
@@ -6301,6 +6293,7 @@
 
   function syncActionGroupLayout(row, group) {
     if (!row || !group) return;
+    if (group.dataset.codexActionLayoutStable === "true") return;
     const rowRect = row.getBoundingClientRect();
     const nativeButtons = nativeActionButtonsFromRow(row);
     const leftmostNative = nativeButtons
@@ -6320,6 +6313,7 @@
     group.style.setProperty("--codex-session-actions-right", `${right}px`);
     row.style.setProperty("--codex-session-title-mask", `${right + groupWidth + 12}px`);
     row.style.setProperty("--codex-session-title-max-width", `${maxTitleWidth}px`);
+    group.dataset.codexActionLayoutStable = "true";
   }
 
   function syncActionGroupsLayout() {
@@ -6515,7 +6509,6 @@
     const deleteReady = !settings.sessionDelete || existingDeleteButton?.dataset.codexDeleteVersion === codexDeleteVersion;
     const groupReady = existingGroup?.dataset.codexActionGroupVersion === codexActionGroupVersion;
     if (groupReady && deleteReady && !hasUnexpectedDelete && !hasUnexpectedMore && !hasUnexpectedExport && !hasUnexpectedMove && !missingDelete && !missingMore) {
-      syncActionGroupLayout(row, existingGroup);
       return;
     }
     removeActionGroups(row);
@@ -7979,7 +7972,6 @@
       refreshForcePluginInstallUnlockLoop();
     }
     sessionRows().forEach(tryAttachButton);
-    syncActionGroupsLayout();
     updateDeleteButtonOffsets();
     scheduleProjectMoveProjection();
     scheduleChatsSortCorrection();
@@ -8094,6 +8086,11 @@
   window.__codexPlusResizeHandler = () => {
     cancelAnimationFrame(codexPlusResizeRafId);
     codexPlusResizeRafId = requestAnimationFrame(() => {
+      sessionRows().forEach((row) => {
+        const group = actionGroupFromRow(row);
+        if (group) delete group.dataset.codexActionLayoutStable;
+      });
+      syncActionGroupsLayout();
       updateFloatingCodexPlusMenuPosition(document.getElementById(codexPlusMenuId));
       runScanStep(refreshConversationTimeline);
       runScanStep(refreshConversationView);


### PR DESCRIPTION
## Summary

This PR reduces visible ghosting / flicker when hovering over the conversation list in Codex++.

The issue came from repeatedly remeasuring and relaying out injected sidebar action controls during scans and hover transitions, which caused unnecessary repaint/reflow churn.

## What changed

- remove the hover-time title width override on `[data-thread-title]`
- cache action-group layout once with `codexActionLayoutStable`
- stop re-running action-group layout sync on every deferred scan
- reuse already-ready action groups instead of remeasuring them again
- invalidate and recompute cached layout only on resize

## Why this helps

This keeps the injected sidebar controls from triggering repeated layout work while the pointer moves across the list, which reduces trailing artifacts and hover flicker.

## Testing

- verified the injected diff is isolated to `assets/inject/renderer-inject.js`
- sanity-checked the updated hover/layout path against the current sidebar action injection logic