### PR TITLE
[codex] 增加 CodexRadar IQ bridge 路由

### DIFF
--- a/crates/codex-plus-core/src/codexradar.rs
+++ b/crates/codex-plus-core/src/codexradar.rs
@@ -1,0 +1,126 @@
+use serde_json::{Value, json};
+
+const CODEX_RADAR_URL: &str = "https://codexradar.com/";
+
+pub async fn fetch_iq() -> anyhow::Result<Value> {
+    let html = reqwest::Client::builder()
+        .user_agent("Codex++ CodexRadar IQ")
+        .build()?
+        .get(CODEX_RADAR_URL)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    Ok(iq_response_from_text(&html))
+}
+
+pub fn iq_response_from_text(text: &str) -> Value {
+    let plain = strip_tags(text);
+    let models = parse_iq_models(&plain);
+    json!({
+        "status": if models.as_object().is_some_and(|object| !object.is_empty()) { "ok" } else { "failed" },
+        "updated_label": updated_label(&plain),
+        "models": models
+    })
+}
+
+fn parse_iq_models(text: &str) -> Value {
+    let tokens = text.split_whitespace().collect::<Vec<_>>();
+    let mut models = serde_json::Map::new();
+    for index in 0..tokens.len().saturating_sub(1) {
+        let Some((model, level)) = model_level(tokens[index]) else {
+            continue;
+        };
+        let Some(iq) = leading_number(tokens[index + 1]) else {
+            continue;
+        };
+        models
+            .entry(model.to_string())
+            .or_insert_with(|| json!({}))
+            .as_object_mut()
+            .unwrap()
+            .insert(level.to_string(), json!(iq));
+    }
+    Value::Object(models)
+}
+
+fn model_level(token: &str) -> Option<(&str, &str)> {
+    let (model, level) = token.rsplit_once('-')?;
+    if !model.starts_with("GPT-") {
+        return None;
+    }
+    match level {
+        "xhigh" | "high" | "medium" | "low" => Some((model, level)),
+        _ => None,
+    }
+}
+
+fn leading_number(token: &str) -> Option<f64> {
+    let number = token
+        .trim_start_matches('*')
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit() || *ch == '.')
+        .collect::<String>();
+    if number.is_empty() {
+        return None;
+    }
+    number.parse().ok()
+}
+
+fn strip_tags(html: &str) -> String {
+    let mut text = String::with_capacity(html.len());
+    let mut in_tag = false;
+    for ch in html.chars() {
+        match ch {
+            '<' => {
+                in_tag = true;
+                text.push(' ');
+            }
+            '>' => {
+                in_tag = false;
+                text.push(' ');
+            }
+            _ if !in_tag => text.push(ch),
+            _ => {}
+        }
+    }
+    text
+}
+
+fn updated_label(text: &str) -> String {
+    let Some(start) = text.find("降智雷达") else {
+        return String::new();
+    };
+    let tail = &text[start..text.len().min(start + 200)];
+    let Some(end) = tail.find("更新") else {
+        return String::new();
+    };
+    tail[..end + "更新".len()]
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_codexradar_iq_values_from_html() {
+        let parsed = iq_response_from_text(
+            r#"
+            <h2>降智雷达 7月6日13:41更新</h2>
+            <div>GPT-5.5-xhigh</div><strong>90.0</strong>$33.1
+            <div>GPT-5.5-high</div><strong>120.0</strong>$23.5
+            <div>GPT-5.5-medium</div><strong>90.0</strong>$18.6
+            <div>GPT-5.5-low</div><strong>75.0</strong>$12.5
+            <div>GPT-5.4-high</div><strong>75.0</strong>$13.0
+            "#,
+        );
+        assert_eq!(parsed["status"], "ok");
+        assert_eq!(parsed["models"]["GPT-5.5"]["high"], 120.0);
+        assert_eq!(parsed["models"]["GPT-5.5"]["low"], 75.0);
+        assert_eq!(parsed["models"]["GPT-5.4"]["high"], 75.0);
+    }
+}

--- a/crates/codex-plus-core/src/lib.rs
+++ b/crates/codex-plus-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cdp;
 pub mod codex_home;
 pub mod codex_local_storage;
 pub mod codex_sqlite;
+pub mod codexradar;
 mod computer_use_guard;
 pub mod diagnostic_log;
 pub mod env_conflicts;

--- a/crates/codex-plus-core/src/routes.rs
+++ b/crates/codex-plus-core/src/routes.rs
@@ -164,6 +164,7 @@ pub async fn handle_bridge_request(
         "/devtools/open" => ctx.runtime.open_devtools().await,
         "/manager/open" => ctx.runtime.open_manager().await,
         "/backend/status" => ctx.runtime.backend_status().await,
+        "/codexradar/iq" => crate::codexradar::fetch_iq().await,
         "/codex-model-catalog" | "/codex-config-model" => ctx.runtime.codex_model_catalog().await,
         "/diagnostics/log" => diagnostic_log_value(payload.clone()),
         "/ads" => ctx.runtime.ads().await,


### PR DESCRIPTION
## 变更内容

- 新增 `/codexradar/iq` bridge 路由。
- 由 Codex++ 后端请求 `https://codexradar.com/`，解析「降智雷达」里的模型 IQ 数据。
- 返回用户脚本可直接使用的 JSON：`updated_label` 和 `models.{model}.{reasoning}`。

## 为什么需要

Codex renderer 里直接请求外部 HTTPS 会失败，用户脚本无法稳定 `fetch("https://codexradar.com/")`。因此要把真实取数放到 Codex++ 后端完成，再通过 bridge 提供给脚本。

配套脚本市场 PR：BigPizzaV3/CodexPlusPlusScriptMarket#41。脚本会优先调用这个 bridge；没有真实数据时不显示，避免展示过期内置值。

## 验证

已运行：

```text
CARGO_TARGET_DIR=$env:TEMP\codexplusplus-codexradar-target-main cargo test -j 2 -p codex-plus-core codexradar --lib
```

结果：

```text
test codexradar::tests::parses_codexradar_iq_values_from_html ... ok
```
