### PR TITLE
Welcome GPT-5.6! Support ChatGPT.app fallback for macOS launch

### DIFF
--- a/crates/codex-plus-core/src/app_paths.rs
+++ b/crates/codex-plus-core/src/app_paths.rs
@@ -223,7 +223,13 @@ pub fn normalize_codex_app_path(path: &Path) -> Option<PathBuf> {
 
 pub fn build_codex_executable(app_dir: &Path) -> PathBuf {
     if app_dir.extension() == Some(OsStr::new("app")) {
-        return app_dir.join("Contents").join("MacOS").join("Codex");
+        let macos_dir = app_dir.join("Contents").join("MacOS");
+        if let Some(executable) = macos_app_plist_value(app_dir, "CFBundleExecutable")
+            .filter(|value| !value.contains('/') && !value.contains('\\'))
+        {
+            return macos_dir.join(executable);
+        }
+        return macos_dir.join("Codex");
     }
     let upper = app_dir.join("Codex.exe");
     if upper.exists() {
@@ -283,9 +289,13 @@ fn codex_package_version(package_dir: &Path) -> Option<String> {
 }
 
 fn macos_app_version(app_dir: &Path) -> Option<String> {
+    macos_app_plist_value(app_dir, "CFBundleShortVersionString")
+        .or_else(|| macos_app_plist_value(app_dir, "CFBundleVersion"))
+}
+
+fn macos_app_plist_value(app_dir: &Path, key: &str) -> Option<String> {
     let plist = std::fs::read_to_string(app_dir.join("Contents").join("Info.plist")).ok()?;
-    plist_string_value(&plist, "CFBundleShortVersionString")
-        .or_else(|| plist_string_value(&plist, "CFBundleVersion"))
+    plist_string_value(&plist, key)
 }
 
 fn plist_string_value(plist: &str, key: &str) -> Option<String> {
@@ -310,7 +320,7 @@ fn macos_app_candidates(root: &Path) -> Vec<PathBuf> {
     if root.extension() == Some(OsStr::new("app")) {
         return vec![root.to_path_buf()];
     }
-    ["Codex.app", "OpenAI Codex.app", "OpenAI.Codex.app"]
+    ["Codex.app", "OpenAI Codex.app", "OpenAI.Codex.app", "ChatGPT.app"]
         .into_iter()
         .map(|name| root.join(name))
         .collect()

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -155,6 +155,36 @@ fn app_paths_find_macos_codex_app_prefers_first_search_root_and_known_names() {
 }
 
 #[test]
+fn app_paths_prefers_codex_app_over_chatgpt_app() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("Applications");
+    let codex = root.join("Codex.app");
+    let chatgpt = root.join("ChatGPT.app");
+    std::fs::create_dir_all(&codex).unwrap();
+    std::fs::create_dir_all(&chatgpt).unwrap();
+
+    assert_eq!(
+        find_macos_codex_app(&[root]).as_deref(),
+        Some(codex.as_path())
+    );
+}
+
+#[test]
+fn app_paths_preserves_legacy_macos_candidates_before_chatgpt_app() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("Applications");
+    let legacy = root.join("OpenAI Codex.app");
+    let chatgpt = root.join("ChatGPT.app");
+    std::fs::create_dir_all(&legacy).unwrap();
+    std::fs::create_dir_all(&chatgpt).unwrap();
+
+    assert_eq!(
+        find_macos_codex_app(&[root]).as_deref(),
+        Some(legacy.as_path())
+    );
+}
+
+#[test]
 fn app_paths_build_macos_bundle_executable() {
     let app = PathBuf::from("/Applications/OpenAI Codex.app");
 
@@ -162,6 +192,37 @@ fn app_paths_build_macos_bundle_executable() {
         build_codex_executable(&app),
         PathBuf::from("/Applications/OpenAI Codex.app/Contents/MacOS/Codex")
     );
+}
+
+#[test]
+fn app_paths_finds_chatgpt_bundle_and_uses_its_declared_executable() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("Applications");
+    let app = root.join("ChatGPT.app");
+    let contents = app.join("Contents");
+    let macos = contents.join("MacOS");
+    std::fs::create_dir_all(&macos).unwrap();
+    std::fs::write(
+        contents.join("Info.plist"),
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>com.openai.codex</string>
+  <key>CFBundleExecutable</key>
+  <string>ChatGPT</string>
+</dict>
+</plist>
+"#,
+    )
+    .unwrap();
+    std::fs::write(macos.join("ChatGPT"), "").unwrap();
+
+    assert_eq!(
+        find_macos_codex_app(&[root]).as_deref(),
+        Some(app.as_path())
+    );
+    assert_eq!(build_codex_executable(&app), macos.join("ChatGPT"));
 }
 
 #[test]


### PR DESCRIPTION
## 摘要
- 今天 ChatGPT 和 Codex 两个 macOS App 合并后，本地入口新增新的 `ChatGPT.app`，这次补上 Codex++ 对新 `ChatGPT.app` 的启动兼容。
- 保留原有 macOS App 发现顺序，只在现有候选之后追加 `ChatGPT.app`，避免破坏旧安装环境。
- 启动 `.app` 时读取 `Info.plist` 里的 `CFBundleExecutable`，确保 `ChatGPT.app` 启动真实的 `Contents/MacOS/ChatGPT`。
- 增加回归测试，覆盖 Codex 优先、旧候选优先、ChatGPT fallback、以及 ChatGPT 可执行文件解析。

## 测试
- [x] `git diff --check`
- [x] `cargo test -p codex-plus-core --test launcher`