### PR TITLE
fix: nest reasoning effort for GPT-5.6+

### DIFF
--- a/crates/codex-plus-core/src/protocol_proxy.rs
+++ b/crates/codex-plus-core/src/protocol_proxy.rs
@@ -3845,12 +3845,17 @@ fn apply_chat_reasoning_options(result: &mut Value, body: &Value, model: &str) {
         ChatReasoningStyle::OpenRouter => {
             result["reasoning"] = json!({ "effort": mapped });
         }
-        ChatReasoningStyle::DeepSeek
-        | ChatReasoningStyle::LowHigh
-        | ChatReasoningStyle::Default
+        ChatReasoningStyle::DeepSeek | ChatReasoningStyle::LowHigh
             if supports_reasoning_effort(model) =>
         {
             result["reasoning_effort"] = json!(mapped);
+        }
+        ChatReasoningStyle::Default if supports_reasoning_effort(model) => {
+            if uses_nested_reasoning_effort(model) {
+                result["reasoning"] = json!({ "effort": mapped });
+            } else {
+                result["reasoning_effort"] = json!(mapped);
+            }
         }
         _ => {}
     }
@@ -3936,13 +3941,40 @@ fn map_chat_reasoning_effort(effort: &str, style: ChatReasoningStyle) -> Option<
 
 fn supports_reasoning_effort(model: &str) -> bool {
     is_openai_o_series(model)
-        || model
-            .to_lowercase()
-            .strip_prefix("gpt-")
-            .and_then(|rest| rest.chars().next())
-            .is_some_and(|ch| ch.is_ascii_digit() && ch >= '5')
+        || openai_gpt_version(model).is_some_and(|(major, _)| major >= 5)
         || infer_chat_reasoning_style(model) == ChatReasoningStyle::DeepSeek
         || infer_chat_reasoning_style(model) == ChatReasoningStyle::LowHigh
+}
+
+fn uses_nested_reasoning_effort(model: &str) -> bool {
+    openai_gpt_version(model).is_some_and(|(major, minor)| major > 5 || (major == 5 && minor >= 6))
+}
+
+fn openai_gpt_version(model: &str) -> Option<(u32, u32)> {
+    let model = model.trim().to_ascii_lowercase();
+    model.match_indices("gpt-").find_map(|(index, _)| {
+        if model[..index]
+            .chars()
+            .next_back()
+            .is_some_and(|ch| ch.is_ascii_alphanumeric())
+        {
+            return None;
+        }
+        let version = &model[index + "gpt-".len()..];
+        let major_len = version.bytes().take_while(u8::is_ascii_digit).count();
+        if major_len == 0 {
+            return None;
+        }
+        let major = version[..major_len].parse().ok()?;
+        let remainder = &version[major_len..];
+        let minor = remainder
+            .strip_prefix('.')
+            .map(|minor| minor.bytes().take_while(u8::is_ascii_digit).count())
+            .filter(|length| *length > 0)
+            .and_then(|length| remainder[1..1 + length].parse().ok())
+            .unwrap_or(0);
+        Some((major, minor))
+    })
 }
 
 fn is_openai_o_series(model: &str) -> bool {

--- a/crates/codex-plus-core/tests/protocol_proxy.rs
+++ b/crates/codex-plus-core/tests/protocol_proxy.rs
@@ -107,6 +107,51 @@ fn responses_request_matches_ccs_reasoning_and_tool_choice_edges() {
 }
 
 #[test]
+fn responses_request_uses_nested_reasoning_for_gpt_5_6_and_newer() {
+    for (model, effort) in [
+        ("gpt-5.6", "high"),
+        ("openai/gpt-5.6-codex", "xhigh"),
+        ("vendor/gpt-5.7-codex[1M]", "medium"),
+        ("azure/openai/gpt-6", "low"),
+        ("gpt-10.2-codex", "minimal"),
+    ] {
+        let converted = responses_to_chat_completions(json!({
+            "model": model,
+            "reasoning": { "effort": effort },
+            "input": "hi"
+        }))
+        .unwrap();
+
+        assert_eq!(converted["reasoning"]["effort"], effort, "{model}");
+        assert!(converted.get("reasoning_effort").is_none(), "{model}");
+    }
+}
+
+#[test]
+fn responses_request_keeps_legacy_reasoning_effort_through_gpt_5_5() {
+    for model in ["gpt-5", "gpt-5.4-codex", "openai/gpt-5.5"] {
+        let converted = responses_to_chat_completions(json!({
+            "model": model,
+            "reasoning": { "effort": "high" },
+            "input": "hi"
+        }))
+        .unwrap();
+
+        assert_eq!(converted["reasoning_effort"], "high", "{model}");
+        assert!(converted.get("reasoning").is_none(), "{model}");
+    }
+
+    let unrelated = responses_to_chat_completions(json!({
+        "model": "notgpt-5.6",
+        "reasoning": { "effort": "high" },
+        "input": "hi"
+    }))
+    .unwrap();
+    assert!(unrelated.get("reasoning").is_none());
+    assert!(unrelated.get("reasoning_effort").is_none());
+}
+
+#[test]
 fn proxy_route_matchers_accept_ccswitch_codex_aliases() {
     for path in [
         "/responses",


### PR DESCRIPTION
## Summary
- emit nested `reasoning.effort` for GPT-5.6 and newer GPT model versions
- keep `reasoning_effort` for GPT-5.5 and older compatible chat backends
- recognize provider-prefixed, Codex-suffixed, and future major-version model names

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p codex-plus-core --test protocol_proxy -j 1 -- --test-threads=1` (46 passed)
- [x] `cargo check -p codex-plus-core -j 1`

Closes #1407