### PR TITLE
fix: fall through to config.toml when aggregate profile has no models

### DIFF
--- a/crates/codex-plus-core/src/model_catalog.rs
+++ b/crates/codex-plus-core/src/model_catalog.rs
@@ -39,7 +39,11 @@ pub async fn read_codex_model_catalog() -> Value {
     let settings_path = crate::paths::default_settings_path();
     if settings_path.exists() {
         if let Ok(settings) = SettingsStore::new(settings_path).load() {
-            return relay_profile_model_catalog_value(&home, &settings.active_relay_profile());
+            let profile = settings.active_relay_profile();
+            let catalog = relay_profile_model_catalog_value(&home, &profile);
+            if catalog.get("models").and_then(Value::as_array).map_or(false, |m| !m.is_empty()) {
+                return catalog;
+            }
         }
     }
     let env = std::env::vars().collect::<HashMap<_, _>>();


### PR DESCRIPTION
## Problem

When activeRelayId points to an aggregate relay profile (relayMode: aggregate), the Codex model selector does not show custom models.

Root cause: read_codex_model_catalog() always returns from the relay profile path when settings.json exists. Aggregate profiles have an empty modelList (models are defined in their members), so it returns {"status":"not_configured","models":[]} without falling through to config.toml.

Related: #1324

## Fix

In read_codex_model_catalog(), check if the relay profile returned models are empty. If empty, do not return early - continue to read_codex_model_catalog_from_home() which reads from config.toml.

```rust
// Before
return relay_profile_model_catalog_value(&home, &settings.active_relay_profile());

// After
let profile = settings.active_relay_profile();
let catalog = relay_profile_model_catalog_value(&home, &profile);
if catalog.get("models").and_then(Value::as_array).map_or(false, |m| !m.is_empty()) {
    return catalog;
}
// Falls through to config.toml path
```

## Test Scenarios

| Scenario | Before | After |
|----------|--------|-------|
| Aggregate profile (empty modelList) | Returns not_configured | Falls through to config.toml |
| Single profile (has modelList) | Works normally | Unchanged |
| No settings.json | Goes to config.toml | Unchanged |

## Notes

- Only modifies model_catalog.rs, +5 -1 lines
- No breaking changes
- PR #1325 (JS fallback) is a workaround; this is the root cause fix
- PR #1360 (graceful degradation) is complementary