### PR TITLE
完善 GPT-5.6 三模型元数据与 Fast 兼容 / Complete GPT-5.6 metadata and Fast compatibility

### DIFF
--- a/assets/gpt56-model-metadata-compat.json
+++ b/assets/gpt56-model-metadata-compat.json
@@ -13,8 +13,8 @@
         { "effort": "max", "description": "Maximum reasoning depth for the hardest problems" },
         { "effort": "ultra", "description": "Maximum reasoning with automatic task delegation" }
       ],
-      "context_window": 372000,
-      "max_context_window": 372000,
+      "context_window": 272000,
+      "max_context_window": 272000,
       "effective_context_window_percent": 100,
       "additional_speed_tiers": ["fast"],
       "service_tiers": [
@@ -42,8 +42,8 @@
         { "effort": "max", "description": "Maximum reasoning depth for the hardest problems" },
         { "effort": "ultra", "description": "Maximum reasoning with automatic task delegation" }
       ],
-      "context_window": 372000,
-      "max_context_window": 372000,
+      "context_window": 272000,
+      "max_context_window": 272000,
       "effective_context_window_percent": 100,
       "additional_speed_tiers": ["fast"],
       "service_tiers": [
@@ -70,8 +70,8 @@
         { "effort": "xhigh", "description": "Extra high reasoning depth for complex problems" },
         { "effort": "max", "description": "Maximum reasoning depth for the hardest problems" }
       ],
-      "context_window": 372000,
-      "max_context_window": 372000,
+      "context_window": 272000,
+      "max_context_window": 272000,
       "effective_context_window_percent": 100,
       "additional_speed_tiers": ["fast"],
       "service_tiers": [

--- a/assets/gpt56-model-metadata-compat.json
+++ b/assets/gpt56-model-metadata-compat.json
@@ -1,0 +1,90 @@
+{
+  "models": [
+    {
+      "slug": "gpt-5.6-sol",
+      "display_name": "GPT-5.6-Sol",
+      "description": "Latest frontier agentic coding model.",
+      "default_reasoning_level": "low",
+      "supported_reasoning_levels": [
+        { "effort": "low", "description": "Fast responses with lighter reasoning" },
+        { "effort": "medium", "description": "Balances speed and reasoning depth for everyday tasks" },
+        { "effort": "high", "description": "Greater reasoning depth for complex problems" },
+        { "effort": "xhigh", "description": "Extra high reasoning depth for complex problems" },
+        { "effort": "max", "description": "Maximum reasoning depth for the hardest problems" },
+        { "effort": "ultra", "description": "Maximum reasoning with automatic task delegation" }
+      ],
+      "context_window": 372000,
+      "max_context_window": 372000,
+      "effective_context_window_percent": 100,
+      "additional_speed_tiers": ["fast"],
+      "service_tiers": [
+        { "id": "priority", "name": "Fast", "description": "1.5x speed, increased usage" }
+      ],
+      "supports_reasoning_summaries": true,
+      "support_verbosity": true,
+      "supports_parallel_tool_calls": true,
+      "input_modalities": ["text", "image"],
+      "supports_search_tool": true,
+      "tool_mode": "code_mode_only",
+      "multi_agent_version": "v2",
+      "use_responses_lite": true
+    },
+    {
+      "slug": "gpt-5.6-terra",
+      "display_name": "GPT-5.6-Terra",
+      "description": "Balanced agentic coding model for everyday work.",
+      "default_reasoning_level": "medium",
+      "supported_reasoning_levels": [
+        { "effort": "low", "description": "Fast responses with lighter reasoning" },
+        { "effort": "medium", "description": "Balances speed and reasoning depth for everyday tasks" },
+        { "effort": "high", "description": "Greater reasoning depth for complex problems" },
+        { "effort": "xhigh", "description": "Extra high reasoning depth for complex problems" },
+        { "effort": "max", "description": "Maximum reasoning depth for the hardest problems" },
+        { "effort": "ultra", "description": "Maximum reasoning with automatic task delegation" }
+      ],
+      "context_window": 372000,
+      "max_context_window": 372000,
+      "effective_context_window_percent": 100,
+      "additional_speed_tiers": ["fast"],
+      "service_tiers": [
+        { "id": "priority", "name": "Fast", "description": "1.5x speed, increased usage" }
+      ],
+      "supports_reasoning_summaries": true,
+      "support_verbosity": true,
+      "supports_parallel_tool_calls": true,
+      "input_modalities": ["text", "image"],
+      "supports_search_tool": true,
+      "tool_mode": "code_mode_only",
+      "multi_agent_version": "v2",
+      "use_responses_lite": true
+    },
+    {
+      "slug": "gpt-5.6-luna",
+      "display_name": "GPT-5.6-Luna",
+      "description": "Fast and affordable agentic coding model.",
+      "default_reasoning_level": "medium",
+      "supported_reasoning_levels": [
+        { "effort": "low", "description": "Fast responses with lighter reasoning" },
+        { "effort": "medium", "description": "Balances speed and reasoning depth for everyday tasks" },
+        { "effort": "high", "description": "Greater reasoning depth for complex problems" },
+        { "effort": "xhigh", "description": "Extra high reasoning depth for complex problems" },
+        { "effort": "max", "description": "Maximum reasoning depth for the hardest problems" }
+      ],
+      "context_window": 372000,
+      "max_context_window": 372000,
+      "effective_context_window_percent": 100,
+      "additional_speed_tiers": ["fast"],
+      "service_tiers": [
+        { "id": "priority", "name": "Fast", "description": "1.5x speed, increased usage" }
+      ],
+      "supports_reasoning_summaries": true,
+      "support_verbosity": true,
+      "supports_parallel_tool_calls": true,
+      "input_modalities": ["text", "image"],
+      "supports_search_tool": true,
+      "tool_mode": "code_mode_only",
+      "multi_agent_version": "v1",
+      "use_responses_lite": true
+    }
+  ]
+}

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -1404,6 +1404,7 @@
   const codexServiceTierSupportedFastModels = new Set(["gpt-5.4", "gpt-5.5"]);
   const codexThreadServiceTierModes = new Set(["inherit", "standard", "fast"]);
   const codexServiceTierControlModes = new Set(["inherit", "global-standard", "global-fast", "custom"]);
+  ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"].forEach((model) => codexServiceTierSupportedFastModels.add(model));
 
   function codexAppAssetUrl(namePart) {
     const urls = [
@@ -2074,14 +2075,38 @@
     return message;
   }
 
+  function codexServiceTierDispatcherFromModule(module) {
+    const values = module && typeof module === "object" ? Object.values(module) : [];
+    const singleton = values.find((candidate) => candidate
+      && typeof candidate === "object"
+      && typeof candidate.dispatchMessage === "function"
+      && typeof candidate.subscribe === "function");
+    if (singleton) return singleton;
+    const dispatcherClass = values.find((candidate) => typeof candidate === "function"
+      && typeof candidate.getInstance === "function"
+      && typeof candidate.prototype?.dispatchMessage === "function");
+    return dispatcherClass?.getInstance?.() || null;
+  }
+
   function installCodexServiceTierDispatcherPatch() {
     if (window.__codexServiceTierRequestOverrideInstalled === codexServiceTierRequestOverrideVersion) return;
+    const loadDispatcher = async () => {
+      const errors = [];
+      for (const assetPrefix of ["setting-storage-", "vscode-api-"]) {
+        try {
+          const module = await loadCodexAppModule(assetPrefix);
+          const dispatcher = codexServiceTierDispatcherFromModule(module);
+          if (dispatcher) return { dispatcher, assetPrefix };
+          errors.push(`${assetPrefix}: dispatcher export unavailable`);
+        } catch (error) {
+          errors.push(`${assetPrefix}: ${error?.message || String(error)}`);
+        }
+      }
+      throw new Error(`Codex dispatcher unavailable (${errors.join("; ")})`);
+    };
     const patch = async () => {
       try {
-        const module = await loadCodexAppModule("setting-storage-");
-        const dispatcherClass = typeof module.v === "function" && String(module.v).includes("dispatchMessage") ? module.v : null;
-        const dispatcher = dispatcherClass?.getInstance?.();
-        if (!dispatcher || typeof dispatcher.dispatchMessage !== "function") throw new Error("Codex dispatcher unavailable");
+        const { dispatcher, assetPrefix } = await loadDispatcher();
         if (dispatcher.__codexServiceTierOriginalDispatchMessage) {
           window.__codexServiceTierRequestOverrideInstalled = codexServiceTierRequestOverrideVersion;
           return;
@@ -2094,7 +2119,7 @@
           return dispatcher.__codexServiceTierOriginalDispatchMessage(nextType, nextPayload);
         };
         window.__codexServiceTierRequestOverrideInstalled = codexServiceTierRequestOverrideVersion;
-        sendCodexPlusDiagnostic("service_tier_dispatcher_patch_installed", {});
+        sendCodexPlusDiagnostic("service_tier_dispatcher_patch_installed", { assetPrefix });
       } catch (error) {
         sendCodexPlusDiagnostic("service_tier_dispatcher_patch_failed", {
           errorName: error?.name || "",
@@ -4554,6 +4579,9 @@
       applyServiceTierOverride: (method, params, threadIdHint = "") => applyCodexServiceTierRequestOverride(method, params, threadIdHint),
       requestOverride: (message) => codexServiceTierRequestOverride(message),
       diagnostics: () => [...(window.__codexPlusServiceTierTestDiagnostics || [])],
+      currentModelName: () => codexServiceTierCurrentModelName(),
+      fastAvailability: (modelName = codexServiceTierCurrentModelName()) => codexServiceTierFastAvailability(modelName),
+      modelDescriptor: (modelName) => codexPlusModelDescriptor(modelName),
       setModelCatalog: (catalog = {}) => {
         codexModelCatalog = {
           status: "ok",
@@ -4581,6 +4609,7 @@
           ...state,
         }));
       },
+      dispatcherFromModule: codexServiceTierDispatcherFromModule,
     };
     return;
   }
@@ -4640,22 +4669,58 @@
     return codexModelCatalogPromise;
   }
 
-  function modelReasoningEfforts() {
-    return ["minimal", "low", "medium", "high", "xhigh"].map((reasoningEffort) => ({ reasoningEffort, description: `${reasoningEffort} effort` }));
+  function codexPlusModelMetadata(modelName) {
+    const metadata = codexModelCatalog.modelMetadata || codexModelCatalog.model_metadata;
+    const normalizedName = codexServiceTierModelFromValue(modelName);
+    const exact = metadata && typeof metadata === "object" ? metadata[normalizedName] : null;
+    const matchedKey = !exact && metadata && typeof metadata === "object"
+      ? Object.keys(metadata).find((key) => key.toLowerCase() === normalizedName.toLowerCase())
+      : null;
+    const value = exact || (matchedKey ? metadata[matchedKey] : null);
+    return value && typeof value === "object" ? value : null;
+  }
+
+  function modelReasoningEfforts(modelName) {
+    const supported = codexPlusModelMetadata(modelName)?.supportedReasoningEfforts;
+    if (Array.isArray(supported) && supported.length > 0) {
+      return supported.map((entry) => ({ ...entry }));
+    }
+    return ["low", "medium", "high", "xhigh"].map((reasoningEffort) => ({ reasoningEffort, description: `${reasoningEffort} effort` }));
+  }
+
+  function applyCodexPlusModelMetadata(descriptor, modelName) {
+    const metadata = codexPlusModelMetadata(modelName);
+    if (!descriptor || !metadata) return false;
+    let changed = false;
+    for (const key of ["displayName", "description", "defaultReasoningEffort"]) {
+      if (typeof metadata[key] === "string" && metadata[key] && descriptor[key] !== metadata[key]) {
+        descriptor[key] = metadata[key];
+        changed = true;
+      }
+    }
+    if (Array.isArray(metadata.supportedReasoningEfforts) && metadata.supportedReasoningEfforts.length > 0) {
+      const nextEfforts = modelReasoningEfforts(modelName);
+      if (JSON.stringify(descriptor.supportedReasoningEfforts || []) !== JSON.stringify(nextEfforts)) {
+        descriptor.supportedReasoningEfforts = nextEfforts;
+        changed = true;
+      }
+    }
+    return changed;
   }
 
   function codexPlusModelDescriptor(modelName) {
+    const metadata = codexPlusModelMetadata(modelName);
     return {
       model: modelName,
       id: modelName,
       slug: modelName,
       name: modelName,
-      displayName: modelName,
-      description: codexModelCatalog.provider_name || codexModelCatalog.model_provider || "Custom model",
+      displayName: metadata?.displayName || modelName,
+      description: metadata?.description || codexModelCatalog.provider_name || codexModelCatalog.model_provider || "Custom model",
       hidden: false,
       isDefault: (codexModelCatalog.default_model || codexModelCatalog.model) === modelName,
-      defaultReasoningEffort: "medium",
-      supportedReasoningEfforts: modelReasoningEfforts(),
+      defaultReasoningEffort: metadata?.defaultReasoningEffort || "medium",
+      supportedReasoningEfforts: modelReasoningEfforts(modelName),
     };
   }
 
@@ -4690,9 +4755,12 @@
     let changed = false;
     const existing = new Map(models.map((item) => [item.model, item]));
     models.forEach((item) => {
-      if (customModels.includes(item.model) && item.hidden !== false) {
-        item.hidden = false;
-        changed = true;
+      if (customModels.includes(item.model)) {
+        if (item.hidden !== false) {
+          item.hidden = false;
+          changed = true;
+        }
+        if (applyCodexPlusModelMetadata(item, item.model)) changed = true;
       }
     });
     customModels.forEach((modelName) => {

--- a/crates/codex-plus-core/src/model_catalog.rs
+++ b/crates/codex-plus-core/src/model_catalog.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use crate::settings::{RelayProfile, SettingsStore};
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 
 const BASE_URL_ENV_KEYS: &[&str] = &[
     "CODEX_PLUS_OPENAI_BASE_URL",
@@ -63,6 +63,7 @@ pub async fn read_codex_model_catalog() -> Value {
                 "provider_name": "",
                 "default_model": "",
                 "models": [],
+                "modelMetadata": {},
                 "sources": [],
                 "responses_api": responses_api_status("unknown", "", "")
             });
@@ -81,6 +82,7 @@ fn relay_profile_model_catalog_value(home: &Path, profile: &RelayProfile) -> Val
         profile.name.trim()
     };
     let model_count = models.len();
+    let model_metadata = model_ui_metadata_map(&models);
     json!({
         "status": if models.is_empty() { "not_configured" } else { "ok" },
         "path": home.join("config.toml").to_string_lossy(),
@@ -89,6 +91,7 @@ fn relay_profile_model_catalog_value(home: &Path, profile: &RelayProfile) -> Val
         "provider_name": provider_name,
         "default_model": default_model,
         "models": models,
+        "modelMetadata": model_metadata,
         "sources": [
             {
                 "id": format!("relay-profile:{}", profile.id),
@@ -115,6 +118,16 @@ fn relay_profile_model_ids(profile: &RelayProfile) -> Vec<String> {
             .map(ToString::to_string)
             .collect(),
     )
+}
+
+fn model_ui_metadata_map(models: &[String]) -> Value {
+    let mut metadata = Map::new();
+    for model in models {
+        if let Some(value) = crate::model_suffix::model_ui_metadata(model) {
+            metadata.insert(model.clone(), value);
+        }
+    }
+    Value::Object(metadata)
 }
 
 pub async fn read_codex_model_catalog_from_home(
@@ -149,6 +162,7 @@ pub async fn read_codex_model_catalog_from_home(
             "provider_name": provider_name,
             "default_model": "",
             "models": [],
+            "modelMetadata": {},
             "sources": [],
             "responses_api": responses_api_status("unknown", "", "")
         });
@@ -203,6 +217,7 @@ pub async fn read_codex_model_catalog_from_home(
         "not_configured"
     };
     let responses_api = preferred_responses_api_status(&source_statuses);
+    let model_metadata = model_ui_metadata_map(&models);
 
     json!({
         "status": status,
@@ -212,6 +227,7 @@ pub async fn read_codex_model_catalog_from_home(
         "provider_name": provider_name,
         "default_model": default_model,
         "models": models,
+        "modelMetadata": model_metadata,
         "sources": source_statuses,
         "responses_api": responses_api
     })

--- a/crates/codex-plus-core/src/model_suffix.rs
+++ b/crates/codex-plus-core/src/model_suffix.rs
@@ -139,6 +139,60 @@ const BUNDLED_TEMPLATE_JSON: &str = include_str!(concat!(
     "/../../assets/codex-models.json"
 ));
 
+const GPT56_METADATA_JSON: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../assets/gpt56-model-metadata-compat.json"
+));
+
+pub fn requires_bundled_metadata_catalog(slug: &str) -> bool {
+    gpt56_metadata_entry(slug).is_some()
+}
+
+pub fn model_ui_metadata(slug: &str) -> Option<Value> {
+    let metadata = gpt56_metadata_entry(slug)?;
+    let levels = metadata
+        .get("supported_reasoning_levels")?
+        .as_array()?
+        .iter()
+        .filter_map(|level| {
+            let effort = level.get("effort")?.as_str()?.trim();
+            if effort.is_empty() {
+                return None;
+            }
+            Some(json!({
+                "reasoningEffort": effort,
+                "description": level
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+            }))
+        })
+        .collect::<Vec<_>>();
+    Some(json!({
+        "displayName": metadata
+            .get("display_name")
+            .and_then(Value::as_str)
+            .unwrap_or(slug),
+        "description": metadata
+            .get("description")
+            .and_then(Value::as_str)
+            .unwrap_or("Custom model"),
+        "defaultReasoningEffort": metadata
+            .get("default_reasoning_level")
+            .and_then(Value::as_str)
+            .unwrap_or("medium"),
+        "supportedReasoningEfforts": levels,
+        "additionalSpeedTiers": metadata
+            .get("additional_speed_tiers")
+            .cloned()
+            .unwrap_or_else(|| json!([])),
+        "serviceTiers": metadata
+            .get("service_tiers")
+            .cloned()
+            .unwrap_or_else(|| json!([]))
+    }))
+}
+
 /// 构建 codex model_catalog_json 内容。
 ///
 /// 采用 cc-switch 的 template-clone 思路：取 codex 自带 bundled entry 做模板，
@@ -160,20 +214,25 @@ pub fn build_model_catalog_json_with_template(
     fallback_window: Option<u64>,
     template: Option<&Value>,
 ) -> String {
-    let template = template
-        .cloned()
-        .or_else(|| load_bundled_template_entry())
-        .unwrap_or_else(|| json!({}));
-
     let models: Vec<Value> = entries
         .iter()
         .enumerate()
         .map(|(index, entry)| {
-            let context_window = entry.suffix_window.or(fallback_window).unwrap_or(272_000);
-            let mut model = template.clone();
+            let (mut model, has_model_metadata) = template
+                .cloned()
+                .map(|template| (template, false))
+                .unwrap_or_else(|| model_template_entry(&entry.slug));
+            let metadata_window = model.get("context_window").and_then(Value::as_u64);
+            let context_window = entry
+                .suffix_window
+                .or(fallback_window)
+                .or(metadata_window)
+                .unwrap_or(272_000);
             model["slug"] = json!(entry.slug);
-            model["display_name"] = json!(entry.display_name);
-            model["description"] = json!(entry.display_name);
+            if !has_model_metadata {
+                model["display_name"] = json!(entry.display_name);
+                model["description"] = json!(entry.display_name);
+            }
             model["context_window"] = json!(context_window);
             model["max_context_window"] = json!(context_window);
             // 默认 95 会让 1M 显示为 950K，显式写 100 以显示真实窗口。
@@ -182,8 +241,10 @@ pub fn build_model_catalog_json_with_template(
             model["priority"] = json!(1000 + index);
             model["visibility"] = json!("list");
             model["supported_in_api"] = json!(true);
-            model["additional_speed_tiers"] = json!([]);
-            model["service_tiers"] = json!([]);
+            if !has_model_metadata {
+                model["additional_speed_tiers"] = json!([]);
+                model["service_tiers"] = json!([]);
+            }
             model["availability_nux"] = Value::Null;
             model["upgrade"] = Value::Null;
             model
@@ -192,8 +253,47 @@ pub fn build_model_catalog_json_with_template(
     serde_json::to_string_pretty(&json!({ "models": models })).unwrap_or_default()
 }
 
-/// 加载内置 bundled catalog 模板的第一条 model entry。
-fn load_bundled_template_entry() -> Option<Value> {
+fn model_template_entry(slug: &str) -> (Value, bool) {
+    if let Some(entry) = bundled_template_entry(slug) {
+        return (entry, true);
+    }
+    if let Some(compatibility) = gpt56_metadata_entry(slug) {
+        let mut template = first_bundled_template_entry().unwrap_or_else(|| json!({}));
+        if let (Some(target), Some(source)) = (template.as_object_mut(), compatibility.as_object())
+        {
+            for (key, value) in source {
+                target.insert(key.clone(), value.clone());
+            }
+        }
+        return (template, true);
+    }
+    (
+        first_bundled_template_entry().unwrap_or_else(|| json!({})),
+        false,
+    )
+}
+
+fn bundled_template_entry(slug: &str) -> Option<Value> {
+    let catalog: Value = serde_json::from_str(BUNDLED_TEMPLATE_JSON).ok()?;
+    catalog
+        .get("models")?
+        .as_array()?
+        .iter()
+        .find(|entry| entry.get("slug").and_then(Value::as_str) == Some(slug))
+        .cloned()
+}
+
+fn first_bundled_template_entry() -> Option<Value> {
     let catalog: Value = serde_json::from_str(BUNDLED_TEMPLATE_JSON).ok()?;
     catalog.get("models")?.as_array()?.first().cloned()
+}
+
+fn gpt56_metadata_entry(slug: &str) -> Option<Value> {
+    let catalog: Value = serde_json::from_str(GPT56_METADATA_JSON).ok()?;
+    catalog
+        .get("models")?
+        .as_array()?
+        .iter()
+        .find(|entry| entry.get("slug").and_then(Value::as_str) == Some(slug))
+        .cloned()
 }

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -226,6 +226,20 @@ pub fn relay_config_status_from_home(home: &Path) -> RelayConfigStatus {
     }
 }
 
+pub fn responses_proxy_configured_in_home(home: &Path) -> bool {
+    let contents = match std::fs::read_to_string(home.join("config.toml")) {
+        Ok(contents) => contents,
+        Err(_) => return false,
+    };
+    provider_string_from_config(&contents, "base_url").as_deref()
+        == Some(
+            crate::protocol_proxy::local_responses_proxy_base_url(
+                crate::protocol_proxy::DEFAULT_PROTOCOL_PROXY_PORT,
+            )
+            .as_str(),
+        )
+}
+
 pub fn apply_relay_config_to_home(
     home: &Path,
     base_url: &str,
@@ -691,6 +705,7 @@ pub fn backfill_relay_profile_from_home_with_common(
     let live_config = read_optional_text(&home.join("config.toml"))?;
     let template_config = profile.config_contents.clone();
     let template_auth = profile.auth_contents.clone();
+    let template_base_url = relay_profile_base_url(profile);
     profile.config_contents = if profile.use_common_config {
         strip_common_config_from_config(&live_config, common_config_contents)?
     } else {
@@ -698,6 +713,23 @@ pub fn backfill_relay_profile_from_home_with_common(
     };
     profile.config_contents =
         restore_profile_provider_id_for_backfill(&profile.config_contents, &template_config)?;
+    if profile.protocol == RelayProtocol::Responses
+        && provider_string_from_config(&profile.config_contents, "base_url").as_deref()
+            == Some(
+                crate::protocol_proxy::local_responses_proxy_base_url(
+                    crate::protocol_proxy::DEFAULT_PROTOCOL_PROXY_PORT,
+                )
+                .as_str(),
+            )
+        && !template_base_url.trim().is_empty()
+    {
+        let mut doc = parse_toml_document(&profile.config_contents)?;
+        let provider_id = active_or_default_provider_id(&doc);
+        ensure_provider_table(&mut doc, &provider_id)?["base_url"] =
+            toml_edit::value(template_base_url.trim());
+        profile.config_contents =
+            move_model_providers_before_profiles(&ensure_trailing_newline(doc.to_string()));
+    }
     profile.auth_contents = read_optional_text(&home.join("auth.json"))?;
     restore_profile_auth_from_live_config(profile, &template_auth)?;
     sync_profile_mode_from_backfilled_live(profile);
@@ -1450,6 +1482,11 @@ fn apply_model_catalog_to_config(
             return Ok(config_text.to_string());
         }
     }
+    if let Some(external_catalog) = live_external_model_catalog(home) {
+        let mut doc = parse_toml_document(config_text)?;
+        doc["model_catalog_json"] = toml_edit::value(external_catalog);
+        return Ok(normalize_optional_toml(doc));
+    }
     let (model_list, model_windows): (String, std::collections::HashMap<String, String>) =
         if profile.model_windows.trim().is_empty() && profile.model_list.contains('[') {
             crate::model_suffix::migrate_model_list_with_suffixes(&profile.model_list)
@@ -1461,8 +1498,11 @@ fn apply_model_catalog_to_config(
         };
     let entries =
         crate::model_suffix::collect_catalog_entries(&model_list, &model_windows, &profile.model);
-    // 无后缀条目则 no-op，保持现有 per-profile 单值行为（保 does_not_write 测试）
-    if !entries.iter().any(|entry| entry.suffix_window.is_some()) {
+    // Known bundled metadata entries need a catalog even without a user-supplied window.
+    if !entries.iter().any(|entry| {
+        entry.suffix_window.is_some()
+            || crate::model_suffix::requires_bundled_metadata_catalog(&entry.slug)
+    }) {
         return Ok(config_text.to_string());
     }
     let fallback = parse_optional_positive_u64(&profile.context_window, "上下文大小")?;
@@ -1475,6 +1515,40 @@ fn apply_model_catalog_to_config(
     let mut doc = parse_toml_document(config_text)?;
     doc["model_catalog_json"] = toml_edit::value(catalog_relative);
     Ok(normalize_optional_toml(doc))
+}
+
+fn live_external_model_catalog(home: &Path) -> Option<String> {
+    let live_text = read_optional_text(&home.join("config.toml")).ok()?;
+    let live = parse_toml_document(&live_text).ok()?;
+    let path = live.get("model_catalog_json")?.as_str()?.trim();
+    (!path.is_empty() && !is_codex_plus_managed_model_catalog(home, path)).then(|| path.to_string())
+}
+
+fn is_codex_plus_managed_model_catalog(home: &Path, path: &str) -> bool {
+    let normalized = path.trim().replace('\\', "/");
+    let relative = normalized.trim_start_matches("./");
+    if relative.to_ascii_lowercase().starts_with("model-catalogs/") {
+        return true;
+    }
+    let normalized_lower = normalized.to_ascii_lowercase();
+    if normalized_lower.contains("/model-catalogs/")
+        || normalized_lower.ends_with("/model-catalogs")
+    {
+        return true;
+    }
+    let managed_root = home
+        .join("model-catalogs")
+        .to_string_lossy()
+        .replace('\\', "/");
+    let managed_root = managed_root.trim_end_matches('/');
+    normalized.eq_ignore_ascii_case(managed_root)
+        || normalized
+            .get(..managed_root.len())
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(managed_root))
+            && normalized
+                .as_bytes()
+                .get(managed_root.len())
+                .is_some_and(|byte| *byte == b'/')
 }
 
 fn sanitize_catalog_filename(id: &str) -> String {

--- a/crates/codex-plus-core/src/watcher.rs
+++ b/crates/codex-plus-core/src/watcher.rs
@@ -104,7 +104,9 @@ fn is_windowsapps_codex_app_process(executable: &str) -> bool {
     let Some((package_name, after_package)) = after_windows_apps.split_once('\\') else {
         return false;
     };
-    crate::app_paths::is_supported_windows_app_package_name(package_name)
+    let supported_package = crate::app_paths::is_supported_windows_app_package_name(package_name)
+        || package_name.starts_with("openai.chatgpt-desktop_");
+    supported_package
         && after_package.starts_with("app\\")
         && !after_package.starts_with("app\\resources\\")
         && after_package

--- a/crates/codex-plus-core/tests/ads.rs
+++ b/crates/codex-plus-core/tests/ads.rs
@@ -242,12 +242,20 @@ async fn fetch_ad_list_tries_backup_url_when_primary_fails() {
     let thread = thread::spawn(move || {
         for _ in 0..2 {
             let (mut stream, _) = listener.accept().unwrap();
+            let mut request = Vec::new();
             let mut buffer = [0; 1024];
-            let read = stream.read(&mut buffer).unwrap();
-            let request = String::from_utf8_lossy(&buffer[..read]);
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let read = stream.read(&mut buffer).unwrap();
+                assert!(read > 0, "client closed before sending complete headers");
+                request.extend_from_slice(&buffer[..read]);
+                assert!(request.len() <= 16 * 1024, "request headers are too large");
+            }
+            let request = String::from_utf8_lossy(&request);
             if request.starts_with("GET /primary.json?") {
                 stream
-                    .write_all(b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n")
+                    .write_all(
+                        b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                    )
                     .unwrap();
             } else {
                 assert!(request.starts_with("GET /backup.json?"), "{request}");
@@ -264,12 +272,13 @@ async fn fetch_ad_list_tries_backup_url_when_primary_fails() {
                 })
                 .to_string();
                 let response = format!(
-                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                     body.len(),
                     body
                 );
                 stream.write_all(response.as_bytes()).unwrap();
             }
+            stream.flush().unwrap();
         }
     });
 

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -601,6 +601,9 @@ fn injection_script_exposes_fast_service_tier_control() {
     assert!(script.contains("codexServiceTierSupportedFastModels"));
     assert!(script.contains("\"gpt-5.4\""));
     assert!(script.contains("\"gpt-5.5\""));
+    assert!(script.contains("\"gpt-5.6-sol\""));
+    assert!(script.contains("\"gpt-5.6-terra\""));
+    assert!(script.contains("\"gpt-5.6-luna\""));
     assert!(script.contains("codexServiceTierFastSupportedForModel"));
     assert!(script.contains("codexServiceTierModelForRequest"));
     assert!(script.contains("codexServiceTierMaybeLoadModelCatalog"));
@@ -657,6 +660,10 @@ fn injection_script_exposes_fast_service_tier_control() {
     assert!(script.contains("当前 thread"));
     assert!(script.contains("standard"));
     assert!(script.contains("fast"));
+    assert!(script.contains("[\"setting-storage-\", \"vscode-api-\"]"));
+    assert!(script.contains("dispatcher export unavailable"));
+    assert!(!script.contains("data-codex-max-reasoning-control"));
+    assert!(!script.contains("codexAppMaxReasoningOverride"));
 }
 
 #[test]
@@ -726,6 +733,18 @@ fn injection_script_applies_fast_service_tier_contract() {
     );
 
     assert_eq!(cases["startConversation"]["serviceTier"], "priority");
+    assert_eq!(cases["solFastAvailability"]["supported"], true);
+    assert_eq!(cases["solDescriptor"]["defaultReasoningEffort"], "low");
+    assert_eq!(
+        cases["solDescriptor"]["supportedReasoningEfforts"][4]["reasoningEffort"],
+        "max"
+    );
+    assert_eq!(
+        cases["solDescriptor"]["supportedReasoningEfforts"][5]["reasoningEffort"],
+        "ultra"
+    );
+    assert_eq!(cases["dispatcherFromSingleton"], true);
+    assert_eq!(cases["dispatcherFromClass"], true);
 }
 
 fn run_service_tier_contract_harness() -> serde_json::Value {
@@ -823,6 +842,47 @@ const startConversation = api.requestOverride({{
   model: "gpt-5.5",
 }});
 
+api.setModelCatalog({{
+  status: "ok",
+  model: "gpt-5.6-sol",
+  default_model: "gpt-5.6-sol",
+  models: ["gpt-5.6-sol"],
+  modelMetadata: {{
+    "gpt-5.6-sol": {{
+      displayName: "GPT-5.6-Sol",
+      description: "Latest frontier agentic coding model.",
+      defaultReasoningEffort: "low",
+      supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"].map((reasoningEffort) => ({{ reasoningEffort }})),
+      additionalSpeedTiers: ["fast"],
+      serviceTiers: [{{ id: "priority", name: "Fast" }}],
+    }},
+  }},
+}});
+const solFastAvailability = api.fastAvailability("gpt-5.6-sol");
+api.setModelCatalog({{
+  status: "ok",
+  model: "gpt-5.6-sol",
+  default_model: "gpt-5.6-sol",
+  models: ["gpt-5.6-sol"],
+  modelMetadata: {{
+    "gpt-5.6-sol": {{
+      displayName: "GPT-5.6-Sol",
+      description: "Latest frontier agentic coding model.",
+      defaultReasoningEffort: "low",
+      supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"].map((reasoningEffort) => ({{ reasoningEffort }})),
+    }},
+  }},
+}});
+const solDescriptor = api.modelDescriptor("gpt-5.6-sol");
+const singletonDispatcher = {{ dispatchMessage() {{}}, subscribe() {{}} }};
+const dispatcherFromSingleton = api.dispatcherFromModule({{ current: singletonDispatcher }}) === singletonDispatcher;
+class DispatcherClass {{
+  static instance = new DispatcherClass();
+  static getInstance() {{ return this.instance; }}
+  dispatchMessage() {{}}
+}}
+const dispatcherFromClass = api.dispatcherFromModule({{ current: DispatcherClass }}) === DispatcherClass.instance;
+
 process.stdout.write(JSON.stringify({{
   supportedFast,
   unsupportedModel,
@@ -830,6 +890,10 @@ process.stdout.write(JSON.stringify({{
   turnWithoutModelDiagnosticModel,
   customInheritUnsupported,
   startConversation,
+  solFastAvailability,
+  solDescriptor,
+  dispatcherFromSingleton,
+  dispatcherFromClass,
 }}));
 "#,
         script_path = serde_json::to_string(&script_path.to_string_lossy().to_string())

--- a/crates/codex-plus-core/tests/model_catalog.rs
+++ b/crates/codex-plus-core/tests/model_catalog.rs
@@ -136,7 +136,8 @@ async fn model_catalog_uses_active_relay_profile_model_list_for_display() {
                     base_url: "https://example.test/v1".to_string(),
                     protocol: RelayProtocol::Responses,
                     relay_mode: RelayMode::MixedApi,
-                    model_list: "deepseek-coder\nqwen3-coder\nclaude-compatible".to_string(),
+                    model_list: "deepseek-coder\nqwen3-coder\nclaude-compatible\ngpt-5.6-sol"
+                        .to_string(),
                     config_contents: "model = \"qwen3-coder\"\n".to_string(),
                     ..RelayProfile::default()
                 }],
@@ -164,7 +165,25 @@ async fn model_catalog_uses_active_relay_profile_model_list_for_display() {
     assert_eq!(result["default_model"], "qwen3-coder");
     assert_eq!(
         result["models"],
-        json!(["qwen3-coder", "deepseek-coder", "claude-compatible"])
+        json!([
+            "qwen3-coder",
+            "deepseek-coder",
+            "claude-compatible",
+            "gpt-5.6-sol"
+        ])
+    );
+    assert_eq!(
+        result["modelMetadata"]["gpt-5.6-sol"]["defaultReasoningEffort"],
+        "low"
+    );
+    assert_eq!(
+        result["modelMetadata"]["gpt-5.6-sol"]["supportedReasoningEfforts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|entry| entry["reasoningEffort"].as_str())
+            .collect::<Vec<_>>(),
+        ["low", "medium", "high", "xhigh", "max", "ultra"]
     );
     assert_eq!(result["sources"][0]["type"], "relay_profile_model_list");
 }
@@ -216,8 +235,8 @@ async fn model_catalog_merges_models_from_config_model_catalog_json() {
         json!({
             "models": [
                 {
-                    "slug": "gpt-5.6",
-                    "display_name": "GPT-5.6",
+                    "slug": "gpt-5.6-sol",
+                    "display_name": "GPT-5.6-Sol",
                     "visibility": "list",
                     "supported_in_api": true
                 }
@@ -230,7 +249,7 @@ async fn model_catalog_merges_models_from_config_model_catalog_json() {
         temp.path(),
         &format!(
             r#"
-model = "gpt-5.6"
+ model = "gpt-5.6-sol"
 model_provider = "relay"
 model_catalog_json = "{}"
 
@@ -252,8 +271,12 @@ experimental_bearer_token = "relay-key"
     .await;
 
     assert_eq!(result["status"], "ok");
-    assert_eq!(result["default_model"], "gpt-5.6");
-    assert_eq!(result["models"], json!(["qwen3-coder", "gpt-5.6"]));
+    assert_eq!(result["default_model"], "gpt-5.6-sol");
+    assert_eq!(result["models"], json!(["qwen3-coder", "gpt-5.6-sol"]));
+    assert_eq!(
+        result["modelMetadata"]["gpt-5.6-sol"]["supportedReasoningEfforts"][5]["reasoningEffort"],
+        "ultra"
+    );
     server.finish();
 }
 

--- a/crates/codex-plus-core/tests/model_suffix.rs
+++ b/crates/codex-plus-core/tests/model_suffix.rs
@@ -134,8 +134,8 @@ fn build_catalog_json_uses_runtime_compatible_gpt56_metadata() {
             .iter()
             .filter_map(|entry| entry["effort"].as_str())
             .collect::<Vec<_>>();
-        assert_eq!(model["context_window"], 372_000);
-        assert_eq!(model["max_context_window"], 372_000);
+        assert_eq!(model["context_window"], 272_000);
+        assert_eq!(model["max_context_window"], 272_000);
         assert_eq!(model["default_reasoning_level"], default_reasoning);
         assert_eq!(efforts, expected_efforts);
         assert!(!efforts.contains(&"minimal"));

--- a/crates/codex-plus-core/tests/model_suffix.rs
+++ b/crates/codex-plus-core/tests/model_suffix.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use codex_plus_core::model_suffix::{
-    build_model_catalog_json, collect_catalog_entries, parse_model_suffix,
+    build_model_catalog_json, collect_catalog_entries, model_ui_metadata, parse_model_suffix,
 };
 
 #[test]
@@ -97,6 +97,62 @@ fn build_catalog_json_uses_fallback_for_no_suffix_entries() {
     let catalog = build_model_catalog_json(&entries, Some(272_000));
     assert!(catalog.contains(r#""slug": "qwen3-coder""#));
     assert!(catalog.contains(r#""context_window": 272000"#));
+}
+
+#[test]
+fn build_catalog_json_uses_runtime_compatible_gpt56_metadata() {
+    let entries = collect_catalog_entries(
+        "gpt-5.6-sol\ngpt-5.6-terra\ngpt-5.6-luna",
+        &HashMap::new(),
+        "gpt-5.6-sol",
+    );
+    let catalog: serde_json::Value =
+        serde_json::from_str(&build_model_catalog_json(&entries, None)).unwrap();
+    let models = catalog["models"].as_array().unwrap();
+
+    for (slug, default_reasoning, expected_efforts) in [
+        (
+            "gpt-5.6-sol",
+            "low",
+            vec!["low", "medium", "high", "xhigh", "max", "ultra"],
+        ),
+        (
+            "gpt-5.6-terra",
+            "medium",
+            vec!["low", "medium", "high", "xhigh", "max", "ultra"],
+        ),
+        (
+            "gpt-5.6-luna",
+            "medium",
+            vec!["low", "medium", "high", "xhigh", "max"],
+        ),
+    ] {
+        let model = models.iter().find(|model| model["slug"] == slug).unwrap();
+        let efforts = model["supported_reasoning_levels"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|entry| entry["effort"].as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(model["context_window"], 372_000);
+        assert_eq!(model["max_context_window"], 372_000);
+        assert_eq!(model["default_reasoning_level"], default_reasoning);
+        assert_eq!(efforts, expected_efforts);
+        assert!(!efforts.contains(&"minimal"));
+        assert_eq!(model["additional_speed_tiers"], serde_json::json!(["fast"]));
+        assert_eq!(model["service_tiers"][0]["id"], "priority");
+    }
+}
+
+#[test]
+fn model_ui_metadata_exposes_fast_service_tier_capability() {
+    let metadata = model_ui_metadata("gpt-5.6-sol").expect("Sol metadata should exist");
+
+    assert_eq!(
+        metadata["additionalSpeedTiers"],
+        serde_json::json!(["fast"])
+    );
+    assert_eq!(metadata["serviceTiers"][0]["id"], "priority");
 }
 
 #[test]

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -346,6 +346,56 @@ fn apply_chat_protocol_relay_points_codex_to_local_responses_proxy() {
 }
 
 #[test]
+fn responses_profile_stays_direct_and_backfill_repairs_legacy_local_proxy() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = RelayProfile {
+        id: "custom".to_string(),
+        relay_mode: RelayMode::PureApi,
+        protocol: RelayProtocol::Responses,
+        config_contents: r#"model = "gpt-5.6-sol"
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://responses.example.test/v1"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-test-redacted"}"#.to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_to_home_with_switch_rules(temp.path(), &profile, "").unwrap();
+    let config_path = temp.path().join("config.toml");
+    let updated = std::fs::read_to_string(&config_path).unwrap();
+
+    assert!(updated.contains("https://responses.example.test/v1"));
+    assert!(!updated.contains(r#"base_url = "http://127.0.0.1:57321/v1""#));
+    assert_eq!(
+        codex_plus_core::relay_config::relay_profile_base_url(&profile),
+        "https://responses.example.test/v1"
+    );
+
+    std::fs::write(
+        &config_path,
+        updated.replace(
+            "https://responses.example.test/v1",
+            "http://127.0.0.1:57321/v1",
+        ),
+    )
+    .unwrap();
+    let mut backfilled = profile.clone();
+    let mut common = String::new();
+    backfill_relay_profile_from_home_with_common(temp.path(), &mut backfilled, &mut common)
+        .unwrap();
+    assert_eq!(
+        codex_plus_core::relay_config::relay_profile_base_url(&backfilled),
+        "https://responses.example.test/v1"
+    );
+}
+
+#[test]
 fn apply_aggregate_relay_points_codex_to_local_responses_proxy_without_snapshot() {
     let temp = tempfile::tempdir().unwrap();
     let profile = RelayProfile {
@@ -1085,6 +1135,78 @@ experimental_bearer_token = "sk-new"
             .join("relay-a.json")
             .exists()
     );
+}
+
+#[test]
+fn apply_relay_profile_preserves_live_external_model_catalog() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("config.toml"),
+        r#"model = "gpt-5.5"
+model_catalog_json = "D:/metadata/gpt56-model-catalog.json"
+"#,
+    )
+    .unwrap();
+    let profile = RelayProfile {
+        id: "relay-a".to_string(),
+        model: "gpt-5.6-sol".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model = "gpt-5.6-sol"
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example/v1"
+experimental_bearer_token = "sk-new"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        model_list: "gpt-5.6-sol\ngpt-5.6-terra\ngpt-5.6-luna".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(config.contains(r#"model_catalog_json = "D:/metadata/gpt56-model-catalog.json""#));
+    assert!(!config.contains("model-catalogs/relay-a.json"));
+    assert!(!temp.path().join("model-catalogs").exists());
+}
+
+#[test]
+fn apply_relay_profile_does_not_carry_previous_managed_model_catalog() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("config.toml"),
+        "model_catalog_json = \"model-catalogs/previous.json\"\n",
+    )
+    .unwrap();
+    let profile = RelayProfile {
+        id: "relay-a".to_string(),
+        model: "qwen3-coder".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model = "qwen3-coder"
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example/v1"
+experimental_bearer_token = "sk-new"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        model_list: "qwen3-coder".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(!config.contains("model_catalog_json"));
 }
 
 #[test]
@@ -2988,6 +3110,49 @@ experimental_bearer_token = "sk-new"
     assert!(!config.contains("model_catalog_json"));
     assert!(config.contains("model_context_window = 200000"));
     assert!(!temp.path().join("model-catalogs").exists());
+}
+
+#[test]
+fn apply_relay_profile_generates_compatible_gpt56_catalog_without_suffix() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = RelayProfile {
+        id: "relay-gpt56".to_string(),
+        model: "gpt-5.6-sol".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model = "gpt-5.6-sol"
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example/v1"
+experimental_bearer_token = "sk-new"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        model_list: "gpt-5.6-sol\ngpt-5.6-terra\ngpt-5.6-luna".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(config.contains(r#"model_catalog_json = "model-catalogs/relay-gpt56.json""#));
+    let catalog: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(temp.path().join("model-catalogs").join("relay-gpt56.json"))
+            .unwrap(),
+    )
+    .unwrap();
+    let sol = catalog["models"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|model| model["slug"] == "gpt-5.6-sol")
+        .unwrap();
+    assert_eq!(sol["context_window"], 372_000);
+    assert_eq!(sol["default_reasoning_level"], "low");
+    assert_eq!(sol["service_tiers"][0]["id"], "priority");
 }
 
 #[test]

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -3150,7 +3150,7 @@ experimental_bearer_token = "sk-new"
         .iter()
         .find(|model| model["slug"] == "gpt-5.6-sol")
         .unwrap();
-    assert_eq!(sol["context_window"], 372_000);
+    assert_eq!(sol["context_window"], 272_000);
     assert_eq!(sol["default_reasoning_level"], "low");
     assert_eq!(sol["service_tiers"][0]["id"], "priority");
 }


### PR DESCRIPTION
> [!IMPORTANT]
> **2026-07-13 官方上下文回滚提醒**
>
> 官方于 2026-07-13 宣布：GPT-5.6 Sol 的上下文上限已从 372K **临时回滚至 272K**，并计划在后续数日重新开放 372K。为避免 Codex++ 在服务端实际上限仍为 272K 时错误声明 372K、延迟压缩并造成上下文超限，本 PR 已同步撤回 372K 元数据，当前三款 GPT-5.6 兼容目录均保守使用 272K。模型识别、推理档位和 Fast 兼容修复不受影响；待官方确认恢复后再单独跟进。
>
> **Official context rollback notice (2026-07-13)**
>
> OpenAI announced on 2026-07-13 that GPT-5.6 Sol's context limit was **temporarily rolled back from 372K to 272K**, with 372K planned to return in the following days. To avoid advertising a window larger than the active server limit, delaying compaction, and causing context-limit failures, this PR now withdraws its 372K metadata and conservatively reports 272K for all three GPT-5.6 compatibility entries. Model recognition, reasoning-effort, and Fast compatibility fixes remain unchanged; 372K can be revisited after the official rollout is confirmed.

## 中文说明

### 摘要

本 PR 独立完善 GPT-5.6 Sol / Terra / Luna 在 Codex++ 启动链中的模型元数据、推理档位、当前 272K 上下文与 Fast 能力兼容。

本 PR 不再提供自定义 Max 按钮或请求覆盖。Codex App 已通过“设置 → 配置 → 模型功能 → 可用推理强度”开放原生 `max`；在 API Key / 第三方 Responses 场景中，已真人验证选择“最高”后，新会话第一条请求会直接以 `reasoning.effort=max` 到达 NewAPI。

### 为什么仍需要这个 PR

官方原生 Max 解决了推理请求本身，但没有解决第三方供应商经 Codex++ 启动时的模型目录兼容问题：

- 直接启动 Codex App 时，既有 GPT-5.6 会话可能显示为“自定义模型”，但原生推理档位完整。
- 经 Codex++ 启动时，Sol / Terra / Luna 能显示为独立模型；如果只注入简化目录，App 会把它们降级为通用自定义模型元数据，导致推理档位减少、上下文信息不完整，Fast 能力也可能被误判为不支持。
- 新版 Codex 已整合进 ChatGPT Desktop，dispatcher 的导出位置和形态会变化；继续依赖固定导出名会造成 Fast 请求补丁偶发找不到后端 dispatcher。

因此本 PR 只补齐 Codex++ 仍需负责的“模型目录与启动链兼容”，不与官方已经可用的 Max 功能竞争。

### 实现内容

- 提供 GPT-5.6 Sol / Terra / Luna 的运行时兼容元数据、默认推理档位和当前官方 272K 上下文。
- 保留官方逐模型能力：Sol / Terra 支持至 `ultra`，Luna 支持至 `max`。
- 为三款 GPT-5.6 模型声明 Fast / `priority` service tier 能力。
- renderer 创建或修补模型描述符时使用后端可信元数据，不再回退成固定四档通用描述符。
- 同时兼容 `setting-storage-*` 与 `vscode-api-*` 中的 dispatcher，并支持 singleton 和 class 两种导出形态。
- 保护供应商显式配置的外部 `model_catalog_json`，不会因为检测到 GPT-5.6 就覆盖用户文件。
- 保留无后缀 `gpt-5.6` 等未知模型名，不擅自猜测为 Sol / Terra / Luna。

### 原生推理档位说明

当前中文界面存在两个“极高”，内部值并不相同：

- `高` → `high`
- 第一个 `极高` → `xhigh`
- `最高` → `max`
- 带“更快消耗使用额度”的第二个 `极高` → `ultra`

Fast 与上述推理档位相互独立，其请求值为 `service_tier=priority`。

### 已移除的实验性 Max 补丁

早期版本曾为了绕过 App 隐藏的 Max gate，加入按会话按钮、renderer 状态、helper route、运行时 localhost provider 包装和最终 Responses 改写。官方原生链路经实测可正确发送 `max` 后，这些代码已全部从本 PR 删除，避免双重入口、状态冲突和不必要的本地代理复杂度。

### 验证

- `node --check assets/inject/renderer-inject.js`
- `npm run check`
- `cargo fmt --all -- --check`
- Windows watcher 识别正式 `OpenAI.ChatGPT-Desktop_*` 包；watcher 17/17、core 全套通过。
- Windows 广告 fallback mock 读取完整请求头并显式关闭连接，避免 loopback RST/abort；目标测试连续 10 次通过。
- `cargo test -q -p codex-plus-core --test cdp_bridge -j 2`：69 passed
- `cargo test -q -p codex-plus-core --test model_catalog --test model_suffix --test relay_config -j 2`：7 + 14 + 99 passed
- 契约测试明确验证三款 GPT-5.6 的 Fast 白名单、Sol 的 `max/ultra` 描述符、新旧 dispatcher 导出，以及自定义 Max 控件和设置字段不存在。
- 真人验证：关闭 Codex++ 自定义 Max 覆盖后，选择官方“最高”创建新会话，第一条 API Key / Responses 请求在 NewAPI 后台显示为 `max`。

## English

### Summary

This PR independently completes model metadata, reasoning-level, current 272K context-window, and Fast capability compatibility for GPT-5.6 Sol, Terra, and Luna in the Codex++ launch path.

It no longer provides a custom Max control or request override. Codex App now exposes native `max` through Settings → Configuration → Model features → Available reasoning strengths. Human validation with an API-key/third-party Responses provider confirmed that selecting native **Max** sends `reasoning.effort=max` on the first request of a fresh thread.

### Why this PR is still needed

Native Max fixes the reasoning request itself, but it does not solve model-catalog compatibility when third-party providers are launched through Codex++:

- When Codex App is launched directly, an existing GPT-5.6 thread may appear as a custom model while retaining the complete native effort list.
- Through Codex++, Sol, Terra, and Luna can be exposed as separate models. A reduced injected catalog can still downgrade them to generic custom-model metadata, reducing visible efforts, losing context information, and incorrectly marking Fast as unsupported.
- Recent Codex builds are integrated into ChatGPT Desktop. Dispatcher exports can move and change shape, so relying on one fixed export causes intermittent Fast request-patch failures.

This PR therefore keeps only the model-catalog and launch-path compatibility that Codex++ still owns, without competing with the now-working native Max feature.

### Implementation

- Adds runtime-compatible metadata, default reasoning efforts, and the current official 272K context window for GPT-5.6 Sol, Terra, and Luna.
- Preserves official per-model capabilities: Sol and Terra support through `ultra`; Luna supports through `max`.
- Declares Fast / `priority` service-tier capability for all three models.
- Uses trusted backend metadata when renderer model descriptors are created or repaired instead of falling back to a fixed four-effort generic descriptor.
- Discovers dispatchers from both `setting-storage-*` and `vscode-api-*`, supporting singleton and class export shapes.
- Preserves explicitly configured external `model_catalog_json` files instead of overwriting user-owned catalogs merely because they contain GPT-5.6.
- Preserves unknown names such as unsuffixed `gpt-5.6` instead of guessing a Sol/Terra/Luna mapping.

### Native reasoning labels

The current Chinese locale uses the same visible label for two different effort values:

- `High` → `high`
- first `Extra High` → `xhigh`
- `Max` → `max`
- final `Extra High` with the usage warning → `ultra`

Fast is independent from reasoning effort and uses `service_tier=priority`.

### Retired experimental Max patch

An earlier revision added a per-thread control, renderer state, helper route, runtime localhost provider wrapper, and final Responses rewrite to bypass the App's hidden Max gate. Once the native path was verified to send `max` correctly, all of that code was removed from this PR to avoid duplicate controls, conflicting state, and unnecessary local-proxy complexity.

### Validation

- `node --check assets/inject/renderer-inject.js`
- `npm run check`
- `cargo fmt --all -- --check`
- The Windows watcher recognizes official `OpenAI.ChatGPT-Desktop_*` packages; watcher passed 17/17 and the full core suite passed.
- The Windows ad-fallback mock reads complete request headers and closes connections explicitly, avoiding loopback RST/abort; the targeted test passed 10 consecutive runs.
- `cargo test -q -p codex-plus-core --test cdp_bridge -j 2`: 69 passed
- `cargo test -q -p codex-plus-core --test model_catalog --test model_suffix --test relay_config -j 2`: 7 + 14 + 99 passed
- Contract coverage verifies the GPT-5.6 Fast allowlist, Sol `max/ultra` descriptors, old and new dispatcher export shapes, and the absence of the custom Max control and setting.
- Human validation: with the Codex++ custom Max override disabled, selecting native Max for a fresh thread produced `max` in NewAPI on the first API-key/Responses request.
