### PR TITLE
fix(app-paths): support Codex desktop app renamed to ChatGPT.app (26.707+) — fixes startup on macOS (#1389)

### DIFF
--- a/crates/codex-plus-core/src/app_paths.rs
+++ b/crates/codex-plus-core/src/app_paths.rs
@@ -223,7 +223,12 @@ pub fn normalize_codex_app_path(path: &Path) -> Option<PathBuf> {
 
 pub fn build_codex_executable(app_dir: &Path) -> PathBuf {
     if app_dir.extension() == Some(OsStr::new("app")) {
-        return app_dir.join("Contents").join("MacOS").join("Codex");
+        // Codex 26.707+ ships the same bundle (id `com.openai.codex`) named
+        // `ChatGPT.app`, whose CFBundleExecutable is `ChatGPT` rather than `Codex`.
+        // Read the executable name from Info.plist so a rename cannot break launch;
+        // fall back to the historical `Codex` name when the plist is unavailable.
+        let exe = macos_bundle_executable(app_dir).unwrap_or_else(|| "Codex".to_string());
+        return app_dir.join("Contents").join("MacOS").join(exe);
     }
     let upper = app_dir.join("Codex.exe");
     if upper.exists() {
@@ -288,6 +293,11 @@ fn macos_app_version(app_dir: &Path) -> Option<String> {
         .or_else(|| plist_string_value(&plist, "CFBundleVersion"))
 }
 
+fn macos_bundle_executable(app_dir: &Path) -> Option<String> {
+    let plist = std::fs::read_to_string(app_dir.join("Contents").join("Info.plist")).ok()?;
+    plist_string_value(&plist, "CFBundleExecutable")
+}
+
 fn plist_string_value(plist: &str, key: &str) -> Option<String> {
     let (_, after_key) = plist.split_once(&format!("<key>{key}</key>"))?;
     let (_, after_string_open) = after_key.split_once("<string>")?;
@@ -310,7 +320,9 @@ fn macos_app_candidates(root: &Path) -> Vec<PathBuf> {
     if root.extension() == Some(OsStr::new("app")) {
         return vec![root.to_path_buf()];
     }
-    ["Codex.app", "OpenAI Codex.app", "OpenAI.Codex.app"]
+    // Codex 26.707+ renamed the desktop bundle to `ChatGPT.app` (bundle id is still
+    // `com.openai.codex`). Keep the historical names first so existing installs win.
+    ["Codex.app", "OpenAI Codex.app", "OpenAI.Codex.app", "ChatGPT.app"]
         .into_iter()
         .map(|name| root.join(name))
         .collect()

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -164,6 +164,59 @@ fn app_paths_build_macos_bundle_executable() {
     );
 }
 
+// Codex 26.707+ ships the same bundle (id `com.openai.codex`) named `ChatGPT.app`,
+// whose CFBundleExecutable is `ChatGPT` instead of `Codex`.
+#[test]
+fn app_paths_finds_renamed_chatgpt_bundle() {
+    let temp = tempfile::tempdir().unwrap();
+    let app = temp.path().join("ChatGPT.app");
+    std::fs::create_dir_all(&app).unwrap();
+
+    assert_eq!(
+        find_macos_codex_app(&[temp.path().to_path_buf()]).as_deref(),
+        Some(app.as_path())
+    );
+}
+
+#[test]
+fn app_paths_build_macos_executable_from_bundle_plist() {
+    let temp = tempfile::tempdir().unwrap();
+    let app = temp.path().join("ChatGPT.app");
+    let contents = app.join("Contents");
+    std::fs::create_dir_all(&contents).unwrap();
+    std::fs::write(
+        contents.join("Info.plist"),
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>com.openai.codex</string>
+  <key>CFBundleExecutable</key>
+  <string>ChatGPT</string>
+</dict>
+</plist>
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        build_codex_executable(&app),
+        contents.join("MacOS").join("ChatGPT")
+    );
+}
+
+#[test]
+fn app_paths_build_macos_executable_falls_back_to_codex_without_plist() {
+    let temp = tempfile::tempdir().unwrap();
+    let app = temp.path().join("Codex.app");
+    std::fs::create_dir_all(app.join("Contents")).unwrap();
+
+    assert_eq!(
+        build_codex_executable(&app),
+        app.join("Contents").join("MacOS").join("Codex")
+    );
+}
+
 #[test]
 fn app_paths_normalizes_executable_and_package_paths() {
     let temp = tempfile::tempdir().unwrap();
@@ -1498,3 +1551,4 @@ impl LaunchHooks for FakeHooks {
         }
     }
 }
+


### PR DESCRIPTION
## 根因 / Root cause

Codex **26.707** 把桌面端 bundle **改名成 `ChatGPT.app`**——但它**还是同一个 app**:

```
$ /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" /Applications/ChatGPT.app/Contents/Info.plist
com.openai.codex                     ← bundle id 未变
$ /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" ...
26.707.30751
$ ls /Applications/ChatGPT.app/Contents/MacOS/
ChatGPT                              ← 可执行文件也从 Codex 改成了 ChatGPT
$ ls -d /Applications/Codex.app
(不存在)
```
`ChatGPT.app` 内仍含 `Codex Framework.framework`、`Resources/codex`,以及 Codex++ 注入所依赖的 `/webview/assets/*.js`(含 `app-initial~app-main~*`)。`mdfind kMDItemCFBundleIdentifier == 'com.openai.codex'` 全机只命中它。

Codex 26.707 renamed the desktop bundle to `ChatGPT.app`. It is the *same* app — `CFBundleIdentifier` is still `com.openai.codex` — but `CFBundleExecutable` changed from `Codex` to `ChatGPT`, and `/Applications/Codex.app` no longer exists.

**两处硬编码因此失效 / Two hardcoded assumptions break startup:**

1. `app_paths.rs::macos_app_candidates()` 只找 `Codex.app` / `OpenAI Codex.app` / `OpenAI.Codex.app` → **找不到 app**。
2. `app_paths.rs::build_codex_executable()` 硬编码 `Contents/MacOS/Codex` → **即使找到 bundle,可执行路径也不存在**。

这解释了 #1389(「新版无法通过 codex++ 启动」)。

## 改动 / Change

- `macos_app_candidates`:候选名单加入 `ChatGPT.app`,**放在历史名字之后**,保证已有 `Codex.app` 安装仍优先命中。
- `build_codex_executable`:对 `.app` 从 bundle 的 **`CFBundleExecutable`** 解析可执行名(复用仓库里已有的 `plist_string_value` 助手,`macos_app_version` 也在用),读不到时**回退 `Codex`**。→ 以后再改名也不会断。

Only `app_paths.rs` + its tests. No behavior change for existing `Codex.app` installs.

## 验证 / Verified

**Live(本机 macOS,Codex 26.707.30751):**
```
find_macos_codex_app(["/Applications"]) → Some("/Applications/ChatGPT.app")
build_codex_executable(...)             → "/Applications/ChatGPT.app/Contents/MacOS/ChatGPT"  exists=true
```

**测试:** 新增 3 个单测,`cargo test -p codex-plus-core` 全绿、无回归。
```
app_paths_finds_renamed_chatgpt_bundle .................. ok
app_paths_build_macos_executable_from_bundle_plist ...... ok
app_paths_build_macos_executable_falls_back_to_codex_without_plist ... ok
test result: ok. 57 passed; 0 failed   (--test launcher)
```

## Windows 说明 / Note on Windows

#1389 的报告人在 Windows。Windows 侧走的是 `CODEX_PACKAGE_IDENTITIES = ["OpenAI.Codex", "OpenAI.CodexBeta"]` 匹配 `WindowsApps` 包名——**改名后很可能同样匹配不上**,需要补上新的 package identity。我没有 Windows 机器无法确证包名,**故本 PR 只修 macOS(已 live 验证)**;若维护者能提供改名后的 Windows 包名,我可以在本 PR 补上。

This PR fixes the macOS path only (live-verified). Windows likely needs the new package identity added to `CODEX_PACKAGE_IDENTITIES`; I have no Windows machine to confirm the new name — happy to add it here if someone can provide it.

Refs #1389
