### PR TITLE
fix: 修复 relay 配置中模型名称输入框失焦问题

### DIFF
--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -4373,7 +4373,7 @@ function RelayProfileEditor({
                 <span />
               </div>
               {modelWindowRows.map((row, index) => (
-                <div className="relay-model-row" key={`${index}-${row.model}`}>
+                <div className="relay-model-row" key={index}>
                   <Input
                     value={row.model}
                     onChange={(event) => updateModelWindowRow(index, { model: event.currentTarget.value })}


### PR DESCRIPTION
Description:

在 relay 配置的模型列表编辑器中，每输入一个字符光标就会跳出输入框。

根因： modelWindowRows.map 的 React key 绑定了模型名称 key={ [ o bj ec tO bj ec t ] in d e x − {row.model} } ，用户每敲一个字符 row.model 就改变，React 销毁并重建整个 DOM 节点，导致焦点丢失。

修复： 改为 key={index} 。该列表无排序/拖拽操作，index 作为 key 是稳定的。

改动量： 1 行。