### PR TITLE
fix: repair Windows portable launch and manager activation

### DIFF
--- a/apps/codex-plus-manager/src-tauri/src/lib.rs
+++ b/apps/codex-plus-manager/src-tauri/src/lib.rs
@@ -232,6 +232,28 @@ fn show_main_window<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>) {
     }
 }
 
+/// Restores and focuses an existing manager window on Windows.
+///
+/// This is a no-op on other platforms.
+pub fn focus_existing_manager_window() {
+    #[cfg(windows)]
+    {
+        let current_process_id = std::process::id();
+        for process in codex_plus_core::windows_enumerate_processes() {
+            if process.process_id == current_process_id {
+                continue;
+            }
+            if process
+                .exe_file
+                .eq_ignore_ascii_case("codex-plus-plus-manager.exe")
+            {
+                let _ = codex_plus_core::windows_activate_process_window(process.process_id);
+                break;
+            }
+        }
+    }
+}
+
 fn install_panic_logger() {
     std::panic::set_hook(Box::new(|panic_info| {
         let payload = panic_info
@@ -273,22 +295,19 @@ fn acquire_single_instance_guard() -> Option<codex_plus_core::ports::LoopbackPor
             }
             Some(guard)
         }
-        Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::AddrInUse | std::io::ErrorKind::WouldBlock
+            ) =>
+        {
             let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
                 "manager.already_running",
                 serde_json::json!({
                     "guard_port": codex_plus_core::ports::manager_guard_port()
                 }),
             );
-            None
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-            let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
-                "manager.already_running",
-                serde_json::json!({
-                    "guard_port": codex_plus_core::ports::manager_guard_port()
-                }),
-            );
+            focus_existing_manager_window();
             None
         }
         Err(error) => {

--- a/apps/codex-plus-manager/src-tauri/src/main.rs
+++ b/apps/codex-plus-manager/src-tauri/src/main.rs
@@ -12,7 +12,7 @@ fn main() {
                             "baseUrl": request.base_url
                         }),
                     );
-                    focus_existing_manager_window();
+                    codex_plus_manager_lib::focus_existing_manager_window();
                 }
                 Err(error) => {
                     let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
@@ -32,23 +32,3 @@ fn main() {
     }
     codex_plus_manager_lib::run();
 }
-
-#[cfg(windows)]
-fn focus_existing_manager_window() {
-    let current_process_id = std::process::id();
-    for process in codex_plus_core::windows_enumerate_processes() {
-        if process.process_id == current_process_id {
-            continue;
-        }
-        if process
-            .exe_file
-            .eq_ignore_ascii_case("codex-plus-plus-manager.exe")
-        {
-            let _ = codex_plus_core::windows_activate_process_window(process.process_id);
-            break;
-        }
-    }
-}
-
-#[cfg(not(windows))]
-fn focus_existing_manager_window() {}

--- a/apps/codex-plus-manager/src-tauri/tests/windows_subsystem.rs
+++ b/apps/codex-plus-manager/src-tauri/tests/windows_subsystem.rs
@@ -32,6 +32,15 @@ fn manager_uses_single_instance_guard_before_starting_tauri() {
 }
 
 #[test]
+fn manager_repeated_launch_activates_existing_window() {
+    let lib_rs = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/lib.rs"))
+        .expect("read manager lib.rs");
+
+    assert!(lib_rs.contains("focus_existing_manager_window();"));
+    assert!(lib_rs.contains("windows_activate_process_window"));
+}
+
+#[test]
 fn manager_main_window_uses_default_window_icon_explicitly() {
     let lib_rs = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/lib.rs"))
         .expect("read manager lib.rs");

--- a/crates/codex-plus-core/src/app_paths.rs
+++ b/crates/codex-plus-core/src/app_paths.rs
@@ -12,7 +12,7 @@ struct AppPackageSpec {
 }
 
 const CODEX_PACKAGE_EXECUTABLES: &[&str] = &["ChatGPT.exe", "Codex.exe", "codex.exe"];
-const STANDALONE_CODEX_EXECUTABLES: &[&str] = &["Codex.exe", "ChatGPT.exe", "codex.exe"];
+const STANDALONE_CODEX_EXECUTABLES: &[&str] = &["ChatGPT.exe", "Codex.exe", "codex.exe"];
 
 const APP_PACKAGE_SPECS: &[AppPackageSpec] = &[
     AppPackageSpec {
@@ -280,6 +280,10 @@ pub fn codex_app_version(app_dir: &Path) -> Option<String> {
         app_dir
     };
     codex_package_version(package_dir)
+        .or_else(|| codex_directory_version(package_dir))
+        .or_else(|| codex_directory_version(app_dir))
+        .or_else(|| codex_version_file(package_dir))
+        .or_else(|| codex_version_file(app_dir))
 }
 
 pub fn packaged_app_user_model_id(app_dir: &Path) -> Option<String> {
@@ -308,6 +312,52 @@ fn codex_package_version(package_dir: &Path) -> Option<String> {
         .rev()
         .find(|part| codex_package_parts(part).is_some())?;
     let (_, version, _) = codex_package_parts(name)?;
+    if version.is_empty() {
+        None
+    } else {
+        Some(version.to_string())
+    }
+}
+
+fn codex_directory_version(app_dir: &Path) -> Option<String> {
+    directory_version(app_dir).or_else(|| {
+        app_dir
+            .canonicalize()
+            .ok()
+            .and_then(|path| directory_version(&path))
+    })
+}
+
+fn directory_version(path: &Path) -> Option<String> {
+    let version = path.file_name()?.to_str()?;
+    if is_version_like(version) {
+        Some(version.to_string())
+    } else {
+        None
+    }
+}
+
+fn is_version_like(version: &str) -> bool {
+    let mut parts = version.split('.');
+    let Some(first) = parts.next() else {
+        return false;
+    };
+    if first.is_empty() || !first.chars().all(|ch| ch.is_ascii_digit()) {
+        return false;
+    }
+    let mut count = 1;
+    for part in parts {
+        if part.is_empty() || !part.chars().all(|ch| ch.is_ascii_digit()) {
+            return false;
+        }
+        count += 1;
+    }
+    count >= 2
+}
+
+fn codex_version_file(app_dir: &Path) -> Option<String> {
+    let version = std::fs::read_to_string(app_dir.join("version")).ok()?;
+    let version = version.trim();
     if version.is_empty() {
         None
     } else {

--- a/crates/codex-plus-core/src/windows_integration.rs
+++ b/crates/codex-plus-core/src/windows_integration.rs
@@ -44,8 +44,9 @@ use windows::Win32::UI::Shell::{
 use windows::Win32::UI::WindowsAndMessaging::SW_SHOWMINNOACTIVE;
 #[cfg(windows)]
 use windows::Win32::UI::WindowsAndMessaging::{
-    EnumWindows, GetWindowThreadProcessId, IsIconic, IsWindowVisible, SW_RESTORE,
-    SetForegroundWindow, ShowWindow,
+    EnumWindows, GWL_EXSTYLE, GetClassNameW, GetWindowLongPtrW, GetWindowTextLengthW,
+    GetWindowThreadProcessId, IsIconic, IsWindowVisible, SW_RESTORE, SW_SHOW, SetForegroundWindow,
+    ShowWindow, WS_EX_APPWINDOW, WS_EX_TOOLWINDOW,
 };
 #[cfg(windows)]
 use windows::Win32::UI::WindowsAndMessaging::{
@@ -346,24 +347,16 @@ pub fn terminate_process(process_id: u32) -> bool {
 
 #[cfg(windows)]
 pub fn activate_process_window(process_id: u32) -> bool {
-    let mut state = ActivateWindowState {
-        process_id,
-        hwnd: HWND::default(),
+    let Some(hwnd) = process_window(process_id, false) else {
+        return false;
     };
     unsafe {
-        let _ = EnumWindows(
-            Some(find_process_window_proc),
-            LPARAM((&mut state as *mut ActivateWindowState) as isize),
-        );
-    }
-    if state.hwnd.is_invalid() {
-        return false;
-    }
-    unsafe {
-        if IsIconic(state.hwnd).as_bool() {
-            let _ = ShowWindow(state.hwnd, SW_RESTORE);
+        if IsIconic(hwnd).as_bool() {
+            let _ = ShowWindow(hwnd, SW_RESTORE);
+        } else if !IsWindowVisible(hwnd).as_bool() {
+            let _ = ShowWindow(hwnd, SW_SHOW);
         }
-        SetForegroundWindow(state.hwnd).as_bool()
+        SetForegroundWindow(hwnd).as_bool()
     }
 }
 
@@ -408,9 +401,16 @@ fn query_process_image_path(process_id: u32) -> Option<PathBuf> {
 
 #[cfg(windows)]
 fn visible_window_for_process(process_id: u32) -> Option<HWND> {
+    process_window(process_id, true)
+}
+
+#[cfg(windows)]
+fn process_window(process_id: u32, visible_only: bool) -> Option<HWND> {
     let mut state = ActivateWindowState {
         process_id,
         hwnd: HWND::default(),
+        visible_only,
+        score: ProcessWindowScore::None,
     };
     unsafe {
         let _ = EnumWindows(
@@ -429,12 +429,24 @@ fn visible_window_for_process(process_id: u32) -> Option<HWND> {
 struct ActivateWindowState {
     process_id: u32,
     hwnd: HWND,
+    visible_only: bool,
+    score: ProcessWindowScore,
+}
+
+#[cfg(windows)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum ProcessWindowScore {
+    None,
+    Fallback,
+    Titled,
+    AppWindow,
+    TauriWindow,
 }
 
 #[cfg(windows)]
 unsafe extern "system" fn find_process_window_proc(hwnd: HWND, lparam: LPARAM) -> BOOL {
     let state = unsafe { &mut *(lparam.0 as *mut ActivateWindowState) };
-    if !unsafe { IsWindowVisible(hwnd) }.as_bool() {
+    if state.visible_only && !unsafe { IsWindowVisible(hwnd) }.as_bool() {
         return BOOL(1);
     }
     let mut window_process_id = 0;
@@ -442,10 +454,50 @@ unsafe extern "system" fn find_process_window_proc(hwnd: HWND, lparam: LPARAM) -
         GetWindowThreadProcessId(hwnd, Some(&mut window_process_id));
     }
     if window_process_id == state.process_id {
-        state.hwnd = hwnd;
-        return BOOL(0);
+        let title_length = unsafe { GetWindowTextLengthW(hwnd) };
+        let extended_style = unsafe { GetWindowLongPtrW(hwnd, GWL_EXSTYLE) } as u32;
+        let mut class_name = [0u16; 256];
+        let class_name_length = unsafe { GetClassNameW(hwnd, &mut class_name) }.max(0) as usize;
+        let class_name = String::from_utf16_lossy(&class_name[..class_name_length]);
+        let score = process_window_score(title_length > 0, extended_style, &class_name);
+        if score > state.score {
+            state.hwnd = hwnd;
+            state.score = score;
+        }
+        if score == ProcessWindowScore::TauriWindow {
+            return BOOL(0);
+        }
     }
     BOOL(1)
+}
+
+#[cfg(windows)]
+fn process_window_score(
+    has_title: bool,
+    extended_style: u32,
+    class_name: &str,
+) -> ProcessWindowScore {
+    let is_app_window = extended_style & WS_EX_APPWINDOW.0 != 0;
+    let is_tool_window = extended_style & WS_EX_TOOLWINDOW.0 != 0;
+    if is_tool_window || is_auxiliary_window_class(class_name) {
+        ProcessWindowScore::Fallback
+    } else if class_name.eq_ignore_ascii_case("Tauri Window") {
+        ProcessWindowScore::TauriWindow
+    } else if is_app_window && !is_tool_window {
+        ProcessWindowScore::AppWindow
+    } else if has_title {
+        ProcessWindowScore::Titled
+    } else {
+        ProcessWindowScore::Fallback
+    }
+}
+
+#[cfg(windows)]
+fn is_auxiliary_window_class(class_name: &str) -> bool {
+    matches!(
+        class_name.to_ascii_lowercase().as_str(),
+        "ime" | "msctfime ui" | "tray_icon_app" | "tao thread event target"
+    )
 }
 
 #[cfg(windows)]
@@ -608,5 +660,24 @@ struct RegistryKeyGuard(HKEY);
 impl Drop for RegistryKeyGuard {
     fn drop(&mut self) {
         let _ = unsafe { RegCloseKey(self.0) };
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn application_window_outranks_titled_ime_and_tool_windows() {
+        let ime_score = process_window_score(true, 0, "IME");
+        let tool_score = process_window_score(false, WS_EX_TOOLWINDOW.0, "Tao Thread Event Target");
+        let app_score = process_window_score(true, WS_EX_APPWINDOW.0, "Chrome_WidgetWin_1");
+        let tauri_score = process_window_score(true, 0, "Tauri Window");
+        let auxiliary_app_score = process_window_score(true, WS_EX_APPWINDOW.0, "tray_icon_app");
+
+        assert!(tauri_score > app_score);
+        assert!(app_score > ime_score);
+        assert_eq!(ime_score, tool_score);
+        assert_eq!(auxiliary_app_score, ProcessWindowScore::Fallback);
     }
 }

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -138,6 +138,49 @@ fn app_paths_extracts_codex_version_from_windows_package_app_dir() {
 }
 
 #[test]
+fn app_paths_extracts_codex_version_from_portable_version_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let app_dir = temp.path().join("versions").join("current");
+    std::fs::create_dir_all(&app_dir).unwrap();
+    std::fs::write(app_dir.join("Codex.exe"), "").unwrap();
+    std::fs::write(app_dir.join("version"), "42.1.0\n").unwrap();
+
+    assert_eq!(codex_app_version(&app_dir).as_deref(), Some("42.1.0"));
+}
+
+#[test]
+fn app_paths_prefers_portable_directory_version_over_internal_version_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let app_dir = temp.path().join("versions").join("26.519.2736.0");
+    std::fs::create_dir_all(&app_dir).unwrap();
+    std::fs::write(app_dir.join("Codex.exe"), "").unwrap();
+    std::fs::write(app_dir.join("version"), "42.1.0\n").unwrap();
+
+    assert_eq!(
+        codex_app_version(&app_dir).as_deref(),
+        Some("26.519.2736.0")
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn app_paths_resolves_portable_current_link_to_directory_version() {
+    let temp = tempfile::tempdir().unwrap();
+    let versions = temp.path().join("versions");
+    let target = versions.join("26.519.2736.0");
+    let current = versions.join("current");
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(target.join("Codex.exe"), "").unwrap();
+    std::fs::write(target.join("version"), "42.1.0\n").unwrap();
+    std::os::windows::fs::symlink_dir(&target, &current).unwrap();
+
+    assert_eq!(
+        codex_app_version(&current).as_deref(),
+        Some("26.519.2736.0")
+    );
+}
+
+#[test]
 fn app_paths_extracts_codex_version_from_macos_bundle_plist() {
     let temp = tempfile::tempdir().unwrap();
     let app = temp.path().join("OpenAI Codex.app");
@@ -290,6 +333,17 @@ fn app_paths_normalizes_executable_and_package_paths() {
         normalize_codex_app_path(&portable).as_deref(),
         Some(app.as_path())
     );
+}
+
+#[test]
+fn app_paths_prefers_chatgpt_entrypoint_when_portable_bundle_contains_codex_shim() {
+    let temp = tempfile::tempdir().unwrap();
+    let app = temp.path().join("current");
+    std::fs::create_dir_all(&app).unwrap();
+    std::fs::write(app.join("Codex.exe"), "").unwrap();
+    std::fs::write(app.join("ChatGPT.exe"), "").unwrap();
+
+    assert_eq!(build_codex_executable(&app), app.join("ChatGPT.exe"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- prefer `ChatGPT.exe` over the `Codex.exe` shim in standalone/portable Windows bundles
- detect portable Codex versions from numeric version directories, resolved `current` links, and `version` files
- restore and focus the existing manager window when the management shortcut is launched again
- rank the Tauri main window above tray, Tao, and IME helper windows during Windows activation

## Root cause

Recent portable Codex desktop bundles can contain both `Codex.exe` and `ChatGPT.exe`. The former behaves as a shim and does not preserve the Chromium remote-debugging arguments required by Codex++, so the helper starts while CDP remains unavailable.

The manager also returned immediately on a single-instance guard conflict without activating the existing window. When hidden to the tray, generic window enumeration could target helper or IME windows instead of the Tauri main window.

## Impact

Portable Windows installations launch the actual Codex desktop process with CDP enabled, report a meaningful version, and allow users to reopen a hidden manager through the desktop shortcut.

## Validation

- `cargo fmt --check`
- `cargo test --all-features`
- `cargo test -p codex-plus-core windows_integration::tests::application_window_outranks_titled_ime_and_tool_windows -- --exact`
- `cargo test -p codex-plus-core --test launcher app_paths` (22 passed)
- `cargo test -p codex-plus-manager --test windows_subsystem` (22 passed)
- runtime differential: `Codex.exe` did not expose CDP; `ChatGPT.exe` did
- runtime manager check: hidden window restored through the desktop shortcut while retaining one manager process

`cargo clippy --all-targets --all-features -- -D warnings` still reports 96 pre-existing warnings across the upstream baseline; no unrelated Clippy cleanup is included here.

Fixes #1481
Fixes #1187