### PR TITLE
fix: harden relay profile configuration updates

### DIFF
--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -63,10 +63,12 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
+  createModelWindowRow,
   mergeModelWindowRows,
   modelWindowRowsFromProfile,
   serializeModelWindowRows,
   type ModelWindowRow,
+  validateModelWindowRows,
 } from "./model-windows";
 import { getLanguage, t, tf, toggleLanguage } from "@/i18n";
 
@@ -1396,13 +1398,13 @@ export function App() {
 
   const saveSettingsValue = async (next: BackendSettings, silent = true) => {
     const normalized = normalizeSettings(next);
-    setSettingsForm(normalized);
     const result = await run(() => call<SettingsResult>("save_settings", { settings: normalized }));
-    if (result) {
-      setSettings(result);
-      setSettingsForm(normalizeSettings(result.settings));
-      if (!silent || !isSuccessStatus(result.status)) showNotice(t("设置保存"), result.message, result.status);
-    }
+    if (!result) return false;
+    if (!silent || !isSuccessStatus(result.status)) showNotice(t("设置保存"), result.message, result.status);
+    if (!isSuccessStatus(result.status)) return false;
+    setSettings(result);
+    setSettingsForm(normalizeSettings(result.settings));
+    return true;
   };
 
   const resetSettings = async () => {
@@ -1569,13 +1571,14 @@ export function App() {
 
   const saveRelayFile = async (kind: "config" | "auth", contents: string, silent = false) => {
     const result = await run(() => call<RelayFilesResult>("save_relay_file", { request: { kind, contents } }));
-    if (result) {
-      setRelayFiles(result);
-      if (!silent || !isSuccessStatus(result.status)) {
-        showNotice(kind === "config" ? "config.toml" : "auth.json", result.message, result.status);
-      }
-      await refreshRelay(true);
+    if (!result) return false;
+    if (!silent || !isSuccessStatus(result.status)) {
+      showNotice(kind === "config" ? "config.toml" : "auth.json", result.message, result.status);
     }
+    if (!isSuccessStatus(result.status)) return false;
+    setRelayFiles(result);
+    await refreshRelay(true);
+    return true;
   };
 
   const upsertContextEntry = async (next: BackendSettings, kind: ContextKind, id: string, tomlBody: string) => {
@@ -1663,12 +1666,12 @@ export function App() {
   const switchRelayProfile = async (next: BackendSettings, previousActiveRelayId = settingsForm.activeRelayId) => {
     if (relaySwitching) {
       showNotice(t("供应商切换中"), t("上一次切换还没有完成，请稍后再试。"), "failed");
-      return;
+      return false;
     }
     let switchSettings = normalizeSettings(next);
     if (!switchSettings.relayProfilesEnabled) {
       showNotice(t("供应商配置已关闭"), t("当前不会写入 Codex config.toml / auth.json。打开供应商配置总开关后再切换。"), "failed");
-      return;
+      return false;
     }
     const targetBeforeSnapshot = activeRelayProfile(switchSettings);
     logDiagnostic("switchRelayProfile.start", {
@@ -1686,9 +1689,13 @@ export function App() {
         error: validationError,
       });
       showNotice(t("供应商配置可能不正确"), validationError, "failed");
-      return;
+      return false;
     }
-    switchSettings = await snapshotActiveRelayFilesBeforeSwitch(switchSettings, previousActiveRelayId);
+    const snapshottedSettings = previousActiveRelayId === switchSettings.activeRelayId
+      ? switchSettings
+      : await snapshotActiveRelayFilesBeforeSwitch(switchSettings, previousActiveRelayId);
+    if (!snapshottedSettings) return false;
+    switchSettings = snapshottedSettings;
     const selectedAfterSave = activeRelayProfile(switchSettings);
     const command = relayProfileSwitchCommand(selectedAfterSave);
 
@@ -1709,9 +1716,19 @@ export function App() {
         logDiagnostic("switchRelayProfile.apply_no_result", {
           targetRelayId: selectedAfterSave.id,
         });
-        return;
+        return false;
       }
       const selectedSettings = normalizeSettings(result.settings);
+      if (!isSuccessStatus(result.status)) {
+        logDiagnostic("switchRelayProfile.apply_failed", {
+          targetRelayId: selectedAfterSave.id,
+          status: result.status,
+          message: result.message,
+          activeRelayId: selectedSettings.activeRelayId,
+        });
+        showNotice(t("供应商切换"), result.message, result.status);
+        return false;
+      }
       setSettings({
         status: result.status,
         message: result.message,
@@ -1726,16 +1743,6 @@ export function App() {
         ...result.relay,
       });
       await refreshRelayFiles(true);
-      if (!isSuccessStatus(result.status)) {
-        logDiagnostic("switchRelayProfile.apply_failed", {
-          targetRelayId: selectedAfterSave.id,
-          status: result.status,
-          message: result.message,
-          activeRelayId: selectedSettings.activeRelayId,
-        });
-        showNotice(t("供应商切换"), result.message, result.status);
-        return;
-      }
       const currentSelected = activeRelayProfile(selectedSettings);
       logDiagnostic("switchRelayProfile.ok", {
         targetRelayId: currentSelected.id,
@@ -1743,6 +1750,7 @@ export function App() {
         status: result.status,
       });
       showNotice(t("供应商切换"), relayProfileModeSwitchedText(currentSelected), result.status);
+      return true;
     } finally {
       setRelaySwitching(false);
     }
@@ -1751,7 +1759,7 @@ export function App() {
   const snapshotActiveRelayFilesBeforeSwitch = async (
     next: BackendSettings,
     previousActiveRelayId: string,
-  ): Promise<BackendSettings> => {
+  ): Promise<BackendSettings | null> => {
     const profileId = previousActiveRelayId.trim();
     if (!profileId) return next;
     const result = await run(() =>
@@ -1759,11 +1767,11 @@ export function App() {
         request: { settings: next, profileId },
       }),
     );
-    if (!result) return next;
+    if (!result) return null;
     const normalized = normalizeSettings(result.settings);
     if (!isSuccessStatus(result.status)) {
       showNotice(t("供应商切换"), result.message, result.status);
-      return next;
+      return null;
     }
     return normalized;
   };
@@ -2218,7 +2226,7 @@ type Actions = {
   checkUpdate: () => Promise<void>;
   performUpdate: () => Promise<void>;
   saveSettings: () => Promise<void>;
-  saveSettingsValue: (settings: BackendSettings, silent?: boolean) => Promise<void>;
+  saveSettingsValue: (settings: BackendSettings, silent?: boolean) => Promise<boolean>;
   refreshSettings: (silent?: boolean) => Promise<BackendSettings | null>;
   resetSettings: () => Promise<void>;
   resetImageOverlaySettings: () => Promise<void>;
@@ -2253,7 +2261,7 @@ type Actions = {
   applyRelayInjection: () => Promise<boolean>;
   applyPureApiInjection: () => Promise<boolean>;
   clearRelayInjection: () => Promise<boolean>;
-  saveRelayFile: (kind: "config" | "auth", contents: string, silent?: boolean) => Promise<void>;
+  saveRelayFile: (kind: "config" | "auth", contents: string, silent?: boolean) => Promise<boolean>;
   upsertContextEntry: (
     settings: BackendSettings,
     kind: ContextKind,
@@ -2266,7 +2274,7 @@ type Actions = {
   diagnoseRelayProfile: (profile: RelayProfile) => Promise<ProviderDoctorResult | null>;
   testStepwiseSettings: (settings: BackendSettings) => Promise<void>;
   fetchRelayProfileModels: (profile: RelayProfile) => Promise<string[] | null>;
-  switchRelayProfile: (settings: BackendSettings, previousActiveRelayId?: string) => Promise<void>;
+  switchRelayProfile: (settings: BackendSettings, previousActiveRelayId?: string) => Promise<boolean>;
   relaySwitching: boolean;
   switchOfficialMode: () => Promise<void>;
   switchPureApiMode: () => Promise<void>;
@@ -2412,8 +2420,9 @@ function RelayScreen({
     : null);
   const isNewProfile = !!newProfileDraft;
   const saveRelaySettings = async (next: BackendSettings) => {
-    onFormChange(next);
-    await actions.saveSettingsValue(next, true);
+    const saved = await actions.saveSettingsValue(next, true);
+    if (saved) onFormChange(next);
+    return saved;
   };
   const createNewAggregateProfile = () => {
     const draft = createAggregateRelayProfile(normalized);
@@ -3649,7 +3658,7 @@ function RelayProfileList({
   actions,
 }: {
   form: BackendSettings;
-  onFormChange: (value: BackendSettings) => void;
+  onFormChange: (value: BackendSettings) => boolean | Promise<boolean>;
   onEdit: (id: string) => void;
   disabled?: boolean;
   actions: Actions;
@@ -3702,7 +3711,7 @@ function SortableRelayProfileCard({
   form: BackendSettings;
   profile: RelayProfile;
   index: number;
-  onFormChange: (value: BackendSettings) => void;
+  onFormChange: (value: BackendSettings) => boolean | Promise<boolean>;
   onEdit: (id: string) => void;
   disabled?: boolean;
   actions: Actions;
@@ -3799,8 +3808,17 @@ function SortableRelayProfileCard({
           </Button>
           <Button
             disabled={form.relayProfiles.length <= 1}
-            onClick={(event) => {
+            onClick={async (event) => {
               event.stopPropagation();
+              if (active) {
+                const nextProfile = form.relayProfiles.find((item) => item.id !== profile.id);
+                if (!nextProfile) return;
+                const switchedSettings = syncLegacyRelayFields({ ...form, activeRelayId: nextProfile.id });
+                const switched = await actions.switchRelayProfile(switchedSettings, profile.id);
+                if (!switched) return;
+                await onFormChange(removeRelayProfile(switchedSettings, profile.id));
+                return;
+              }
               onFormChange(removeRelayProfile(form, profile.id));
             }}
             size="icon"
@@ -3864,7 +3882,7 @@ function RelayProfileDetail({
   form: BackendSettings;
   isNew?: boolean;
   onBack: () => void;
-  onFormChange: (value: BackendSettings) => void | Promise<void>;
+  onFormChange: (value: BackendSettings) => boolean | Promise<boolean>;
   onSaved?: () => void;
   actions: Actions;
 }) {
@@ -3889,7 +3907,10 @@ function RelayProfileDetail({
     setDraft(nextDraft);
     setModelWindowRows(modelWindowRowsFromProfile(nextDraft.modelList, nextDraft.modelWindows || ""));
   }, [profile.id, profile.modelList, profile.modelWindows, profileUsesLiveFiles, isActive, isNew, relayFiles?.configContents, relayFiles?.authContents]);
-  const validationError = isAggregateRelayProfile(draft) ? aggregateRelayProfileValidation(draft) : null;
+  const modelWindowValidationError = isAggregateRelayProfile(draft) ? null : validateModelWindowRows(modelWindowRows);
+  const validationError = isAggregateRelayProfile(draft)
+    ? aggregateRelayProfileValidation(draft)
+    : modelWindowValidationError;
   const draftWithModelRows = () => {
     const serializedRows = serializeModelWindowRows(modelWindowRows);
     return { ...draft, modelList: serializedRows.modelList, modelWindows: serializedRows.modelWindows };
@@ -3901,19 +3922,20 @@ function RelayProfileDetail({
     const next = isNew
       ? addRelayProfile(form, normalizedDraft)
       : updateRelayProfile(form, profile.id, normalizedDraft);
-    await onFormChange(next);
-    if (isActive && relayProfileUsesLiveFiles(normalizedDraft)) {
-      await actions.saveRelayFile(
-        "config",
-        effectiveRelayConfigPreview(normalizedDraft, form, normalizedDraft),
-        true,
-      );
-      await actions.saveRelayFile("auth", normalizedDraft.authContents, true);
+    if (isActive) {
+      const switched = await actions.switchRelayProfile(next, profile.id);
+      if (switched) onSaved?.();
+      return;
     }
+    if (!await onFormChange(next)) return;
     onSaved?.();
   };
-  const switchDraft = () => {
+  const switchDraft = async () => {
     if (isNew || !form.relayProfilesEnabled) return;
+    if (validationError) {
+      await actions.showMessage(t("供应商配置可能不正确"), validationError, "failed");
+      return;
+    }
     const draftWithWindows = draftWithModelRows();
     const normalizedDraft = isAggregateRelayProfile(draftWithWindows) ? normalizeAggregateRelayProfile(draftWithWindows, form) : deriveRelayProfileFromFiles(draftWithWindows);
     const previousActiveRelayId = form.activeRelayId;
@@ -3922,7 +3944,7 @@ function RelayProfileDetail({
       relayProfiles: form.relayProfiles.map((item) => (item.id === profile.id ? normalizedDraft : item)),
       activeRelayId: profile.id,
     });
-    void actions.switchRelayProfile(next, previousActiveRelayId);
+    await actions.switchRelayProfile(next, previousActiveRelayId);
   };
   return (
     <div className="relay-detail-page" key={profile.id}>
@@ -3998,7 +4020,7 @@ function RelayProfileEditor({
   form: BackendSettings;
   isNew?: boolean;
   onProfileChange: (value: RelayProfile) => void;
-  onSwitch: () => void;
+  onSwitch: () => void | Promise<void>;
   actions: Actions;
   modelWindowRows: ModelWindowRow[];
   setModelWindowRows: (value: ModelWindowRow[]) => void;
@@ -4029,11 +4051,12 @@ function RelayProfileEditor({
   };
   const removeModelWindowRow = (index: number) => {
     const nextRows = modelWindowRows.filter((_, rowIndex) => rowIndex !== index);
-    setModelWindowRows(nextRows.length ? nextRows : [{ model: "", window: "" }]);
+    setModelWindowRows(nextRows.length ? nextRows : [createModelWindowRow()]);
   };
   const addModelWindowRows = (rows: ModelWindowRow[]) => {
     setModelWindowRows(mergeModelWindowRows(modelWindowRows, rows));
   };
+  const modelWindowValidationError = validateModelWindowRows(modelWindowRows);
   const runProviderDoctor = async () => {
     setDoctorOpen(true);
     setDoctorRunning(true);
@@ -4230,7 +4253,7 @@ function RelayProfileEditor({
                 <span />
               </div>
               {modelWindowRows.map((row, index) => (
-                <div className="relay-model-row" key={`${index}-${row.model}`}>
+                <div className="relay-model-row" key={row.id}>
                   <Input
                     value={row.model}
                     onChange={(event) => updateModelWindowRow(index, { model: event.currentTarget.value })}
@@ -4256,7 +4279,7 @@ function RelayProfileEditor({
             </div>
             <div className="relay-model-list-tools">
               <Button
-                onClick={() => setModelWindowRows([...modelWindowRows, { model: "", window: "" }])}
+                onClick={() => setModelWindowRows([...modelWindowRows, createModelWindowRow()])}
                 size="sm"
                 type="button"
                 variant="secondary"
@@ -4273,7 +4296,7 @@ function RelayProfileEditor({
                     modelWindows: serializedRows.modelWindows,
                   });
                   if (models?.length) {
-                    addModelWindowRows(models.map((model) => ({ model, window: "" })));
+                    addModelWindowRows(models.map((model) => createModelWindowRow(model)));
                   }
                 }}
                 size="sm"
@@ -4287,6 +4310,7 @@ function RelayProfileEditor({
             <p className="field-hint">
               {t("每行一个模型；上下文窗口可填")} <code>1M</code>{t("、")}<code>200K</code> {t("或")} <code>1000000</code>{t("，留空表示使用 Codex 默认长度。")}
             </p>
+            {modelWindowValidationError ? <p className="field-error">{modelWindowValidationError}</p> : null}
           </Field>
         ) : null}
         {showApiFields ? (
@@ -6601,6 +6625,10 @@ function relayProfileSwitchValidation(profile: RelayProfile): string | null {
   if (isAggregateRelayProfile(profile)) {
     return aggregateRelayProfileValidation(profile);
   }
+  const modelWindowError = validateModelWindowRows(
+    modelWindowRowsFromProfile(profile.modelList, profile.modelWindows || ""),
+  );
+  if (modelWindowError) return modelWindowError;
   if (profile.relayMode === "official" && !profile.officialMixApiKey) return null;
   if (!profile.configContents.trim()) {
     return tf("供应商「{0}」缺少独立 config.toml，已停止切换，避免继续显示上一套配置文件。请先在该供应商详情里保存 config.toml。", [profile.name || profile.id]);

--- a/apps/codex-plus-manager/src/model-windows.test.ts
+++ b/apps/codex-plus-manager/src/model-windows.test.ts
@@ -3,11 +3,14 @@ import { describe, it } from "node:test";
 import type { RelayProfile } from "./App.tsx";
 import {
   buildModelWindows,
+  createModelWindowRow,
   modelWindowRowsFromProfile,
   modelWindowsMapToText,
   modelWindowsTextToMap,
   serializeModelWindowRows,
   mergeModelWindowRows,
+  modelWindowTokenError,
+  validateModelWindowRows,
 } from "./model-windows.ts";
 
 // 类型检查：确保 RelayProfile 包含 modelWindows 字段
@@ -81,21 +84,18 @@ describe("model-windows helpers", () => {
 
   it("modelWindowRowsFromProfile 把模型和窗口合成同一组行", () => {
     assert.deepStrictEqual(
-      modelWindowRowsFromProfile("a\nb\nc", '{"a":"1M","c":"200K"}'),
-      [
-        { model: "a", window: "1M" },
-        { model: "b", window: "" },
-        { model: "c", window: "200K" },
-      ],
+      modelWindowRowsFromProfile("a\nb\nc", '{"a":"1M","c":"200K"}')
+        .map((row) => `${row.model}:${row.window}`),
+      ["a:1M", "b:", "c:200K"],
     );
   });
 
   it("serializeModelWindowRows 从行控件生成 modelList 和 modelWindows", () => {
     assert.deepStrictEqual(
       serializeModelWindowRows([
-        { model: "a", window: "1M" },
-        { model: "", window: "400K" },
-        { model: "b", window: "" },
+        createModelWindowRow("a", "1M"),
+        createModelWindowRow("", "400K"),
+        createModelWindowRow("b", ""),
       ]),
       {
         modelList: "a\nb",
@@ -108,19 +108,31 @@ describe("model-windows helpers", () => {
     assert.deepStrictEqual(
       mergeModelWindowRows(
         [
-          { model: "deepseek-v4-flash", window: "1M" },
-          { model: "  ", window: "" },
+          createModelWindowRow("deepseek-v4-flash", "1M"),
+          createModelWindowRow("  ", ""),
         ],
         [
-          { model: "deepseek-v4-flash", window: "" },
-          { model: "deepseek-v4-pro", window: "" },
-          { model: " deepseek-v4-pro ", window: "200K" },
+          createModelWindowRow("deepseek-v4-flash", ""),
+          createModelWindowRow("deepseek-v4-pro", ""),
+          createModelWindowRow(" deepseek-v4-pro ", "200K"),
         ],
-      ),
-      [
-        { model: "deepseek-v4-flash", window: "1M" },
-        { model: "deepseek-v4-pro", window: "" },
-      ],
+      ).map((row) => `${row.model}:${row.window}`),
+      ["deepseek-v4-flash:1M", "deepseek-v4-pro:"],
     );
+  });
+
+  it("严格接受整数和 K/M 后缀，拒绝小数及其他后缀", () => {
+    assert.strictEqual(modelWindowTokenError("200K"), null);
+    assert.strictEqual(modelWindowTokenError("1m"), null);
+    assert.strictEqual(modelWindowTokenError("1000000"), null);
+    assert.ok(modelWindowTokenError("200KB"));
+    assert.ok(modelWindowTokenError("1.5M"));
+    assert.ok(modelWindowTokenError("0"));
+  });
+
+  it("拒绝没有模型名称的窗口，并保留已有行 id", () => {
+    const row = createModelWindowRow("a", "1M");
+    assert.strictEqual(mergeModelWindowRows([row], [])[0].id, row.id);
+    assert.ok(validateModelWindowRows([createModelWindowRow("", "1M")]));
   });
 });

--- a/apps/codex-plus-manager/src/model-windows.ts
+++ b/apps/codex-plus-manager/src/model-windows.ts
@@ -25,9 +25,41 @@ export function modelWindowsTextToMap(modelList: string, modelWindowsText: strin
 }
 
 export type ModelWindowRow = {
+  id: string;
   model: string;
   window: string;
 };
+
+let nextModelWindowRowId = 0;
+
+export function createModelWindowRow(model = "", window = ""): ModelWindowRow {
+  nextModelWindowRowId += 1;
+  return { id: `model-window-${nextModelWindowRowId}`, model, window };
+}
+
+export function modelWindowTokenError(value: string): string | null {
+  const token = value.trim();
+  if (!token) return null;
+  if (!/^[1-9]\d*(?:K|M)?$/i.test(token)) {
+    return `上下文窗口“${value}”格式无效，请填写正整数或 K/M 后缀（例如 200K、1M）。`;
+  }
+  const suffix = token.slice(-1).toUpperCase();
+  const multiplier = suffix === "K" ? 1_000n : suffix === "M" ? 1_000_000n : 1n;
+  const numberText = suffix === "K" || suffix === "M" ? token.slice(0, -1) : token;
+  if (BigInt(numberText) * multiplier > 9_223_372_036_854_775_807n) {
+    return `上下文窗口“${value}”超出支持范围。`;
+  }
+  return null;
+}
+
+export function validateModelWindowRows(rows: ModelWindowRow[]): string | null {
+  for (const row of rows) {
+    const error = modelWindowTokenError(row.window);
+    if (error) return row.model.trim() ? `模型 ${row.model.trim()}：${error}` : error;
+    if (!row.model.trim() && row.window.trim()) return "填写上下文窗口前必须先填写模型名称。";
+  }
+  return null;
+}
 
 export function mergeModelWindowRows(
   currentRows: ModelWindowRow[],
@@ -39,11 +71,11 @@ export function mergeModelWindowRows(
     const model = row.model.trim();
     if (!model || seen.has(model)) return;
     seen.add(model);
-    rows.push({ model, window: row.window.trim() });
+    rows.push({ ...row, model, window: row.window.trim() });
   };
   currentRows.forEach(append);
   incomingRows.forEach(append);
-  return rows.length ? rows : [{ model: "", window: "" }];
+  return rows.length ? rows : [createModelWindowRow()];
 }
 
 export function modelWindowRowsFromProfile(modelList: string, modelWindows: string): ModelWindowRow[] {
@@ -57,8 +89,8 @@ export function modelWindowRowsFromProfile(modelList: string, modelWindows: stri
     .split("\n")
     .map((model) => model.trim())
     .filter(Boolean)
-    .map((model) => ({ model, window: map[model] ?? "" }));
-  return rows.length ? rows : [{ model: "", window: "" }];
+    .map((model) => createModelWindowRow(model, map[model] ?? ""));
+  return rows.length ? rows : [createModelWindowRow()];
 }
 
 export function serializeModelWindowRows(rows: ModelWindowRow[]): { modelList: string; modelWindows: string } {

--- a/crates/codex-plus-core/src/app_paths.rs
+++ b/crates/codex-plus-core/src/app_paths.rs
@@ -376,6 +376,11 @@ pub(crate) fn is_supported_windows_app_package_name(package_name: &str) -> bool 
     codex_package_parts(package_name).is_some()
 }
 
+pub(crate) fn is_supported_windows_watcher_package_name(package_name: &str) -> bool {
+    is_supported_windows_app_package_name(package_name)
+        || package_name_parts(package_name, "OpenAI.ChatGPT-Desktop").is_some()
+}
+
 pub(crate) fn is_supported_app_executable_name(name: &str) -> bool {
     name.eq_ignore_ascii_case("Codex.exe") || name.eq_ignore_ascii_case("ChatGPT.exe")
 }
@@ -435,21 +440,19 @@ fn executable_in_dir(dir: &Path) -> Option<PathBuf> {
 
 fn codex_package_parts(package_name: &str) -> Option<(AppPackageSpec, &str, &str)> {
     for spec in APP_PACKAGE_SPECS {
-        let Some(rest) = strip_prefix_ignore_ascii_case(package_name, spec.identity) else {
-            continue;
-        };
-        let Some(rest) = rest.strip_prefix('_') else {
-            continue;
-        };
-        let Some((version, rest)) = rest.split_once('_') else {
-            continue;
-        };
-        let Some((_, publisher_id)) = rest.rsplit_once("__") else {
+        let Some((version, publisher_id)) = package_name_parts(package_name, spec.identity) else {
             continue;
         };
         return Some((*spec, version, publisher_id));
     }
     None
+}
+
+fn package_name_parts<'a>(package_name: &'a str, identity: &str) -> Option<(&'a str, &'a str)> {
+    let rest = strip_prefix_ignore_ascii_case(package_name, identity)?.strip_prefix('_')?;
+    let (version, rest) = rest.split_once('_')?;
+    let (_, publisher_id) = rest.rsplit_once("__")?;
+    (!version.is_empty() && !publisher_id.is_empty()).then_some((version, publisher_id))
 }
 
 fn strip_prefix_ignore_ascii_case<'a>(value: &'a str, prefix: &str) -> Option<&'a str> {

--- a/crates/codex-plus-core/src/model_suffix.rs
+++ b/crates/codex-plus-core/src/model_suffix.rs
@@ -69,7 +69,7 @@ fn parse_window_token(token: &str) -> Option<u64> {
         .trim()
         .parse::<u64>()
         .ok()
-        .map(|value| value * multiplier)
+        .and_then(|value| value.checked_mul(multiplier))
         .filter(|value| *value > 0)
 }
 
@@ -92,16 +92,18 @@ pub fn collect_catalog_entries(
         .map(str::trim)
         .filter(|value| !value.is_empty())
     {
-        let (slug, _) = parse_model_suffix(raw);
+        let (slug, explicit_window) = parse_model_suffix(raw);
         if slug.is_empty() {
             continue;
         }
         if !seen.insert(slug.clone()) {
             continue;
         }
-        let suffix_window = model_windows
-            .get(&slug)
-            .and_then(|token| parse_window_token(token));
+        let suffix_window = explicit_window.or_else(|| {
+            model_windows
+                .get(&slug)
+                .and_then(|token| parse_window_token(token))
+        });
         list_entries.push(ModelCatalogEntry {
             display_name: slug.clone(),
             slug,
@@ -113,11 +115,13 @@ pub fn collect_catalog_entries(
     let current_model = current_model.trim();
     let mut entries = Vec::new();
     if !current_model.is_empty() {
-        let (slug, _) = parse_model_suffix(current_model);
+        let (slug, explicit_window) = parse_model_suffix(current_model);
         if !slug.is_empty() {
-            let suffix_window = model_windows
-                .get(&slug)
-                .and_then(|token| parse_window_token(token));
+            let suffix_window = explicit_window.or_else(|| {
+                model_windows
+                    .get(&slug)
+                    .and_then(|token| parse_window_token(token))
+            });
             entries.push(ModelCatalogEntry {
                 display_name: slug.clone(),
                 slug: slug.clone(),

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -1,7 +1,9 @@
 use anyhow::Context;
+use fs2::FileExt;
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::collections::HashSet;
+use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use toml_edit::{DocumentMut, Item, Table, TableLike};
@@ -63,6 +65,11 @@ pub struct RelayProfileTestResult {
     pub http_status: u16,
     pub endpoint: String,
     pub response_preview: String,
+}
+
+struct PendingModelCatalog {
+    path: PathBuf,
+    contents: Vec<u8>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -365,8 +372,15 @@ pub fn apply_relay_profile_files_to_home_with_context(
         &profile.context_window,
         &profile.auto_compact_limit,
     )?;
-    let config_with_catalog = apply_model_catalog_to_config(home, profile, &config_with_limits)?;
-    apply_relay_files_to_home(home, &config_with_catalog, &profile.auth_contents)
+    let (config_with_catalog, catalog) =
+        apply_model_catalog_to_config(home, profile, &config_with_limits)?;
+    write_relay_files_to_home_with_catalog(
+        home,
+        &config_with_catalog,
+        &profile.auth_contents,
+        catalog.as_ref(),
+        false,
+    )
 }
 
 pub fn apply_relay_profile_to_home_with_switch_rules(
@@ -402,21 +416,24 @@ pub fn apply_relay_profile_to_home_with_switch_rules_and_computer_use_guard(
         &profile.context_window,
         &profile.auto_compact_limit,
     )?;
-    let config_with_catalog = apply_model_catalog_to_config(home, profile, &config_with_limits)?;
+    let (config_with_catalog, catalog) =
+        apply_model_catalog_to_config(home, profile, &config_with_limits)?;
 
     if profile.relay_mode == crate::settings::RelayMode::PureApi {
-        apply_relay_files_to_home_with_computer_use_guard(
+        write_relay_files_to_home_with_catalog(
             home,
             &config_with_catalog,
             &profile.auth_contents,
+            catalog.as_ref(),
             preserve_computer_use_guard,
         )
     } else {
         let auth_contents = official_profile_auth_for_switch(home, &profile.auth_contents)?;
-        apply_relay_files_to_home_with_computer_use_guard(
+        write_relay_files_to_home_with_catalog(
             home,
             &config_with_catalog,
             &auth_contents,
+            catalog.as_ref(),
             preserve_computer_use_guard,
         )
     }
@@ -434,13 +451,28 @@ pub fn apply_relay_profile_config_to_home_with_context(
     };
     let profile_config = complete_relay_profile_config(profile)?;
     let config_with_common = merge_common_config_into_config(&profile_config, &selected_common)?;
+    let config_with_common =
+        preserve_unmanaged_live_context_entries(home, &config_with_common, common_config_contents)?;
     let config_with_limits = apply_context_limits_to_config(
         &config_with_common,
         &profile.context_window,
         &profile.auto_compact_limit,
     )?;
-    let config_with_catalog = apply_model_catalog_to_config(home, profile, &config_with_limits)?;
-    apply_relay_config_file_to_home(home, &config_with_catalog)
+    let (config_with_catalog, catalog) =
+        apply_model_catalog_to_config(home, profile, &config_with_limits)?;
+    let backup_path = write_codex_live_atomic_with_catalog(
+        home,
+        Some(&config_with_catalog),
+        None,
+        false,
+        catalog.as_ref(),
+    )?;
+    let status = relay_config_status_from_home(home);
+    Ok(RelayApplyResult {
+        config_path: status.config_path,
+        backup_path,
+        configured: status.configured,
+    })
 }
 
 pub fn apply_relay_config_file_to_home(
@@ -625,13 +657,13 @@ pub fn clear_relay_config_to_home_with_auth_and_computer_use_guard(
         );
     }
     let mut updated = without_tables;
-    for key in [
-        "OPENAI_API_KEY",
-        "model_provider",
-        "model_catalog_json",
-        "base_url",
-    ] {
+    for key in ["OPENAI_API_KEY", "model_provider", "base_url"] {
         updated = remove_root_key(&updated, key);
+    }
+    if root_key_string(&updated, "model_catalog_json")
+        .is_some_and(|path| is_managed_model_catalog_path(&path))
+    {
+        updated = remove_root_key(&updated, "model_catalog_json");
     }
     let backup_path = write_codex_live_atomic(
         home,
@@ -878,7 +910,9 @@ fn preserve_unmanaged_live_context_entries(
         return Ok(ensure_trailing_newline(config_text.to_string()));
     }
     let mut target_doc = parse_toml_document(config_text)?;
-    let live_doc = parse_toml_document(&live_config)?;
+    let Ok(live_doc) = parse_toml_document(&live_config) else {
+        return Ok(normalize_optional_toml(target_doc));
+    };
     let managed_doc =
         parse_toml_document(&sanitize_common_config_contents(managed_context_config))?;
     preserve_unmanaged_context_tables(
@@ -1049,7 +1083,29 @@ fn write_codex_live_atomic(
     auth_bytes: Option<&[u8]>,
     preserve_computer_use_guard: bool,
 ) -> anyhow::Result<Option<String>> {
+    write_codex_live_atomic_with_catalog(
+        home,
+        config_text,
+        auth_bytes,
+        preserve_computer_use_guard,
+        None,
+    )
+}
+
+fn write_codex_live_atomic_with_catalog(
+    home: &Path,
+    config_text: Option<&str>,
+    auth_bytes: Option<&[u8]>,
+    preserve_computer_use_guard: bool,
+    catalog: Option<&PendingModelCatalog>,
+) -> anyhow::Result<Option<String>> {
     std::fs::create_dir_all(home)?;
+    let lock_file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(home.join(".codex-plus-live.lock"))?;
+    lock_file.lock_exclusive()?;
     let config_path = home.join("config.toml");
     let auth_path = home.join("auth.json");
     #[cfg(windows)]
@@ -1099,13 +1155,27 @@ fn write_codex_live_atomic(
         validate_auth_json(auth_bytes, &auth_path)?;
     }
 
+    let old_catalog = catalog
+        .map(|catalog| read_optional_bytes(&catalog.path))
+        .transpose()?
+        .flatten();
     let old_config = read_optional_bytes(&config_path)?;
     let old_auth = read_optional_bytes(&auth_path)?;
     let backup_path = create_live_backup(home, old_config.as_deref(), old_auth.as_deref())?;
+    if let Some(catalog) = catalog {
+        if let Some(parent) = catalog.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        crate::settings::atomic_write(&catalog.path, &catalog.contents)
+            .context("write model catalog failed")?;
+    }
     let mut auth_written = false;
 
     if let Some(auth_bytes) = auth_bytes {
         if let Err(error) = crate::settings::atomic_write(&auth_path, auth_bytes) {
+            if let Some(catalog) = catalog {
+                let _ = restore_optional_file(&catalog.path, old_catalog.as_deref());
+            }
             return Err(error.context("写入 auth.json 失败"));
         }
         auth_written = true;
@@ -1117,11 +1187,39 @@ fn write_codex_live_atomic(
                 let _ = restore_optional_file(&auth_path, old_auth.as_deref());
             }
             let _ = restore_optional_file(&config_path, old_config.as_deref());
+            if let Some(catalog) = catalog {
+                let _ = restore_optional_file(&catalog.path, old_catalog.as_deref());
+            }
             return Err(error.context("写入 config.toml 失败"));
         }
     }
 
     Ok(backup_path)
+}
+
+fn write_relay_files_to_home_with_catalog(
+    home: &Path,
+    config_contents: &str,
+    auth_contents: &str,
+    catalog: Option<&PendingModelCatalog>,
+    preserve_computer_use_guard: bool,
+) -> anyhow::Result<RelayApplyResult> {
+    if config_contents.trim().is_empty() {
+        anyhow::bail!("config.toml must not be empty");
+    }
+    let backup_path = write_codex_live_atomic_with_catalog(
+        home,
+        Some(config_contents.trim_start_matches('\u{feff}')),
+        Some(auth_contents.trim_start_matches('\u{feff}').as_bytes()),
+        preserve_computer_use_guard,
+        catalog,
+    )?;
+    let status = relay_config_status_from_home(home);
+    Ok(RelayApplyResult {
+        config_path: status.config_path,
+        backup_path,
+        configured: status.configured,
+    })
 }
 
 fn preserve_live_marketplace_configs(home: &Path, config_text: &str) -> anyhow::Result<String> {
@@ -1131,7 +1229,9 @@ fn preserve_live_marketplace_configs(home: &Path, config_text: &str) -> anyhow::
     }
 
     let mut target = parse_toml_document(config_text)?;
-    let live = parse_toml_document(&live_config)?;
+    let Ok(live) = parse_toml_document(&live_config) else {
+        return Ok(ensure_trailing_newline(target.to_string()));
+    };
     let Some(live_marketplaces) = live.get("marketplaces").and_then(Item::as_table_like) else {
         return Ok(ensure_trailing_newline(target.to_string()));
     };
@@ -1426,10 +1526,12 @@ fn apply_context_limits_to_config(
 ) -> anyhow::Result<String> {
     let mut doc = parse_toml_document(config_text)?;
     if let Some(value) = parse_optional_positive_u64(context_window, "上下文大小")? {
-        doc["model_context_window"] = toml_edit::value(value as i64);
+        let value = i64::try_from(value).context("model context window exceeds i64")?;
+        doc["model_context_window"] = toml_edit::value(value);
     }
     if let Some(value) = parse_optional_positive_u64(auto_compact_limit, "压缩上下文大小")? {
-        doc["model_auto_compact_token_limit"] = toml_edit::value(value as i64);
+        let value = i64::try_from(value).context("auto compact limit exceeds i64")?;
+        doc["model_auto_compact_token_limit"] = toml_edit::value(value);
     }
     Ok(normalize_optional_toml(doc))
 }
@@ -1438,7 +1540,7 @@ fn apply_model_catalog_to_config(
     home: &Path,
     profile: &RelayProfile,
     config_text: &str,
-) -> anyhow::Result<String> {
+) -> anyhow::Result<(String, Option<PendingModelCatalog>)> {
     let catalog_relative = format!(
         "model-catalogs/{}.json",
         sanitize_catalog_filename(&profile.id)
@@ -1446,8 +1548,8 @@ fn apply_model_catalog_to_config(
     // 用户已手写 model_catalog_json 指针时保留，不覆盖（保 preserves_user_model_catalog_json 测试）
     // 仅当现有指针指向本 profile 自己生成的 catalog 时才重新生成。
     if let Some(existing) = root_key_string(config_text, "model_catalog_json") {
-        if existing != catalog_relative {
-            return Ok(config_text.to_string());
+        if existing != catalog_relative && !is_managed_model_catalog_path(&existing) {
+            return Ok((config_text.to_string(), None));
         }
     }
     let (model_list, model_windows): (String, std::collections::HashMap<String, String>) =
@@ -1463,18 +1565,35 @@ fn apply_model_catalog_to_config(
         crate::model_suffix::collect_catalog_entries(&model_list, &model_windows, &profile.model);
     // 无后缀条目则 no-op，保持现有 per-profile 单值行为（保 does_not_write 测试）
     if !entries.iter().any(|entry| entry.suffix_window.is_some()) {
-        return Ok(config_text.to_string());
+        let mut doc = parse_toml_document(config_text)?;
+        if doc
+            .get("model_catalog_json")
+            .and_then(Item::as_str)
+            .is_some_and(is_managed_model_catalog_path)
+        {
+            doc.remove("model_catalog_json");
+        }
+        return Ok((normalize_optional_toml(doc), None));
     }
     let fallback = parse_optional_positive_u64(&profile.context_window, "上下文大小")?;
     let catalog_path = home.join(&catalog_relative);
-    if let Some(parent) = catalog_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
     let catalog_json = crate::model_suffix::build_model_catalog_json(&entries, fallback);
-    std::fs::write(&catalog_path, catalog_json)?;
     let mut doc = parse_toml_document(config_text)?;
     doc["model_catalog_json"] = toml_edit::value(catalog_relative);
-    Ok(normalize_optional_toml(doc))
+    Ok((
+        normalize_optional_toml(doc),
+        Some(PendingModelCatalog {
+            path: catalog_path,
+            contents: catalog_json.into_bytes(),
+        }),
+    ))
+}
+
+fn is_managed_model_catalog_path(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    normalized
+        .strip_prefix("model-catalogs/")
+        .is_some_and(|name| name.ends_with(".json") && !name.contains('/'))
 }
 
 fn sanitize_catalog_filename(id: &str) -> String {
@@ -2017,9 +2136,12 @@ fn complete_relay_profile_config(profile: &RelayProfile) -> anyhow::Result<Strin
 }
 
 pub fn normalize_relay_profile_for_storage(profile: &mut RelayProfile) -> anyhow::Result<()> {
-    if profile.model_windows.trim().is_empty() && profile.model_list.contains('[') {
-        let (clean_list, windows) =
+    if profile.model_list.contains('[') {
+        let (clean_list, suffix_windows) =
             crate::model_suffix::migrate_model_list_with_suffixes(&profile.model_list);
+        let mut windows: std::collections::HashMap<String, String> =
+            serde_json::from_str(&profile.model_windows).unwrap_or_default();
+        windows.extend(suffix_windows);
         profile.model_list = clean_list;
         profile.model_windows = serde_json::to_string(&windows).unwrap_or_default();
     }
@@ -2307,10 +2429,25 @@ fn create_live_backup(
         return Ok(None);
     }
 
-    let backup_dir = home
-        .join("backups")
-        .join(format!("codex-plus-live-{}", timestamp_millis()));
-    std::fs::create_dir_all(&backup_dir)?;
+    let backups_dir = home.join("backups");
+    std::fs::create_dir_all(&backups_dir)?;
+    let backup_dir = (0_u32..)
+        .find_map(|sequence| {
+            let suffix = if sequence == 0 {
+                String::new()
+            } else {
+                format!("-{sequence}")
+            };
+            let candidate =
+                backups_dir.join(format!("codex-plus-live-{}{suffix}", timestamp_millis()));
+            match std::fs::create_dir(&candidate) {
+                Ok(()) => Some(Ok(candidate)),
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => None,
+                Err(error) => Some(Err(error)),
+            }
+        })
+        .transpose()?
+        .context("unable to allocate a unique live backup directory")?;
     if let Some(config) = config {
         std::fs::write(backup_dir.join("config.toml"), config)?;
     }

--- a/crates/codex-plus-core/src/settings.rs
+++ b/crates/codex-plus-core/src/settings.rs
@@ -699,6 +699,13 @@ impl SettingsStore {
             return self.load();
         };
 
+        // Reject the entire update before touching disk when any profile is malformed.
+        // Falling back to an empty Vec here can silently erase every saved profile.
+        if let Some(profiles) = payload.get("relayProfiles") {
+            serde_json::from_value::<Vec<RelayProfile>>(profiles.clone())
+                .context("invalid relayProfiles payload")?;
+        }
+
         let mut raw = self.load_raw_object()?;
         merge_known_setting_fields(&mut raw, &payload);
         let settings = normalize_settings_config_sections(
@@ -1931,6 +1938,31 @@ experimental_bearer_token = "sk-existing""#
                 .unwrap();
         assert!(saved["relayProfiles"][1].get("baseUrl").is_none());
         assert!(saved["relayProfiles"][1].get("apiKey").is_none());
+    }
+
+    #[test]
+    fn settings_store_update_rejects_malformed_relay_profile_without_writing() {
+        let dir = temp_dir();
+        let path = dir.join("settings.json");
+        let store = SettingsStore::new(path.clone());
+        store
+            .update(json!({
+                "relayProfiles": [{ "id": "relay-a", "name": "Relay A" }],
+                "activeRelayId": "relay-a"
+            }))
+            .unwrap();
+        let original = std::fs::read(&path).unwrap();
+
+        let result = store.update(json!({
+            "relayProfiles": [
+                { "id": "relay-b", "name": "Relay B" },
+                { "name": "missing required id" }
+            ]
+        }));
+
+        assert!(result.is_err());
+        assert_eq!(std::fs::read(&path).unwrap(), original);
+        assert_eq!(store.load().unwrap().relay_profiles[0].id, "relay-a");
     }
 
     #[test]

--- a/crates/codex-plus-core/src/watcher.rs
+++ b/crates/codex-plus-core/src/watcher.rs
@@ -104,7 +104,7 @@ fn is_windowsapps_codex_app_process(executable: &str) -> bool {
     let Some((package_name, after_package)) = after_windows_apps.split_once('\\') else {
         return false;
     };
-    crate::app_paths::is_supported_windows_app_package_name(package_name)
+    crate::app_paths::is_supported_windows_watcher_package_name(package_name)
         && after_package.starts_with("app\\")
         && !after_package.starts_with("app\\resources\\")
         && after_package

--- a/crates/codex-plus-core/tests/model_suffix.rs
+++ b/crates/codex-plus-core/tests/model_suffix.rs
@@ -52,6 +52,14 @@ fn parse_suffix_rejects_zero_and_negative() {
 }
 
 #[test]
+fn parse_suffix_rejects_multiplication_overflow() {
+    assert_eq!(
+        parse_model_suffix("foo[18446744073709551615M]"),
+        ("foo[18446744073709551615M]".to_string(), None)
+    );
+}
+
+#[test]
 fn collect_entries_includes_current_model_and_strips_suffix() {
     let mut windows = HashMap::new();
     windows.insert("deepseek-v4-pro".to_string(), "1M".to_string());
@@ -139,6 +147,18 @@ fn collect_entries_prefers_later_suffix_when_reversed() {
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].slug, "deepseek/deepseek-v4-flash");
     assert_eq!(entries[0].suffix_window, Some(200_000));
+}
+
+#[test]
+fn collect_entries_prefers_explicit_suffix_over_stale_window_map() {
+    let mut windows = HashMap::new();
+    windows.insert("deepseek-v4-pro".to_string(), "1M".to_string());
+
+    let entries = collect_catalog_entries("deepseek-v4-pro[2M]", &windows, "");
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].slug, "deepseek-v4-pro");
+    assert_eq!(entries[0].suffix_window, Some(2_000_000));
 }
 
 #[test]

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -2,6 +2,7 @@ use codex_plus_core::codex_sqlite::codex_session_db_path_from_home;
 use codex_plus_core::relay_config::{
     apply_pure_api_config_to_home, apply_relay_config_file_to_home, apply_relay_config_to_home,
     apply_relay_files_to_home, apply_relay_files_to_home_with_common,
+    apply_relay_profile_config_to_home_with_context,
     apply_relay_profile_files_to_home_with_context, apply_relay_profile_to_home_with_switch_rules,
     apply_relay_profile_to_home_with_switch_rules_and_computer_use_guard,
     backfill_relay_profile_from_home, backfill_relay_profile_from_home_with_common,
@@ -3279,6 +3280,152 @@ experimental_bearer_token = "sk-new"
         .unwrap();
     assert_eq!(flash["context_window"].as_u64().unwrap(), 1_000_000);
     assert_eq!(pro["context_window"].as_u64().unwrap(), 200_000);
+}
+
+#[test]
+fn apply_profile_invalid_auth_does_not_change_existing_catalog() {
+    let temp = tempfile::tempdir().unwrap();
+    let catalog_path = temp.path().join("model-catalogs").join("relay-a.json");
+    std::fs::create_dir_all(catalog_path.parent().unwrap()).unwrap();
+    std::fs::write(&catalog_path, "old catalog").unwrap();
+    let profile = RelayProfile {
+        id: "relay-a".to_string(),
+        model: "model-a".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: "model = \"model-a\"\n".to_string(),
+        auth_contents: "not json".to_string(),
+        model_list: "model-a[1M]".to_string(),
+        ..RelayProfile::default()
+    };
+
+    assert!(apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").is_err());
+    assert_eq!(
+        std::fs::read_to_string(catalog_path).unwrap(),
+        "old catalog"
+    );
+    assert!(!temp.path().join("config.toml").exists());
+}
+
+#[test]
+fn apply_profile_without_windows_removes_managed_catalog_pointer() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = RelayProfile {
+        id: "relay-a".to_string(),
+        model: "model-a".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents:
+            "model = \"model-a\"\nmodel_catalog_json = \"model-catalogs/relay-old.json\"\n"
+                .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-a"}"#.to_string(),
+        model_list: "model-a".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(!config.contains("model_catalog_json"));
+}
+
+#[test]
+fn apply_profile_without_windows_removes_managed_catalog_pointer_for_default_id() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = RelayProfile {
+        id: "default".to_string(),
+        model: "model-a".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents:
+            "model = \"model-a\"\nmodel_catalog_json = \"model-catalogs/default.json\"\n"
+                .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-a"}"#.to_string(),
+        model_list: "model-a".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(!config.contains("model_catalog_json"));
+}
+
+#[test]
+fn clear_relay_preserves_user_catalog_pointer() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("config.toml"),
+        "model_provider = \"custom\"\nmodel_catalog_json = \"C:/catalogs/user.json\"\n",
+    )
+    .unwrap();
+
+    clear_relay_config_to_home(temp.path()).unwrap();
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(config.contains("C:/catalogs/user.json"));
+}
+
+#[test]
+fn config_only_apply_preserves_unmanaged_live_context() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("config.toml"),
+        "[mcp_servers.local]\ncommand = \"local-tool\"\n",
+    )
+    .unwrap();
+    let profile = RelayProfile {
+        model: "model-a".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: "model = \"model-a\"\n".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_config_to_home_with_context(temp.path(), &profile, "").unwrap();
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(config.contains("[mcp_servers.local]"));
+    assert!(config.contains("local-tool"));
+}
+
+#[test]
+fn valid_profile_repairs_malformed_live_config() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("config.toml"), "invalid = [").unwrap();
+    let profile = RelayProfile {
+        model: "model-a".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: "model = \"model-a\"\n".to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-a"}"#.to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(config.contains("model = \"model-a\""));
+}
+
+#[test]
+fn normalize_profile_new_suffix_overrides_existing_window() {
+    let mut profile = RelayProfile {
+        model_list: "model-a[2M]".to_string(),
+        model_windows: r#"{"model-a":"1M"}"#.to_string(),
+        ..RelayProfile::default()
+    };
+
+    normalize_relay_profile_for_storage(&mut profile).unwrap();
+    let windows: serde_json::Value = serde_json::from_str(&profile.model_windows).unwrap();
+    assert_eq!(windows["model-a"], "2000000");
+    assert_eq!(profile.model_list, "model-a");
+}
+
+#[test]
+fn apply_profile_rejects_context_window_above_i64() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = RelayProfile {
+        model: "model-a".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: "model = \"model-a\"\n".to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-a"}"#.to_string(),
+        context_window: u64::MAX.to_string(),
+        ..RelayProfile::default()
+    };
+
+    assert!(apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").is_err());
+    assert!(!temp.path().join("config.toml").exists());
 }
 
 #[test]

--- a/docs/report/20260710105144113_项目Bug审计报告.md
+++ b/docs/report/20260710105144113_项目Bug审计报告.md
@@ -1,0 +1,129 @@
+# CodexPlusPlus Bug 审计报告
+
+- 审计时间：2026-07-10
+- 本地基线：`7576677`（v1.2.33）
+- 上游基线：`3495647`（比本地多 3 个 macOS 启动回退提交）
+- 工作树：审计前干净；未清除、未重拉、未修改业务代码
+- 修复状态：下列问题已在 `codex/fix-audit-bugs` 分支完成修复并补充回归测试，等待上游 PR 审核。
+
+## 高风险
+
+### H1. catalog 提前落盘，apply 失败仍会改变当前运行配置
+
+- 位置：`crates/codex-plus-core/src/relay_config.rs:1469`、`:1474`、`:1095`
+- 触发：已有 config 指向本 profile catalog；生成新窗口后，auth JSON 校验或后续 config 写入失败。
+- 影响：调用返回失败，但 catalog 已被覆盖；运行中的 Codex 仍会悄然采用新窗口。普通 `std::fs::write` 失败时还可能留下截断 JSON。
+- 建议：catalog 先在内存生成并验证，用原子写；与 config/auth 一并纳入备份和回滚。
+
+### H2. 并发 apply 可能写出跨 profile 的 config/auth 组合
+
+- 位置：`crates/codex-plus-core/src/relay_config.rs:1102`、`:1107`、`:1114`、`:2301`
+- 触发：两个 core apply 调用并发执行。Tauri 的 switch command 有互斥锁，但 core 公共写入路径自身没有按 home 加锁，其他 apply 入口不受该锁完整保护。
+- 影响：写入可交错为 B 的 auth + A 的 config，凭据和供应商错配；同毫秒备份目录还可能碰撞。
+- 建议：以 canonical home 为键加进程级互斥；锁内完成读取、备份、写入、回滚；备份目录使用 UUID 或 `create_new`。
+
+### H3. 畸形 relayProfiles 更新会清空全部供应商
+
+- 位置：`crates/codex-plus-core/src/settings.rs:920`
+- 触发：JSON 更新中的任一 profile 反序列化失败，例如 `modelWindows` 传 object、枚举拼错、缺少必填字段。
+- 影响：整组 `Vec<RelayProfile>` 经 `unwrap_or_default()` 变成空数组并保存，所有供应商配置丢失。
+- 建议：反序列化失败直接返回错误且不写盘；至少保留旧值，并补单项畸形输入回归测试。
+
+### H4. 删除当前供应商后，UI 与真实 Codex 配置分叉
+
+- 位置：`apps/codex-plus-manager/src/App.tsx:3804`、`:2414`、`:6793`
+- 触发：存在至少两个 profile，删除当前正在使用的 profile。
+- 影响：设置中的 active id 改为另一个 profile，但 `$CODEX_HOME/config.toml` 和 `auth.json` 仍指向已删除供应商，真实请求继续走旧配置。
+- 建议：删除 active profile 时调用原子 switch 流程；切换成功后再提交删除，失败则保留原状态。
+
+### H5. profile 保存失败后仍继续写 live 文件并退出编辑页
+
+- 位置：`apps/codex-plus-manager/src/App.tsx:1397`、`:3897`、`:3904`、`:3906`、`:3913`、`:1570`
+- 触发：设置目录或 Codex home 只读、磁盘满、瞬时 I/O 错误。
+- 影响：设置保存失败后仍写 config/auth；config 写失败后仍可能继续写 auth，最后仍关闭详情页，造成存储、UI、live 文件三方不一致。
+- 建议：所有保存 action 返回明确 Result；任一步失败立即停止并保留编辑页；最好由单个后端事务 command 完成。
+
+## 中高风险
+
+### M1. 清空每模型窗口后，旧 catalog 继续生效
+
+- 位置：`crates/codex-plus-core/src/relay_config.rs:1448`、`:1465`
+- 触发：profile 曾生成自有 catalog，随后清空全部 `modelWindows` 再应用。
+- 影响：函数直接返回原 config，不移除自有 `model_catalog_json` 指针；UI 显示已清空，运行时仍使用旧窗口。
+- 建议：若指针属于当前 profile 且已无窗口配置，从 TOML 删除指针，并在成功提交后清理或归档旧文件。
+
+### M2. Windows ChatGPT Desktop 包无法被 watcher 识别
+
+- 位置：`crates/codex-plus-core/src/app_paths.rs:17`、`:360`；`crates/codex-plus-core/src/watcher.rs:99`
+- 证据：`watcher` 的两项现有测试稳定失败，期望识别 `OpenAI.ChatGPT-Desktop`，实际只识别 `OpenAI.Codex`。
+- 影响：重启/停止流程漏掉实际 ChatGPT Desktop 主进程，可能导致增强注入或版本切换失败。
+- 建议：将正式 ChatGPT Desktop package identity 纳入受支持包表，并保持 resources 内 CLI 排除规则。
+
+### M3. 二次编辑 suffix 会静默沿用旧窗口
+
+- 位置：`crates/codex-plus-core/src/relay_config.rs:2020`；`crates/codex-plus-core/src/model_suffix.rs:95`、`:116`
+- 触发：首次迁移后 `model_windows` 已非空，再把 `A[1M]` 改为 `A[2M]` 或新增 `B[200K]`。
+- 影响：新 suffix 被忽略，旧值继续生效或新模型回退默认窗口。
+- 建议：每次解析显式 suffix，并让新 suffix 覆盖 map 中同名项；补二次编辑测试。
+
+### M4. config-only apply 会丢失未托管上下文条目
+
+- 位置：`crates/codex-plus-core/src/relay_config.rs:425`；对照完整路径 `:361`、`:398`
+- 触发：live config 含不在 common config 中的手工 MCP/skill/plugin，走 config-only apply。
+- 影响：手工条目被覆盖删除。
+- 建议：config-only 路径也调用 `preserve_unmanaged_live_context_entries`。
+
+## 中风险
+
+### M5. 模型名输入每按一个字符都会 remount，焦点丢失
+
+- 位置：`apps/codex-plus-manager/src/App.tsx:4232`、`:4236`
+- 触发：编辑模型名称。
+- 影响：row key 包含正在变化的 `row.model`，React 每次输入都替换整行 DOM，核心功能难以正常输入。
+- 建议：为行分配稳定 UI id 作为 key；补连续输入交互测试。
+
+### M6. 上下文窗口无输入校验，非法值静默回退
+
+- 位置：`apps/codex-plus-manager/src/App.tsx:4239`；`apps/codex-plus-manager/src/model-windows.ts:71`；`crates/codex-plus-core/src/model_suffix.rs:102`
+- 触发：输入 `200KB`、`1.5M` 等非法 token。
+- 影响：保存看似成功，后端将其视为无窗口并使用 profile fallback 或 272000，行为与用户输入不符。
+- 建议：前后端都严格校验 `^[1-9]\d*[KkMm]?$` 与数值范围，非法时阻止保存/切换。
+
+### M7. 大整数转换和 K/M 乘法可溢出
+
+- 位置：`crates/codex-plus-core/src/relay_config.rs:1413`、`:1429`；`crates/codex-plus-core/src/model_suffix.rs:68`
+- 触发：输入超过 `i64::MAX` 的纯数字，或会让 `u64 * 1000/1000000` 溢出的 suffix。
+- 影响：纯数字被 cast 成负 TOML；suffix 在 debug 构建 panic，release 构建可能回绕成错误窗口。
+- 建议：使用 `i64::try_from` 和 `checked_mul`，并限制合理业务上限；校验 compact limit 不大于 context window。
+
+### M8. 损坏的 live TOML 阻止用有效配置进行修复
+
+- 位置：`crates/codex-plus-core/src/relay_config.rs:1127`、`:1134`
+- 触发：当前 live config TOML 已损坏，再应用一份有效新配置。
+- 影响：为保留 marketplace 而解析旧文件时直接报错，新配置无法落盘，用户被困在损坏状态。
+- 建议：严格校验 incoming；旧 live 解析失败时跳过 marketplace preservation 或做 best-effort 文本恢复。
+
+### M9. clear relay 会删除用户自定义 catalog 指针
+
+- 位置：`crates/codex-plus-core/src/relay_config.rs:628`
+- 触发：用户配置外部 `model_catalog_json` 后执行 clear relay。
+- 影响：与 relay 无关的自定义 Codex catalog 配置被删除。
+- 建议：仅删除指向工具受管 `model-catalogs/<profile>.json` 的指针。
+
+## 验证结果
+
+- `cargo test -p codex-plus-core --tests --no-fail-fast`：除 `watcher` 2 项外，其余执行到的测试通过；失败为 15/17 通过、2/17 失败。
+- `cargo test -p codex-plus-core --test relay_config apply_relay_profile_ -- --test-threads=1`：21/21 通过。
+- `cargo test -p codex-plus-core --test model_suffix --test model_catalog`：19/19 通过。
+- `cargo test -p codex-plus-core settings::tests`：32/32 通过。
+- `npm run check`、`npm run vite:build`：未执行成功，工作区没有 `node_modules`，`tsc`/`vite` 不存在；未擅自安装依赖。
+
+## 建议修复顺序
+
+1. 先修 H1/H2/H5：统一 catalog/config/auth/settings 的事务和锁边界。
+2. 再修 H3/H4/M1：阻止 profile 数据丢失与 UI/live 状态分叉。
+3. 最后修 M2-M9，并为失败注入、状态迁移、溢出和 React 连续输入补回归测试。
+
+## 风险与回滚
+
+本轮只新增审计报告并更新了 `upstream/main` 远端引用，未修改业务代码；无需业务回滚。不要通过清空重拉解决上述问题，它只会丢失本地状态，不会修复上游当前仍存在的缺陷。


### PR DESCRIPTION
## Summary

- make model catalog, config.toml, and auth.json updates share one locked transactional write path with rollback
- reject malformed relay profiles and invalid or overflowing model window values
- keep relay profile UI, persisted settings, and live Codex files consistent on save and delete failures
- fix stale per-model catalogs, suffix updates, unmanaged context preservation, and custom catalog cleanup
- recognize the official ChatGPT Desktop package in the Windows watcher
- stabilize model window row keys and add frontend validation

## Tests

- cargo fmt --all -- --check
- cargo check -p codex-plus-core
- cargo test -p codex-plus-core --tests --no-fail-fast
- cargo test -p codex-plus-data --no-fail-fast
- node --experimental-strip-types --test src/model-windows.test.ts (11 passed)

## Environment notes

- cargo test --workspace reached the Tauri manager but could not compile generate_context because frontend dist is absent; this checkout has no node_modules, so vite and tsc were not installed locally
- codex-plus-launcher compiled, but Windows refused to execute its requireAdministrator test binary without elevation (os error 740)