### PR TITLE
fix(inject): graceful fallback for app-server model patch when module is missing (#1324)

### DIFF
--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -4979,8 +4979,36 @@
     return true;
   }
 
+  const appServerModelRequestPatchMaxMisses = 8;
+  let appServerModelRequestPatchMissCount = 0;
+  let appServerModelRequestPatchDisabled = false;
+
+  function noteAppServerModelRequestPatchMiss(event, detail) {
+    appServerModelRequestPatchMissCount += 1;
+    // installAppServerModelRequestPatch() runs on every model-whitelist
+    // refresh tick (~120ms). On Codex builds where the app-server module was
+    // renamed/removed (e.g. 26.623+, issue #1324) this layer never succeeds
+    // and would otherwise emit the same diagnostic on every tick forever.
+    // Report the first miss so telemetry still captures the cause, then stay
+    // quiet, and finally disable this layer once it is clearly unavailable.
+    // This is a graceful fallback: the remaining whitelist layers (Statsig
+    // config / React state / response JSON patch) keep injecting the custom
+    // models on their own.
+    if (appServerModelRequestPatchMissCount === 1) {
+      sendCodexPlusDiagnostic(event, detail);
+    }
+    if (appServerModelRequestPatchMissCount >= appServerModelRequestPatchMaxMisses && !appServerModelRequestPatchDisabled) {
+      appServerModelRequestPatchDisabled = true;
+      sendCodexPlusDiagnostic("model_app_server_request_patch_skipped", {
+        misses: appServerModelRequestPatchMissCount,
+        lastEvent: event,
+      });
+    }
+  }
+
   function installAppServerModelRequestPatch() {
     if (window.__codexPlusAppServerModelRequestPatchInstalled === codexAppServerModelRequestPatchVersion) return;
+    if (appServerModelRequestPatchDisabled) return;
     const patch = async () => {
       try {
         const module = await loadCodexAppModule("app-server-manager-signals-");
@@ -4996,19 +5024,20 @@
           }
         }
         if (patchedCount > 0) {
+          appServerModelRequestPatchMissCount = 0;
           window.__codexPlusAppServerModelRequestPatchInstalled = codexAppServerModelRequestPatchVersion;
           sendCodexPlusDiagnostic("model_app_server_request_patch_installed", {
             candidateCount: candidates.length,
             patchedCount,
           });
         } else {
-          sendCodexPlusDiagnostic("model_app_server_request_patch_not_found", {
+          noteAppServerModelRequestPatchMiss("model_app_server_request_patch_not_found", {
             exportCount: Object.keys(module || {}).length,
             candidateCount: candidates.length,
           });
         }
       } catch (error) {
-        sendCodexPlusDiagnostic("model_app_server_request_patch_failed", {
+        noteAppServerModelRequestPatchMiss("model_app_server_request_patch_failed", {
           errorName: error?.name || "",
           errorMessage: error?.message || String(error),
         });


### PR DESCRIPTION
## 问题 / Problem

`installAppServerModelRequestPatch()` 会在模型白名单刷新循环里被反复调用（`scheduleCodexModelWhitelistRefresh` 每 **120ms** tick 一次）。在 Codex `26.623+` 版本里 `app-server-manager-signals-*` 模块被改名/移除后，`loadCodexAppModule("app-server-manager-signals-")` 每一 tick 都抛异常：

- 每个扫描周期都上报一次 `model_app_server_request_patch_failed`（诊断日志被刷屏）；
- 失败的模块查找被无限重试（`loadCodexAppModule` 失败即删缓存，每次都重新扫描）。

对应 issue **#1324**。维护者也在该 issue 中指出：这一层（app-server request patch）失败并**不致命**——其它层（Statsig / React state / 响应 JSON patch）仍能把自定义模型补进模型选择器。所以现状只是「无谓的噪音 + 无谓的重试」。

`installAppServerModelRequestPatch()` runs on every whitelist refresh tick (~120ms). On Codex `26.623+`, where the `app-server-manager-signals-*` module was renamed/removed, `loadCodexAppModule()` throws every tick, so `model_app_server_request_patch_failed` was emitted continuously and the doomed lookup was retried forever. Per the maintainer's own note on #1324 this layer is non-fatal — the other whitelist layers still inject the custom models.

## 改动 / Change

只改 `assets/inject/renderer-inject.js` 一个文件，纯 opt-out 降级，不改成功路径行为：

- 第 1 次 miss 照常上报（保留遥测，仍能看到根因）；
- 之后静默；
- 累计 `8` 次仍失败 → 判定该 Codex 版本确实没有此模块，**停用这一层**并补一条 `model_app_server_request_patch_skipped` 汇总；
- 计数在**成功时清零**、且注入脚本按文档重新执行（导航后自然重置），因此**晚加载的模块 chunk 仍会被 patch**，不会被误伤。

Graceful fallback, JS-only, no change to the success path:
- report the **first** miss (telemetry preserved), stay quiet afterwards;
- after `8` consecutive misses, disable this layer and emit one `model_app_server_request_patch_skipped` summary;
- the counter resets on success and per document, so a late-loaded module chunk is still patched.

其余白名单层（`patchStatsigModelWhitelist` / `patchReactModelState` / `installModelJsonResponsePatch`）不受影响，继续照常工作。

## 范围说明 / Scope

本 PR **只**处理 #1324 里的「日志刷屏 + 无限重试」问题（即 issue 建议里的第 2 点，优雅降级）。#1324 里关于聚合 profile 的 `read_codex_model_catalog()` 修复（问题 B）由 #1325 / @Marnie0415 跟进，本 PR 不涉及、无冲突。

Scope: this PR only addresses the diagnostic spam / infinite retry from #1324 (suggestion #2, graceful fallback). The aggregate-profile `read_codex_model_catalog()` fix (part B) is handled separately in #1325 by @Marnie0415 and is out of scope here.

## 测试 / Testing

- `node --check assets/inject/renderer-inject.js` 通过；
- `renderer-inject.js` 为纯注入资产，仓库内无对应 JS 测试套件；未触碰任何 Rust 代码，`cargo` 构建/测试不受影响。
