### PR TITLE
fix: model catalog fallback for not_configured status

### DIFF
--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -4589,8 +4589,25 @@
     if (!force && codexModelCatalogPromise) return codexModelCatalogPromise;
     if (!force && codexModelCatalogLoadedAt && Date.now() - codexModelCatalogLoadedAt < 10000) return codexModelCatalog;
     codexModelCatalogPromise = postJson("/codex-model-catalog", {})
-      .then((result) => {
+      .then(async (result) => {
         codexModelCatalog = result && typeof result === "object" ? result : { status: "failed", model: "", default_model: "", model_provider: "", provider_name: "", models: [], sources: [], responses_api: { status: "unknown", message: "" } };
+        if ((!codexModelCatalog.models || codexModelCatalog.models.length === 0) && codexModelCatalog.status === "not_configured") {
+          try {
+            const settings = await postJson("/settings/get", {});
+            if (settings && settings.relayProfiles && Array.isArray(settings.relayProfiles)) {
+              const activeId = settings.activeRelayId || "";
+              const profile = settings.relayProfiles.find(p => p.id === activeId) || settings.relayProfiles[0];
+              if (profile && profile.modelList) {
+                const extraModels = profile.modelList.split(/[\r\n,]+/).map(s => s.trim()).filter(Boolean);
+                if (extraModels.length > 0) {
+                  codexModelCatalog.models = extraModels;
+                  codexModelCatalog.status = "ok";
+                  codexModelCatalog.default_model = codexModelCatalog.default_model || extraModels[0];
+                }
+              }
+            }
+          } catch (_) {}
+        }
         codexModelCatalogLoadedAt = Date.now();
         renderCodexPlusMenu();
         scheduleCodexModelWhitelistRefresh();

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -4593,20 +4593,24 @@
         codexModelCatalog = result && typeof result === "object" ? result : { status: "failed", model: "", default_model: "", model_provider: "", provider_name: "", models: [], sources: [], responses_api: { status: "unknown", message: "" } };
         if ((!codexModelCatalog.models || codexModelCatalog.models.length === 0) && codexModelCatalog.status === "not_configured") {
           try {
-            const settings = await postJson("/settings/get", {});
-            if (settings && settings.relayProfiles && Array.isArray(settings.relayProfiles)) {
-              const activeId = settings.activeRelayId || "";
-              const profile = settings.relayProfiles.find(p => p.id === activeId) || settings.relayProfiles[0];
+            const settingsPromise = postJson("/settings/get", {});
+            const timeoutPromise = new Promise((_, reject) => setTimeout(() => reject(new Error("fallback timeout")), 3000));
+            const settingsResp = await Promise.race([settingsPromise, timeoutPromise]);
+            if (settingsResp && settingsResp.relayProfiles && Array.isArray(settingsResp.relayProfiles)) {
+              const activeId = settingsResp.activeRelayId || "";
+              const profile = settingsResp.relayProfiles.find(p => p.id === activeId) || settingsResp.relayProfiles[0];
               if (profile && profile.modelList) {
                 const extraModels = profile.modelList.split(/[\r\n,]+/).map(s => s.trim()).filter(Boolean);
                 if (extraModels.length > 0) {
                   codexModelCatalog.models = extraModels;
-                  codexModelCatalog.status = "ok";
                   codexModelCatalog.default_model = codexModelCatalog.default_model || extraModels[0];
+                  sendCodexPlusDiagnostic("model_catalog_fallback_applied", { count: extraModels.length });
                 }
               }
             }
-          } catch (_) {}
+          } catch (fallbackError) {
+            sendCodexPlusDiagnostic("model_catalog_fallback_error", { error: String(fallbackError?.message || fallbackError) });
+          }
         }
         codexModelCatalogLoadedAt = Date.now();
         renderCodexPlusMenu();

--- a/crates/codex-plus-core/src/model_catalog.rs
+++ b/crates/codex-plus-core/src/model_catalog.rs
@@ -39,7 +39,11 @@ pub async fn read_codex_model_catalog() -> Value {
     let settings_path = crate::paths::default_settings_path();
     if settings_path.exists() {
         if let Ok(settings) = SettingsStore::new(settings_path).load() {
-            return relay_profile_model_catalog_value(&home, &settings.active_relay_profile());
+            let profile = settings.active_relay_profile();
+            let catalog = relay_profile_model_catalog_value(&home, &profile);
+            if catalog.get("models").and_then(Value::as_array).map_or(false, |m| !m.is_empty()) {
+                return catalog;
+            }
         }
     }
     let env = std::env::vars().collect::<HashMap<_, _>>();


### PR DESCRIPTION
## Summary

Two fixes for model whitelist injection failure on Codex App 26.623+:

1. **Rust backend** (`model_catalog.rs`): When settings.json exists but the active relay profile has no models, fall through to read from config.toml instead of returning `not_configured` immediately.

2. **Inject script** (`renderer-inject.js`): When `/codex-model-catalog` returns `not_configured`, add a fallback that reads `modelList` from the active relay profile via `/settings/get`.

## Problem

On Codex App 26.623+:
- `app-server-manager-signals-` module is not found, breaking one layer of whitelist injection
- `/codex-model-catalog` returns `{"status":"not_configured"}` even when settings.json has a populated `modelList` in the active relay profile
- This happens because `read_codex_model_catalog()` returns early from the relay profile path without checking config.toml when models are empty

## Root Cause

In `read_codex_model_catalog()` (model_catalog.rs), when settings.json exists, the function always returns from the relay profile path. If `relay_profile_model_ids()` returns empty (e.g. modelList parsing issue), it returns `not_configured` without ever falling through to read `model_catalog_json` from config.toml.

## Fix Details

### Rust (model_catalog.rs)
- Check if relay profile models are non-empty before returning
- If empty, continue to `read_codex_model_catalog_from_home()` which reads config.toml

### JS (renderer-inject.js)
- In `loadCodexModelCatalog()`, when bridge returns `not_configured` with empty models
- Fetch settings via `/settings/get` with 3s timeout
- Parse `modelList` from active relay profile
- Populate `codexModelCatalog.models`
- Diagnostic events for fallback success/failure

## Testing

- Non-breaking: fallback only triggers when original path returns empty models
- Verified: relay profile modelList format is newline/comma separated

## Related

- Closes #1324