### PR TITLE
fix(config): strip UTF-8 BOM from relay config file input

### DIFF
--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -447,6 +447,7 @@ pub fn apply_relay_config_file_to_home(
     home: &Path,
     config_contents: &str,
 ) -> anyhow::Result<RelayApplyResult> {
+    let config_contents = config_contents.strip_prefix('\u{feff}').unwrap_or(config_contents);
     if config_contents.trim().is_empty() {
         anyhow::bail!("config.toml 内容不能为空");
     }


### PR DESCRIPTION
## 问题

当 config.toml 以 UTF-8 BOM (`\u{feff}`) 开头时，`relay_config_status_from_home()` 报告 `configured=false`。

## 根因

`root_key_value()` 行解析时 `trim()` 不去掉 BOM（BOM 不是 ASCII 空白），导致第一行解析为 `\u{feff}model_provider = "custom"` 而非 `model_provider = "custom"`，匹配失败。

## 修复

在 `apply_relay_config_file_to_home()` 入口处 strip BOM 前缀。

```rust
let config_contents = config_contents.strip_prefix('\u{feff}').unwrap_or(config_contents);
```

## 验证

- `apply_relay_config_file_accepts_utf8_bom_config` 测试通过 :white_check_mark:
- 1 文件，+2 行