### PR TITLE
feat: pre-compute model catalog for all configured models

### DIFF
--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -366,6 +366,7 @@ pub fn apply_relay_profile_files_to_home_with_context(
         &profile.auto_compact_limit,
     )?;
     let config_with_catalog = apply_model_catalog_to_config(home, profile, &config_with_limits)?;
+    let config_with_catalog = ensure_full_model_catalog(home, &config_with_catalog, profile)?;
     apply_relay_files_to_home(home, &config_with_catalog, &profile.auth_contents)
 }
 
@@ -403,6 +404,7 @@ pub fn apply_relay_profile_to_home_with_switch_rules_and_computer_use_guard(
         &profile.auto_compact_limit,
     )?;
     let config_with_catalog = apply_model_catalog_to_config(home, profile, &config_with_limits)?;
+    let config_with_catalog = ensure_full_model_catalog(home, &config_with_catalog, profile)?;
 
     if profile.relay_mode == crate::settings::RelayMode::PureApi {
         apply_relay_files_to_home_with_computer_use_guard(
@@ -440,6 +442,7 @@ pub fn apply_relay_profile_config_to_home_with_context(
         &profile.auto_compact_limit,
     )?;
     let config_with_catalog = apply_model_catalog_to_config(home, profile, &config_with_limits)?;
+    let config_with_catalog = ensure_full_model_catalog(home, &config_with_catalog, profile)?;
     apply_relay_config_file_to_home(home, &config_with_catalog)
 }
 
@@ -1487,6 +1490,51 @@ fn sanitize_catalog_filename(id: &str) -> String {
             }
         })
         .collect()
+}
+
+/// Generate a full model catalog from profile.model_list for ALL models,
+/// regardless of whether they have context window suffixes.
+/// This follows the cc-switch pattern: pre-compute model_catalog_json so
+/// Codex can read models without waiting for an app-server RPC round-trip.
+///
+/// No-ops when:
+/// - model_catalog_json is already set by apply_model_catalog_to_config
+/// - model_list is empty
+fn ensure_full_model_catalog(
+    home: &Path,
+    config_text: &str,
+    profile: &RelayProfile,
+) -> anyhow::Result<String> {
+    let mut doc = parse_toml_document(config_text)?;
+    if doc.contains_key("model_catalog_json") {
+        return Ok(config_text.to_string());
+    }
+
+    let model_windows: std::collections::HashMap<String, String> =
+        serde_json::from_str(&profile.model_windows).unwrap_or_default();
+    let entries = crate::model_suffix::collect_catalog_entries(
+        &profile.model_list,
+        &model_windows,
+        &profile.model,
+    );
+
+    if entries.is_empty() {
+        return Ok(config_text.to_string());
+    }
+
+    let fallback = parse_optional_positive_u64(&profile.context_window, "上下文大小")?;
+    let catalog_relative = format!(
+        "model-catalogs/{}.json",
+        sanitize_catalog_filename(&profile.id)
+    );
+    let catalog_path = home.join(&catalog_relative);
+    if let Some(parent) = catalog_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let catalog_json = crate::model_suffix::build_model_catalog_json(&entries, fallback);
+    std::fs::write(&catalog_path, catalog_json)?;
+    doc["model_catalog_json"] = toml_edit::value(catalog_relative);
+    Ok(normalize_optional_toml(doc))
 }
 
 fn sync_context_limits_from_config(profile: &mut RelayProfile, config_text: &str) {

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -1015,7 +1015,7 @@ enabled = true
 }
 
 #[test]
-fn apply_relay_profile_does_not_write_model_catalog_json_for_selected_models() {
+fn apply_relay_profile_writes_model_catalog_json_for_selected_models() {
     let temp = tempfile::tempdir().unwrap();
     let profile = RelayProfile {
         id: "relay-a".to_string(),
@@ -1044,10 +1044,10 @@ experimental_bearer_token = "sk-new"
     apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
 
     let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
-    assert!(!config.contains("model_catalog_json"));
+    assert!(config.contains("model_catalog_json"));
     assert!(config.contains("model_context_window = 200000"));
     assert!(config.contains("model_auto_compact_token_limit = 160000"));
-    assert!(!temp.path().join("model-catalogs").exists());
+    assert!(temp.path().join("model-catalogs").exists());
 }
 
 #[test]
@@ -2956,7 +2956,7 @@ experimental_bearer_token = "sk-new"
 }
 
 #[test]
-fn apply_relay_profile_no_catalog_when_model_list_has_no_suffix() {
+fn apply_relay_profile_generates_catalog_for_models_without_suffix() {
     let temp = tempfile::tempdir().unwrap();
     let profile = RelayProfile {
         id: "relay-a".to_string(),
@@ -2985,9 +2985,14 @@ experimental_bearer_token = "sk-new"
     apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
 
     let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
-    assert!(!config.contains("model_catalog_json"));
+    assert!(config.contains("model_catalog_json"));
     assert!(config.contains("model_context_window = 200000"));
-    assert!(!temp.path().join("model-catalogs").exists());
+    assert!(temp.path().join("model-catalogs").exists());
+    let catalog_path = temp.path().join("model-catalogs/relay-a.json");
+    assert!(catalog_path.exists());
+    let catalog = std::fs::read_to_string(&catalog_path).unwrap();
+    assert!(catalog.contains("deepseek-coder"));
+    assert!(catalog.contains("qwen3-coder"));
 }
 
 #[test]

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -3319,3 +3319,319 @@ experimental_bearer_token = "sk-new"
     );
     assert!(!windows.contains_key("deepseek-v4-pro"));
 }
+
+// === Adversarial tests for ensure_full_model_catalog ===
+
+#[test]
+fn full_catalog_skips_when_model_list_and_model_are_empty() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = RelayProfile {
+        id: "relay-empty".to_string(),
+        name: "Empty".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example/v1"
+experimental_bearer_token = "sk-new"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(!config.contains("model_catalog_json"));
+    assert!(!temp.path().join("model-catalogs").exists());
+}
+
+#[test]
+fn full_catalog_strips_model_list_suffixes_in_catalog() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = RelayProfile {
+        id: "relay-suffix".to_string(),
+        name: "Suffix".to_string(),
+        model: "deepseek-v4-pro".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model = "deepseek-v4-pro"
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example/v1"
+experimental_bearer_token = "sk-new"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        model_list: "deepseek-v4-pro[1M]\nclaude-sonnet-4[200K]\nqwen3-coder".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(config.contains("model_catalog_json"));
+    let catalog = std::fs::read_to_string(
+        temp.path().join("model-catalogs/relay-suffix.json"),
+    )
+    .unwrap();
+    // Suffixes stripped from catalog output
+    assert!(!catalog.contains("[1M]"));
+    assert!(!catalog.contains("[200K]"));
+    // All models present in catalog
+    assert!(catalog.contains("deepseek-v4-pro"));
+    assert!(catalog.contains("claude-sonnet-4"));
+    assert!(catalog.contains("qwen3-coder"));
+    // Suffix-derived context windows respected
+    assert!(catalog.contains("1000000"));
+    assert!(catalog.contains("200000"));
+}
+
+#[test]
+fn full_catalog_preserves_user_defined_model_catalog_json() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = RelayProfile {
+        id: "relay-user-catalog".to_string(),
+        name: "User Catalog".to_string(),
+        model: "deepseek-v4-pro".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model = "deepseek-v4-pro"
+model_catalog_json = "/custom/path/catalog.json"
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example/v1"
+experimental_bearer_token = "sk-new"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        model_list: "deepseek-v4-pro\nqwen3-coder".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    // Preserves user's own catalog path
+    assert!(config.contains(r#"model_catalog_json = "/custom/path/catalog.json""#));
+}
+
+#[test]
+fn full_catalog_skips_when_suffix_catalog_already_set() {
+    let temp = tempfile::tempdir().unwrap();
+    // apply_model_catalog_to_config generates catalog for suffixed models
+    // ensure_full_model_catalog should skip because catalog is already set
+    let profile = RelayProfile {
+        id: "relay-hybrid".to_string(),
+        name: "Hybrid".to_string(),
+        model: "deepseek-v4-pro".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model = "deepseek-v4-pro"
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example/v1"
+experimental_bearer_token = "sk-new"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        // Has suffix models → apply_model_catalog_to_config generates catalog
+        model_list: "deepseek-v4-pro[1M]\nqwen3-coder".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(config.contains("model_catalog_json"));
+    // Only one catalog file written (not duplicated by ensure_full_model_catalog)
+    let catalog_entries: Vec<_> = std::fs::read_dir(temp.path().join("model-catalogs"))
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .collect();
+    assert_eq!(catalog_entries.len(), 1);
+}
+
+#[test]
+fn full_catalog_handles_model_list_with_only_whitespace() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = RelayProfile {
+        id: "relay-space".to_string(),
+        name: "Space".to_string(),
+        model: "qwen3-coder".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model = "qwen3-coder"
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example/v1"
+experimental_bearer_token = "sk-new"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        model_list: "  \n  \n  ".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    // Whitespace-only model_list → only current model "qwen3-coder" gets catalog entry
+    assert!(config.contains("model_catalog_json"));
+    let catalog = std::fs::read_to_string(temp.path().join("model-catalogs/relay-space.json")).unwrap();
+    assert!(catalog.contains("qwen3-coder"));
+}
+
+#[test]
+fn full_catalog_deduplicates_model_names() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = RelayProfile {
+        id: "relay-dup".to_string(),
+        name: "Dup".to_string(),
+        model: "qwen3-coder".to_string(), // also in model_list
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model = "qwen3-coder"
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example/v1"
+experimental_bearer_token = "sk-new"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        model_list: "qwen3-coder\ndeepseek-v4-pro\nqwen3-coder".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(config.contains("model_catalog_json"));
+    let catalog = std::fs::read_to_string(
+        temp.path().join("model-catalogs/relay-dup.json"),
+    )
+    .unwrap();
+    // qwen3-coder slug appears exactly once (deduplicated by collect_catalog_entries)
+    let slug_count = catalog.matches("\"slug\": \"qwen3-coder\"").count();
+    assert_eq!(slug_count, 1, "qwen3-coder slug appears {} times, expected 1", slug_count);
+}
+
+#[test]
+fn full_catalog_respects_model_windows_for_context_window() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = RelayProfile {
+        id: "relay-windows".to_string(),
+        name: "Windows".to_string(),
+        model: "deepseek-v4-pro".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model = "deepseek-v4-pro"
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example/v1"
+experimental_bearer_token = "sk-new"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        model_list: "deepseek-v4-pro\nkimi-k2.6".to_string(),
+        model_windows: r#"{"kimi-k2.6":"262000"}"#.to_string(),
+        context_window: "1000000".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+    let catalog = std::fs::read_to_string(
+        temp.path().join("model-catalogs/relay-windows.json"),
+    )
+    .unwrap();
+    // kimi-k2.6 gets its explicit window from model_windows
+    assert!(catalog.contains("262000"));
+    // deepseek-v4-pro gets the fallback context_window
+    assert!(catalog.contains("1000000"));
+}
+
+#[test]
+fn full_catalog_handles_model_list_with_commas() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = RelayProfile {
+        id: "relay-comma".to_string(),
+        name: "Comma".to_string(),
+        model: "gpt-5".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model = "gpt-5"
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example/v1"
+experimental_bearer_token = "sk-new"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        model_list: "gpt-5,gpt-5-mini,claude-sonnet-4".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+    let catalog = std::fs::read_to_string(
+        temp.path().join("model-catalogs/relay-comma.json"),
+    )
+    .unwrap();
+    assert!(catalog.contains("gpt-5"));
+    assert!(catalog.contains("gpt-5-mini"));
+    assert!(catalog.contains("claude-sonnet-4"));
+}
+
+#[test]
+fn full_catalog_keeps_current_model_first_in_catalog() {
+    // collect_catalog_entries puts current model first, ensure_full_model_catalog uses it
+    let temp = tempfile::tempdir().unwrap();
+    let profile = RelayProfile {
+        id: "relay-order".to_string(),
+        name: "Order".to_string(),
+        model: "zulu-model".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model = "zulu-model"
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example/v1"
+experimental_bearer_token = "sk-new"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        model_list: "alpha-model\nzulu-model\nbeta-model".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+    let catalog = std::fs::read_to_string(
+        temp.path().join("model-catalogs/relay-order.json"),
+    )
+    .unwrap();
+    // zulu-model (current model) should come before alpha-model in the JSON array
+    let zulu_pos = catalog.find("\"zulu-model\"").unwrap();
+    let alpha_pos = catalog.find("\"alpha-model\"").unwrap();
+    assert!(zulu_pos < alpha_pos, "current model should appear first in catalog");
+}


### PR DESCRIPTION
## What

Following the cc-switch pattern: pre-compute `model_catalog.json` for ALL models in `profile.model_list`, not just those with context window suffixes like `[1M]`.

## Why

Currently `apply_model_catalog_to_config()` only generates a catalog when at least one model has a suffix (`deepseek-v4-pro[1M]`). Most users don't use suffixes — the catalog is never generated, and Codex falls back to the slow `list-models-for-host` RPC on every startup.

## How

New function `ensure_full_model_catalog()`:

- Parses all models from `model_list` (comma/newline separated, with or without suffixes)
- Reuses existing `collect_catalog_entries()` and `build_model_catalog_json()`
- Writes `model-catalogs/{profile_id}.json`
- Sets `model_catalog_json` in `config.toml`

**No-op when:** catalog already set (by suffix engine or user), or model_list is empty.

**Relationship to #1261:** complementary — this pre-computes the full catalog; #1261 adds per-model `context_window` values to it.

## Test Coverage (9 adversarial tests)

| Test | Edge Case |
|------|-----------|
| `skips_when_model_list_and_model_are_empty` | Empty inputs → no-op |
| `strips_model_list_suffixes_in_catalog` | `[1M]` suffixes stripped, windows respected |
| `preserves_user_defined_model_catalog_json` | User's custom path never overwritten |
| `skips_when_suffix_catalog_already_set` | No duplicate catalog files |
| `handles_model_list_with_only_whitespace` | Whitespace → only current model |
| `deduplicates_model_names` | Duplicate model names → single entry |
| `respects_model_windows_for_context_window` | Per-model windows from `model_windows` JSON |
| `handles_model_list_with_commas` | Comma-separated model_list |
| `keeps_current_model_first_in_catalog` | `profile.model` always first entry |

All 102 relay_config tests pass.
