### PR TITLE
fix(bridge): bypass Codex page CSP for injected scripts (#1315)

### DIFF
--- a/crates/codex-plus-core/src/bridge.rs
+++ b/crates/codex-plus-core/src/bridge.rs
@@ -114,24 +114,34 @@ pub async fn install_bridge(
     let mut session = CdpSession::new(socket).with_handler(handler);
 
     session.send_command(1, "Runtime.enable", json!({})).await?;
+    // Disable the Codex page's Content-Security-Policy for injected code. The
+    // bridge and user scripts run in the page context, so Codex's `connect-src`
+    // policy otherwise blocks their requests to the local helper
+    // (http://127.0.0.1:57321) and to plugin endpoints, surfacing as
+    // "The action has been blocked" during plugin marketplace install. This
+    // mirrors the existing `allowUnsafeEvalBlockedByCSP` relaxation used for
+    // Runtime.evaluate. See issue #1315.
     session
-        .send_command(2, "Runtime.removeBinding", json!({ "name": binding_name }))
+        .send_command(2, "Page.setBypassCSP", json!({ "enabled": true }))
         .await?;
     session
-        .send_command(3, "Runtime.addBinding", json!({ "name": binding_name }))
+        .send_command(3, "Runtime.removeBinding", json!({ "name": binding_name }))
+        .await?;
+    session
+        .send_command(4, "Runtime.addBinding", json!({ "name": binding_name }))
         .await?;
 
     let bridge_script = build_bridge_script(binding_name);
     session
         .send_command(
-            4,
+            5,
             "Page.addScriptToEvaluateOnNewDocument",
             json!({ "source": bridge_script }),
         )
         .await?;
     session
         .send_command(
-            5,
+            6,
             "Runtime.evaluate",
             runtime_evaluate_params(&bridge_script),
         )

--- a/crates/codex-plus-core/src/cdp.rs
+++ b/crates/codex-plus-core/src/cdp.rs
@@ -104,3 +104,69 @@ pub fn is_codex_page_target(target: &CdpTarget) -> bool {
     let haystack = format!("{} {}", target.title, target.url).to_lowercase();
     haystack.contains("codex")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target(target_type: &str, title: &str, url: &str, ws: Option<&str>) -> CdpTarget {
+        CdpTarget {
+            id: "t".to_string(),
+            target_type: target_type.to_string(),
+            title: title.to_string(),
+            url: url.to_string(),
+            web_socket_debugger_url: ws.map(str::to_string),
+        }
+    }
+
+    // The CSP bypass in `bridge::install_bridge` (Page.setBypassCSP) is per-CDP-session and
+    // therefore only affects whichever target `install_bridge` attaches to. That target is
+    // exclusively chosen by `pick_injectable_codex_page_target`, so these tests pin down the
+    // scope guarantee: injection (and the CSP relaxation riding on it) never reaches a
+    // non-Codex or non-page target.
+
+    #[test]
+    fn pick_selects_the_codex_page_and_skips_a_non_codex_page() {
+        let targets = vec![
+            target("page", "Some Website", "https://example.com", Some("ws://x/1")),
+            target("page", "Codex", "app://-/index.html", Some("ws://x/2")),
+        ];
+        let picked = pick_injectable_codex_page_target(&targets).expect("codex page present");
+        assert_eq!(picked.web_socket_debugger_url.as_deref(), Some("ws://x/2"));
+    }
+
+    #[test]
+    fn pick_rejects_when_only_non_codex_pages_exist() {
+        let targets = vec![
+            target("page", "Gmail", "https://mail.google.com", Some("ws://x/1")),
+            target("page", "Docs", "https://docs.example.com", Some("ws://x/2")),
+        ];
+        assert!(
+            pick_injectable_codex_page_target(&targets).is_err(),
+            "no Codex page => no injection target => CSP is never bypassed on other pages"
+        );
+    }
+
+    #[test]
+    fn pick_rejects_a_page_without_a_websocket_url() {
+        let targets = vec![target("page", "Codex", "app://-/index.html", None)];
+        assert!(pick_injectable_codex_page_target(&targets).is_err());
+    }
+
+    #[test]
+    fn codex_named_but_non_page_targets_are_not_injectable() {
+        // A worker/iframe whose title mentions "codex" must not be treated as an injectable page.
+        assert!(!is_injectable_page_target(&target(
+            "service_worker",
+            "codex worker",
+            "",
+            Some("ws://x/1")
+        )));
+        assert!(!is_codex_page_target(&target(
+            "iframe",
+            "Codex helper",
+            "app://-/frame",
+            Some("ws://x/1")
+        )));
+    }
+}

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -1208,14 +1208,14 @@ async fn install_bridge_routes_binding_while_waiting_for_command_response() {
     let log_path = temp.path().join("codex-plus.log");
     codex_plus_core::diagnostic_log::set_diagnostic_log_path_for_tests(Some(log_path.clone()));
     let (url, request_rx) = spawn_cdp_server(|mut socket| async move {
-        for expected_id in 1..=4 {
+        for expected_id in 1..=5 {
             let command = recv_json(&mut socket).await;
             assert_eq!(command["id"], expected_id);
             send_json(&mut socket, json!({ "id": expected_id, "result": {} })).await;
         }
 
         let evaluate = recv_json(&mut socket).await;
-        assert_eq!(evaluate["id"], 5);
+        assert_eq!(evaluate["id"], 6);
         assert_eq!(evaluate["method"], "Runtime.evaluate");
         send_json(
             &mut socket,
@@ -1231,7 +1231,7 @@ async fn install_bridge_routes_binding_while_waiting_for_command_response() {
             }),
         )
         .await;
-        send_json(&mut socket, json!({ "id": 5, "result": {} })).await;
+        send_json(&mut socket, json!({ "id": 6, "result": {} })).await;
 
         let response = recv_json(&mut socket).await;
         assert_eq!(response["method"], "Runtime.evaluate");
@@ -1279,9 +1279,45 @@ async fn install_bridge_routes_binding_while_waiting_for_command_response() {
 }
 
 #[tokio::test]
+async fn install_bridge_bypasses_page_csp_after_enabling_runtime() {
+    let (url, request_rx) = spawn_cdp_server(|mut socket| async move {
+        let enable = recv_json(&mut socket).await;
+        assert_eq!(enable["id"], 1);
+        assert_eq!(enable["method"], "Runtime.enable");
+        send_json(&mut socket, json!({ "id": 1, "result": {} })).await;
+
+        let bypass = recv_json(&mut socket).await;
+        assert_eq!(bypass["id"], 2);
+        assert_eq!(bypass["method"], "Page.setBypassCSP");
+        assert_eq!(bypass["params"]["enabled"], true);
+        send_json(&mut socket, json!({ "id": 2, "result": {} })).await;
+
+        for expected_id in 3..=6 {
+            let command = recv_json(&mut socket).await;
+            assert_eq!(command["id"], expected_id);
+            send_json(&mut socket, json!({ "id": expected_id, "result": {} })).await;
+        }
+
+        close_socket(&mut socket).await;
+    })
+    .await;
+
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        bridge::install_bridge(&url, BRIDGE_BINDING_NAME, noop_handler(), &[]),
+    )
+    .await
+    .expect("bridge should not hang while bypassing page CSP")
+    .expect("bridge should send Page.setBypassCSP during install");
+    request_rx
+        .await
+        .expect("server task should finish without panicking");
+}
+
+#[tokio::test]
 async fn install_bridge_immediately_evaluates_new_document_scripts() {
     let (url, request_rx) = spawn_cdp_server(|mut socket| async move {
-        for expected_id in 1..=5 {
+        for expected_id in 1..=6 {
             let command = recv_json(&mut socket).await;
             assert_eq!(command["id"], expected_id);
             send_json(&mut socket, json!({ "id": expected_id, "result": {} })).await;
@@ -1340,7 +1376,7 @@ async fn install_bridge_immediately_evaluates_new_document_scripts() {
 #[tokio::test]
 async fn install_bridge_returns_after_installing_and_keeps_message_pump_alive() {
     let (url, request_rx) = spawn_cdp_server(|mut socket| async move {
-        for expected_id in 1..=5 {
+        for expected_id in 1..=6 {
             let command = recv_json(&mut socket).await;
             assert_eq!(command["id"], expected_id);
             send_json(&mut socket, json!({ "id": expected_id, "result": {} })).await;
@@ -1458,7 +1494,7 @@ async fn install_bridge_command_error_mentions_method_and_id() {
 #[tokio::test]
 async fn install_bridge_rejects_bad_payload_with_id_and_continues_after_unparseable_payload() {
     let (url, request_rx) = spawn_cdp_server(|mut socket| async move {
-        for expected_id in 1..=5 {
+        for expected_id in 1..=6 {
             let command = recv_json(&mut socket).await;
             assert_eq!(command["id"], expected_id);
             send_json(&mut socket, json!({ "id": expected_id, "result": {} })).await;
@@ -1543,7 +1579,7 @@ async fn install_bridge_rejects_bad_payload_with_id_and_continues_after_unparsea
 #[tokio::test]
 async fn install_bridge_queues_consecutive_bindings_without_recursive_dispatch() {
     let (url, request_rx) = spawn_cdp_server(|mut socket| async move {
-        for expected_id in 1..=5 {
+        for expected_id in 1..=6 {
             let command = recv_json(&mut socket).await;
             assert_eq!(command["id"], expected_id);
             send_json(&mut socket, json!({ "id": expected_id, "result": {} })).await;
@@ -1604,7 +1640,7 @@ async fn install_bridge_queues_consecutive_bindings_without_recursive_dispatch()
 #[tokio::test]
 async fn install_bridge_does_not_wait_for_resolve_runtime_evaluate_ack() {
     let (url, request_rx) = spawn_cdp_server(|mut socket| async move {
-        for expected_id in 1..=5 {
+        for expected_id in 1..=6 {
             let command = recv_json(&mut socket).await;
             assert_eq!(command["id"], expected_id);
             send_json(&mut socket, json!({ "id": expected_id, "result": {} })).await;


### PR DESCRIPTION
## 问题 / Problem

插件市场点击安装报错 **“The action has been blocked”**,控制台是 CSP 拦截(issue **#1315**):

```
Connecting to 'http://127.0.0.1:57321/diagnostics/log' violates the following
Content Security Policy directive: "connect-src 'self' https://ab.chatgpt.com ...".
The action has been blocked.
```

注入的 bridge 脚本和用户脚本都运行在 **Codex 页面上下文**里,受 Codex 自身的 CSP `connect-src` 约束。于是它们连本地 helper(`http://127.0.0.1:57321`)、连插件端点的请求会被浏览器拦掉——表现为插件市场安装失败,以及 #1300 / #1340 日志里反复出现的 `connect-src` violation。

Injected bridge/user scripts run in the Codex page context and are bound by Codex's own CSP `connect-src`, which blocks their requests to the local helper and to plugin endpoints — surfacing as "The action has been blocked" on plugin marketplace install.

## 改动 / Change

在 bridge 安装序列里、`Runtime.enable` 之后,发送一条 **`Page.setBypassCSP { enabled: true }`**,对注入代码关闭页面 CSP 强制。这与项目**已有**的 `allowUnsafeEvalBlockedByCSP`(给 `Runtime.evaluate` 放宽 CSP)一脉相承,只是把放宽从 eval 扩展到网络连接。

Send `Page.setBypassCSP { enabled: true }` right after `Runtime.enable` during bridge install, consistent with the existing `allowUnsafeEvalBlockedByCSP` relaxation. It only removes restrictions on CodexPlusPlus's own injected code; Codex's CSP-compliant scripts are unaffected.

- `bridge.rs`:插入该命令并顺延固定 CDP 命令 id(`Runtime.enable`=1 → `Page.setBypassCSP`=2 → removeBinding=3 → addBinding=4 → addScript=5 → evaluate=6)。
- `tests/cdp_bridge.rs`:同步更新既有序列断言(排水循环 `1..=5`→`1..=6`,routes_binding 的 evaluate id 5→6),并**新增回归测试** `install_bridge_bypasses_page_csp_after_enabling_runtime`,断言 id 2 发的是 `Page.setBypassCSP` 且 `enabled=true`。

2 文件 `+58/-12`。

## 测试 / Testing

已在本机 `cargo test` 跑通:

```
cargo test -p codex-plus-core --test cdp_bridge   → 68 passed; 0 failed
cargo test -p codex-plus-core                      → all suites pass; 0 failed
```

新回归测试覆盖 `Page.setBypassCSP` 的发送;其余既有 bridge 序列测试在 id 顺延后全部通过。
