### PR TITLE
fix: keep launcher alive until packaged codex exits

### DIFF
--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -669,15 +669,26 @@ impl LaunchHooks for DefaultLaunchHooks {
                 if let Some(mut child) = self.child.lock().await.take() {
                     let _ = child.wait().await;
                 }
-                Ok(())
             }
             CodexLaunch::PackagedActivation { process_id, .. } => {
                 if let Some(process_id) = process_id {
                     wait_for_windows_process_id(*process_id).await?;
                 }
-                Ok(())
             }
         }
+        let mut empty_streak = 0u32;
+        loop {
+            if crate::watcher::find_codex_processes().is_empty() {
+                empty_streak = empty_streak.saturating_add(1);
+                if empty_streak >= 3 {
+                    break;
+                }
+            } else {
+                empty_streak = 0;
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        }
+        Ok(())
     }
 
     async fn shutdown_helper(&self, _helper_port: u16) {


### PR DESCRIPTION
## Problem

After upgrading to v1.2.11, Codex++ fails to open on Windows: the launcher (`codex-plus-plus.exe`) starts, but the Codex window never appears (or flashes and disappears immediately).

## Root cause

`DefaultLaunchHooks::wait_for_codex_exit` returns `Ok(())` right after launching codex in **both** arms of the `CodexLaunch` match:

```rust
CodexLaunch::Child { .. } => {
    if let Some(mut child) = self.child.lock().await.take() {
        let _ = child.wait().await;
    }
    Ok(())          // <- returns immediately
}
CodexLaunch::PackagedActivation { process_id, .. } => {
    if let Some(process_id) = process_id {
        wait_for_windows_process_id(*process_id).await?;
    }
    Ok(())          // <- returns immediately
}
```

`main()` then returns and the launcher process exits. On Windows the launched codex is tied to the launcher, so when the launcher vanishes the codex window is torn down — the app "can't open".

The launcher → codex → bridge pipeline itself works fine (CDP injection and renderer patches all succeed, visible in `codex-plus.log`); the only thing missing is the launcher staying alive.

## Fix

After the existing match, poll `find_codex_processes()` and only return once codex has actually exited (3 consecutive empty checks, 2s apart):

```rust
let mut empty_streak = 0u32;
loop {
    if crate::watcher::find_codex_processes().is_empty() {
        empty_streak = empty_streak.saturating_add(1);
        if empty_streak >= 3 {
            break;
        }
    } else {
        empty_streak = 0;
    }
    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
}
Ok(())
```

This keeps the launcher process alive as codex's host/guardian until codex truly exits.

## Verification

- Build: `cargo build --release -p codex-plus-launcher` ✅
- Replaced the installed `codex-plus-plus.exe` (official v1.2.11) with the patched build.
- Launched Codex++: launcher process stays alive, the Codex window opens (`MainWindowTitle` = "Codex"), CDP port 9229 is listening, bridge injection succeeds. ✅

Happy to adjust the exit-detection strategy (e.g. rely on the `Child` handle / `process_id` instead of polling) if a non-polling approach is preferred.
