### PR TITLE
fix: 修复 Codex Desktop WSL 模式会话同步

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -304,10 +304,14 @@ impl LaunchHooks for LauncherHooks {
     }
 
     async fn run_provider_sync(&self) -> anyhow::Result<()> {
-        let _ = tokio::task::spawn_blocking(|| codex_plus_data::run_provider_sync(None))
+        let result = tokio::task::spawn_blocking(|| codex_plus_data::run_provider_sync(None))
             .await
             .map_err(|error| anyhow::anyhow!("provider sync task failed: {error}"))?;
-        Ok(())
+        if matches!(result.status, codex_plus_data::ProviderSyncStatus::Synced) {
+            Ok(())
+        } else {
+            anyhow::bail!(result.message)
+        }
     }
 
     async fn apply_active_relay_profile(

--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -1960,7 +1960,8 @@ pub async fn sync_providers_now(target_provider: Option<String>) -> CommandResul
     .map_err(|error| anyhow::anyhow!("provider sync task failed: {error}"));
     match result {
         Ok(sync) => {
-            if is_success_sync_status(&sync.status) {
+            let succeeded = is_success_sync_status(&sync.status);
+            if succeeded {
                 persist_provider_sync_selection(
                     target_for_settings
                         .as_deref()
@@ -1971,29 +1972,40 @@ pub async fn sync_providers_now(target_provider: Option<String>) -> CommandResul
                     "manager.sync_providers_now.after",
                 );
             }
-            ok(
-                &format!(
-                    "供应商已同步一次：{} 个会话文件，{} 行索引，跳过 {} 个占用文件。",
-                    sync.changed_session_files,
-                    sync.sqlite_rows_updated,
-                    sync.skipped_locked_rollout_files.len()
-                ),
-                json!({
-                    "syncStatus": sync.status,
-                    "targetProvider": sync.target_provider,
-                    "changedSessionFiles": sync.changed_session_files,
-                    "skippedLockedRolloutFiles": sync.skipped_locked_rollout_files,
-                    "sqliteRowsUpdated": sync.sqlite_rows_updated,
-                    "sqliteProviderRowsUpdated": sync.sqlite_provider_rows_updated,
-                    "sqliteUserEventRowsUpdated": sync.sqlite_user_event_rows_updated,
-                    "sqliteCwdRowsUpdated": sync.sqlite_cwd_rows_updated,
-                    "sqliteCatalogRowsInserted": sync.sqlite_catalog_rows_inserted,
-                    "updatedWorkspaceRoots": sync.updated_workspace_roots,
-                    "encryptedContentWarning": sync.encrypted_content_warning,
-                    "backupDir": sync.backup_dir,
-                    "syncMessage": sync.message,
-                }),
-            )
+            let summary = format!(
+                "供应商已同步一次：{} 个会话文件，{} 行索引，其中 WSL 正本更新 {} 行（{} 个数据库），跳过 {} 个占用文件。",
+                sync.changed_session_files,
+                sync.sqlite_rows_updated,
+                sync.wsl_sqlite_rows_updated,
+                sync.wsl_sqlite_databases_updated,
+                sync.skipped_locked_rollout_files.len()
+            );
+            let failure_message = format!("供应商同步未完成：{}", sync.message);
+            let payload = json!({
+                "syncStatus": sync.status,
+                "targetProvider": sync.target_provider,
+                "changedSessionFiles": sync.changed_session_files,
+                "skippedLockedRolloutFiles": sync.skipped_locked_rollout_files,
+                "sqliteRowsUpdated": sync.sqlite_rows_updated,
+                "sqliteProviderRowsUpdated": sync.sqlite_provider_rows_updated,
+                "sqliteUserEventRowsUpdated": sync.sqlite_user_event_rows_updated,
+                "sqliteCwdRowsUpdated": sync.sqlite_cwd_rows_updated,
+                "sqliteCatalogRowsInserted": sync.sqlite_catalog_rows_inserted,
+                "wslSqliteRowsUpdated": sync.wsl_sqlite_rows_updated,
+                "wslSqliteProviderRowsUpdated": sync.wsl_sqlite_provider_rows_updated,
+                "wslSqliteUserEventRowsUpdated": sync.wsl_sqlite_user_event_rows_updated,
+                "wslSqliteCwdRowsUpdated": sync.wsl_sqlite_cwd_rows_updated,
+                "wslSqliteDatabasesUpdated": sync.wsl_sqlite_databases_updated,
+                "updatedWorkspaceRoots": sync.updated_workspace_roots,
+                "encryptedContentWarning": sync.encrypted_content_warning,
+                "backupDir": sync.backup_dir,
+                "syncMessage": sync.message,
+            });
+            if succeeded {
+                ok(&summary, payload)
+            } else {
+                failed(&failure_message, payload)
+            }
         }
         Err(error) => failed(&format!("供应商同步失败：{error}"), json!({})),
     }

--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -551,6 +551,11 @@ type ProviderSyncPayload = {
   sqliteUserEventRowsUpdated?: number;
   sqliteCwdRowsUpdated?: number;
   sqliteCatalogRowsInserted?: number;
+  wslSqliteRowsUpdated?: number;
+  wslSqliteProviderRowsUpdated?: number;
+  wslSqliteUserEventRowsUpdated?: number;
+  wslSqliteCwdRowsUpdated?: number;
+  wslSqliteDatabasesUpdated?: number;
   updatedWorkspaceRoots?: number;
   prunedSessionIndexEntries?: number;
   encryptedContentWarning?: string | null;
@@ -572,7 +577,7 @@ type SessionIndexCleanupApplyPayload = {
   backupDir?: string | null;
 };
 
-type ProviderSyncTargetSource = "config" | "rollout" | "sqlite" | "manual";
+type ProviderSyncTargetSource = "config" | "rollout" | "sqlite" | "wsl_sqlite" | "manual";
 
 type ProviderSyncTargetOption = {
   id: string;
@@ -678,19 +683,28 @@ type ScriptMarketResult = CommandResult<{
 }>;
 
 function providerSyncProgressMessage(result: CommandResult<ProviderSyncPayload>): string {
+  if (!isSuccessStatus(result.status)) {
+    return result.message || t("历史会话修复失败，请查看错误提示后重试。");
+  }
   const changed = result.changedSessionFiles ?? 0;
   const rows = result.sqliteRowsUpdated ?? 0;
   const insertedCatalogRows = result.sqliteCatalogRowsInserted ?? 0;
   const pruned = result.prunedSessionIndexEntries ?? 0;
   const target = result.targetProvider || t("当前 provider");
   const skipped = result.skippedLockedRolloutFiles?.length ?? 0;
+  const wslRows = result.wslSqliteRowsUpdated ?? 0;
+  const wslDatabases = result.wslSqliteDatabasesUpdated ?? 0;
+  const wslText = wslRows || wslDatabases
+    ? tf("，其中 WSL 正本更新 {0} 行（{1} 个数据库）", [wslRows, wslDatabases])
+    : "";
   const prunedText = pruned ? tf("，清理 {0} 条失效任务索引", [pruned]) : "";
   const skippedText = skipped ? tf("，跳过 {0} 个占用文件", [skipped]) : "";
   const catalogText = insertedCatalogRows ? tf("，补齐 {0} 条侧边栏索引", [insertedCatalogRows]) : "";
-  return tf("已同步到 {0}：修复 {1} 个会话文件，更新 {2} 行数据库索引{3}{4}{5}。", [
+  return tf("已同步到 {0}：修复 {1} 个会话文件，更新 {2} 行数据库索引{3}{4}{5}{6}。", [
     target,
     changed,
     rows,
+    wslText,
     catalogText,
     prunedText,
     skippedText,
@@ -701,6 +715,7 @@ const providerSyncSourceLabels: Record<ProviderSyncTargetSource, string> = {
   config: t("配置"),
   rollout: t("会话"),
   sqlite: t("索引"),
+  wsl_sqlite: t("WSL 索引"),
   manual: t("手动"),
 };
 
@@ -1996,7 +2011,7 @@ export function App() {
               : completion.result.message),
           result: completion.result,
         });
-        if (targetProvider) {
+        if (targetProvider && isSuccessStatus(result.status)) {
           const next = {
             ...settingsForm,
             providerSyncLastSelectedProvider: targetProvider,

--- a/apps/codex-plus-manager/src/i18n-en.ts
+++ b/apps/codex-plus-manager/src/i18n-en.ts
@@ -32,6 +32,7 @@ export const EN_PLAIN: Record<string, string> = {
     "MCP, Skills and Plugins are managed independently as global config and merged in whenever you switch providers.",
   "Markdown 导出": "Markdown export",
   "Provider 同步目标": "Provider sync target",
+  "WSL 索引": "WSL index",
   "Stepwise 直接发送": "Stepwise direct send",
   "基于当前对话生成下一步建议，使用独立 API 配置。": "Generate next-step suggestions from the current conversation using a separate API configuration.",
   "VLM API Key": "VLM API Key",
@@ -864,8 +865,11 @@ export const EN_TEMPLATE: Record<string, string> = {
   "已删除 {0} 个会话。": "Deleted {0} session(s).",
   "已删除 {0} 个，失败 {1} 个：{2}": "Deleted {0}, failed {1}: {2}",
   "已加载 {0} 条推荐": "Loaded {0} recommendation(s)",
-  "已同步到 {0}：修复 {1} 个会话文件，更新 {2} 行数据库索引{3}{4}。":
-    "Synced to {0}: repaired {1} session file(s) and updated {2} database index row(s){3}{4}.",
+  "已同步到 {0}：修复 {1} 个会话文件，更新 {2} 行数据库索引{3}{4}{5}{6}。":
+    "Synced to {0}: repaired {1} session file(s) and updated {2} database index row(s){3}{4}{5}{6}.",
+  "，其中 WSL 正本更新 {0} 行（{1} 个数据库）":
+    ", including {0} row(s) in {1} authoritative WSL database(s)",
+  "，补齐 {0} 条侧边栏索引": ", restored {0} sidebar index row(s)",
   "已安装 {0}": "Installed {0}",
   "已缓存 {0} 个插件 / {1} 个技能。": "Cached {0} plugin(s) / {1} skill(s).",
   "已运行 {0} 分钟": "Running for {0} minute(s)",
@@ -1005,6 +1009,8 @@ export const EN_BACKEND_PATTERNS: Array<[RegExp, string]> = [
   [/^无法在 Zed Remote 打开项目。$/, "Cannot open project in Zed Remote."],
   [/^移除 Zed 远程项目失败。$/, "Failed to remove Zed remote project."],
   [/^供应商已同步一次：(\d+) 个会话文件，(\d+) 行索引，跳过 (\d+) 个占用文件。$/, "Provider synced: $1 session file(s), $2 index row(s), skipped $3 locked file(s)."],
+  [/^供应商已同步一次：(\d+) 个会话文件，(\d+) 行索引，其中 WSL 正本更新 (\d+) 行（(\d+) 个数据库），跳过 (\d+) 个占用文件。$/, "Provider synced: $1 session file(s), $2 index row(s), including $3 row(s) in $4 authoritative WSL database(s), skipped $5 locked file(s)."],
+  [/^供应商同步未完成：(.+)$/, "Provider sync did not complete: $1"],
   [/^供应商同步失败：(.+)$/, "Provider sync failed: $1"],
   [/^推荐内容加载失败：(.+)$/, "Failed to load recommendations: $1"],
   [/^脚本市场加载失败：(.+)$/, "Failed to load script marketplace: $1"],

--- a/crates/codex-plus-data/src/lib.rs
+++ b/crates/codex-plus-data/src/lib.rs
@@ -2,6 +2,7 @@ pub mod backup;
 pub mod markdown;
 pub mod provider_sync;
 pub mod storage;
+mod wsl_sqlite;
 
 pub use backup::BackupStore;
 pub use markdown::{MarkdownExportService, export_markdown_from_paths};

--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -7,6 +7,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::wsl_sqlite::{
+    WslSqliteBackup, WslSqliteContext, WslSqliteUpdateCounts, WslSqliteUpdateResult,
+};
+
 const DEFAULT_PROVIDER: &str = "openai";
 const SESSION_DIRS: [&str; 2] = ["sessions", "archived_sessions"];
 const BACKUP_KEEP_COUNT: usize = 5;
@@ -36,6 +40,11 @@ pub struct ProviderSyncResult {
     pub sqlite_user_event_rows_updated: usize,
     pub sqlite_cwd_rows_updated: usize,
     pub sqlite_catalog_rows_inserted: usize,
+    pub wsl_sqlite_rows_updated: usize,
+    pub wsl_sqlite_provider_rows_updated: usize,
+    pub wsl_sqlite_user_event_rows_updated: usize,
+    pub wsl_sqlite_cwd_rows_updated: usize,
+    pub wsl_sqlite_databases_updated: usize,
     pub updated_workspace_roots: usize,
     pub encrypted_content_warning: Option<String>,
 }
@@ -75,6 +84,7 @@ pub enum ProviderSyncTargetSource {
     Config,
     Rollout,
     Sqlite,
+    WslSqlite,
     Manual,
 }
 
@@ -139,6 +149,12 @@ struct SessionIndexPlan {
     original_text: String,
     snapshot_sha256: String,
     candidates: Vec<SessionIndexCleanupCandidate>,
+}
+
+#[derive(Debug)]
+struct ProviderSyncBackup {
+    dir: PathBuf,
+    wsl_sqlite: Vec<WslSqliteBackup>,
 }
 
 #[derive(Debug, Default)]
@@ -255,11 +271,22 @@ pub fn run_provider_sync_with_target(
         )?;
         let catalog_insert_count =
             count_missing_local_thread_catalog_rows(&sqlite_paths, &target_provider)?;
+        let wsl_sqlite = WslSqliteContext::discover_if_enabled(&home.join("config.toml"))?;
+        let wsl_sqlite_update_counts = if let Some(context) = &wsl_sqlite {
+            context.count_updates(
+                &target_provider,
+                &thread_ids_with_user_events,
+                &cwd_by_thread_id,
+            )?
+        } else {
+            WslSqliteUpdateCounts::default()
+        };
         let global_state_update_count =
             count_global_state_updates(&home.join(".codex-global-state.json"))?;
         if rewrite_changes.is_empty()
             && sqlite_update_count == 0
             && catalog_insert_count == 0
+            && wsl_sqlite_update_counts.total() == 0
             && global_state_update_count == 0
         {
             let mut synced = result(
@@ -274,8 +301,46 @@ pub fn run_provider_sync_with_target(
             synced.encrypted_content_warning = encrypted_content_warning;
             return Ok(synced);
         }
-        let backup_dir = create_backup(&home, &target_provider, &rewrite_changes)?;
+        if wsl_sqlite_update_counts.total() > 0 {
+            wsl_sqlite
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("WSL SQLite 上下文意外丢失"))?
+                .preflight_write()?;
+        }
+        let backup = create_backup(
+            &home,
+            &target_provider,
+            &rewrite_changes,
+            if wsl_sqlite_update_counts.total() > 0 {
+                wsl_sqlite.as_ref()
+            } else {
+                None
+            },
+        )?;
         let applied = apply_session_changes(&rewrite_changes)?;
+        let wsl_updates = if wsl_sqlite_update_counts.total() > 0 {
+            let context = wsl_sqlite
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("WSL SQLite 上下文意外丢失"))?;
+            match context.apply_updates(
+                &target_provider,
+                &thread_ids_with_user_events,
+                &cwd_by_thread_id,
+                &backup.wsl_sqlite,
+            ) {
+                Ok(updates) => updates,
+                Err(error) => {
+                    if let Err(restore_error) = restore_session_changes(&applied.changes) {
+                        return Err(anyhow::anyhow!(
+                            "{error}; 会话文件回滚也失败：{restore_error}"
+                        ));
+                    }
+                    return Err(error);
+                }
+            }
+        } else {
+            WslSqliteUpdateResult::default()
+        };
         let apply_result = (|| -> anyhow::Result<(SqliteUpdateCounts, usize)> {
             let sqlite_updates = apply_sqlite_update_for_paths(
                 &sqlite_paths,
@@ -294,17 +359,38 @@ pub fn run_provider_sync_with_target(
         let (sqlite_updates, updated_workspace_roots) = match apply_result {
             Ok(counts) => counts,
             Err(err) => {
-                let _ = restore_session_changes(&applied.changes);
-                return Err(err);
+                let mut rollback_errors = Vec::new();
+                if wsl_updates.counts.total() > 0 {
+                    if let Some(context) = wsl_sqlite.as_ref() {
+                        if let Err(error) = context.restore_backups(&backup.wsl_sqlite) {
+                            rollback_errors.push(format!("WSL 索引回滚失败：{error}"));
+                        }
+                    } else {
+                        rollback_errors.push("WSL 索引回滚失败：同步上下文丢失".to_string());
+                    }
+                }
+                if let Err(error) = restore_session_changes(&applied.changes) {
+                    rollback_errors.push(format!("会话文件回滚失败：{error}"));
+                }
+                if rollback_errors.is_empty() {
+                    return Err(err);
+                }
+                return Err(anyhow::anyhow!("{err}; {}", rollback_errors.join("；")));
             }
+        };
+        let combined_sqlite_updates = SqliteUpdateCounts {
+            provider_rows: sqlite_updates.provider_rows + wsl_updates.counts.provider_rows,
+            user_event_rows: sqlite_updates.user_event_rows + wsl_updates.counts.user_event_rows,
+            cwd_rows: sqlite_updates.cwd_rows + wsl_updates.counts.cwd_rows,
+            catalog_insert_rows: sqlite_updates.catalog_insert_rows,
         };
         let mut synced = result(
             ProviderSyncStatus::Synced,
             "Provider sync complete",
             &target_provider,
-            Some(backup_dir),
+            Some(backup.dir),
             applied.changes.len(),
-            sqlite_updates.total(),
+            combined_sqlite_updates.total(),
         );
         synced.skipped_locked_rollout_files = collected.skipped_locked_rollout_files;
         synced
@@ -312,10 +398,15 @@ pub fn run_provider_sync_with_target(
             .extend(applied.skipped_locked_rollout_files);
         synced.skipped_locked_rollout_files.sort();
         synced.skipped_locked_rollout_files.dedup();
-        synced.sqlite_provider_rows_updated = sqlite_updates.provider_rows;
-        synced.sqlite_user_event_rows_updated = sqlite_updates.user_event_rows;
-        synced.sqlite_cwd_rows_updated = sqlite_updates.cwd_rows;
+        synced.sqlite_provider_rows_updated = combined_sqlite_updates.provider_rows;
+        synced.sqlite_user_event_rows_updated = combined_sqlite_updates.user_event_rows;
+        synced.sqlite_cwd_rows_updated = combined_sqlite_updates.cwd_rows;
         synced.sqlite_catalog_rows_inserted = sqlite_updates.catalog_insert_rows;
+        synced.wsl_sqlite_rows_updated = wsl_updates.counts.total();
+        synced.wsl_sqlite_provider_rows_updated = wsl_updates.counts.provider_rows;
+        synced.wsl_sqlite_user_event_rows_updated = wsl_updates.counts.user_event_rows;
+        synced.wsl_sqlite_cwd_rows_updated = wsl_updates.counts.cwd_rows;
+        synced.wsl_sqlite_databases_updated = wsl_updates.databases_updated;
         synced.updated_workspace_roots = updated_workspace_roots;
         synced.encrypted_content_warning = encrypted_content_warning;
         Ok(synced)
@@ -353,6 +444,11 @@ fn result(
         sqlite_user_event_rows_updated: 0,
         sqlite_cwd_rows_updated: 0,
         sqlite_catalog_rows_inserted: 0,
+        wsl_sqlite_rows_updated: 0,
+        wsl_sqlite_provider_rows_updated: 0,
+        wsl_sqlite_user_event_rows_updated: 0,
+        wsl_sqlite_cwd_rows_updated: 0,
+        wsl_sqlite_databases_updated: 0,
         updated_workspace_roots: 0,
         encrypted_content_warning: None,
     }
@@ -405,6 +501,11 @@ pub fn load_provider_sync_targets(codex_home: Option<&Path>) -> ProviderSyncTarg
         if let Ok(ids) = sqlite_provider_ids(&db_path) {
             add_sources(&mut sources, ids, ProviderSyncTargetSource::Sqlite);
         }
+    }
+    if let Ok(Some(context)) = WslSqliteContext::discover_if_enabled(&home.join("config.toml"))
+        && let Ok(ids) = context.provider_ids()
+    {
+        add_sources(&mut sources, ids, ProviderSyncTargetSource::WslSqlite);
     }
 
     let mut targets = sources
@@ -1076,7 +1177,8 @@ fn create_backup(
     home: &Path,
     target_provider: &str,
     changes: &[SessionChange],
-) -> anyhow::Result<PathBuf> {
+    wsl_sqlite: Option<&WslSqliteContext>,
+) -> anyhow::Result<ProviderSyncBackup> {
     let backup_root = home.join("backups_state/provider-sync");
     let mut backup_dir = backup_root.join(timestamp_name());
     let mut suffix = 0;
@@ -1124,6 +1226,20 @@ fn create_backup(
         backup_dir.join("session-meta-backup.json"),
         serde_json::to_string_pretty(&manifest)?,
     )?;
+    let wsl_sqlite_backups = if let Some(context) = wsl_sqlite {
+        context.create_backups(&backup_dir)?
+    } else {
+        Vec::new()
+    };
+    let wsl_db_files = wsl_sqlite_backups
+        .iter()
+        .map(|backup| {
+            json!({
+                "source": backup.source_path,
+                "backup": backup.relative_path.to_string_lossy().replace('\\', "/"),
+            })
+        })
+        .collect::<Vec<_>>();
     fs::write(
         backup_dir.join("metadata.json"),
         serde_json::to_string_pretty(&json!({
@@ -1133,11 +1249,15 @@ fn create_backup(
             "targetProvider": target_provider,
             "createdAt": chrono::Utc::now().to_rfc3339(),
             "dbFiles": db_files,
+            "wslDbFiles": wsl_db_files,
             "changedSessionFiles": changes.len(),
             "managedBy": "Codex++ provider sync"
         }))?,
     )?;
-    Ok(backup_dir)
+    Ok(ProviderSyncBackup {
+        dir: backup_dir,
+        wsl_sqlite: wsl_sqlite_backups,
+    })
 }
 
 fn create_session_index_cleanup_backup(

--- a/crates/codex-plus-data/src/wsl_sqlite.rs
+++ b/crates/codex-plus-data/src/wsl_sqlite.rs
@@ -1,0 +1,826 @@
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, bail};
+
+#[cfg(windows)]
+use std::io::Write;
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+#[cfg(windows)]
+use std::process::{Command, Stdio};
+
+const WSL_DISCOVERY_SCRIPT: &str = r#"
+set -eu
+if ! command -v sqlite3 >/dev/null 2>&1; then
+    echo "WSL 中未找到 sqlite3" >&2
+    exit 127
+fi
+scan_sqlite_dir() {
+    [ -d "$1" ] || return 0
+    find "$1" -maxdepth 1 -type f \( -name '*.db' -o -name '*.sqlite' -o -name '*.sqlite3' \) -print
+}
+if [ -n "${CODEX_SQLITE_HOME:-}" ]; then
+    scan_sqlite_dir "$CODEX_SQLITE_HOME"
+elif [ -n "${HOME:-}" ]; then
+    scan_sqlite_dir "$HOME/.codex/sqlite"
+    if [ -d "$HOME/.codex" ]; then
+        find "$HOME/.codex" -maxdepth 1 -type f \( -name 'state_*.db' -o -name 'state_*.sqlite' -o -name 'state_*.sqlite3' \) -print
+    fi
+fi
+"#;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct WslSqliteUpdateCounts {
+    pub(crate) provider_rows: usize,
+    pub(crate) user_event_rows: usize,
+    pub(crate) cwd_rows: usize,
+}
+
+impl WslSqliteUpdateCounts {
+    pub(crate) fn total(&self) -> usize {
+        self.provider_rows + self.user_event_rows + self.cwd_rows
+    }
+
+    fn add(&mut self, other: Self) {
+        self.provider_rows += other.provider_rows;
+        self.user_event_rows += other.user_event_rows;
+        self.cwd_rows += other.cwd_rows;
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct WslSqliteUpdateResult {
+    pub(crate) counts: WslSqliteUpdateCounts,
+    pub(crate) databases_updated: usize,
+}
+
+#[derive(Debug, Clone)]
+struct WslSqliteDatabase {
+    path: String,
+    has_model_provider: bool,
+    has_user_event: bool,
+    has_cwd: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct WslSqliteBackup {
+    pub(crate) source_path: String,
+    backup_path: String,
+    pub(crate) relative_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct WslSqliteContext {
+    databases: Vec<WslSqliteDatabase>,
+}
+
+impl WslSqliteContext {
+    pub(crate) fn discover_if_enabled(config_path: &Path) -> anyhow::Result<Option<Self>> {
+        if !desktop_wsl_enabled(config_path) {
+            return Ok(None);
+        }
+
+        #[cfg(windows)]
+        {
+            Self::discover().map(Some)
+        }
+
+        #[cfg(not(windows))]
+        {
+            Ok(None)
+        }
+    }
+
+    #[cfg(windows)]
+    fn discover() -> anyhow::Result<Self> {
+        let output = run_wsl_command(&["--exec", "sh", "-lc", WSL_DISCOVERY_SCRIPT], None)
+            .context("无法扫描 WSL 中的 Codex SQLite 索引")?;
+        let mut seen = HashSet::new();
+        let mut databases = Vec::new();
+        for path in output
+            .lines()
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+        {
+            if !seen.insert(path.to_string()) {
+                continue;
+            }
+            let metadata = read_database_metadata(path)
+                .with_context(|| format!("无法检查 WSL Codex 索引：{path}"))?;
+            let Some((has_model_provider, has_user_event, has_cwd)) = metadata else {
+                continue;
+            };
+            databases.push(WslSqliteDatabase {
+                path: path.to_string(),
+                has_model_provider,
+                has_user_event,
+                has_cwd,
+            });
+        }
+        databases.sort_by(|left, right| left.path.cmp(&right.path));
+        if databases.is_empty() {
+            bail!("Codex Desktop 已启用 WSL，但没有发现包含 threads 表的 WSL SQLite 正本");
+        }
+        Ok(Self { databases })
+    }
+
+    pub(crate) fn provider_ids(&self) -> anyhow::Result<Vec<String>> {
+        let mut ids = HashSet::new();
+        for database in self
+            .databases
+            .iter()
+            .filter(|database| database.has_model_provider)
+        {
+            let output = run_sqlite(
+                &database.path,
+                true,
+                ".timeout 10000\n.bail on\nSELECT DISTINCT hex(CAST(model_provider AS BLOB)) FROM threads WHERE COALESCE(model_provider, '') <> '' ORDER BY 1;\n",
+            )?;
+            for line in output
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+            {
+                let bytes = decode_hex(line).with_context(|| {
+                    format!("WSL 索引返回了无效的 Provider ID：{}", database.path)
+                })?;
+                let id = String::from_utf8(bytes).with_context(|| {
+                    format!("WSL 索引返回了非 UTF-8 Provider ID：{}", database.path)
+                })?;
+                if is_valid_provider_id(&id) {
+                    ids.insert(id);
+                }
+            }
+        }
+        let mut ids = ids.into_iter().collect::<Vec<_>>();
+        ids.sort();
+        Ok(ids)
+    }
+
+    pub(crate) fn count_updates(
+        &self,
+        target_provider: &str,
+        user_event_thread_ids: &HashSet<String>,
+        cwd_by_thread_id: &HashMap<String, String>,
+    ) -> anyhow::Result<WslSqliteUpdateCounts> {
+        let mut total = WslSqliteUpdateCounts::default();
+        for database in self
+            .databases
+            .iter()
+            .filter(|database| database.has_model_provider)
+        {
+            let script = build_count_script(
+                database,
+                target_provider,
+                user_event_thread_ids,
+                cwd_by_thread_id,
+            );
+            let output = run_sqlite(&database.path, true, &script)
+                .with_context(|| format!("无法读取 WSL Codex 索引：{}", database.path))?;
+            total.add(
+                parse_counts_with_integrity(&output)
+                    .with_context(|| format!("无法解析 WSL Codex 索引统计：{}", database.path))?,
+            );
+        }
+        Ok(total)
+    }
+
+    pub(crate) fn preflight_write(&self) -> anyhow::Result<()> {
+        for database in self
+            .databases
+            .iter()
+            .filter(|database| database.has_model_provider)
+        {
+            run_sqlite(
+                &database.path,
+                false,
+                ".timeout 10000\n.bail on\nBEGIN IMMEDIATE;\nROLLBACK;\n",
+            )
+            .with_context(|| format!("WSL Codex 索引当前不可写：{}", database.path))?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn create_backups(&self, backup_dir: &Path) -> anyhow::Result<Vec<WslSqliteBackup>> {
+        let databases = self
+            .databases
+            .iter()
+            .filter(|database| database.has_model_provider)
+            .collect::<Vec<_>>();
+        if databases.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let windows_dir = backup_dir.join("wsl-db");
+        fs::create_dir_all(&windows_dir)?;
+        let wsl_dir = windows_path_to_wsl(&windows_dir)?;
+        let mut backups = Vec::new();
+        for (index, database) in databases.into_iter().enumerate() {
+            let base_name = database
+                .path
+                .rsplit('/')
+                .next()
+                .map(sanitize_backup_name)
+                .filter(|name| !name.is_empty())
+                .unwrap_or_else(|| "state.sqlite".to_string());
+            let file_name = format!("{index:03}-{base_name}");
+            let relative_path = PathBuf::from("wsl-db").join(&file_name);
+            let windows_path = backup_dir.join(&relative_path);
+            let backup_path = format!("{}/{}", wsl_dir.trim_end_matches('/'), file_name);
+            let script = format!(
+                ".timeout 10000\n.bail on\n.backup {}\n",
+                sqlite_dot_quote(&backup_path)
+            );
+            run_sqlite(&database.path, false, &script)
+                .with_context(|| format!("无法备份 WSL Codex 索引：{}", database.path))?;
+            if !windows_path.is_file() {
+                bail!("WSL Codex 索引备份未生成：{}", windows_path.display());
+            }
+            let integrity = run_sqlite(
+                &backup_path,
+                true,
+                ".timeout 10000\n.bail on\nPRAGMA quick_check;\n",
+            )?;
+            ensure_quick_check(&integrity)
+                .with_context(|| format!("WSL Codex 索引备份校验失败：{backup_path}"))?;
+            backups.push(WslSqliteBackup {
+                source_path: database.path.clone(),
+                backup_path,
+                relative_path,
+            });
+        }
+        Ok(backups)
+    }
+
+    pub(crate) fn apply_updates(
+        &self,
+        target_provider: &str,
+        user_event_thread_ids: &HashSet<String>,
+        cwd_by_thread_id: &HashMap<String, String>,
+        backups: &[WslSqliteBackup],
+    ) -> anyhow::Result<WslSqliteUpdateResult> {
+        let mut result = WslSqliteUpdateResult::default();
+        for database in self
+            .databases
+            .iter()
+            .filter(|database| database.has_model_provider)
+        {
+            let update = (|| -> anyhow::Result<WslSqliteUpdateCounts> {
+                let script = build_update_script(
+                    database,
+                    target_provider,
+                    user_event_thread_ids,
+                    cwd_by_thread_id,
+                );
+                let output = run_sqlite(&database.path, false, &script)
+                    .with_context(|| format!("无法更新 WSL Codex 索引：{}", database.path))?;
+                parse_counts_with_integrity(&output)
+                    .with_context(|| format!("WSL Codex 索引更新结果无效：{}", database.path))
+            })();
+            let counts = match update {
+                Ok(counts) => counts,
+                Err(error) => {
+                    let rollback = self.restore_backups(backups);
+                    if let Err(rollback_error) = rollback {
+                        bail!("{error}; WSL 索引回滚也失败：{rollback_error}");
+                    }
+                    return Err(error);
+                }
+            };
+            if counts.total() > 0 {
+                result.databases_updated += 1;
+            }
+            result.counts.add(counts);
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn restore_backups(&self, backups: &[WslSqliteBackup]) -> anyhow::Result<()> {
+        let mut errors = Vec::new();
+        for backup in backups {
+            let script = format!(
+                ".timeout 10000\n.bail on\n.restore {}\nPRAGMA quick_check;\n",
+                sqlite_dot_quote(&backup.backup_path)
+            );
+            match run_sqlite(&backup.source_path, false, &script)
+                .and_then(|output| ensure_quick_check(&output))
+            {
+                Ok(()) => {}
+                Err(error) => errors.push(format!("{}：{error}", backup.source_path)),
+            }
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            bail!(errors.join("；"))
+        }
+    }
+}
+
+fn desktop_wsl_enabled(config_path: &Path) -> bool {
+    fs::read_to_string(config_path)
+        .ok()
+        .is_some_and(|text| desktop_wsl_enabled_in_text(&text))
+}
+
+fn desktop_wsl_enabled_in_text(text: &str) -> bool {
+    let mut in_desktop = false;
+    for raw_line in text.lines() {
+        let line = strip_toml_comment(raw_line).trim();
+        if line.starts_with('[') && line.ends_with(']') {
+            in_desktop = line.trim_start_matches('[').trim_end_matches(']').trim() == "desktop";
+            continue;
+        }
+        if !in_desktop {
+            continue;
+        }
+        let Some((raw_key, raw_value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = raw_key.trim().trim_matches(['\'', '"']);
+        if matches!(
+            key,
+            "runCodexInWindowsSubsystemForLinux" | "run_codex_in_windows_subsystem_for_linux"
+        ) {
+            return raw_value.trim().eq_ignore_ascii_case("true");
+        }
+    }
+    false
+}
+
+fn strip_toml_comment(line: &str) -> &str {
+    let mut quote = None;
+    let mut escaped = false;
+    for (index, ch) in line.char_indices() {
+        if let Some(active_quote) = quote {
+            if active_quote == '"' && escaped {
+                escaped = false;
+            } else if active_quote == '"' && ch == '\\' {
+                escaped = true;
+            } else if ch == active_quote {
+                quote = None;
+            }
+        } else if matches!(ch, '\'' | '"') {
+            quote = Some(ch);
+        } else if ch == '#' {
+            return &line[..index];
+        }
+    }
+    line
+}
+
+fn read_database_metadata(path: &str) -> anyhow::Result<Option<(bool, bool, bool)>> {
+    let output = run_sqlite(
+        path,
+        true,
+        ".timeout 10000\n.bail on\nSELECT printf('%d|%d|%d|%d', EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'threads'), EXISTS(SELECT 1 FROM pragma_table_info('threads') WHERE name = 'model_provider'), EXISTS(SELECT 1 FROM pragma_table_info('threads') WHERE name = 'has_user_event'), EXISTS(SELECT 1 FROM pragma_table_info('threads') WHERE name = 'cwd'));\n",
+    )?;
+    parse_database_metadata(&output)
+}
+
+fn parse_database_metadata(output: &str) -> anyhow::Result<Option<(bool, bool, bool)>> {
+    let line = output.lines().map(str::trim).find(|line| !line.is_empty());
+    let Some(line) = line else {
+        bail!("数据库元数据为空");
+    };
+    let values = line.split('|').collect::<Vec<_>>();
+    if values.len() != 4 || values.iter().any(|value| !matches!(*value, "0" | "1")) {
+        bail!("数据库元数据格式无效：{line}");
+    }
+    if values[0] == "0" {
+        return Ok(None);
+    }
+    Ok(Some((values[1] == "1", values[2] == "1", values[3] == "1")))
+}
+
+fn build_count_script(
+    database: &WslSqliteDatabase,
+    target_provider: &str,
+    user_event_thread_ids: &HashSet<String>,
+    cwd_by_thread_id: &HashMap<String, String>,
+) -> String {
+    let mut script = String::from(".timeout 10000\n.bail on\n");
+    script.push_str(&format!(
+        "SELECT COUNT(*) FROM threads WHERE COALESCE(model_provider, '') <> {};\n",
+        sqlite_text_expression(target_provider)
+    ));
+    script.push_str(&count_user_event_sql(
+        database.has_user_event,
+        user_event_thread_ids,
+    ));
+    script.push_str(&count_cwd_sql(database.has_cwd, cwd_by_thread_id));
+    script.push_str("PRAGMA quick_check;\n");
+    script
+}
+
+fn build_update_script(
+    database: &WslSqliteDatabase,
+    target_provider: &str,
+    user_event_thread_ids: &HashSet<String>,
+    cwd_by_thread_id: &HashMap<String, String>,
+) -> String {
+    let provider = sqlite_text_expression(target_provider);
+    let mut script = String::from(".timeout 10000\n.bail on\nBEGIN IMMEDIATE;\n");
+    script.push_str(&format!(
+        "UPDATE threads SET model_provider = {provider} WHERE COALESCE(model_provider, '') <> {provider};\nSELECT changes();\n"
+    ));
+    script.push_str(&update_user_event_sql(
+        database.has_user_event,
+        user_event_thread_ids,
+    ));
+    script.push_str(&update_cwd_sql(database.has_cwd, cwd_by_thread_id));
+    script.push_str("COMMIT;\nPRAGMA quick_check;\n");
+    script
+}
+
+fn count_user_event_sql(has_column: bool, ids: &HashSet<String>) -> String {
+    let values = sorted_id_values(ids);
+    if !has_column || values.is_empty() {
+        return "SELECT 0;\n".to_string();
+    }
+    format!(
+        "WITH desired(id) AS (VALUES {})\nSELECT COUNT(*) FROM threads JOIN desired ON desired.id = threads.id WHERE COALESCE(threads.has_user_event, 0) <> 1;\n",
+        values.join(", ")
+    )
+}
+
+fn update_user_event_sql(has_column: bool, ids: &HashSet<String>) -> String {
+    let values = sorted_id_values(ids);
+    if !has_column || values.is_empty() {
+        return "SELECT 0;\n".to_string();
+    }
+    format!(
+        "WITH desired(id) AS (VALUES {})\nUPDATE threads SET has_user_event = 1 WHERE id IN (SELECT id FROM desired) AND COALESCE(has_user_event, 0) <> 1;\nSELECT changes();\n",
+        values.join(", ")
+    )
+}
+
+fn count_cwd_sql(has_column: bool, cwd_by_thread_id: &HashMap<String, String>) -> String {
+    let values = sorted_cwd_values(cwd_by_thread_id);
+    if !has_column || values.is_empty() {
+        return "SELECT 0;\n".to_string();
+    }
+    format!(
+        "WITH desired(id, cwd) AS (VALUES {})\nSELECT COUNT(*) FROM threads JOIN desired ON desired.id = threads.id WHERE COALESCE(threads.cwd, '') <> desired.cwd;\n",
+        values.join(", ")
+    )
+}
+
+fn update_cwd_sql(has_column: bool, cwd_by_thread_id: &HashMap<String, String>) -> String {
+    let values = sorted_cwd_values(cwd_by_thread_id);
+    if !has_column || values.is_empty() {
+        return "SELECT 0;\n".to_string();
+    }
+    format!(
+        "WITH desired(id, cwd) AS (VALUES {})\nUPDATE threads SET cwd = (SELECT desired.cwd FROM desired WHERE desired.id = threads.id) WHERE EXISTS (SELECT 1 FROM desired WHERE desired.id = threads.id AND COALESCE(threads.cwd, '') <> desired.cwd);\nSELECT changes();\n",
+        values.join(", ")
+    )
+}
+
+fn sorted_id_values(ids: &HashSet<String>) -> Vec<String> {
+    let mut ids = ids.iter().collect::<Vec<_>>();
+    ids.sort();
+    ids.into_iter()
+        .map(|id| format!("({})", sqlite_text_expression(id)))
+        .collect()
+}
+
+fn sorted_cwd_values(cwd_by_thread_id: &HashMap<String, String>) -> Vec<String> {
+    let mut items = cwd_by_thread_id.iter().collect::<Vec<_>>();
+    items.sort_by(|left, right| left.0.cmp(right.0));
+    items
+        .into_iter()
+        .map(|(id, cwd)| {
+            format!(
+                "({}, {})",
+                sqlite_text_expression(id),
+                sqlite_text_expression(cwd)
+            )
+        })
+        .collect()
+}
+
+fn sqlite_text_expression(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut encoded = String::with_capacity(value.len() * 2);
+    for byte in value.as_bytes() {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    format!("CAST(X'{encoded}' AS TEXT)")
+}
+
+fn sqlite_dot_quote(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+fn parse_counts_with_integrity(output: &str) -> anyhow::Result<WslSqliteUpdateCounts> {
+    let lines = output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    if lines.len() != 4 || lines[3] != "ok" {
+        bail!("SQLite 返回结果或 quick_check 无效：{}", lines.join(" | "));
+    }
+    Ok(WslSqliteUpdateCounts {
+        provider_rows: lines[0].parse()?,
+        user_event_rows: lines[1].parse()?,
+        cwd_rows: lines[2].parse()?,
+    })
+}
+
+fn ensure_quick_check(output: &str) -> anyhow::Result<()> {
+    let lines = output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    if lines == ["ok"] {
+        Ok(())
+    } else {
+        bail!("quick_check 未通过：{}", lines.join(" | "))
+    }
+}
+
+fn is_valid_provider_id(value: &str) -> bool {
+    !value.trim().is_empty() && !value.chars().any(char::is_control)
+}
+
+fn decode_hex(value: &str) -> anyhow::Result<Vec<u8>> {
+    if !value.len().is_multiple_of(2) {
+        bail!("十六进制文本长度无效");
+    }
+    let mut decoded = Vec::with_capacity(value.len() / 2);
+    let bytes = value.as_bytes();
+    for pair in bytes.chunks_exact(2) {
+        let high = decode_hex_digit(pair[0])?;
+        let low = decode_hex_digit(pair[1])?;
+        decoded.push((high << 4) | low);
+    }
+    Ok(decoded)
+}
+
+fn decode_hex_digit(value: u8) -> anyhow::Result<u8> {
+    match value {
+        b'0'..=b'9' => Ok(value - b'0'),
+        b'a'..=b'f' => Ok(value - b'a' + 10),
+        b'A'..=b'F' => Ok(value - b'A' + 10),
+        _ => bail!("无效的十六进制字符"),
+    }
+}
+
+fn sanitize_backup_name(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn windows_path_to_wsl(path: &Path) -> anyhow::Result<String> {
+    let raw = path.to_string_lossy();
+    let output = run_wsl_command(&["--exec", "wslpath", "-a", "-u", &raw], None)
+        .with_context(|| format!("无法把 Windows 备份路径映射到 WSL：{}", path.display()))?;
+    let mapped = output.trim();
+    if mapped.is_empty() {
+        bail!("wslpath 返回了空路径：{}", path.display());
+    }
+    Ok(mapped.to_string())
+}
+
+fn run_sqlite(path: &str, readonly: bool, script: &str) -> anyhow::Result<String> {
+    let mut args = vec!["--exec", "sqlite3", "-batch", "-noheader"];
+    if readonly {
+        args.push("-readonly");
+    }
+    args.push(path);
+    run_wsl_command(&args, Some(script))
+}
+
+#[cfg(windows)]
+fn run_wsl_command(args: &[&str], input: Option<&str>) -> anyhow::Result<String> {
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    let mut command = Command::new("wsl.exe");
+    command
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .creation_flags(CREATE_NO_WINDOW);
+    let mut child = command.spawn().context("无法启动 wsl.exe")?;
+    if let Some(input) = input {
+        let Some(mut stdin) = child.stdin.take() else {
+            let _ = child.kill();
+            let _ = child.wait();
+            bail!("无法打开 WSL 命令的标准输入");
+        };
+        match stdin.write_all(input.as_bytes()) {
+            Ok(()) => {}
+            Err(error) => {
+                drop(stdin);
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error).context("无法向 WSL 命令写入数据");
+            }
+        }
+    }
+    drop(child.stdin.take());
+    let output = child.wait_with_output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        bail!(
+            "wsl.exe 执行失败（{}）：{}",
+            output
+                .status
+                .code()
+                .map(|code| code.to_string())
+                .unwrap_or_else(|| "terminated".to_string()),
+            if stderr.is_empty() {
+                "未返回错误详情"
+            } else {
+                &stderr
+            }
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[cfg(not(windows))]
+fn run_wsl_command(_args: &[&str], _input: Option<&str>) -> anyhow::Result<String> {
+    bail!("WSL SQLite 同步仅在 Windows 上可用")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn desktop_wsl_switch_is_read_only_from_desktop_table() {
+        assert!(desktop_wsl_enabled_in_text(
+            r#"
+model_provider = "custom"
+
+[desktop]
+runCodexInWindowsSubsystemForLinux = true # Desktop 使用 WSL
+"#
+        ));
+        assert!(!desktop_wsl_enabled_in_text(
+            r#"
+runCodexInWindowsSubsystemForLinux = true
+[desktop]
+runCodexInWindowsSubsystemForLinux = false
+"#
+        ));
+        assert!(desktop_wsl_enabled_in_text(
+            r##"
+[desktop]
+run_codex_in_windows_subsystem_for_linux = true
+label = "# 不是注释"
+"##
+        ));
+    }
+
+    #[test]
+    fn sqlite_text_expression_encodes_quotes_unicode_and_control_bytes() {
+        assert_eq!(
+            sqlite_text_expression("a'清\n\0"),
+            "CAST(X'6127E6B8850A00' AS TEXT)"
+        );
+    }
+
+    #[test]
+    fn generated_scripts_keep_values_out_of_sql_syntax() {
+        let database = WslSqliteDatabase {
+            path: "/tmp/state.sqlite".to_string(),
+            has_model_provider: true,
+            has_user_event: true,
+            has_cwd: true,
+        };
+        let ids = HashSet::from(["thread'1".to_string()]);
+        let cwd = HashMap::from([(
+            "thread'1".to_string(),
+            "C:/工作区'; DROP TABLE threads;".to_string(),
+        )]);
+        let script = build_update_script(&database, "future-provider", &ids, &cwd);
+
+        assert!(script.contains("BEGIN IMMEDIATE;"));
+        assert!(script.contains("COMMIT;\nPRAGMA quick_check;"));
+        assert!(!script.contains("DROP TABLE"));
+        assert!(!script.contains("thread'1"));
+        assert_eq!(script.matches("SELECT changes();").count(), 3);
+    }
+
+    #[test]
+    fn count_output_requires_three_counts_and_successful_integrity_check() {
+        assert_eq!(
+            parse_counts_with_integrity("4\n3\n2\nok\n").unwrap(),
+            WslSqliteUpdateCounts {
+                provider_rows: 4,
+                user_event_rows: 3,
+                cwd_rows: 2,
+            }
+        );
+        assert!(parse_counts_with_integrity("4\n3\n2\ncorrupt\n").is_err());
+        assert!(parse_counts_with_integrity("4\n3\nok\n").is_err());
+    }
+
+    #[test]
+    fn database_metadata_requires_threads_and_tracks_optional_columns() {
+        assert_eq!(
+            parse_database_metadata("1|1|0|1\n").unwrap(),
+            Some((true, false, true))
+        );
+        assert_eq!(parse_database_metadata("0|0|0|0\n").unwrap(), None);
+        assert!(parse_database_metadata("1|yes|0|1\n").is_err());
+    }
+
+    #[test]
+    fn provider_hex_and_backup_names_are_safe() {
+        assert_eq!(
+            decode_hex("746573745F70726F7669646572").unwrap(),
+            b"test_provider"
+        );
+        assert!(decode_hex("ABC").is_err());
+        assert_eq!(
+            sanitize_backup_name("state 5/主.sqlite"),
+            "state_5__.sqlite"
+        );
+        assert_eq!(
+            sqlite_dot_quote("/mnt/c/A B/\"db\""),
+            "\"/mnt/c/A B/\\\"db\\\"\""
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn non_windows_build_keeps_existing_provider_sync_behavior() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = temp.path().join("config.toml");
+        fs::write(
+            &config,
+            "[desktop]\nrunCodexInWindowsSubsystemForLinux = true\n",
+        )
+        .unwrap();
+        assert!(
+            WslSqliteContext::discover_if_enabled(&config)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[ignore = "需要由专项端到端验证准备隔离的 WSL SQLite 数据库"]
+    fn isolated_wsl_sqlite_round_trip() {
+        let expected_db = std::env::var("CODEX_PLUS_WSL_TEST_DB")
+            .expect("CODEX_PLUS_WSL_TEST_DB 必须指向隔离测试数据库");
+        let temp = tempfile::tempdir().unwrap();
+        let config = temp.path().join("config.toml");
+        fs::write(
+            &config,
+            "[desktop]\nrunCodexInWindowsSubsystemForLinux = true\n",
+        )
+        .unwrap();
+        let context = WslSqliteContext::discover_if_enabled(&config)
+            .unwrap()
+            .unwrap();
+        assert_eq!(context.databases.len(), 1);
+        assert_eq!(context.databases[0].path, expected_db);
+
+        let ids = HashSet::from(["thread-1".to_string()]);
+        let cwd = HashMap::from([("thread-1".to_string(), "C:/workspace".to_string())]);
+        let before = context
+            .count_updates("future-provider", &ids, &cwd)
+            .unwrap();
+        assert_eq!(before.total(), 3);
+        context.preflight_write().unwrap();
+        let backups = context.create_backups(temp.path()).unwrap();
+        let applied = context
+            .apply_updates("future-provider", &ids, &cwd, &backups)
+            .unwrap();
+        assert_eq!(applied.counts.total(), 3);
+        assert_eq!(applied.databases_updated, 1);
+        assert_eq!(
+            context
+                .count_updates("future-provider", &ids, &cwd)
+                .unwrap()
+                .total(),
+            0
+        );
+        context.restore_backups(&backups).unwrap();
+        assert!(
+            context
+                .provider_ids()
+                .unwrap()
+                .contains(&"old-provider".to_string())
+        );
+    }
+}

--- a/crates/codex-plus-data/tests/provider_sync.rs
+++ b/crates/codex-plus-data/tests/provider_sync.rs
@@ -1269,3 +1269,89 @@ fn session_index_cleanup_write_failure_reports_backup_and_preserves_original() {
         original
     );
 }
+
+#[cfg(windows)]
+#[test]
+#[ignore = "需要由专项端到端验证准备隔离的 WSL SQLite 数据库"]
+fn provider_sync_public_entry_updates_windows_and_wsl_indexes() {
+    let expected_wsl_db = std::env::var("CODEX_PLUS_WSL_TEST_DB")
+        .expect("CODEX_PLUS_WSL_TEST_DB 必须指向隔离测试数据库");
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    fs::create_dir(&home).unwrap();
+    fs::write(
+        home.join("config.toml"),
+        r#"model_provider = "old-provider"
+
+[desktop]
+runCodexInWindowsSubsystemForLinux = true
+"#,
+    )
+    .unwrap();
+    let rollout = home.join("sessions/2026/rollout-wsl-integration.jsonl");
+    write_rollout(&rollout, "old-provider", "thread-1", "C:/workspace");
+    create_state_db(&home.join("state_5.sqlite"));
+
+    let targets = load_provider_sync_targets(Some(&home));
+    let old_provider = targets
+        .targets
+        .iter()
+        .find(|target| target.id == "old-provider")
+        .unwrap();
+    assert!(
+        old_provider
+            .sources
+            .contains(&ProviderSyncTargetSource::WslSqlite)
+    );
+
+    let result = run_provider_sync_with_target(Some(&home), Some("future-provider"));
+
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert_eq!(result.changed_session_files, 1);
+    assert_eq!(result.sqlite_rows_updated, 6);
+    assert_eq!(result.sqlite_provider_rows_updated, 2);
+    assert_eq!(result.sqlite_user_event_rows_updated, 2);
+    assert_eq!(result.sqlite_cwd_rows_updated, 2);
+    assert_eq!(result.wsl_sqlite_rows_updated, 3);
+    assert_eq!(result.wsl_sqlite_provider_rows_updated, 1);
+    assert_eq!(result.wsl_sqlite_user_event_rows_updated, 1);
+    assert_eq!(result.wsl_sqlite_cwd_rows_updated, 1);
+    assert_eq!(result.wsl_sqlite_databases_updated, 1);
+
+    let first: serde_json::Value = serde_json::from_str(
+        fs::read_to_string(&rollout)
+            .unwrap()
+            .lines()
+            .next()
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(first["payload"]["model_provider"], "future-provider");
+    let db = Connection::open(home.join("state_5.sqlite")).unwrap();
+    let local_row = db
+        .query_row(
+            "SELECT model_provider, has_user_event, cwd FROM threads WHERE id = 'thread-1'",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert_eq!(
+        local_row,
+        ("future-provider".to_string(), 1, "C:/workspace".to_string())
+    );
+
+    let backup_dir = result.backup_dir.unwrap();
+    let metadata: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(backup_dir.join("metadata.json")).unwrap())
+            .unwrap();
+    assert_eq!(metadata["wslDbFiles"].as_array().unwrap().len(), 1);
+    assert_eq!(metadata["wslDbFiles"][0]["source"], expected_wsl_db);
+    let relative_backup = metadata["wslDbFiles"][0]["backup"].as_str().unwrap();
+    assert!(backup_dir.join(relative_backup).is_file());
+}


### PR DESCRIPTION
## 问题背景

Codex Desktop 开启 `[desktop] runCodexInWindowsSubsystemForLinux = true` 后，`CODEX_HOME` 可以位于 Windows，而当前实际使用的会话索引位于 WSL 的 `CODEX_SQLITE_HOME`。现有 Provider 同步只扫描 Windows `CODEX_HOME` 下的 SQLite，因此会出现：

- JSONL 与 Windows 旧索引已经更新；
- WSL 实时 `threads.model_provider` 仍保留旧 Provider；
- 管理器显示同步成功，但 Desktop 侧边栏仍按旧标签过滤历史。

## 修复内容

- 仅在 Windows 且 Desktop WSL 开关开启时启用 WSL SQLite 同步，其他平台和现有非 WSL 流程保持不变。
- 通过默认发行版的 `wsl.exe` 动态发现 `${CODEX_SQLITE_HOME}`，并回退扫描 `$HOME/.codex/sqlite` 与 `$HOME/.codex/state_*`，只接纳包含 `threads` 表的数据库。
- 将 WSL 数据库中的 Provider ID 加入同步目标发现，未来新增会话或供应商不依赖硬编码 ID。
- 写入前使用 `BEGIN IMMEDIATE` 检查可写性；使用 SQLite `.backup` 创建在线一致性备份；单事务更新 `model_provider`、`has_user_event`、`cwd`；提交后执行 `PRAGMA quick_check`。
- WSL 更新失败时自动从备份回滚，并让管理器/启动器返回明确失败，避免假成功。
- `sqlite_rows_updated` 保持 Windows + WSL 总数，同时增加独立的 `wsl_sqlite_*` 统计并在管理器显示。
- 启动前自动同步不再吞掉 `Skipped`/失败状态。

## 安全与兼容性

- 所有动态 SQL 文本均编码为十六进制 SQLite 文本表达式，更新脚本通过 stdin 传入，避免命令行长度与注入问题。
- 不通过 UNC 路径直接写正在使用的 WSL SQLite。
- 不增加 Cargo/npm 依赖。
- WSL 开关开启但无法发现正本、缺少 `sqlite3`、数据库被占用或完整性校验失败时，整次同步明确失败。

## 验证

- `cargo.exe test --workspace`
- `cargo.exe test -p codex-plus-data`
- `cargo.exe test -p codex-plus-manager -p codex-plus-launcher`
- `npm run check`
- `npm run vite:build`
- `node tools/i18n-verify.mjs`
- 手动启用两个默认忽略的 Windows/WSL 隔离测试：
  - WSL 发现 → 计数 → 可写检查 → 在线备份 → 三字段更新 → `quick_check` → 回滚
  - 公开 Provider 同步入口同时更新 JSONL、Windows SQLite 与 WSL SQLite，并验证备份清单和目标发现

上述测试均通过。