### PR TITLE
fix(model-catalog): keep versioned base URL when fetching model list (#1349)

### DIFF
--- a/crates/codex-plus-core/src/model_catalog.rs
+++ b/crates/codex-plus-core/src/model_catalog.rs
@@ -562,7 +562,12 @@ fn models_endpoint(base_url: &str) -> String {
     if cleaned.ends_with("/models") {
         return cleaned;
     }
-    if cleaned.ends_with("/v1") {
+    // Only append the default `/v1` version prefix when the base URL does not
+    // already carry a version segment. Providers such as Volcano Engine ARK use
+    // a versioned base (e.g. `.../api/coding/v3`), so blindly appending
+    // `/v1/models` produced `.../api/coding/v3/v1/models` and 404'd. This mirrors
+    // the version handling already used by the protocol proxy. See issue #1349.
+    if crate::protocol_proxy::has_version_suffix(&cleaned) {
         return format!("{cleaned}/models");
     }
     format!("{cleaned}/v1/models")

--- a/crates/codex-plus-core/src/protocol_proxy.rs
+++ b/crates/codex-plus-core/src/protocol_proxy.rs
@@ -917,7 +917,7 @@ pub fn models_url(base_url: &str) -> String {
     url
 }
 
-fn has_version_suffix(base_url: &str) -> bool {
+pub(crate) fn has_version_suffix(base_url: &str) -> bool {
     let segment = base_url.rsplit('/').next().unwrap_or(base_url);
     let Some(rest) = segment.strip_prefix('v') else {
         return false;

--- a/crates/codex-plus-core/tests/model_catalog.rs
+++ b/crates/codex-plus-core/tests/model_catalog.rs
@@ -68,6 +68,51 @@ experimental_bearer_token = "relay-key"
 }
 
 #[tokio::test]
+async fn model_catalog_appends_models_to_versioned_base_url() {
+    // Volcano Engine ARK (and other providers) expose a versioned base URL such
+    // as `.../api/coding/v3`. The model list must be fetched from
+    // `<base>/models`, not `<base>/v1/models` (which 404s). Regression for #1349.
+    let temp = tempfile::tempdir().unwrap();
+    let server = spawn_models_server(json!({
+        "data": [
+            {"id": "doubao-seed-code-preview"}
+        ]
+    }));
+    let versioned_base = format!("{}/api/coding/v3", server.base_url);
+    write_config(
+        temp.path(),
+        &format!(
+            r#"
+model = "doubao-seed-code-preview"
+model_provider = "ark"
+
+[model_providers.ark]
+name = "ARK"
+base_url = "{versioned_base}"
+experimental_bearer_token = "ark-key"
+"#
+        ),
+    );
+
+    let result = read_codex_model_catalog_from_home(
+        temp.path(),
+        &HashMap::new(),
+        reqwest::Client::builder().no_proxy().build().unwrap(),
+    )
+    .await;
+
+    assert_eq!(result["status"], "ok");
+    assert_eq!(result["models"], json!(["doubao-seed-code-preview"]));
+    assert_eq!(
+        result["sources"][0]["endpoint"],
+        format!("{versioned_base}/models")
+    );
+    let requests = server.finish();
+    assert_eq!(requests[0].path, "/api/coding/v3/models");
+    assert_eq!(requests[0].authorization, "Bearer ark-key");
+}
+
+#[tokio::test]
 async fn model_catalog_uses_active_relay_profile_model_list_for_display() {
     let temp = tempfile::tempdir().unwrap();
     let codex_home = temp.path().join("codex-home");


### PR DESCRIPTION
## 问题 / Problem

配置火山引擎 ARK 供应商后，「诊断供应商」失败、「从上游获取模型」报 **HTTP 404**，但进入 Codex 聊天一切正常（issue **#1349**）。

根因在 `model_catalog.rs::models_endpoint()`：它只把结尾是 `/v1` 的 base URL 特判为 `<base>/models`，其它一律拼 `<base>/v1/models`。ARK 的 base 形如 `.../api/coding/v3`（仓库自己的测试 `tests/relay_config.rs` 也用这个值），于是被拼成：

```
https://ark.cn-beijing.volces.com/api/coding/v3/v1/models   ← 404（多了一段 /v1）
```

有意思的是，`protocol_proxy.rs` **早就用 `has_version_suffix()` 正确处理了任意 `/vN` 版本段**（`/v1/v1` 还会被折叠），所以实际聊天请求走 proxy 正常——只有客户端这条「拉模型列表」的路径用了这个过时的、只认 `/v1` 的实现，两边逻辑分叉才导致 404。

`models_endpoint()` only special-cased base URLs ending in `/v1`, appending `/v1/models` to everything else. Providers with a different version segment (Volcano Engine ARK: `.../api/coding/v3`) got `.../api/coding/v3/v1/models` → 404 on "fetch models from upstream" and provider doctor, even though chat completions worked. `protocol_proxy.rs` already handles arbitrary `/vN` suffixes via `has_version_suffix()`; only this client-side path diverged.

## 改动 / Change

- `protocol_proxy::has_version_suffix` 由私有提升为 `pub(crate)`；
- `model_catalog::models_endpoint` 复用它 —— base 已带版本段(`/v1`、`/v3`、`/api/coding/v3` …)时直接追加 `/models`，否则维持追加 `/v1/models`。**`/v1` 与无版本 base 的现有行为完全不变**，只修好了非 `/v1` 版本段被重复拼 `/v1` 的 bug。
- 新增回归测试 `model_catalog_appends_models_to_versioned_base_url`：用 `.../api/coding/v3` base，断言实际请求路径是 `/api/coding/v3/models`（而非 `/api/coding/v3/v1/models`）。测试骨架沿用现有 `spawn_models_server` mock。

Reuse the proxy's already-tested `has_version_suffix()` so the two code paths agree. `/v1` and version-less bases are unchanged.

3 文件 `+52/-2`。

## 测试 / Testing

⚠️ **透明说明**：提交环境未安装 Rust 工具链，我**无法在本地跑 `cargo test`**。改动已逐行人工核对（`&String`→`&str` deref 强转、inline format 捕获、无新 import），且复用的 `has_server_suffix` 已被 proxy 侧覆盖使用。烦请维护者在合并前跑一次 `cargo test -p codex-plus-core --test model_catalog`；如需我在有工具链的机器上补跑并回帖也可以。

⚠️ Could not run `cargo test` locally (no Rust toolchain in the submitting environment). The change is small and manually reviewed; please run `cargo test -p codex-plus-core --test model_catalog` before merging, or let me know and I'll run it on a machine with the toolchain and report back.
