### PR TITLE
fix: preserve ChatGPT login with relay API auth

### DIFF
--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -260,6 +260,7 @@ pub fn apply_relay_config_to_home_with_protocol(
     let auth_contents = serde_json::to_string_pretty(&json!({
         "OPENAI_API_KEY": bearer_token
     }))?;
+    let auth_contents = provider_scoped_auth_for_switch(home, &auth_contents)?;
     let backup_path =
         write_codex_live_atomic(home, Some(&updated), Some(auth_contents.as_bytes()), false)?;
     let status = relay_config_status_from_home(home);
@@ -404,22 +405,17 @@ pub fn apply_relay_profile_to_home_with_switch_rules_and_computer_use_guard(
     )?;
     let config_with_catalog = apply_model_catalog_to_config(home, profile, &config_with_limits)?;
 
-    if profile.relay_mode == crate::settings::RelayMode::PureApi {
-        apply_relay_files_to_home_with_computer_use_guard(
-            home,
-            &config_with_catalog,
-            &profile.auth_contents,
-            preserve_computer_use_guard,
-        )
+    let auth_contents = if profile.relay_mode == crate::settings::RelayMode::PureApi {
+        provider_scoped_auth_for_switch(home, &profile.auth_contents)?
     } else {
-        let auth_contents = official_profile_auth_for_switch(home, &profile.auth_contents)?;
-        apply_relay_files_to_home_with_computer_use_guard(
-            home,
-            &config_with_catalog,
-            &auth_contents,
-            preserve_computer_use_guard,
-        )
-    }
+        official_profile_auth_for_switch(home, &profile.auth_contents)?
+    };
+    apply_relay_files_to_home_with_computer_use_guard(
+        home,
+        &config_with_catalog,
+        &auth_contents,
+        preserve_computer_use_guard,
+    )
 }
 
 pub fn apply_relay_profile_config_to_home_with_context(
@@ -485,6 +481,7 @@ pub fn apply_pure_api_config_to_home_with_protocol(
     let auth_contents = serde_json::to_string_pretty(&json!({
         "OPENAI_API_KEY": bearer_token
     }))?;
+    let auth_contents = provider_scoped_auth_for_switch(home, &auth_contents)?;
     let backup_path =
         write_codex_live_atomic(home, Some(&updated), Some(auth_contents.as_bytes()), false)?;
     let status = relay_config_status_from_home(home);
@@ -1794,47 +1791,29 @@ fn restore_profile_auth_from_live_config(
     profile: &mut RelayProfile,
     template_auth: &str,
 ) -> anyhow::Result<()> {
-    let Some(token) = experimental_bearer_token_from_config(&profile.config_contents)? else {
+    let Some(provider_token) = experimental_bearer_token_from_config(&profile.config_contents)?
+    else {
         return Ok(());
     };
-    profile.api_key = token.clone();
 
     if profile.relay_mode == crate::settings::RelayMode::Official && profile.official_mix_api_key {
+        profile.api_key = provider_token;
         profile.auth_contents = remove_openai_api_key_from_auth_contents(&profile.auth_contents)?;
         return Ok(());
     }
 
-    if !profile.auth_contents.trim().is_empty() {
-        if codex_auth_api_key(&profile.auth_contents).is_none() {
-            return Ok(());
-        }
-        profile.config_contents =
-            remove_experimental_bearer_token_from_config(&profile.config_contents)?;
-        return Ok(());
-    }
-
+    let token = codex_auth_api_key(&profile.auth_contents).unwrap_or(provider_token);
+    profile.api_key = token.clone();
     profile.config_contents =
-        remove_experimental_bearer_token_from_config(&profile.config_contents)?;
-
-    let mut auth = if template_auth.trim().is_empty() {
-        json!({})
-    } else {
-        serde_json::from_str::<Value>(template_auth).with_context(|| "auth.json JSON 解析失败")?
-    };
-    if !auth.is_object() {
-        auth = json!({});
+        set_experimental_bearer_token_in_config(&profile.config_contents, &token)?;
+    if profile.auth_contents.trim().is_empty() && !template_auth.trim().is_empty() {
+        profile.auth_contents = remove_openai_api_key_from_auth_contents(template_auth)?;
     }
-    if let Some(auth_object) = auth.as_object_mut() {
-        auth_object.insert("OPENAI_API_KEY".to_string(), Value::String(token));
-    } else {
-        anyhow::bail!("auth.json 必须是 JSON 对象");
-    }
-    profile.auth_contents = serde_json::to_string_pretty(&auth)?;
     Ok(())
 }
 
 fn sync_profile_mode_from_backfilled_live(profile: &mut RelayProfile) {
-    if profile.relay_mode == crate::settings::RelayMode::Official && !profile.official_mix_api_key {
+    if profile.relay_mode != crate::settings::RelayMode::Official || !profile.official_mix_api_key {
         return;
     }
 
@@ -1863,6 +1842,21 @@ fn official_profile_auth_for_switch(home: &Path, auth_contents: &str) -> anyhow:
         auth_contents.to_string()
     };
     remove_openai_api_key_from_auth_contents(&source)
+}
+
+fn provider_scoped_auth_for_switch(home: &Path, auth_contents: &str) -> anyhow::Result<String> {
+    let profile_auth = remove_openai_api_key_from_auth_contents(auth_contents)?;
+    if !profile_auth.trim().is_empty() {
+        return Ok(profile_auth);
+    }
+
+    let live_auth = read_optional_text(&home.join("auth.json"))?;
+    let live_auth = remove_openai_api_key_from_auth_contents(&live_auth)?;
+    if live_auth.trim().is_empty() {
+        Ok("{}\n".to_string())
+    } else {
+        Ok(live_auth)
+    }
 }
 
 fn codex_auth_api_key(auth_contents: &str) -> Option<String> {
@@ -2005,9 +1999,7 @@ fn complete_relay_profile_config(profile: &RelayProfile) -> anyhow::Result<Strin
     if !provider_base_url.trim().is_empty() {
         provider["base_url"] = toml_edit::value(provider_base_url.trim());
     }
-    if profile.relay_mode == crate::settings::RelayMode::PureApi {
-        provider.remove("experimental_bearer_token");
-    } else if !api_key.trim().is_empty() {
+    if !api_key.trim().is_empty() {
         provider["experimental_bearer_token"] = toml_edit::value(api_key.trim());
     }
 
@@ -2181,14 +2173,21 @@ fn experimental_bearer_token_from_config(config_contents: &str) -> anyhow::Resul
     Ok(None)
 }
 
-fn remove_experimental_bearer_token_from_config(config_contents: &str) -> anyhow::Result<String> {
+fn set_experimental_bearer_token_in_config(
+    config_contents: &str,
+    token: &str,
+) -> anyhow::Result<String> {
     let mut doc = parse_toml_document(config_contents)?;
-    if let Some(providers) = doc.get_mut("model_providers").and_then(Item::as_table_mut) {
-        for (_, item) in providers.iter_mut() {
-            if let Some(provider) = item.as_table_like_mut() {
-                provider.remove("experimental_bearer_token");
-            }
-        }
+    let Some(provider_id) = active_provider_id(&doc) else {
+        return Ok(ensure_trailing_newline(doc.to_string()));
+    };
+    if let Some(provider) = doc
+        .get_mut("model_providers")
+        .and_then(Item::as_table_mut)
+        .and_then(|providers| providers.get_mut(&provider_id))
+        .and_then(Item::as_table_like_mut)
+    {
+        provider.insert("experimental_bearer_token", toml_edit::value(token.trim()));
     }
     Ok(ensure_trailing_newline(doc.to_string()))
 }

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -484,7 +484,7 @@ fn official_mix_api_profile_removes_auth_api_key_on_storage() {
 }
 
 #[test]
-fn apply_pure_api_config_switches_auth_json_and_writes_provider_token() {
+fn apply_pure_api_config_preserves_chatgpt_auth_and_writes_provider_token() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::write(
         temp.path().join("auth.json"),
@@ -506,10 +506,9 @@ fn apply_pure_api_config_switches_auth_json_and_writes_provider_token() {
     let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
     assert!(result.configured);
     assert!(!config.contains(r#"model = "gpt-5""#));
-    assert_eq!(
-        auth,
-        serde_json::json!({"OPENAI_API_KEY":"sk-test-redacted"})
-    );
+    assert_eq!(auth["auth_mode"], "chatgpt");
+    assert_eq!(auth["tokens"]["access_token"], "old");
+    assert!(auth.get("OPENAI_API_KEY").is_none());
     assert!(config.contains(r#"model_provider = "custom""#));
     assert!(config.contains("[model_providers.custom]"));
     assert!(config.contains(r#"name = "custom""#));
@@ -1292,8 +1291,12 @@ model_provider = "vendor_alpha"
             .config_contents
             .contains(r#"model_provider = "vendor_alpha""#)
     );
-    let auth: serde_json::Value = serde_json::from_str(&profile.auth_contents).unwrap();
-    assert_eq!(auth["OPENAI_API_KEY"], "sk-new");
+    assert!(profile.auth_contents.is_empty());
+    assert!(
+        profile
+            .config_contents
+            .contains(r#"experimental_bearer_token = "sk-new""#)
+    );
 }
 
 #[test]
@@ -1774,12 +1777,16 @@ enabled = true
             .config_contents
             .contains("[plugins.\"superpowers@openai-curated\"]")
     );
-    let auth: serde_json::Value = serde_json::from_str(&profile.auth_contents).unwrap();
-    assert_eq!(auth["OPENAI_API_KEY"], "sk-live-token");
+    assert!(profile.auth_contents.is_empty());
+    assert!(
+        profile
+            .config_contents
+            .contains(r#"experimental_bearer_token = "sk-live-token""#)
+    );
 }
 
 #[test]
-fn backfill_relay_profile_with_common_lifts_bearer_token_to_auth() {
+fn backfill_relay_profile_with_common_keeps_provider_scoped_bearer_token() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::write(
         temp.path().join("config.toml"),
@@ -1797,16 +1804,16 @@ experimental_bearer_token = "sk-live-token"
     backfill_relay_profile_from_home_with_common(temp.path(), &mut profile, &mut common).unwrap();
 
     assert!(
-        !profile
+        profile
             .config_contents
-            .contains("experimental_bearer_token")
+            .contains(r#"experimental_bearer_token = "sk-live-token""#)
     );
-    let auth: serde_json::Value = serde_json::from_str(&profile.auth_contents).unwrap();
-    assert_eq!(auth["OPENAI_API_KEY"], "sk-live-token");
+    assert_eq!(profile.api_key, "sk-live-token");
+    assert!(profile.auth_contents.is_empty());
 }
 
 #[test]
-fn backfill_relay_profile_prefers_live_auth_over_provider_token() {
+fn backfill_relay_profile_syncs_live_auth_key_into_provider_token() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::write(
         temp.path().join("config.toml"),
@@ -1838,10 +1845,11 @@ experimental_bearer_token = "sk-old"
     let auth: serde_json::Value = serde_json::from_str(&profile.auth_contents).unwrap();
     assert_eq!(auth["OPENAI_API_KEY"], "sk-edited");
     assert!(
-        !profile
+        profile
             .config_contents
-            .contains("experimental_bearer_token")
+            .contains(r#"experimental_bearer_token = "sk-edited""#)
     );
+    assert_eq!(profile.api_key, "sk-edited");
 }
 
 #[test]
@@ -1906,8 +1914,14 @@ model = "gpt-5.4"
             .contains("[model_providers.custom]")
     );
     let auth: serde_json::Value = serde_json::from_str(&provider_b.auth_contents).unwrap();
-    assert_eq!(auth["OPENAI_API_KEY"], "aihubmix-key");
-    assert!(auth.get("tokens").is_none());
+    assert_eq!(auth["auth_mode"], "chatgpt");
+    assert_eq!(auth["tokens"]["access_token"], "official");
+    assert!(auth.get("OPENAI_API_KEY").is_none());
+    assert!(
+        provider_b
+            .config_contents
+            .contains(r#"experimental_bearer_token = "aihubmix-key""#)
+    );
 }
 
 #[test]
@@ -2253,7 +2267,7 @@ experimental_bearer_token = "22222222222222222222222222222222222"
 }
 
 #[test]
-fn apply_relay_profile_to_home_with_switch_rules_switches_auth_and_writes_provider_token() {
+fn apply_relay_profile_to_home_preserves_login_and_writes_provider_token() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::write(
         temp.path().join("auth.json"),
@@ -2281,11 +2295,11 @@ base_url = "https://relay.example/v1"
 
     let auth = std::fs::read_to_string(temp.path().join("auth.json")).unwrap();
     let auth: serde_json::Value = serde_json::from_str(&auth).unwrap();
-    assert_eq!(auth["OPENAI_API_KEY"], "sk-new");
-    assert!(auth.get("auth_mode").is_none());
-    assert!(auth.get("tokens").is_none());
+    assert!(auth.get("OPENAI_API_KEY").is_none());
+    assert_eq!(auth["auth_mode"], "chatgpt");
+    assert_eq!(auth["tokens"]["access_token"], "official");
     let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
-    assert!(!config.contains("experimental_bearer_token"));
+    assert!(config.contains(r#"experimental_bearer_token = "sk-new""#));
     assert!(config.contains(r#"model_provider = "custom""#));
     assert!(config.contains("[model_providers.custom]"));
 }
@@ -2328,7 +2342,7 @@ experimental_bearer_token = "sk-new"
     assert!(config.contains(r#"wire_api = "responses""#));
     assert!(config.contains("requires_openai_auth = true"));
     assert!(config.contains(r#"base_url = "https://relay.example/v1""#));
-    assert!(!config.contains("experimental_bearer_token"));
+    assert!(config.contains(r#"experimental_bearer_token = "sk-new""#));
     assert!(!config.contains("live_provider"));
     assert!(!config.contains("https://live.example/v1"));
 }
@@ -2363,7 +2377,7 @@ requires_openai_auth = true
     assert!(config.contains("[model_providers.max_ai]"));
     assert!(config.contains(r#"name = "max_ai""#));
     assert!(config.contains(r#"base_url = "https://max2.jojocode.com/v1""#));
-    assert!(!config.contains("experimental_bearer_token"));
+    assert!(config.contains(r#"experimental_bearer_token = "sk-new""#));
     assert!(!config.contains("[model_providers.custom]"));
 }
 
@@ -2683,7 +2697,7 @@ base_url = "http://192.168.188.245:3001/v1"
 }
 
 #[test]
-fn apply_relay_profile_to_home_with_switch_rules_switches_auth_even_when_provider_token_exists() {
+fn apply_relay_profile_preserves_login_when_provider_token_exists() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::write(
         temp.path().join("auth.json"),
@@ -2712,10 +2726,12 @@ experimental_bearer_token = "sk-provider-token"
 
     let auth = std::fs::read_to_string(temp.path().join("auth.json")).unwrap();
     let auth: serde_json::Value = serde_json::from_str(&auth).unwrap();
-    assert!(auth.as_object().is_some_and(|object| object.is_empty()));
+    assert_eq!(auth["auth_mode"], "chatgpt");
+    assert_eq!(auth["tokens"]["access_token"], "official");
+    assert!(auth.get("OPENAI_API_KEY").is_none());
 
     let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
-    assert!(!config.contains("experimental_bearer_token"));
+    assert!(config.contains(r#"experimental_bearer_token = "sk-provider-token""#));
 }
 
 #[test]
@@ -2878,7 +2894,7 @@ experimental_bearer_token = "sk-new"
     assert!(config.contains(r#"base_url = "https://max2.jojocode.com/v1""#));
     assert!(config.contains(r#"wire_api = "responses""#));
     assert!(config.contains("requires_openai_auth = true"));
-    assert!(!config.contains("experimental_bearer_token"));
+    assert!(config.contains(r#"experimental_bearer_token = "sk-new""#));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- keep relay API keys in each custom provider's `experimental_bearer_token` instead of relying on global `auth.json`
- preserve ChatGPT login credentials when switching to pure API profiles
- keep provider-scoped credentials intact through profile backfill and synchronization

## Why
Recent Codex versions load ChatGPT credentials from the OS keyring before `auth.json`. Removing the provider token caused Codex to send the ChatGPT bearer token to a custom relay, which returned 401. Provider-scoped auth has explicit precedence in current Codex and avoids mixing the two credential domains.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo test -p codex-plus-core --test relay_config` (95 passed)
- [x] `cargo test -p codex-plus-core --lib` (116 passed)