### PR TITLE
fix: prefer threads database for Codex session path selection

### DIFF
--- a/crates/codex-plus-core/src/codex_sqlite.rs
+++ b/crates/codex-plus-core/src/codex_sqlite.rs
@@ -13,9 +13,16 @@ pub fn codex_session_db_path() -> PathBuf {
 }
 
 pub fn codex_session_db_path_from_home(home: &Path) -> PathBuf {
-    codex_sqlite_dir_session_dbs(home)
-        .into_iter()
-        .next()
+    let mut paths = codex_sqlite_dir_session_dbs(home);
+    let legacy = legacy_state_db_path(home);
+    if !paths.iter().any(|path| path == &legacy) {
+        paths.push(legacy.clone());
+    }
+    paths
+        .iter()
+        .find(|path| sqlite_has_table(path, "threads"))
+        .cloned()
+        .or_else(|| paths.into_iter().next())
         .unwrap_or_else(|| legacy_state_db_path(home))
 }
 
@@ -80,20 +87,22 @@ fn is_sqlite_candidate(path: &Path) -> bool {
 }
 
 fn has_session_table(path: &Path) -> bool {
+    ["threads", "automation_runs", "inbox_items"]
+        .iter()
+        .any(|table| sqlite_has_table(path, table))
+}
+
+fn sqlite_has_table(path: &Path, table: &str) -> bool {
     let Ok(db) = Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
     else {
         return false;
     };
-    ["threads", "automation_runs", "inbox_items"]
-        .iter()
-        .any(|table| {
-            db.query_row(
-                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1 LIMIT 1",
-                [table],
-                |_| Ok(()),
-            )
-            .is_ok()
-        })
+    db.query_row(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1 LIMIT 1",
+        [table],
+        |_| Ok(()),
+    )
+    .is_ok()
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -60,6 +60,39 @@ fn codex_session_db_path_accepts_new_automation_runs_schema() {
 }
 
 #[test]
+fn codex_session_db_path_prefers_threads_db_over_codex_dev_inbox_db() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path();
+    let sqlite_dir = home.join("sqlite");
+    std::fs::create_dir(&sqlite_dir).unwrap();
+
+    let inbox_path = sqlite_dir.join("codex-dev.db");
+    let inbox = rusqlite::Connection::open(&inbox_path).unwrap();
+    inbox
+        .execute(
+            "CREATE TABLE automation_runs (thread_id TEXT PRIMARY KEY)",
+            [],
+        )
+        .unwrap();
+    inbox
+        .execute("CREATE TABLE inbox_items (id TEXT PRIMARY KEY)", [])
+        .unwrap();
+    drop(inbox);
+
+    let threads_path = sqlite_dir.join("state_5.sqlite");
+    let threads = rusqlite::Connection::open(&threads_path).unwrap();
+    threads
+        .execute(
+            "CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT, cwd TEXT, title TEXT)",
+            [],
+        )
+        .unwrap();
+    drop(threads);
+
+    assert_eq!(codex_session_db_path_from_home(home), threads_path);
+}
+
+#[test]
 fn codex_session_db_path_falls_back_to_legacy_state_db() {
     let temp = tempfile::tempdir().unwrap();
     let home = temp.path();


### PR DESCRIPTION
## Problem

When Codex++ is launched on a Codex installation where `~/.codex/sqlite/codex-dev.db` contains only `automation_runs` / `inbox_items`, thread-specific operations can fail with:

```text
Unsupported local storage schema
```

One visible case is moving a conversation to another workspace/project.

In this layout, the actual thread records are stored in `~/.codex/sqlite/state_5.sqlite`, which contains the `threads` table with `cwd` and `rollout_path`.

## Root cause

`codex_session_db_path_from_home()` selects the first session-like SQLite database returned by `codex_sqlite_dir_session_dbs()`.

`codex_sqlite_dir_session_dbs()` treats `threads`, `automation_runs`, and `inbox_items` as session tables, and sorts `codex-dev.db` first. As a result, a `codex-dev.db` that only contains automation/inbox tables can be selected for thread-specific operations.

Those operations expect the `threads` schema, so they reject the selected DB as an unsupported local storage schema.

## Fix

Prefer a SQLite database containing the `threads` table when selecting the primary Codex session DB.

If no `threads` DB exists, keep the existing fallback behavior and still allow automation/inbox-only databases to be selected.

This preserves compatibility for non-thread storage layouts while making thread-specific operations select the correct DB when both DB types exist.

## Testing

- `git diff --check`
- `cargo test -p codex-plus-core --test relay_config codex_session_db_path`
- `cargo check -p codex-plus-core`
- `cargo check -p codex-plus-launcher`

## Note

Full `cargo fmt --check` currently reports pre-existing formatting differences in unrelated upstream code, so this PR intentionally does not include formatting-only changes.
