### PR TITLE
fix: sync providers in local_thread_catalog

### DIFF
--- a/crates/codex-plus-core/src/codex_sqlite.rs
+++ b/crates/codex-plus-core/src/codex_sqlite.rs
@@ -87,9 +87,14 @@ fn is_sqlite_candidate(path: &Path) -> bool {
 }
 
 fn has_session_table(path: &Path) -> bool {
-    ["threads", "automation_runs", "inbox_items"]
-        .iter()
-        .any(|table| sqlite_has_table(path, table))
+    [
+        "threads",
+        "local_thread_catalog",
+        "automation_runs",
+        "inbox_items",
+    ]
+    .iter()
+    .any(|table| sqlite_has_table(path, table))
 }
 
 fn sqlite_has_table(path: &Path, table: &str) -> bool {

--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -810,18 +810,20 @@ fn sqlite_provider_ids(path: &Path) -> anyhow::Result<Vec<String>> {
         return Ok(Vec::new());
     }
     let db = Connection::open(path)?;
-    let columns = table_columns(&db, "threads")?;
-    if !columns.contains("model_provider") {
-        return Ok(Vec::new());
-    }
-    let mut stmt = db.prepare(
-        "SELECT DISTINCT COALESCE(model_provider, '') FROM threads WHERE COALESCE(model_provider, '') <> ''",
-    )?;
     let mut ids = HashSet::new();
-    for item in stmt.query_map([], |row| row.get::<_, String>(0))? {
-        let id = item?;
-        if is_valid_provider_id_for_discovery(&id) {
-            ids.insert(id);
+    for table in ["threads", "local_thread_catalog"] {
+        let columns = table_columns(&db, table)?;
+        if !columns.contains("model_provider") {
+            continue;
+        }
+        let mut stmt = db.prepare(&format!(
+            "SELECT DISTINCT COALESCE(model_provider, '') FROM {table} WHERE COALESCE(model_provider, '') <> ''"
+        ))?;
+        for item in stmt.query_map([], |row| row.get::<_, String>(0))? {
+            let id = item?;
+            if is_valid_provider_id_for_discovery(&id) {
+                ids.insert(id);
+            }
         }
     }
     Ok(sorted_provider_ids(ids))
@@ -838,14 +840,22 @@ fn count_sqlite_updates(
     }
     let db = Connection::open(path)?;
     let columns = table_columns(&db, "threads")?;
-    if !columns.contains("model_provider") {
-        return Ok(0);
+    let catalog_columns = table_columns(&db, "local_thread_catalog")?;
+    let mut total = 0;
+    if columns.contains("model_provider") {
+        total += db.query_row(
+            "SELECT COUNT(*) FROM threads WHERE COALESCE(model_provider, '') <> ?1",
+            [target_provider],
+            |row| row.get::<_, i64>(0),
+        )? as usize;
     }
-    let mut total: usize = db.query_row(
-        "SELECT COUNT(*) FROM threads WHERE COALESCE(model_provider, '') <> ?1",
-        [target_provider],
-        |row| row.get::<_, i64>(0),
-    )? as usize;
+    if catalog_columns.contains("model_provider") {
+        total += db.query_row(
+            "SELECT COUNT(*) FROM local_thread_catalog WHERE COALESCE(model_provider, '') <> ?1",
+            [target_provider],
+            |row| row.get::<_, i64>(0),
+        )? as usize;
+    }
     if columns.contains("has_user_event") {
         for thread_id in user_event_thread_ids {
             total += db.query_row(
@@ -896,15 +906,24 @@ fn apply_sqlite_update(
     }
     let mut db = Connection::open(path)?;
     let columns = table_columns(&db, "threads")?;
-    if !columns.contains("model_provider") {
+    let catalog_columns = table_columns(&db, "local_thread_catalog")?;
+    if !columns.contains("model_provider") && !catalog_columns.contains("model_provider") {
         return Ok(SqliteUpdateCounts::default());
     }
     let tx = db.transaction()?;
     let mut counts = SqliteUpdateCounts::default();
-    counts.provider_rows = tx.execute(
-        "UPDATE threads SET model_provider = ?1 WHERE COALESCE(model_provider, '') <> ?1",
-        [target_provider],
-    )?;
+    if columns.contains("model_provider") {
+        counts.provider_rows += tx.execute(
+            "UPDATE threads SET model_provider = ?1 WHERE COALESCE(model_provider, '') <> ?1",
+            [target_provider],
+        )?;
+    }
+    if catalog_columns.contains("model_provider") {
+        counts.provider_rows += tx.execute(
+            "UPDATE local_thread_catalog SET model_provider = ?1 WHERE COALESCE(model_provider, '') <> ?1",
+            [target_provider],
+        )?;
+    }
     if columns.contains("has_user_event") {
         for thread_id in user_event_thread_ids {
             counts.user_event_rows += tx.execute(

--- a/crates/codex-plus-data/tests/provider_sync.rs
+++ b/crates/codex-plus-data/tests/provider_sync.rs
@@ -74,6 +74,22 @@ fn create_state_db_with_providers(path: &Path, rows: &[(&str, &str, i64)]) {
     }
 }
 
+fn create_local_thread_catalog_db(path: &Path, rows: &[(&str, &str)]) {
+    let db = Connection::open(path).unwrap();
+    db.execute(
+        "CREATE TABLE local_thread_catalog (host_id TEXT NOT NULL, thread_id TEXT NOT NULL, model_provider TEXT NOT NULL, PRIMARY KEY (host_id, thread_id))",
+        [],
+    )
+    .unwrap();
+    for (thread_id, provider) in rows {
+        db.execute(
+            "INSERT INTO local_thread_catalog VALUES ('local', ?1, ?2)",
+            (thread_id, provider),
+        )
+        .unwrap();
+    }
+}
+
 #[test]
 fn provider_sync_targets_merge_config_rollout_sqlite_and_sort_current_first() {
     let tmp = tempdir().unwrap();
@@ -346,6 +362,43 @@ fn provider_sync_updates_new_codex_sqlite_directory_db() {
         row,
         ("apigather".to_string(), 1, "C:/workspace".to_string())
     );
+    let backup_dir = result.backup_dir.unwrap();
+    assert!(backup_dir.join("db/sqlite/codex-dev.db").exists());
+}
+
+#[test]
+fn provider_sync_updates_and_discovers_local_thread_catalog() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    let sqlite_dir = home.join("sqlite");
+    fs::create_dir_all(&sqlite_dir).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    let db_path = sqlite_dir.join("codex-dev.db");
+    create_local_thread_catalog_db(&db_path, &[("thread-1", "openai"), ("thread-2", "custom")]);
+
+    let targets = load_provider_sync_targets(Some(&home));
+    let ids = targets
+        .targets
+        .iter()
+        .map(|target| target.id.as_str())
+        .collect::<Vec<_>>();
+    assert!(ids.contains(&"openai"));
+    assert!(ids.contains(&"custom"));
+
+    let result = run_provider_sync(Some(&home));
+
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert_eq!(result.sqlite_rows_updated, 2);
+    assert_eq!(result.sqlite_provider_rows_updated, 2);
+    let db = Connection::open(&db_path).unwrap();
+    let remaining = db
+        .query_row(
+            "SELECT COUNT(*) FROM local_thread_catalog WHERE model_provider <> 'apigather'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(remaining, 0);
     let backup_dir = result.backup_dir.unwrap();
     assert!(backup_dir.join("db/sqlite/codex-dev.db").exists());
 }
@@ -668,6 +721,60 @@ fn provider_sync_rolls_back_sqlite_provider_update_when_later_update_fails() {
         )
         .unwrap();
     assert_eq!(row, ("old-provider".to_string(), 1, "C:/old".to_string()));
+}
+
+#[test]
+fn provider_sync_rolls_back_threads_when_local_catalog_update_fails() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    fs::create_dir(&home).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    write_rollout(
+        &home.join("sessions/rollout-current.jsonl"),
+        "apigather",
+        "thread-1",
+        "C:/workspace",
+    );
+    let db_path = home.join("state_5.sqlite");
+    create_state_db(&db_path);
+    let db = Connection::open(&db_path).unwrap();
+    db.execute(
+        "CREATE TABLE local_thread_catalog (host_id TEXT NOT NULL, thread_id TEXT NOT NULL, model_provider TEXT NOT NULL, PRIMARY KEY (host_id, thread_id))",
+        [],
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO local_thread_catalog VALUES ('local', 'thread-1', 'catalog-provider')",
+        [],
+    )
+    .unwrap();
+    db.execute(
+        "CREATE TRIGGER fail_catalog_provider_update BEFORE UPDATE OF model_provider ON local_thread_catalog BEGIN SELECT RAISE(ABORT, 'boom'); END",
+        [],
+    )
+    .unwrap();
+    drop(db);
+
+    let result = run_provider_sync(Some(&home));
+
+    assert_eq!(result.status, ProviderSyncStatus::Skipped);
+    let db = Connection::open(&db_path).unwrap();
+    let thread_provider = db
+        .query_row(
+            "SELECT model_provider FROM threads WHERE id = 'thread-1'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .unwrap();
+    let catalog_provider = db
+        .query_row(
+            "SELECT model_provider FROM local_thread_catalog WHERE thread_id = 'thread-1'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .unwrap();
+    assert_eq!(thread_provider, "old-provider");
+    assert_eq!(catalog_provider, "catalog-provider");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- discover Codex SQLite databases that only contain the newer `local_thread_catalog` table
- include provider IDs from both `threads` and `local_thread_catalog` in provider sync target discovery
- count and update `model_provider` in both tables within the same SQLite transaction
- keep the existing provider-sync result shape and database backup flow unchanged

## Problem

Recent Codex desktop builds maintain a second history catalog at `sqlite/codex-dev.db/local_thread_catalog`. Provider sync currently rewrites rollout `session_meta.model_provider` and `threads.model_provider`, but it does not update this newer catalog.

After switching from an official subscription to a custom provider, the rollout files and legacy index can be synchronized while the desktop catalog still contains the old provider IDs. Codex then filters or rebuilds the sidebar from inconsistent metadata, so only conversations originally created with the active provider remain visible.

## Implementation

- treat `local_thread_catalog` as a session database marker in `codex_sqlite_dir_session_dbs`
- read provider IDs from both supported tables
- aggregate update counts from both tables
- update both tables in one transaction when they coexist in a database
- include catalog-only databases in the existing backup path

## Tests

- added coverage for a `codex-dev.db` containing only `local_thread_catalog`
- verifies provider discovery, row updates, update counts, and backup creation
- added rollback coverage proving a catalog update failure also rolls back the preceding `threads` update
- `cargo fmt --all -- --check`
- `cargo test -p codex-plus-data --test provider_sync` (19 passed)
- frontend `npm install --package-lock=false` and `npm run vite:build`
- workspace tests passed until the local Windows installer test executable required elevation (`os error 740`); GitHub Actions will run the complete elevated Windows job

Related to #726 and #240.
