### PR TITLE
fix: authenticate local helper and protocol proxy

### DIFF
--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -233,6 +233,11 @@
   installCodexPlusForceChineseLocale();
 
   const helperBase = window.__CODEX_SESSION_DELETE_HELPER__ || "http://127.0.0.1:57321";
+  const helperAuthToken = window.__CODEX_PLUS_HELPER_TOKEN__ || "";
+  const helperJsonHeaders = () => ({
+    "Content-Type": "application/json",
+    "X-Codex-Plus-Token": helperAuthToken,
+  });
   const buttonClass = "codex-delete-button";
   const exportButtonClass = "codex-export-button";
   const projectMoveButtonClass = "codex-project-move-button";
@@ -3743,15 +3748,9 @@
       window.__codexSessionDeleteBridge("/diagnostics/log", payload).catch(() => {});
     }
     const body = JSON.stringify(payload);
-    try {
-      if (navigator.sendBeacon) {
-        const blob = new Blob([body], { type: "application/json" });
-        if (navigator.sendBeacon(`${helperBase}/diagnostics/log`, blob)) return;
-      }
-    } catch (_) {}
     fetch(`${helperBase}/diagnostics/log`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: helperJsonHeaders(),
       body,
       keepalive: true,
     }).catch(() => {});
@@ -4387,7 +4386,7 @@
         try {
           const response = await fetch(`${helperBase}${path}`, {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: helperJsonHeaders(),
             body: JSON.stringify(payload || {}),
           });
           return await response.json();
@@ -4408,7 +4407,7 @@
       try {
         const response = await fetch(`${helperBase}${path}`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: helperJsonHeaders(),
           body: JSON.stringify(payload || {}),
         });
         return await response.json();

--- a/crates/codex-plus-core/src/assets.rs
+++ b/crates/codex-plus-core/src/assets.rs
@@ -31,6 +31,18 @@ pub fn injection_script(helper_port: u16) -> String {
 }
 
 pub fn injection_script_with_settings(helper_port: u16, settings: &BackendSettings) -> String {
+    injection_script_with_settings_and_token(
+        helper_port,
+        settings,
+        crate::launcher::helper_auth_token(),
+    )
+}
+
+fn injection_script_with_settings_and_token(
+    helper_port: u16,
+    settings: &BackendSettings,
+    helper_auth_token: &str,
+) -> String {
     let helper_url = format!("http://127.0.0.1:{helper_port}");
     let sponsor_images = sponsor_image_data_uris();
     let image_overlay = image_overlay_config(helper_port, settings);
@@ -39,8 +51,9 @@ pub fn injection_script_with_settings(helper_port: u16, settings: &BackendSettin
     let force_chinese_locale = force_chinese_locale_config(settings);
     let fast_startup = fast_startup_config(settings);
     format!(
-        "window.__CODEX_SESSION_DELETE_HELPER__ = {};\nwindow.__CODEX_PLUS_SPONSOR_IMAGES__ = {};\nwindow.__CODEX_PLUS_VERSION__ = {};\nwindow.__CODEX_PLUS_BUILD__ = {};\nwindow.__CODEX_PLUS_IMAGE_OVERLAY__ = {};\nwindow.__CODEX_PLUS_PLUGIN_MARKETPLACES__ = {};\nwindow.__CODEX_PLUS_PASTE_FIX__ = {};\nwindow.__CODEX_PLUS_FORCE_CHINESE_LOCALE__ = {};\nwindow.__CODEX_PLUS_FAST_STARTUP__ = {};\n{}\n{}",
+        "window.__CODEX_SESSION_DELETE_HELPER__ = {};\nwindow.__CODEX_PLUS_HELPER_TOKEN__ = {};\nwindow.__CODEX_PLUS_SPONSOR_IMAGES__ = {};\nwindow.__CODEX_PLUS_VERSION__ = {};\nwindow.__CODEX_PLUS_BUILD__ = {};\nwindow.__CODEX_PLUS_IMAGE_OVERLAY__ = {};\nwindow.__CODEX_PLUS_PLUGIN_MARKETPLACES__ = {};\nwindow.__CODEX_PLUS_PASTE_FIX__ = {};\nwindow.__CODEX_PLUS_FORCE_CHINESE_LOCALE__ = {};\nwindow.__CODEX_PLUS_FAST_STARTUP__ = {};\n{}\n{}",
         serde_json::to_string(&helper_url).expect("helper URL should serialize"),
+        serde_json::to_string(helper_auth_token).expect("helper auth token should serialize"),
         serde_json::to_string(&sponsor_images).expect("sponsor images should serialize"),
         serde_json::to_string(crate::version::VERSION).expect("version should serialize"),
         serde_json::to_string(DIAGNOSTIC_BUILD_ID).expect("build id should serialize"),
@@ -302,6 +315,17 @@ fn image_content_type(path: &Path) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn injection_script_embeds_helper_auth_token() {
+        let script = injection_script_with_settings_and_token(
+            57321,
+            &BackendSettings::default(),
+            "test-helper-token",
+        );
+
+        assert!(script.contains(r#"window.__CODEX_PLUS_HELPER_TOKEN__ = "test-helper-token";"#));
+    }
 
     #[test]
     fn image_overlay_config_includes_fit_mode() {

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
@@ -14,6 +14,15 @@ use tokio::sync::Mutex;
 
 use crate::settings::{BackendSettings, SettingsStore, normalize_codex_extra_args};
 use crate::status::{LaunchStatus, StatusStore};
+
+const HELPER_AUTH_HEADER: &str = "x-codex-plus-token";
+static HELPER_AUTH_TOKEN: OnceLock<String> = OnceLock::new();
+
+pub fn helper_auth_token() -> &'static str {
+    HELPER_AUTH_TOKEN
+        .get_or_init(|| uuid::Uuid::new_v4().simple().to_string())
+        .as_str()
+}
 
 #[cfg(windows)]
 const POST_LAUNCH_COMPUTER_USE_GUARD_SECONDS: &[u64] = &[0, 5, 15, 30, 60, 120, 180, 240, 300];
@@ -939,6 +948,10 @@ async fn handle_helper_connection(
     let request_body = http_request_body(&request);
     let request_user_agent = header_value_from_request(&request, "user-agent");
     let remote_addr_text = remote_addr.map(|addr| addr.to_string());
+    let is_responses_proxy = crate::protocol_proxy::is_responses_proxy_path(path);
+    let is_chat_proxy = crate::protocol_proxy::is_chat_completions_proxy_path(path);
+    let is_models_proxy = crate::protocol_proxy::is_models_proxy_path(path);
+    let is_protocol_proxy = is_responses_proxy || is_chat_proxy || is_models_proxy;
 
     let _ = crate::diagnostic_log::append_diagnostic_log(
         "helper.request",
@@ -951,7 +964,36 @@ async fn handle_helper_connection(
         }),
     );
 
-    if crate::protocol_proxy::is_responses_proxy_path(path) && method == "POST" {
+    if is_protocol_proxy && method == "OPTIONS" {
+        write_http_response(
+            &mut stream,
+            "405 Method Not Allowed",
+            "application/json; charset=utf-8",
+            br#"{"status":"failed","message":"CORS preflight is not supported"}"#,
+        )
+        .await?;
+        stream.shutdown().await?;
+        return Ok(());
+    }
+    if is_protocol_proxy && !protocol_proxy_request_authorized(&request) {
+        write_http_response(
+            &mut stream,
+            "401 Unauthorized",
+            "application/json; charset=utf-8",
+            br#"{"status":"failed","message":"Unauthorized"}"#,
+        )
+        .await?;
+        log_helper_response(
+            "helper.protocol_proxy_unauthorized",
+            method,
+            path,
+            "401 Unauthorized",
+            remote_addr_text,
+        );
+        stream.shutdown().await?;
+        return Ok(());
+    }
+    if is_responses_proxy && method == "POST" {
         return handle_protocol_proxy_connection(
             &mut stream,
             request_body,
@@ -962,7 +1004,7 @@ async fn handle_helper_connection(
         )
         .await;
     }
-    if crate::protocol_proxy::is_chat_completions_proxy_path(path) && method == "POST" {
+    if is_chat_proxy && method == "POST" {
         return handle_chat_completions_proxy_connection(
             &mut stream,
             request_body,
@@ -973,7 +1015,7 @@ async fn handle_helper_connection(
         )
         .await;
     }
-    if crate::protocol_proxy::is_models_proxy_path(path) && matches!(method, "GET" | "OPTIONS") {
+    if is_models_proxy && method == "GET" {
         return handle_models_proxy_connection(
             &mut stream,
             request_user_agent.as_deref(),
@@ -982,6 +1024,36 @@ async fn handle_helper_connection(
             remote_addr_text,
         )
         .await;
+    }
+    if is_protocol_proxy {
+        write_http_response(
+            &mut stream,
+            "405 Method Not Allowed",
+            "application/json; charset=utf-8",
+            br#"{"status":"failed","message":"Method not allowed"}"#,
+        )
+        .await?;
+        stream.shutdown().await?;
+        return Ok(());
+    }
+
+    let is_renderer_helper_path = matches!(
+        path,
+        "/backend/status" | "/diagnostics/log" | "/overlay/image"
+    );
+    if is_renderer_helper_path
+        && method != "OPTIONS"
+        && !renderer_helper_request_authorized(&request)
+    {
+        write_cors_http_response(
+            &mut stream,
+            "401 Unauthorized",
+            "application/json; charset=utf-8",
+            br#"{"status":"failed","message":"Unauthorized"}"#,
+        )
+        .await?;
+        stream.shutdown().await?;
+        return Ok(());
     }
 
     let (status, body, content_type, log_event) = if path == "/backend/status"
@@ -1057,11 +1129,11 @@ async fn handle_helper_connection(
     );
     let response = if method == "OPTIONS" {
         format!(
-            "HTTP/1.1 204 No Content\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: GET, POST, OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type, Authorization\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            "HTTP/1.1 204 No Content\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: GET, POST, OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type, {HELPER_AUTH_HEADER}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
         )
     } else {
         format!(
-            "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: GET, POST, OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type, Authorization\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: GET, POST, OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type, {HELPER_AUTH_HEADER}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
             body.len()
         )
     };
@@ -1131,17 +1203,6 @@ async fn handle_models_proxy_connection(
     path: &str,
     remote_addr_text: Option<String>,
 ) -> anyhow::Result<()> {
-    if method == "OPTIONS" {
-        write_http_response(
-            stream,
-            "204 No Content",
-            "application/json; charset=utf-8",
-            &[],
-        )
-        .await?;
-        stream.shutdown().await?;
-        return Ok(());
-    }
     let upstream = match crate::protocol_proxy::open_models_proxy_request(request_user_agent).await
     {
         Ok(upstream) => upstream,
@@ -1438,7 +1499,22 @@ async fn write_http_response(
     body: &[u8],
 ) -> anyhow::Result<()> {
     let response = format!(
-        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: GET, POST, OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type, Authorization\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    stream.write_all(response.as_bytes()).await?;
+    stream.write_all(body).await?;
+    Ok(())
+}
+
+async fn write_cors_http_response(
+    stream: &mut tokio::net::TcpStream,
+    status: &str,
+    content_type: &str,
+    body: &[u8],
+) -> anyhow::Result<()> {
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: GET, POST, OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type, {HELPER_AUTH_HEADER}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
         body.len()
     );
     stream.write_all(response.as_bytes()).await?;
@@ -1452,7 +1528,7 @@ async fn write_http_stream_headers(
     content_type: &str,
 ) -> anyhow::Result<()> {
     let response = format!(
-        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nCache-Control: no-cache\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: GET, POST, OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type, Authorization\r\nConnection: close\r\n\r\n"
+        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n"
     );
     stream.write_all(response.as_bytes()).await?;
     Ok(())
@@ -1478,7 +1554,10 @@ fn log_helper_response(
 
 #[cfg(test)]
 mod computer_use_tests {
-    use super::{header_value_from_request, overlay_image_content_type};
+    use super::{
+        bearer_token, header_value_from_request, helper_auth_token, overlay_image_content_type,
+        protocol_proxy_request_authorized_for_key, renderer_helper_request_authorized,
+    };
     use std::path::Path;
 
     #[test]
@@ -1506,6 +1585,41 @@ mod computer_use_tests {
             header_value_from_request(request, "user-agent").as_deref(),
             Some("Codex/26.614")
         );
+    }
+
+    #[test]
+    fn helper_authorization_requires_exact_runtime_token() {
+        let token = helper_auth_token();
+        let authorized =
+            format!("POST /backend/status HTTP/1.1\r\nX-Codex-Plus-Token: {token}\r\n\r\n");
+        let unauthorized = "POST /backend/status HTTP/1.1\r\nX-Codex-Plus-Token: wrong\r\n\r\n";
+
+        assert!(renderer_helper_request_authorized(&authorized));
+        assert!(!renderer_helper_request_authorized(unauthorized));
+    }
+
+    #[test]
+    fn bearer_token_requires_bearer_scheme_and_value() {
+        assert_eq!(bearer_token("Bearer sk-test"), Some("sk-test"));
+        assert_eq!(bearer_token("bearer   sk-test  "), Some("sk-test"));
+        assert_eq!(bearer_token("Basic sk-test"), None);
+        assert_eq!(bearer_token("Bearer"), None);
+    }
+
+    #[test]
+    fn protocol_proxy_authorization_requires_active_relay_key() {
+        let authorized = "POST /v1/responses HTTP/1.1\r\nAuthorization: Bearer sk-active\r\n\r\n";
+        let unauthorized = "POST /v1/responses HTTP/1.1\r\nAuthorization: Bearer sk-other\r\n\r\n";
+
+        assert!(protocol_proxy_request_authorized_for_key(
+            authorized,
+            "sk-active"
+        ));
+        assert!(!protocol_proxy_request_authorized_for_key(
+            unauthorized,
+            "sk-active"
+        ));
+        assert!(!protocol_proxy_request_authorized_for_key(authorized, ""));
     }
 }
 
@@ -1577,6 +1691,33 @@ fn header_value_from_request(request: &str, header_name: &str) -> Option<String>
                 .then(|| value.trim().to_string())
         })
         .filter(|value| !value.is_empty())
+}
+
+fn renderer_helper_request_authorized(request: &str) -> bool {
+    header_value_from_request(request, HELPER_AUTH_HEADER)
+        .is_some_and(|token| token == helper_auth_token())
+}
+
+fn protocol_proxy_request_authorized(request: &str) -> bool {
+    let Ok(settings) = SettingsStore::default().load() else {
+        return false;
+    };
+    let relay = settings.active_relay_profile();
+    let expected = crate::relay_config::relay_profile_api_key(&relay);
+    protocol_proxy_request_authorized_for_key(request, &expected)
+}
+
+fn protocol_proxy_request_authorized_for_key(request: &str, expected: &str) -> bool {
+    !expected.is_empty()
+        && header_value_from_request(request, "authorization")
+            .and_then(|header| bearer_token(&header).map(ToString::to_string))
+            .is_some_and(|provided| provided == expected)
+}
+
+fn bearer_token(header: &str) -> Option<&str> {
+    let (scheme, token) = header.trim().split_once(' ')?;
+    let token = token.trim();
+    (scheme.eq_ignore_ascii_case("bearer") && !token.is_empty()).then_some(token)
 }
 
 fn sanitize_diagnostic_event(event: &str) -> String {

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -14,7 +14,7 @@ use codex_plus_core::launcher::{
     build_codex_command_with_native_menu_inspector, build_macos_cleanup_command,
     build_macos_open_command, build_macos_open_command_with_native_menu_inspector,
     build_packaged_activation, build_packaged_activation_with_native_menu_inspector,
-    launch_and_inject_with_hooks,
+    helper_auth_token, launch_and_inject_with_hooks,
 };
 #[cfg(windows)]
 use codex_plus_core::launcher::{WindowsProcessControlStrategy, windows_process_control_strategy};
@@ -661,8 +661,17 @@ async fn default_helper_serves_backend_status_over_http() {
 
     hooks.start_helper(port).await.unwrap();
     let client = reqwest::Client::builder().no_proxy().build().unwrap();
+    let unauthorized = client
+        .post(format!("http://127.0.0.1:{port}/backend/status"))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(unauthorized.status(), reqwest::StatusCode::UNAUTHORIZED);
+
     let response = client
         .post(format!("http://127.0.0.1:{port}/backend/status"))
+        .header("X-Codex-Plus-Token", helper_auth_token())
         .json(&serde_json::json!({}))
         .send()
         .await
@@ -694,11 +703,18 @@ async fn default_helper_accepts_diagnostic_log_events_over_http() {
     drop(listener);
 
     hooks.start_helper(port).await.unwrap();
-    let response = reqwest::Client::builder()
-        .no_proxy()
-        .build()
-        .unwrap()
+    let client = reqwest::Client::builder().no_proxy().build().unwrap();
+    let unauthorized = client
         .post(format!("http://127.0.0.1:{port}/diagnostics/log"))
+        .json(&serde_json::json!({ "event": "must_not_be_logged" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(unauthorized.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    let response = client
+        .post(format!("http://127.0.0.1:{port}/diagnostics/log"))
+        .header("X-Codex-Plus-Token", helper_auth_token())
         .json(&serde_json::json!({
             "event": "backend_check_failed",
             "message": "fetch failed",
@@ -716,7 +732,51 @@ async fn default_helper_accepts_diagnostic_log_events_over_http() {
     let contents = std::fs::read_to_string(&log_path).unwrap();
     assert!(contents.contains("renderer.backend_check_failed"));
     assert!(contents.contains("fetch failed"));
+    assert!(!contents.contains("must_not_be_logged"));
     codex_plus_core::diagnostic_log::set_diagnostic_log_path_for_tests(None);
+}
+
+#[tokio::test]
+async fn protocol_proxy_rejects_unauthorized_cross_origin_requests() {
+    let hooks = DefaultLaunchHooks::default();
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+
+    hooks.start_helper(port).await.unwrap();
+    let client = reqwest::Client::builder().no_proxy().build().unwrap();
+    let response = client
+        .post(format!("http://127.0.0.1:{port}/v1/responses"))
+        .header("Origin", "https://attacker.example")
+        .json(&serde_json::json!({ "model": "gpt-5.6" }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), reqwest::StatusCode::UNAUTHORIZED);
+    assert!(
+        !response
+            .headers()
+            .contains_key("access-control-allow-origin")
+    );
+
+    let preflight = client
+        .request(
+            reqwest::Method::OPTIONS,
+            format!("http://127.0.0.1:{port}/v1/responses"),
+        )
+        .header("Origin", "https://attacker.example")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(preflight.status(), reqwest::StatusCode::METHOD_NOT_ALLOWED);
+    assert!(
+        !preflight
+            .headers()
+            .contains_key("access-control-allow-origin")
+    );
+
+    hooks.shutdown_helper(port).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- require the local protocol proxy to receive the active relay bearer token before forwarding requests
- protect renderer-only helper routes with a per-process token injected into Codex
- remove wildcard CORS from protocol responses and reject proxy preflights

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] focused launcher/helper authorization tests
- [x] `cargo check -p codex-plus-core -j 1`
- [x] `node --check assets/inject/renderer-inject.js`

## Environment note
The full launcher integration target compiled and reached the new tests, but the Windows test process later aborted with a host memory-allocation failure. All focused security regressions passed serially.