### PR TITLE
fix portable ChatGPT desktop launching

### DIFF
--- a/crates/codex-plus-core/src/app_paths.rs
+++ b/crates/codex-plus-core/src/app_paths.rs
@@ -283,12 +283,27 @@ pub fn codex_app_version(app_dir: &Path) -> Option<String> {
 }
 
 pub fn packaged_app_user_model_id(app_dir: &Path) -> Option<String> {
+    // An unpacked/portable MSIX keeps the package-shaped directory name, but it is
+    // not registered with Windows and therefore cannot be started through
+    // IApplicationActivationManager. Only genuine WindowsApps installs should use
+    // packaged activation; portable copies must launch ChatGPT.exe/Codex.exe
+    // directly.
+    if !path_is_inside_windows_apps(app_dir) {
+        return None;
+    }
     let package_name = package_name_from_app_dir(app_dir)?;
     let (spec, _, publisher_id) = codex_package_parts(&package_name)?;
     if publisher_id.is_empty() {
         return None;
     }
     Some(format!("{}_{publisher_id}!{}", spec.identity, spec.app_id))
+}
+
+fn path_is_inside_windows_apps(path: &Path) -> bool {
+    path.to_string_lossy()
+        .replace('\\', "/")
+        .split('/')
+        .any(|part| part.eq_ignore_ascii_case("WindowsApps"))
 }
 
 fn package_name_from_app_dir(app_dir: &Path) -> Option<String> {

--- a/crates/codex-plus-core/src/watcher.rs
+++ b/crates/codex-plus-core/src/watcher.rs
@@ -214,12 +214,11 @@ pub fn find_codex_processes_from_snapshot(
             .map(|(pid, path)| (*pid, path.as_str())),
     );
 
-    // Local/portable installs use Codex.exe as the Electron main process. Do not match
-    // lowercase codex.exe here; that is commonly the CLI binary. ChatGPT.exe is accepted
-    // only for packaged Store apps above, because the standalone ChatGPT app can be a
-    // normal ChatGPT session rather than Codex.
+    // Local/portable installs use Codex.exe or, since Codex was merged into the ChatGPT
+    // desktop app, ChatGPT.exe as the Electron main process. Do not match lowercase
+    // codex.exe here; that is commonly the CLI binary.
     for process in processes {
-        if process.exe_file == "Codex.exe" {
+        if process.exe_file == "Codex.exe" || process.exe_file == "ChatGPT.exe" {
             ids.push(process.process_id);
         }
     }

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -307,9 +307,24 @@ fn app_paths_normalizes_chatgpt_desktop_executable_and_builds_it() {
         Some(app.as_path())
     );
     assert_eq!(build_codex_executable(&app), app.join("ChatGPT.exe"));
+    assert_eq!(packaged_app_user_model_id(&app), None);
+}
+
+#[test]
+fn unpacked_package_named_directory_launches_chatgpt_executable_directly() {
+    let temp = tempfile::tempdir().unwrap();
+    let app = temp
+        .path()
+        .join("OpenAI.Codex_1.2026.133.0_x64__abc")
+        .join("app");
+    std::fs::create_dir_all(&app).unwrap();
+    std::fs::write(app.join("ChatGPT.exe"), "").unwrap();
+
+    assert_eq!(packaged_app_user_model_id(&app), None);
+    assert_eq!(build_packaged_activation(&app, 9229, &[]), None);
     assert_eq!(
-        packaged_app_user_model_id(&app).as_deref(),
-        Some("OpenAI.Codex_abc!App")
+        build_codex_command(&app, 9229, &[])[0],
+        app.join("ChatGPT.exe").to_string_lossy()
     );
 }
 

--- a/crates/codex-plus-core/tests/watcher.rs
+++ b/crates/codex-plus-core/tests/watcher.rs
@@ -156,6 +156,21 @@ fn find_codex_processes_finds_local_install_with_capitial_c() {
 
 #[cfg(windows)]
 #[test]
+fn find_codex_processes_finds_portable_chatgpt_desktop() {
+    let processes = [WindowsProcessInfo {
+        process_id: 46,
+        parent_process_id: 0,
+        exe_file: "ChatGPT.exe".to_string(),
+        executable_path: Some(std::path::PathBuf::from(
+            r"D:\Apps\OpenAI.Codex_1.2026.133.0_x64__abc\app\ChatGPT.exe",
+        )),
+    }];
+
+    assert_eq!(find_codex_processes_from_snapshot(&processes), vec![46]);
+}
+
+#[cfg(windows)]
+#[test]
 fn find_codex_processes_ignores_lowercase_local_cli_binary() {
     let processes = [WindowsProcessInfo {
         process_id: 43,


### PR DESCRIPTION
## What changed

- restrict AppX activation to Codex installations that are actually inside a `WindowsApps` directory
- launch unpacked/portable packages directly through `ChatGPT.exe` or `Codex.exe`
- recognize portable `ChatGPT.exe` processes after Codex was merged into ChatGPT Desktop
- add regression coverage for unpacked package-shaped directories and portable ChatGPT process detection

## Root cause

An unpacked MSIX keeps a directory name such as `OpenAI.Codex_<version>_x64__<publisher>`. Codex++ inferred the App User Model ID from that name alone and attempted `IApplicationActivationManager` activation. A portable copy is not registered with Windows, so activation fails even though its `ChatGPT.exe` is directly runnable.

The process watcher also deliberately accepted local `Codex.exe` but excluded local `ChatGPT.exe`, which no longer matches the merged desktop app layout.

## User impact

Users can select and launch a portable/unpacked Codex/ChatGPT Desktop build whose entry point is `ChatGPT.exe`, while Microsoft Store installs continue to use packaged activation.

## Validation

- `cargo fmt --check`
- `git diff --check`
- Added focused launcher and watcher regression tests
