### PR TITLE
fix: stabilize Windows Codex launch

### DIFF
--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -1445,6 +1445,110 @@
     return await codexServiceTierModulePromises.get(namePart);
   }
 
+  async function loadCodexAppModuleAny(nameParts) {
+    let lastError = null;
+    for (const namePart of nameParts) {
+      try {
+        return await loadCodexAppModule(namePart);
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError || new Error(`未找到 Codex App asset: ${nameParts.join(", ")}`);
+  }
+
+  function codexAppServerReactKeys(element) {
+    return Object.keys(element || {}).filter((key) => key.startsWith("__reactFiber") || key.startsWith("__reactInternalInstance") || key.startsWith("__reactProps"));
+  }
+
+  function codexAppScopeCandidates() {
+    const roots = [
+      document.getElementById("root"),
+      document.body,
+      ...Array.from(document.querySelectorAll("main, aside, [role='dialog'], [role='menu'], [role='listbox'], [data-radix-popper-content-wrapper]") || []),
+    ].filter(Boolean);
+    const queue = [];
+    for (const node of roots) {
+      for (const key of codexAppServerReactKeys(node)) {
+        let fiber = node[key];
+        for (let depth = 0; fiber && depth < 80; depth += 1, fiber = fiber.return) {
+          queue.push(fiber);
+          let context = fiber.dependencies?.firstContext;
+          for (let contextDepth = 0; context && contextDepth < 50; contextDepth += 1, context = context.next) {
+            queue.push(context.memoizedValue);
+          }
+        }
+      }
+    }
+
+    const scopes = [];
+    const visited = new WeakSet();
+    for (let index = 0; index < queue.length && index < 12000 && scopes.length < 80; index += 1) {
+      const value = queue[index];
+      if (!value || typeof value !== "object" || visited.has(value)) continue;
+      visited.add(value);
+      let keys = [];
+      try {
+        keys = Object.keys(value);
+      } catch {
+        continue;
+      }
+      if (keys.includes("chain") && keys.includes("node") && typeof value.get === "function" && typeof value.set === "function" && typeof value.watch === "function") {
+        scopes.push(value);
+      }
+      for (const key of keys.slice(0, 80)) {
+        if (key === "ownerDocument" || key === "parentElement" || key === "parentNode" || key === "children" || key === "childNodes") continue;
+        try {
+          const child = value[key];
+          if (child && (typeof child === "object" || typeof child === "function")) queue.push(child);
+        } catch {
+        }
+      }
+    }
+    return scopes;
+  }
+
+  function isCodexAppServerRegistryClass(value) {
+    return typeof value === "function"
+      && typeof value.prototype?.getAll === "function"
+      && typeof value.prototype?.getDefault === "function"
+      && typeof value.prototype?.getForHostId === "function";
+  }
+
+  function pushCodexAppServerCandidate(candidates, visited, value) {
+    if (!value || typeof value !== "object" || visited.has(value)) return;
+    visited.add(value);
+    candidates.push(value);
+    try {
+      if (value.requestClient && typeof value.requestClient === "object") pushCodexAppServerCandidate(candidates, visited, value.requestClient);
+    } catch {
+    }
+  }
+
+  function codexAppServerRequestCandidates(module) {
+    const candidates = [];
+    const visited = new WeakSet();
+    for (const value of Object.values(module || {})) {
+      if (value && typeof value === "object") pushCodexAppServerCandidate(candidates, visited, value);
+    }
+
+    const Registry = Object.values(module || {}).find(isCodexAppServerRegistryClass);
+    if (Registry) {
+      for (const scope of codexAppScopeCandidates()) {
+        try {
+          const registry = new Registry(scope);
+          const all = typeof registry.getAll === "function" ? registry.getAll() : [];
+          if (Array.isArray(all)) all.forEach((manager) => pushCodexAppServerCandidate(candidates, visited, manager));
+          pushCodexAppServerCandidate(candidates, visited, registry.getDefault?.());
+          pushCodexAppServerCandidate(candidates, visited, registry.getForHostId?.("local"));
+          pushCodexAppServerCandidate(candidates, visited, registry.getImplForHostId?.("local"));
+        } catch {
+        }
+      }
+    }
+    return candidates;
+  }
+
   async function codexSettingStorageModule() {
     const module = await loadCodexAppModule("setting-storage-");
     if (typeof module.n !== "function" || typeof module.s !== "function") {
@@ -2074,8 +2178,89 @@
     return message;
   }
 
+  function applyCodexServiceTierRequestClientParams(method, params) {
+    const requestMethod = appServerModelRequestMethod(String(method || ""), params);
+    const directParams = applyCodexServiceTierRequestOverride(requestMethod, params);
+    if (directParams !== params) return directParams;
+
+    if (!params || typeof params !== "object" || !params.params || typeof params.params !== "object") {
+      return params;
+    }
+    const nestedMethod = appServerModelRequestMethod(String(params.method || method || ""), params.params);
+    const nestedParams = applyCodexServiceTierRequestOverride(
+      nestedMethod,
+      params.params,
+      params.conversationId || params.threadId || ""
+    );
+    return nestedParams === params.params ? params : { ...params, params: nestedParams };
+  }
+
+  function patchCodexServiceTierRequestClient(client) {
+    if (!client || typeof client.sendRequest !== "function") return false;
+    if (client.__codexServiceTierRequestPatch === codexServiceTierRequestOverrideVersion) return true;
+    const originalSendRequest = client.__codexServiceTierOriginalSendRequest || client.sendRequest.bind(client);
+    client.__codexServiceTierOriginalSendRequest = originalSendRequest;
+    client.sendRequest = function codexServiceTierPatchedSendRequest(method, params, options) {
+      const nextParams = applyCodexServiceTierRequestClientParams(method, params);
+      return originalSendRequest(method, nextParams, options);
+    };
+    client.__codexServiceTierRequestPatch = codexServiceTierRequestOverrideVersion;
+    return true;
+  }
+
+  function installCodexServiceTierAppServerRequestPatch() {
+    if (window.__codexServiceTierAppServerRequestPatchInstalled === codexServiceTierRequestOverrideVersion) return;
+    const patch = async () => {
+      try {
+        const module = await loadCodexAppModuleAny([
+          "app-server-manager-signals-",
+          "app-server-manager-hooks-",
+        ]);
+        const candidates = codexAppServerRequestCandidates(module);
+        let patchedCount = 0;
+        for (const candidate of candidates) {
+          if (patchCodexServiceTierRequestClient(candidate)) patchedCount += 1;
+          if (typeof candidate.sendRequest !== "function" && typeof candidate.get === "function") {
+            try {
+              if (patchCodexServiceTierRequestClient(candidate.get())) patchedCount += 1;
+            } catch {
+            }
+          }
+        }
+        if (patchedCount > 0) {
+          window.__codexServiceTierAppServerRequestPatchInstalled = codexServiceTierRequestOverrideVersion;
+          window.__codexServiceTierRequestOverrideInstalled = codexServiceTierRequestOverrideVersion;
+          sendCodexPlusDiagnostic("service_tier_app_server_request_patch_installed", {
+            candidateCount: candidates.length,
+            patchedCount,
+          });
+        } else {
+          sendCodexPlusDiagnosticOnce(
+            "service-tier-app-server-request-patch-not-found",
+            "service_tier_app_server_request_patch_not_found",
+            {
+              exportCount: Object.keys(module || {}).length,
+              candidateCount: candidates.length,
+            }
+          );
+        }
+      } catch (error) {
+        sendCodexPlusDiagnosticOnce(
+          "service-tier-app-server-request-patch-failed",
+          "service_tier_app_server_request_patch_failed",
+          {
+            errorName: error?.name || "",
+            errorMessage: error?.message || String(error),
+          }
+        );
+      }
+    };
+    void patch();
+  }
+
   function installCodexServiceTierDispatcherPatch() {
     if (window.__codexServiceTierRequestOverrideInstalled === codexServiceTierRequestOverrideVersion) return;
+    installCodexServiceTierAppServerRequestPatch();
     const patch = async () => {
       try {
         const module = await loadCodexAppModule("setting-storage-");
@@ -2096,10 +2281,14 @@
         window.__codexServiceTierRequestOverrideInstalled = codexServiceTierRequestOverrideVersion;
         sendCodexPlusDiagnostic("service_tier_dispatcher_patch_installed", {});
       } catch (error) {
-        sendCodexPlusDiagnostic("service_tier_dispatcher_patch_failed", {
-          errorName: error?.name || "",
-          errorMessage: error?.message || String(error),
-        });
+        sendCodexPlusDiagnosticOnce(
+          "service-tier-dispatcher-patch-failed",
+          "service_tier_dispatcher_patch_failed",
+          {
+            errorName: error?.name || "",
+            errorMessage: error?.message || String(error),
+          }
+        );
       }
     };
     void patch();
@@ -3232,6 +3421,10 @@
   function runPluginAutoExpand(force = false) {
     if (!codexPlusSettings().pluginAutoExpand) return;
     const currentSignature = pluginAutoExpandSignature();
+    if (!currentSignature) {
+      window.__codexPluginAutoExpandLastSignature = "";
+      return;
+    }
     if (!force && currentSignature && currentSignature === window.__codexPluginAutoExpandLastSignature) return;
     window.__codexPluginAutoExpandLastSignature = currentSignature;
     window.__codexPluginAutoExpandRunning = true;
@@ -3244,11 +3437,13 @@
       const button = pluginAutoExpandButtonCandidates()[0];
       if (!button || window.__codexPluginAutoExpandClicks >= codexPluginAutoExpandMaxClicks) {
         window.__codexPluginAutoExpandRunning = false;
-        sendCodexPlusDiagnostic("plugin_auto_expand_finished", {
-          version: codexPluginAutoExpandVersion,
-          clicks: window.__codexPluginAutoExpandClicks || 0,
-          exhausted: !!button,
-        });
+        if ((window.__codexPluginAutoExpandClicks || 0) > 0 || !!button) {
+          sendCodexPlusDiagnostic("plugin_auto_expand_finished", {
+            version: codexPluginAutoExpandVersion,
+            clicks: window.__codexPluginAutoExpandClicks || 0,
+            exhausted: !!button,
+          });
+        }
         return;
       }
       window.__codexPluginAutoExpandClicks = (window.__codexPluginAutoExpandClicks || 0) + 1;
@@ -3505,8 +3700,11 @@
     if (!codexPlusSettings().pluginMarketplaceUnlock) return;
     const patch = async () => {
       try {
-        const module = await loadCodexAppModule("app-server-manager-signals-");
-        const candidates = Object.values(module).filter((value) => value && typeof value === "object");
+        const module = await loadCodexAppModuleAny([
+          "app-server-manager-signals-",
+          "app-server-manager-hooks-",
+        ]);
+        const candidates = codexAppServerRequestCandidates(module);
         let patchedCount = 0;
         for (const candidate of candidates) {
           if (patchPluginMarketplaceRequestClient(candidate)) patchedCount += 1;
@@ -3530,10 +3728,14 @@
           });
         }
       } catch (error) {
-        sendCodexPlusDiagnostic("plugin_marketplace_request_patch_failed", {
-          errorName: error?.name || "",
-          errorMessage: error?.message || String(error),
-        });
+        sendCodexPlusDiagnosticOnce(
+          "plugin-marketplace-request-patch-failed",
+          "plugin_marketplace_request_patch_failed",
+          {
+            errorName: error?.name || "",
+            errorMessage: error?.message || String(error),
+          }
+        );
       }
     };
     void patch();
@@ -3755,6 +3957,13 @@
       body,
       keepalive: true,
     }).catch(() => {});
+  }
+
+  function sendCodexPlusDiagnosticOnce(key, event, detail) {
+    window.__codexPlusDiagnosticOnce = window.__codexPlusDiagnosticOnce || new Set();
+    if (window.__codexPlusDiagnosticOnce.has(key)) return;
+    window.__codexPlusDiagnosticOnce.add(key);
+    sendCodexPlusDiagnostic(event, detail);
   }
 
   sendCodexPlusDiagnostic("script_loaded", {
@@ -4983,8 +5192,11 @@
     if (window.__codexPlusAppServerModelRequestPatchInstalled === codexAppServerModelRequestPatchVersion) return;
     const patch = async () => {
       try {
-        const module = await loadCodexAppModule("app-server-manager-signals-");
-        const candidates = Object.values(module).filter((value) => value && typeof value === "object");
+        const module = await loadCodexAppModuleAny([
+          "app-server-manager-signals-",
+          "app-server-manager-hooks-",
+        ]);
+        const candidates = codexAppServerRequestCandidates(module);
         let patchedCount = 0;
         for (const candidate of candidates) {
           if (patchAppServerModelRequestClient(candidate)) patchedCount += 1;
@@ -5008,10 +5220,14 @@
           });
         }
       } catch (error) {
-        sendCodexPlusDiagnostic("model_app_server_request_patch_failed", {
-          errorName: error?.name || "",
-          errorMessage: error?.message || String(error),
-        });
+        sendCodexPlusDiagnosticOnce(
+          "model-app-server-request-patch-failed",
+          "model_app_server_request_patch_failed",
+          {
+            errorName: error?.name || "",
+            errorMessage: error?.message || String(error),
+          }
+        );
       }
     };
     void patch();

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -385,8 +385,28 @@ fn relay_protocol_proxy_enabled(settings: &BackendSettings) -> bool {
 }
 
 fn select_native_menu_inspector_port(debug_port: u16) -> u16 {
+    select_native_menu_inspector_port_with(
+        debug_port,
+        cfg!(windows),
+        crate::ports::select_platform_loopback_port,
+    )
+}
+
+fn select_native_menu_inspector_port_with(
+    debug_port: u16,
+    is_windows: bool,
+    select_loopback_port: impl Fn(u16) -> u16,
+) -> u16 {
     let requested = debug_port.saturating_add(100);
-    crate::ports::select_platform_loopback_port(requested)
+    if is_windows {
+        // Windows packaged-app activation reuses an existing Codex instance and
+        // ignores new command-line arguments. If the existing instance already
+        // listens on the requested inspector port, choosing a random free port
+        // only makes the native-menu localizer retry against a dead port.
+        requested
+    } else {
+        select_loopback_port(requested)
+    }
 }
 
 fn start_native_menu_localizer(inspector_port: u16) {
@@ -2271,5 +2291,19 @@ mod tests {
             3,
             &missing_runtime_package
         ));
+    }
+
+    #[test]
+    fn native_menu_inspector_port_keeps_requested_port_on_windows() {
+        let selected = select_native_menu_inspector_port_with(9229, true, |_| 62528);
+
+        assert_eq!(selected, 9329);
+    }
+
+    #[test]
+    fn native_menu_inspector_port_uses_loopback_selector_off_windows() {
+        let selected = select_native_menu_inspector_port_with(9229, false, |_| 62528);
+
+        assert_eq!(selected, 62528);
     }
 }

--- a/crates/codex-plus-core/src/ports.rs
+++ b/crates/codex-plus-core/src/ports.rs
@@ -83,11 +83,16 @@ pub fn select_packaged_codex_debug_port(requested: u16) -> u16 {
 
 pub fn select_packaged_codex_debug_port_with(
     requested: u16,
-    is_windows: bool,
-    can_bind: impl Fn(u16) -> bool,
-    find_available: impl Fn() -> u16,
+    _is_windows: bool,
+    _can_bind: impl Fn(u16) -> bool,
+    _find_available: impl Fn() -> u16,
 ) -> u16 {
-    select_platform_loopback_port_with(requested, is_windows, can_bind, find_available)
+    // Windows packaged-app activation reuses an existing Codex instance when one
+    // is already running. In that case new command-line arguments are ignored,
+    // so selecting a random free debug port here makes the launcher inject into
+    // a port that Codex will never open. Keep the requested port stable and let
+    // CDP probing handle IPv4/IPv6 availability.
+    requested
 }
 
 pub fn select_platform_loopback_port_with(

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -269,6 +269,15 @@ fn injection_script_disables_plugin_auto_expand_in_relay_mode() {
 }
 
 #[test]
+fn injection_script_does_not_log_plugin_auto_expand_noops() {
+    let script = assets::injection_script(57321);
+
+    assert!(script.contains("if (!currentSignature)"));
+    assert!(script.contains("window.__codexPluginAutoExpandLastSignature = \"\""));
+    assert!(script.contains("if ((window.__codexPluginAutoExpandClicks || 0) > 0 || !!button)"));
+}
+
+#[test]
 fn injection_script_defines_version_gated_plugin_unlock_strategy() {
     let script = assets::injection_script(57321);
 
@@ -612,6 +621,16 @@ fn injection_script_exposes_fast_service_tier_control() {
     assert!(script.contains("data-codex-service-tier-controls"));
     assert!(script.contains("removeCodexServiceTierBadges"));
     assert!(script.contains("installCodexServiceTierDispatcherPatch"));
+    assert!(script.contains("installCodexServiceTierAppServerRequestPatch"));
+    assert!(script.contains("patchCodexServiceTierRequestClient"));
+    assert!(script.contains("__codexServiceTierAppServerRequestPatchInstalled"));
+    assert!(script.contains("service_tier_app_server_request_patch_installed"));
+    assert!(script.contains("applyCodexServiceTierRequestClientParams"));
+    assert!(
+        script.contains(
+            "nestedParams === params.params ? params : { ...params, params: nestedParams }"
+        )
+    );
     assert!(script.contains("服务模式"));
     assert!(script.contains("data-codex-service-tier-status"));
     assert!(script.contains("data-codex-service-tier-inherit"));
@@ -1740,4 +1759,30 @@ fn noop_handler() -> bridge::BridgeHandler {
         Box::pin(async { Ok(json!({ "status": "ok" })) })
             as Pin<Box<dyn Future<Output = anyhow::Result<serde_json::Value>> + Send>>
     })
+}
+
+#[test]
+fn renderer_script_falls_back_to_app_server_manager_hooks_asset() {
+    let script = assets::renderer_script().replace("\r\n", "\n");
+
+    assert!(script.contains("async function loadCodexAppModuleAny(nameParts)"));
+    assert!(script.contains("function codexAppServerRequestCandidates(module)"));
+    assert!(script.contains("function isCodexAppServerRegistryClass(value)"));
+    assert!(script.contains("function codexAppScopeCandidates()"));
+    assert!(script.contains("\"app-server-manager-signals-\""));
+    assert!(script.contains("\"app-server-manager-hooks-\""));
+    assert!(script.contains("loadCodexAppModuleAny([\n          \"app-server-manager-signals-\",\n          \"app-server-manager-hooks-\",\n        ])"));
+    assert!(script.contains(
+        "const Registry = Object.values(module || {}).find(isCodexAppServerRegistryClass);"
+    ));
+    assert!(script.contains("registry.getImplForHostId?.(\"local\")"));
+}
+
+#[test]
+fn renderer_script_rate_limits_repeated_app_server_manager_patch_failures() {
+    let script = assets::renderer_script().replace("\r\n", "\n");
+
+    assert!(script.contains("function sendCodexPlusDiagnosticOnce(key, event, detail)"));
+    assert!(script.contains("plugin-marketplace-request-patch-failed"));
+    assert!(script.contains("model-app-server-request-patch-failed"));
 }

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -500,10 +500,10 @@ fn ports_windows_falls_back_to_ephemeral_when_requested_is_busy() {
 }
 
 #[test]
-fn ports_windows_packaged_debug_falls_back_to_ephemeral_when_requested_is_busy() {
+fn ports_windows_packaged_debug_keeps_requested_when_requested_is_busy() {
     let selected = select_packaged_codex_debug_port_with(9229, true, |_| false, || 43001);
 
-    assert_eq!(selected, 43001);
+    assert_eq!(selected, 9229);
 }
 
 #[test]


### PR DESCRIPTION
## 概述

这个 PR 修复 Windows 上 Codex++ 拉起 CodexDesktop 时的启动/注入稳定性问题，尤其是 packaged app 复用已有 Codex 实例时，新命令行参数可能被忽略导致的 debug/inspector port 不稳定问题。

## 修改内容

- Windows packaged Codex 启动时保持 requested debug port 稳定。
- native menu inspector port 在 Windows 上保持稳定。
- 继续交给已有 CDP probing 逻辑判断 Codex 是否可连接。
- renderer 注入侧同时兼容 `app-server-manager-signals-*` 和 `app-server-manager-hooks-*` 资源。
- 通过运行时 registry 尝试发现 app server request client。
- 对重复失败的诊断日志做限流。
- 插件自动展开没有可操作 UI 时不再反复记录 no-op 日志。

## 背景

在 Windows packaged app activation 场景下，如果系统里已经有 CodexDesktop 实例，Windows 可能会复用已有实例，并忽略新传入的命令行参数。

原逻辑在端口占用时会选择随机空闲端口，但已有 Codex 实例不会切换到这个新端口，导致 Codex++ 后续注入/本地化逻辑可能等待一个 Codex 永远不会打开的端口，从而表现为启动后间歇性卡顿或等待。

## 测试

已验证：

```powershell
cargo fmt --check
cargo test -p codex-plus-core native_menu_inspector_port
cargo test -p codex-plus-core ports_windows_packaged_debug_keeps_requested_when_requested_is_busy
cargo test -p codex-plus-core renderer_script_falls_back_to_app_server_manager_hooks_asset
git diff --cached --check