### PR TITLE
fix(update): Intel版本更新检查下载arm问题

### DIFF
--- a/crates/codex-plus-core/src/update.rs
+++ b/crates/codex-plus-core/src/update.rs
@@ -149,18 +149,21 @@ pub fn release_from_latest_json_payload(payload: &Value) -> anyhow::Result<Relea
 pub fn select_update_asset(assets: &[(String, String)]) -> Option<ReleaseAsset> {
     let named = assets
         .iter()
-        .filter(|(name, url)| !name.trim().is_empty() && !url.trim().is_empty())
-        .collect::<Vec<_>>();
-    for (name, url) in &named {
-        let lower = name.to_ascii_lowercase();
-        if platform_asset_rank(&lower) == 0 {
-            return Some(ReleaseAsset {
-                name: (*name).clone(),
-                browser_download_url: (*url).clone(),
-            });
+        .filter(|(name, url)| !name.trim().is_empty() && !url.trim().is_empty());
+    let mut best: Option<(u8, &str, &str)> = None;
+    for (name, url) in named {
+        let rank = platform_asset_rank(&name.to_ascii_lowercase());
+        if rank >= 2 {
+            continue;
+        }
+        if best.map_or(true, |(r, _, _)| rank < r) {
+            best = Some((rank, name.as_str(), url.as_str()));
         }
     }
-    None
+    best.map(|(_, name, url)| ReleaseAsset {
+        name: name.to_string(),
+        browser_download_url: url.to_string(),
+    })
 }
 
 pub async fn fetch_latest_release(latest_json_url: &str) -> anyhow::Result<Release> {
@@ -250,13 +253,46 @@ pub fn safe_asset_name(name: &str) -> anyhow::Result<String> {
 }
 
 fn platform_asset_rank(name: &str) -> u8 {
+    // 0 = exact match (current OS + native arch)
+    // 1 = same OS, other arch (acceptable fallback, e.g. x86_64 on arm64 or vice versa)
+    // 2 = wrong platform
+    if cfg!(target_os = "macos") {
+        if !is_macos_installer_asset(name) {
+            return 2;
+        }
+        if is_macos_native_arch_asset(name) {
+            return 0;
+        }
+        return 1;
+    }
     if cfg!(windows) && is_windows_installer_asset(name) {
         return 0;
     }
-    if cfg!(target_os = "macos") && is_macos_installer_asset(name) {
-        return 0;
-    }
     2
+}
+
+fn is_macos_native_arch_asset(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    let native_arch_token = match std::env::consts::ARCH {
+        "x86_64" => "x64",
+        "aarch64" => "arm64",
+        _ => return true, // unknown arch — accept anything
+    };
+    // Modern filename shape: `...-macos-x64.dmg` or `...-macos-arm64.dmg`
+    if lower.contains(&format!("-{native_arch_token}.")) {
+        return true;
+    }
+    // Old filename shape: `CodexPlusPlus_1.0.9_x64.dmg`
+    if lower.contains(&format!("_{native_arch_token}.")) {
+        return true;
+    }
+    // Newer but alternative shape: `..._x64.dmg` (no `macos-` token)
+    let other_token = if native_arch_token == "x64" { "arm64" } else { "x64" };
+    if lower.contains(&format!("_{other_token}.")) || lower.contains(&format!("-{other_token}.")) {
+        return false;
+    }
+    // No arch token at all — assume it matches the current arch.
+    true
 }
 
 fn is_windows_installer_asset(name: &str) -> bool {
@@ -270,6 +306,8 @@ fn is_windows_installer_asset(name: &str) -> bool {
 }
 
 fn is_macos_installer_asset(name: &str) -> bool {
+    // Loose shape check; arch preference is handled by platform_asset_rank
+    // via is_macos_native_arch_asset.
     name.contains("codex") && name.contains("plus") && name.ends_with(".dmg")
 }
 

--- a/crates/codex-plus-core/tests/updater.rs
+++ b/crates/codex-plus-core/tests/updater.rs
@@ -113,6 +113,40 @@ fn asset_selection_prefers_current_platform_artifacts() {
 }
 
 #[test]
+fn asset_selection_distinguishes_x64_and_arm64_macos_dmgs() {
+    // Regression test for the bug where an x86_64 Mac user could be handed
+    // the arm64 DMG (or vice versa) because `is_macos_installer_asset` did
+    // not check the arch token in the filename.
+    let assets = vec![
+        (
+            "CodexPlusPlus-1.2.17-macos-arm64.dmg".to_string(),
+            "https://example.test/app-arm64.dmg".to_string(),
+        ),
+        (
+            "CodexPlusPlus-1.2.17-macos-x64.dmg".to_string(),
+            "https://example.test/app-x64.dmg".to_string(),
+        ),
+    ];
+
+    if cfg!(target_os = "macos") {
+        let selected = select_update_asset(&assets)
+            .expect("a macOS DMG should be selected for the running arch");
+        let expected = match std::env::consts::ARCH {
+            "x86_64" => "CodexPlusPlus-1.2.17-macos-x64.dmg",
+            "aarch64" => "CodexPlusPlus-1.2.17-macos-arm64.dmg",
+            other => panic!("unexpected target arch in test: {other}"),
+        };
+        assert_eq!(
+            selected.name, expected,
+            "x86_64 binary must select x64 DMG, aarch64 binary must select arm64 DMG"
+        );
+    } else {
+        // Non-macOS platforms should not pick either macOS DMG.
+        assert!(select_update_asset(&assets).is_none());
+    }
+}
+
+#[test]
 fn safe_asset_name_rejects_path_traversal() {
     assert_eq!(safe_asset_name("pkg.zip").unwrap(), "pkg.zip");
     assert!(safe_asset_name("../pkg.zip").is_err());


### PR DESCRIPTION
## Bug
 
在 macOS 上点「关于 → 检查更新」时，x86_64 机器可能返回 `CodexPlusPlus-X.Y.Z-macos-arm64.dmg` 的下载链接（arm64 资产），反之亦然。
 
## Root cause
 
`crates/codex-plus-core/src/update.rs` 里的 `is_macos_installer_asset` 只检查 `name.contains("codex") && name.contains("plus") && name.ends_with(".dmg")` —— 完全不检查文件名里的 arch token。每次 release 都会同时上传 `...-macos-x64.dmg` 和 `...-macos-arm64.dmg`，GitHub release assets 数组顺序不保证 native arch 在前，所以 `select_update_asset` 选到的就是「第一个匹配 macOS dmg 的」，**与运行 binary 的 arch 无关**。
 
Windows 看起来没事是因为 workflow 每次只产一个 `_x64-setup.exe`。如果以后 Windows 也出 arm64 installer，会立刻出现一样的 bug。
 
仓库 0 处 `std::env::consts::ARCH` / `uname` 用在 selection 路径上。
 
## Fix
 
1. `platform_asset_rank` 改为 3 级 rank：
   - `0` = 当前 OS + native arch（最优）
   - `1` = 同 OS 但 arch 不匹配（Rosetta / 跨架构 fallback）
   - `2` = 错平台
2. 新增 `is_macos_native_arch_asset(name)`：检查 `macos-x64` / `macos-arm64` / 老格式 `_x64` / `_arm64` token；未知 arch 接受任何
3. `select_update_asset` 改为「选最小 rank」而非「第一个 rank-0」
 
## Test
 
- 新增回归测试 `asset_selection_distinguishes_x64_and_arm64_macos_dmgs`：asset 列表里同时放 x64 和 arm64 DMG，x86_64 编译断言选 x64、aarch64 编译断言选 arm64
- 反向验证：临时把 `is_macos_native_arch_asset` 改 `return true`，测试正确 fail（"left: arm64.dmg, right: x64.dmg"）—— 证明测试真的抓得到 bug
 
## Files changed
 
- `crates/codex-plus-core/src/update.rs` — arch-aware ranking + new helper (+51 / -13)
- `crates/codex-plus-core/tests/updater.rs` — regression test (+34 / 0)
 
## Test results
 
```
cargo test -p codex-plus-core --test updater
running 8 tests
test asset_selection_distinguishes_x64_and_arm64_macos_dmgs ... ok
test asset_selection_prefers_current_platform_artifacts ... ok
test latest_json_payload_selects_platform_installer_without_github_api_shape ... ok
test github_payload_selects_platform_installer ... ok
test safe_asset_name_rejects_path_traversal ... ok
test parse_version_tag_accepts_prefix_and_suffix ... ok
test version_comparison_uses_numeric_segments ... ok
test download_asset_to_writes_bytes ... ok
test result: ok. 8 passed; 0 failed
```
 
## Verified against real BigPizzaV3 latest.json
 
```
host arch: x86_64
selected asset_name: CodexPlusPlus-1.2.18-macos-x64.dmg
selected asset_url:  https://github.com/BigPizzaV3/CodexPlusPlus/releases/download/v1.2.18/CodexPlusPlus-1.2.18-macos-x64.dmg
```
 
## 验证 DMG
 
`dist/macos/CodexPlusPlus-1.2.17-fixupdate.2-macos-x86_64.dmg` (15MB, x86_64) 已构建并测试：
- 装好后点「关于 → 检查更新」
- 「资源」metric 应显示 `...-macos-x64.dmg`（不是 `...-macos-arm64.dmg`）