### PR TITLE
fix: preserve plugin marketplace config

### DIFF
--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -583,6 +583,27 @@ impl LaunchHooks for DefaultLaunchHooks {
                 );
             }
         }
+        match crate::plugin_marketplace::ensure_role_specific_plugins_marketplace_config(&home) {
+            Ok(configured) => {
+                if configured {
+                    let _ = crate::diagnostic_log::append_diagnostic_log(
+                        "launcher.role_specific_plugins_marketplace_configured",
+                        serde_json::json!({
+                            "home": home,
+                        }),
+                    );
+                }
+            }
+            Err(error) => {
+                let _ = crate::diagnostic_log::append_diagnostic_log(
+                    "launcher.role_specific_plugins_marketplace_config_failed",
+                    serde_json::json!({
+                        "home": home,
+                        "message": error.to_string(),
+                    }),
+                );
+            }
+        }
         Ok(())
     }
 

--- a/crates/codex-plus-core/src/plugin_marketplace.rs
+++ b/crates/codex-plus-core/src/plugin_marketplace.rs
@@ -7,6 +7,7 @@ use toml_edit::{DocumentMut, Item, Table};
 const OPENAI_CURATED_MARKETPLACE: &str = "openai-curated";
 const OPENAI_API_CURATED_MARKETPLACE: &str = "openai-api-curated";
 const OPENAI_CURATED_REMOTE_MARKETPLACE: &str = "openai-curated-remote";
+const ROLE_SPECIFIC_PLUGINS_MARKETPLACE: &str = "role-specific-plugins";
 const OPENAI_PLUGINS_ZIP_URL: &str =
     "https://codeload.github.com/openai/plugins/zip/refs/heads/main";
 const OPENAI_PLUGINS_DOWNLOAD_LIMIT_BYTES: usize = 128 * 1024 * 1024;
@@ -40,6 +41,23 @@ pub fn ensure_openai_curated_remote_marketplace_config(home: &Path) -> anyhow::R
         home,
         &[OPENAI_CURATED_REMOTE_MARKETPLACE],
         &marketplace_root,
+    )
+}
+
+pub fn ensure_role_specific_plugins_marketplace_config(home: &Path) -> anyhow::Result<bool> {
+    let Some(marketplace_root) = local_role_specific_plugins_marketplace_root(home)? else {
+        return Ok(false);
+    };
+    let plugin_ids =
+        local_marketplace_plugin_names(&marketplace_root, ROLE_SPECIFIC_PLUGINS_MARKETPLACE)?
+            .into_iter()
+            .map(|name| format!("{name}@{ROLE_SPECIFIC_PLUGINS_MARKETPLACE}"))
+            .collect::<Vec<_>>();
+    ensure_marketplace_configs_with_plugins(
+        home,
+        &[ROLE_SPECIFIC_PLUGINS_MARKETPLACE],
+        &marketplace_root,
+        &plugin_ids,
     )
 }
 
@@ -176,6 +194,74 @@ fn local_openai_curated_marketplace_root(home: &Path) -> anyhow::Result<Option<P
         return Ok(None);
     }
     Ok(Some(root))
+}
+
+fn local_role_specific_plugins_marketplace_root(home: &Path) -> anyhow::Result<Option<PathBuf>> {
+    let root = home
+        .join(".tmp")
+        .join("marketplaces")
+        .join(ROLE_SPECIFIC_PLUGINS_MARKETPLACE);
+    local_marketplace_root_from_root(&root, ROLE_SPECIFIC_PLUGINS_MARKETPLACE)
+}
+
+fn local_marketplace_root_from_root(
+    root: &Path,
+    marketplace_name: &str,
+) -> anyhow::Result<Option<PathBuf>> {
+    let marketplace_path = root
+        .join(".agents")
+        .join("plugins")
+        .join("marketplace.json");
+    if !marketplace_path.is_file() {
+        return Ok(None);
+    }
+    let text = std::fs::read_to_string(&marketplace_path)
+        .with_context(|| format!("failed to read {}", marketplace_path.display()))?;
+    let marketplace: serde_json::Value = serde_json::from_str(&text)
+        .with_context(|| format!("failed to parse {}", marketplace_path.display()))?;
+    if marketplace.get("name").and_then(serde_json::Value::as_str) != Some(marketplace_name) {
+        return Ok(None);
+    }
+    let has_plugins = marketplace
+        .get("plugins")
+        .and_then(serde_json::Value::as_array)
+        .map(|plugins| !plugins.is_empty())
+        .unwrap_or(false);
+    if !has_plugins || !root.join("plugins").is_dir() {
+        return Ok(None);
+    }
+    Ok(Some(root.to_path_buf()))
+}
+
+fn local_marketplace_plugin_names(
+    root: &Path,
+    marketplace_name: &str,
+) -> anyhow::Result<Vec<String>> {
+    let marketplace_path = root
+        .join(".agents")
+        .join("plugins")
+        .join("marketplace.json");
+    let text = std::fs::read_to_string(&marketplace_path)
+        .with_context(|| format!("failed to read {}", marketplace_path.display()))?;
+    let marketplace: serde_json::Value = serde_json::from_str(&text)
+        .with_context(|| format!("failed to parse {}", marketplace_path.display()))?;
+    if marketplace.get("name").and_then(serde_json::Value::as_str) != Some(marketplace_name) {
+        return Ok(Vec::new());
+    }
+    Ok(marketplace
+        .get("plugins")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|plugin| {
+            plugin
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .map(str::to_string)
+        })
+        .collect())
 }
 
 fn local_openai_curated_remote_marketplace_root(home: &Path) -> anyhow::Result<Option<PathBuf>> {
@@ -513,6 +599,15 @@ fn ensure_marketplace_configs(
     marketplace_names: &[&str],
     marketplace_root: &Path,
 ) -> anyhow::Result<bool> {
+    ensure_marketplace_configs_with_plugins(home, marketplace_names, marketplace_root, &[])
+}
+
+fn ensure_marketplace_configs_with_plugins(
+    home: &Path,
+    marketplace_names: &[&str],
+    marketplace_root: &Path,
+    plugin_ids: &[String],
+) -> anyhow::Result<bool> {
     let config_path = home.join("config.toml");
     let existing = match std::fs::read(&config_path) {
         Ok(bytes) => String::from_utf8(bytes)
@@ -523,8 +618,12 @@ fn ensure_marketplace_configs(
         }
     };
     let without_bom = existing.trim_start_matches('\u{feff}');
-    let updated =
-        merge_marketplace_configs_into_text(without_bom, marketplace_names, marketplace_root)?;
+    let updated = merge_marketplace_configs_and_plugins_into_text(
+        without_bom,
+        marketplace_names,
+        marketplace_root,
+        plugin_ids,
+    )?;
     if updated.as_bytes() == without_bom.as_bytes() {
         return Ok(false);
     }
@@ -536,6 +635,20 @@ fn merge_marketplace_configs_into_text(
     config_text: &str,
     marketplace_names: &[&str],
     marketplace_root: &Path,
+) -> anyhow::Result<String> {
+    merge_marketplace_configs_and_plugins_into_text(
+        config_text,
+        marketplace_names,
+        marketplace_root,
+        &[],
+    )
+}
+
+fn merge_marketplace_configs_and_plugins_into_text(
+    config_text: &str,
+    marketplace_names: &[&str],
+    marketplace_root: &Path,
+    plugin_ids: &[String],
 ) -> anyhow::Result<String> {
     let mut doc = parse_toml_document(config_text)?;
     let marketplaces = table_mut_or_insert(&mut doc, "marketplaces")?;
@@ -550,6 +663,22 @@ fn merge_marketplace_configs_into_text(
         marketplaces[marketplace_name]["source_type"] = toml_edit::value("local");
         marketplaces[marketplace_name]["source"] =
             toml_edit::value(windows_extended_path(marketplace_root));
+    }
+    if !plugin_ids.is_empty() {
+        let plugins = table_mut_or_insert(&mut doc, "plugins")?;
+        for plugin_id in plugin_ids {
+            let existing_enabled = plugins
+                .get(plugin_id)
+                .and_then(Item::as_table)
+                .and_then(|table| table.get("enabled"))
+                .and_then(Item::as_bool);
+            if plugins.get(plugin_id).and_then(Item::as_table).is_none() {
+                plugins[plugin_id] = toml_edit::table();
+            }
+            if existing_enabled.is_none() {
+                plugins[plugin_id]["enabled"] = toml_edit::value(true);
+            }
+        }
     }
     Ok(ensure_trailing_newline(doc.to_string()))
 }
@@ -653,6 +782,30 @@ mod tests {
         .unwrap();
     }
 
+    fn write_role_specific_marketplace(home: &Path) {
+        let root = home
+            .join(".tmp")
+            .join("marketplaces")
+            .join("role-specific-plugins");
+        std::fs::create_dir_all(root.join(".agents").join("plugins")).unwrap();
+        for plugin in [
+            "sales",
+            "data-analytics",
+            "product-design",
+            "financial-markets",
+            "customer-support",
+        ] {
+            std::fs::create_dir_all(root.join("plugins").join(plugin)).unwrap();
+        }
+        std::fs::write(
+            root.join(".agents")
+                .join("plugins")
+                .join("marketplace.json"),
+            r#"{"name":"role-specific-plugins","plugins":[{"name":"sales"},{"name":"data-analytics"},{"name":"product-design"},{"name":"financial-markets"},{"name":"customer-support"}]}"#,
+        )
+        .unwrap();
+    }
+
     #[test]
     fn ensure_openai_curated_marketplace_config_registers_local_marketplace() {
         let temp = tempfile::tempdir().unwrap();
@@ -705,6 +858,80 @@ mod tests {
 
         assert!(!changed);
         assert!(!temp.path().join("config.toml").exists());
+    }
+
+    #[test]
+    fn ensure_role_specific_plugins_marketplace_config_repairs_installed_plugin_entries() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path();
+        write_role_specific_marketplace(home);
+        std::fs::write(
+            home.join("config.toml"),
+            "model_provider = \"custom\"\nexperimental_bearer_token = \"sk-redacted\"\n",
+        )
+        .unwrap();
+
+        let changed = ensure_role_specific_plugins_marketplace_config(home).unwrap();
+
+        assert!(changed);
+        let config = std::fs::read_to_string(home.join("config.toml")).unwrap();
+        let parsed = config.parse::<DocumentMut>().unwrap();
+        assert_eq!(
+            parsed["marketplaces"]["role-specific-plugins"]["source_type"].as_str(),
+            Some("local")
+        );
+        assert_eq!(
+            parsed["marketplaces"]["role-specific-plugins"]["source"].as_str(),
+            Some(
+                format!(
+                    r"\\?\{}",
+                    home.join(".tmp")
+                        .join("marketplaces")
+                        .join("role-specific-plugins")
+                        .display()
+                )
+                .as_str()
+            )
+        );
+        for plugin in [
+            "sales@role-specific-plugins",
+            "data-analytics@role-specific-plugins",
+            "product-design@role-specific-plugins",
+            "financial-markets@role-specific-plugins",
+            "customer-support@role-specific-plugins",
+        ] {
+            assert_eq!(parsed["plugins"][plugin]["enabled"].as_bool(), Some(true));
+        }
+        assert_eq!(
+            parsed["experimental_bearer_token"].as_str(),
+            Some("sk-redacted")
+        );
+    }
+
+    #[test]
+    fn ensure_role_specific_plugins_marketplace_config_preserves_disabled_plugin_choice() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path();
+        write_role_specific_marketplace(home);
+        std::fs::write(
+            home.join("config.toml"),
+            "[plugins.\"sales@role-specific-plugins\"]\nenabled = false\n",
+        )
+        .unwrap();
+
+        let changed = ensure_role_specific_plugins_marketplace_config(home).unwrap();
+
+        assert!(changed);
+        let config = std::fs::read_to_string(home.join("config.toml")).unwrap();
+        let parsed = config.parse::<DocumentMut>().unwrap();
+        assert_eq!(
+            parsed["plugins"]["sales@role-specific-plugins"]["enabled"].as_bool(),
+            Some(false)
+        );
+        assert_eq!(
+            parsed["plugins"]["customer-support@role-specific-plugins"]["enabled"].as_bool(),
+            Some(true)
+        );
     }
 
     #[test]

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -1076,6 +1076,12 @@ fn write_codex_live_atomic(
     let config_text = guarded_config_text.as_deref();
 
     let config_text = match config_text {
+        Some(config_text) => Some(preserve_live_marketplace_configs(home, config_text)?),
+        None => None,
+    };
+    let config_text = config_text.as_deref();
+
+    let config_text = match config_text {
         Some(config_text) => Some(
             crate::plugin_marketplace::preserve_openai_curated_remote_marketplace_config(
                 home,
@@ -1116,6 +1122,47 @@ fn write_codex_live_atomic(
     }
 
     Ok(backup_path)
+}
+
+fn preserve_live_marketplace_configs(home: &Path, config_text: &str) -> anyhow::Result<String> {
+    let live_config = read_optional_text(&home.join("config.toml"))?;
+    if live_config.trim().is_empty() {
+        return Ok(config_text.to_string());
+    }
+
+    let mut target = parse_toml_document(config_text)?;
+    let live = parse_toml_document(&live_config)?;
+    let Some(live_marketplaces) = live.get("marketplaces").and_then(Item::as_table_like) else {
+        return Ok(ensure_trailing_newline(target.to_string()));
+    };
+    if live_marketplaces.is_empty() {
+        return Ok(ensure_trailing_newline(target.to_string()));
+    }
+
+    if target.get("marketplaces").is_none() {
+        target["marketplaces"] = toml_edit::table();
+    }
+    if target
+        .get("marketplaces")
+        .and_then(Item::as_table_like)
+        .is_none()
+    {
+        target["marketplaces"] = toml_edit::table();
+    }
+    let Some(target_marketplaces) = target
+        .get_mut("marketplaces")
+        .and_then(Item::as_table_like_mut)
+    else {
+        return Ok(ensure_trailing_newline(target.to_string()));
+    };
+
+    for (name, marketplace) in live_marketplaces.iter() {
+        if target_marketplaces.get(name).is_none() {
+            target_marketplaces.insert(name, marketplace.clone());
+        }
+    }
+
+    Ok(ensure_trailing_newline(target.to_string()))
 }
 
 fn active_provider_id(doc: &DocumentMut) -> Option<String> {

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -412,6 +412,14 @@ fn launcher_no_longer_contains_mobile_control_runtime() {
 }
 
 #[test]
+fn launcher_plugin_marketplace_unlock_repairs_role_specific_plugins() {
+    let launcher_source = include_str!("../src/launcher.rs");
+
+    assert!(launcher_source.contains("ensure_openai_curated_marketplace_config(&home)"));
+    assert!(launcher_source.contains("ensure_role_specific_plugins_marketplace_config(&home)"));
+}
+
+#[test]
 fn app_paths_parse_appx_install_location_from_powershell_output() {
     let output =
         "\r\nC:\\Program Files\\WindowsApps\\OpenAI.Codex_26.611.7849.0_x64__2p2nqsd0c76g0\r\n";

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -2487,6 +2487,10 @@ command = "manual-command"
 
 [plugins.manual]
 enabled = true
+
+[marketplaces.role-specific-plugins]
+source_type = "local"
+source = 'C:\Users\me\.codex\.tmp\marketplaces\role-specific-plugins'
 "#,
     )
     .unwrap();
@@ -2518,6 +2522,9 @@ command = "managed-command"
     assert!(config.contains("[plugins.manual]"));
     assert!(config.contains("[mcp_servers.managed]"));
     assert!(config.contains(r#"command = "managed-command""#));
+    assert!(config.contains("[marketplaces.role-specific-plugins]"));
+    assert!(config.contains(r#"source_type = "local""#));
+    assert!(config.contains("role-specific-plugins"));
 }
 
 #[test]


### PR DESCRIPTION
## 概述

这个 PR 修复供应商/relay 配置切换后，`~/.codex/config.toml` 中已有插件市场配置被覆盖，导致本地已安装插件不再显示的问题。

## 修改内容

- 写入 Codex live config 时保留已有 `[marketplaces.*]` 配置。
- 在插件市场解锁开启时，自动修复本地已缓存的 `role-specific-plugins` marketplace。
- 从本地 `marketplace.json` 动态读取插件名，不硬编码插件列表。
- 自动补充缺失的 `[plugins."<name>@role-specific-plugins"]` 配置。
- 保留用户已有选择，例如 `enabled = false` 不会被强制改成 true。
- 不读取、不修改 API key 或 auth 文件。

## 背景

某些供应商切换或 relay profile 写入会重写 `~/.codex/config.toml`。如果 `[marketplaces.*]` 或 `[plugins.*]` 配置被移除，插件实际仍在本地缓存目录中，但 CodexDesktop UI 不再显示这些插件。

这个 PR 让 Codex++ 在写配置和启动解锁时保留/修复这些 marketplace 配置。

## 测试

已验证：

```powershell
cargo fmt --check
cargo test -p codex-plus-core plugin_marketplace::tests::ensure_role_specific_plugins_marketplace_config
cargo test -p codex-plus-core launcher_plugin_marketplace_unlock_repairs_role_specific_plugins
cargo test -p codex-plus-core apply_relay_profile_to_home_with_switch_rules_preserves_unmanaged_live_context_entries
git diff --check