### PR TITLE
fix: 修复 macOS 管理器长页面无法滚动

### DIFF
--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -2750,7 +2750,7 @@ function EnhanceScreen({
     : t("未发现本地缓存；点击按钮会从 Codex++ 内置快照释放并注册，无需官方账号预缓存。");
   return (
     <>
-      <Panel>
+      <Panel className="enhance-panel">
         <CardHead title={t("Codex增强")} detail={t("会话删除、导出、项目移动和用户脚本等界面能力")} />
         <CardContent>
           <label className="switch-row">

--- a/apps/codex-plus-manager/src/styles.css
+++ b/apps/codex-plus-manager/src/styles.css
@@ -337,7 +337,9 @@ body {
   gap: 12px;
   min-width: 0;
   min-height: 0;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   padding: 16px 20px 24px;
   scrollbar-gutter: stable;
   animation: screen-enter 260ms var(--motion-ease) both;
@@ -3618,11 +3620,15 @@ select {
 }
 
 .panel {
-  overflow: clip;
+  overflow: visible;
   border-color: hsl(var(--border));
   border-radius: 10px;
   background: hsl(var(--card));
   box-shadow: none;
+}
+
+.enhance-panel {
+  min-height: max-content;
 }
 
 .panel:hover {


### PR DESCRIPTION
## 修改内容

- 将主内容区明确设置为纵向滚动容器，避免横向溢出
- 移除全局面板的内容裁切
- 为 Codex 增强长面板声明完整内容高度，确保 WebKit 正确计算滚动范围

## 验证

- npm run check
- npm run vite:build
- 默认窗口：内容高度 2184px，可滚动到 1525px，底部保存按钮完整可见
- 最小窗口 960x720：可滚动到 1514px，无横向溢出，底部保存按钮完整可见

Fixes #1503