### PR TITLE
fix: #1455 新版 App 桌宠兼容更新 / restore #1455 on newer Codex App

### DIFF
--- a/crates/codex-plus-core/src/assets.rs
+++ b/crates/codex-plus-core/src/assets.rs
@@ -24,16 +24,44 @@ pub fn pet_real_mouse_script() -> &'static str {
     PET_REAL_MOUSE_SCRIPT
 }
 
-pub fn pet_real_mouse_capability_probe_script() -> &'static str {
-    r#"
+const PET_V2_SPRITE_DETECTION_SCRIPT: &str = r#"
+  const isV2Sprite = (mascot) => {
+    if (!mascot) return false;
+    if (Array.from(mascot.querySelectorAll("img")).some((image) =>
+      image.naturalWidth === 1536 && image.naturalHeight === 2288
+    )) return true;
+    for (const element of [mascot, ...mascot.querySelectorAll("*")]) {
+      const background = getComputedStyle(element).backgroundImage || "";
+      const match = background.match(/url\(["']?data:image\/png;base64,([^"')]+)/i);
+      if (!match) continue;
+      try {
+        const header = atob(match[1].slice(0, 48));
+        if (header.length < 24) continue;
+        const uint32 = (offset) => (
+          ((header.charCodeAt(offset) << 24) >>> 0)
+          + (header.charCodeAt(offset + 1) << 16)
+          + (header.charCodeAt(offset + 2) << 8)
+          + header.charCodeAt(offset + 3)
+        );
+        if (uint32(16) === 1536 && uint32(20) === 2288) return true;
+      } catch {
+      }
+    }
+    return false;
+  };
+"#;
+
+pub fn pet_real_mouse_capability_probe_script() -> String {
+    let mut script = String::from(
+        r#"
 (async () => {
   const mascot = document.querySelector('[data-avatar-mascot="true"]');
-  if (!mascot) return false;
-  const spriteImages = Array.from(mascot.querySelectorAll("img"));
-  const currentSpriteIsV2 = spriteImages.some((image) =>
-    image.naturalWidth === 1536 && image.naturalHeight === 2288
-  );
-  if (!currentSpriteIsV2) return false;
+"#,
+    );
+    script.push_str(PET_V2_SPRITE_DETECTION_SCRIPT);
+    script.push_str(
+        r#"
+  if (!isV2Sprite(mascot)) return false;
   const urls = [
     ...Array.from(document.scripts || []).map((script) => script.src),
     ...Array.from(document.querySelectorAll("link[href]") || []).map((link) => link.href),
@@ -63,20 +91,25 @@ pub fn pet_real_mouse_capability_probe_script() -> &'static str {
     return false;
   }
 })()
-"#
+"#,
+    );
+    script
 }
 
 pub fn pet_real_mouse_update_script(x: i32, y: i32) -> String {
-    format!(
-        r#"(() => {{
+    let mut script = String::from(
+        r#"(() => {
   const mascot = document.querySelector('[data-avatar-mascot="true"]');
-  const currentSpriteIsV2 = !!mascot && Array.from(mascot.querySelectorAll("img")).some((image) =>
-    image.naturalWidth === 1536 && image.naturalHeight === 2288
-  );
-  return currentSpriteIsV2
+"#,
+    );
+    script.push_str(PET_V2_SPRITE_DETECTION_SCRIPT);
+    script.push_str(&format!(
+        r#"
+  return isV2Sprite(mascot)
     && window.__codexPlusPetRealMouseLook?.updateScreenPoint?.({{ x: {x}, y: {y} }}) === true;
 }})()"#
-    )
+    ));
+    script
 }
 
 pub fn pet_real_mouse_stop_script() -> &'static str {

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -1887,7 +1887,7 @@ async fn confirmed_pet_overlay_targets(
 async fn pet_overlay_supports_v2_cursor(websocket_url: &str) -> bool {
     crate::bridge::evaluate_script_with_await_promise(
         websocket_url,
-        crate::assets::pet_real_mouse_capability_probe_script(),
+        &crate::assets::pet_real_mouse_capability_probe_script(),
         true,
     )
     .await

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -96,8 +96,10 @@ fn pet_real_mouse_capability_probe_rejects_v1_without_explicit_v2_evidence() {
     assert!(probe.contains("data-avatar-mascot"));
     assert!(probe.contains("image.naturalWidth === 1536"));
     assert!(probe.contains("image.naturalHeight === 2288"));
+    assert!(probe.contains("getComputedStyle(element).backgroundImage"));
+    assert!(probe.contains("data:image\\/png;base64"));
     assert!(!probe.contains("new Image()"));
-    assert!(probe.contains("if (!currentSpriteIsV2) return false"));
+    assert!(probe.contains("if (!isV2Sprite(mascot)) return false"));
     assert!(!probe.contains("spriteVersionNumber"));
     assert!(probe.contains("dispatchHostMessage"));
     assert!(probe.contains("typeof value.subscribe === \"function\""));
@@ -112,7 +114,76 @@ fn pet_real_mouse_update_script_stops_when_runtime_capability_is_missing() {
     assert!(script.contains("data-avatar-mascot"));
     assert!(script.contains("image.naturalWidth === 1536"));
     assert!(script.contains("image.naturalHeight === 2288"));
+    assert!(script.contains("getComputedStyle(element).backgroundImage"));
+    assert!(script.contains("uint32(16) === 1536 && uint32(20) === 2288"));
     assert!(script.contains("updateScreenPoint?.({ x: -125, y: 640 }) === true"));
+}
+
+#[test]
+fn pet_real_mouse_update_script_accepts_css_background_v2_and_rejects_v1() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let script_path = temp.path().join("pet-update.js");
+    let harness_path = temp.path().join("pet-update-harness.cjs");
+    std::fs::write(&script_path, assets::pet_real_mouse_update_script(120, 240))
+        .expect("pet update script should be written");
+    let mut harness = std::fs::File::create(&harness_path).expect("harness should be created");
+    write!(
+        harness,
+        r#"
+const fs = require("fs");
+const vm = require("vm");
+const script = fs.readFileSync({script_path}, "utf8");
+function pngDataUri(width, height) {{
+  const bytes = Buffer.alloc(24);
+  bytes.set([137, 80, 78, 71, 13, 10, 26, 10], 0);
+  bytes.writeUInt32BE(width, 16);
+  bytes.writeUInt32BE(height, 20);
+  return `url("data:image/png;base64,${{bytes.toString("base64")}}")`;
+}}
+function run({{ image = null, background = "none" }} = {{}}) {{
+  let calls = 0;
+  const element = {{ querySelectorAll: () => [] }};
+  const mascot = {{
+    querySelectorAll: (selector) => selector === "img" ? (image ? [image] : []) : [element],
+  }};
+  const context = {{
+    document: {{ querySelector: () => mascot }},
+    getComputedStyle: (target) => ({{ backgroundImage: target === element ? background : "none" }}),
+    atob: (value) => Buffer.from(value, "base64").toString("latin1"),
+    window: {{ __codexPlusPetRealMouseLook: {{ updateScreenPoint: () => {{ calls += 1; return true; }} }} }},
+  }};
+  const result = vm.runInNewContext(script, context);
+  return {{ result, calls }};
+}}
+process.stdout.write(JSON.stringify({{
+  cssV2: run({{ background: pngDataUri(1536, 2288) }}),
+  cssV1: run({{ background: pngDataUri(1536, 1872) }}),
+  imgV2: run({{ image: {{ naturalWidth: 1536, naturalHeight: 2288 }} }}),
+  missing: run(),
+}}));
+"#,
+        script_path = serde_json::to_string(&script_path.to_string_lossy().to_string())
+            .expect("script path should serialize")
+    )
+    .expect("harness should be written");
+    drop(harness);
+
+    let output = Command::new("node")
+        .arg(&harness_path)
+        .output()
+        .expect("node should run pet update harness");
+    assert!(
+        output.status.success(),
+        "node harness failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let cases: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("harness stdout should be JSON");
+    assert_eq!(cases["cssV2"], json!({ "result": true, "calls": 1 }));
+    assert_eq!(cases["imgV2"], json!({ "result": true, "calls": 1 }));
+    assert_eq!(cases["cssV1"], json!({ "result": false, "calls": 0 }));
+    assert_eq!(cases["missing"], json!({ "result": false, "calls": 0 }));
 }
 
 #[test]


### PR DESCRIPTION
## 中文

### #1455 新版 Codex App 紧急兼容更新（2026-07-13）

这是已合并 PR #1455 的后续兼容修复，希望能够尽快审查并合并。#1455 合并时已经通过真人测试，V2 桌宠真实鼠标朝向、原生 hover 交互和 Computer Use 优先级均正常；但 Codex App `26.707.8479.0` 随后改变了 V2 spritesheet 的渲染结构，导致已合并功能在新版 App 中无法识别桌宠并安全 no-op。如果本修复未合并，#1455 提供的“桌宠跟随真实鼠标”会在该新版 App 中保持不可用。

### 为什么会失效

旧版 App 将 V2 spritesheet 渲染为桌宠节点下的 `<img>`，#1455 通过 `naturalWidth === 1536 && naturalHeight === 2288` 确认 V2 素材，避免错误驱动 V1 宠物。

新版 App 不再创建该 `<img>`，而是将同一份 `1536×2288` PNG 作为 `.codex-avatar-root` 的 CSS `background-image` data URI。功能本身和素材版本没有变化，但旧探针找不到 `<img>` 后会按设计停止注入，因此真实鼠标朝向完全失效。这是新版 App 渲染结构变化带来的兼容回归，不是 #1455 初始实现时就存在的问题。

### 本次修改

- 保留原有 `<img>` V2 尺寸检测，继续兼容旧版 App。
- 新增 CSS `background-image` PNG data URI 检测，只读取 Base64 头部并解析 PNG IHDR 宽高，不解码完整 spritesheet。
- capability probe 与每次坐标更新共用同一 V2 判定逻辑，避免探针通过但更新被拒绝。
- 仍只接受 `1536×2288` V2；`1536×1872` V1 和缺失素材继续安全拒绝。
- 不改变 #1455 的功能入口、交互优先级、Windows 平台限制或用户宠物素材。

### 验证

- Codex App `26.707.8479.0` 现场检查：新版 CSS V2 spritesheet 可识别，热注入后运行状态恢复正常。
- `cargo fmt --all -- --check`
- `cargo test -q -p codex-plus-core --test cdp_bridge -j 2`：`77/77` 通过。
- `cargo check -q -p codex-plus-launcher -j 2`
- 执行级 Node harness 覆盖：CSS V2 接受、旧 `<img>` V2 接受、CSS V1 拒绝、缺失素材拒绝。

## English

### Urgent compatibility follow-up for #1455 on newer Codex App (2026-07-13)

This is a compatibility follow-up to merged PR #1455, and an early review/merge would be appreciated. #1455 was human-tested when merged: V2 real-mouse gaze, native hover interactions, and Computer Use priority all worked correctly. Codex App `26.707.8479.0` later changed how the V2 spritesheet is rendered, so the merged feature can no longer identify the pet and intentionally no-ops on the newer App. Without this follow-up, the real-mouse pet gaze delivered by #1455 remains unavailable on that App version.

### Why it regressed

The previous App rendered the V2 spritesheet as a descendant `<img>`, and #1455 safely identified V2 through `naturalWidth === 1536 && naturalHeight === 2288` to avoid driving V1 pets.

The newer App no longer creates that `<img>`. It renders the same `1536×2288` PNG as a CSS `background-image` data URI on `.codex-avatar-root`. The feature and sprite version are unchanged, but the original probe cannot find its `<img>` evidence and therefore stops injection by design. This is a compatibility regression caused by the newer App rendering structure, not a defect that existed when #1455 was introduced.

### Changes

- Preserve legacy `<img>` V2 dimension detection for older App builds.
- Detect CSS `background-image` PNG data URIs by reading only the Base64 header and parsing PNG IHDR dimensions, without decoding the full spritesheet.
- Share the same V2 predicate between the capability probe and every coordinate update.
- Continue accepting only `1536×2288` V2; reject `1536×1872` V1 and missing sprites safely.
- Do not change #1455's settings entry, interaction priority, Windows-only scope, or user pet assets.

### Verification

- Live inspection on Codex App `26.707.8479.0`: the CSS V2 spritesheet is detected and the injected runtime becomes healthy again.
- `cargo fmt --all -- --check`
- `cargo test -q -p codex-plus-core --test cdp_bridge -j 2`: `77/77` passed.
- `cargo check -q -p codex-plus-launcher -j 2`
- Execution-level Node harness covers CSS V2 accepted, legacy `<img>` V2 accepted, CSS V1 rejected, and missing sprite rejected.