### PR TITLE
修复供应商状态与无项目任务 / Preserve provider state and projectless tasks

### DIFF
--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -1253,6 +1253,8 @@ pub async fn sync_providers_now(target_provider: Option<String>) -> CommandResul
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
     let target_for_settings = target_provider.clone();
+    let home = codex_plus_core::relay_config::default_codex_home_dir();
+    prepare_codex_app_state_before_provider_switch(&home, "manager.sync_providers_now.before");
     let result = tauri::async_runtime::spawn_blocking(move || {
         codex_plus_data::run_provider_sync_with_target(None, target_provider.as_deref())
     })
@@ -1265,6 +1267,10 @@ pub async fn sync_providers_now(target_provider: Option<String>) -> CommandResul
                     target_for_settings
                         .as_deref()
                         .unwrap_or(&sync.target_provider),
+                );
+                finish_codex_app_state_after_provider_switch(
+                    &home,
+                    "manager.sync_providers_now.after",
                 );
             }
             ok(
@@ -2611,10 +2617,18 @@ pub fn apply_relay_injection() -> CommandResult<RelayPayload> {
             relay_payload(status, None),
         );
     }
+    prepare_codex_app_state_before_provider_switch(&home, "manager.apply_relay_injection.before");
     let relay = settings.active_relay_profile();
     log_relay_apply_request("manager.apply_relay_injection", &settings, &relay);
     if settings.active_aggregate_relay_profile().is_some() {
-        return apply_aggregate_relay_injection_to_home(&home);
+        let response = apply_aggregate_relay_injection_to_home(&home);
+        if response.status == "ok" {
+            finish_codex_app_state_after_provider_switch(
+                &home,
+                "manager.apply_relay_injection.aggregate",
+            );
+        }
+        return response;
     }
     if relay_has_complete_files(&relay) {
         return match codex_plus_core::relay_config::apply_relay_profile_to_home_with_switch_rules_and_computer_use_guard(
@@ -2624,6 +2638,10 @@ pub fn apply_relay_injection() -> CommandResult<RelayPayload> {
             settings.computer_use_guard_enabled,
         ) {
             Ok(result) => {
+                finish_codex_app_state_after_provider_switch(
+                    &home,
+                    "manager.apply_relay_injection.profile",
+                );
                 let status = codex_plus_core::relay_config::relay_status_from_home(&home);
                 log_relay_apply_result(
                     "manager.apply_relay_injection.ok",
@@ -2678,6 +2696,10 @@ pub fn apply_relay_injection() -> CommandResult<RelayPayload> {
         codex_plus_core::protocol_proxy::DEFAULT_PROTOCOL_PROXY_PORT,
     ) {
         Ok(result) => {
+            finish_codex_app_state_after_provider_switch(
+                &home,
+                "manager.apply_relay_injection.generated",
+            );
             let status = codex_plus_core::relay_config::relay_status_from_home(&home);
             log_relay_apply_result(
                 "manager.apply_relay_injection.ok",
@@ -2746,6 +2768,10 @@ pub fn apply_pure_api_injection() -> CommandResult<RelayPayload> {
             relay_payload(status, None),
         );
     }
+    prepare_codex_app_state_before_provider_switch(
+        &home,
+        "manager.apply_pure_api_injection.before",
+    );
     let relay = settings.active_relay_profile();
     log_relay_apply_request("manager.apply_pure_api_injection", &settings, &relay);
     if relay_has_complete_files(&relay) {
@@ -2756,6 +2782,10 @@ pub fn apply_pure_api_injection() -> CommandResult<RelayPayload> {
             settings.computer_use_guard_enabled,
         ) {
             Ok(result) => {
+                finish_codex_app_state_after_provider_switch(
+                    &home,
+                    "manager.apply_pure_api_injection.profile",
+                );
                 let status = codex_plus_core::relay_config::relay_status_from_home(&home);
                 log_relay_apply_result(
                     "manager.apply_pure_api_injection.ok",
@@ -2800,6 +2830,10 @@ pub fn apply_pure_api_injection() -> CommandResult<RelayPayload> {
         codex_plus_core::protocol_proxy::DEFAULT_PROTOCOL_PROXY_PORT,
     ) {
         Ok(result) => {
+            finish_codex_app_state_after_provider_switch(
+                &home,
+                "manager.apply_pure_api_injection.generated",
+            );
             let status = codex_plus_core::relay_config::relay_status_from_home(&home);
             log_relay_apply_result(
                 "manager.apply_pure_api_injection.ok",
@@ -2842,6 +2876,7 @@ pub fn clear_relay_injection() -> CommandResult<RelayPayload> {
     let settings = SettingsStore::default().load().unwrap_or_default();
     let relay = settings.active_relay_profile();
     log_manager_event("manager.clear_relay_injection.start", json!({}));
+    prepare_codex_app_state_before_provider_switch(&home, "manager.clear_relay_injection.before");
     let auth_contents = (relay.relay_mode == codex_plus_core::settings::RelayMode::Official
         && !relay.official_mix_api_key
         && !relay.auth_contents.trim().is_empty())
@@ -2849,6 +2884,10 @@ pub fn clear_relay_injection() -> CommandResult<RelayPayload> {
     match codex_plus_core::relay_config::clear_relay_config_to_home_with_auth(&home, auth_contents)
     {
         Ok(result) => {
+            finish_codex_app_state_after_provider_switch(
+                &home,
+                "manager.clear_relay_injection.after",
+            );
             let status = codex_plus_core::relay_config::relay_status_from_home(&home);
             log_manager_event(
                 "manager.clear_relay_injection.ok",
@@ -2877,6 +2916,14 @@ pub fn clear_relay_injection() -> CommandResult<RelayPayload> {
             )
         }
     }
+}
+
+fn prepare_codex_app_state_before_provider_switch(home: &Path, source: &str) {
+    codex_plus_core::codex_app_state::capture_app_state_snapshot_nonfatal(home, source);
+}
+
+fn finish_codex_app_state_after_provider_switch(home: &Path, source: &str) {
+    codex_plus_core::codex_app_state::sync_app_state_after_provider_switch_nonfatal(home, source);
 }
 
 fn relay_has_complete_files(relay: &codex_plus_core::settings::RelayProfile) -> bool {
@@ -3372,6 +3419,68 @@ mod tests {
         CODEX_HOME_TEST_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    #[test]
+    fn provider_switch_state_helpers_restore_only_safe_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join("codex-home");
+        std::fs::create_dir(&home).unwrap();
+        let state_path = home.join(".codex-global-state.json");
+        std::fs::write(
+            &state_path,
+            json!({
+                "electron-saved-workspace-roots": ["C:/work/app"],
+                "thread-writable-roots": {"thread-1": ["C:/work/app"]},
+                "electron-persisted-atom-state": {
+                    "default-service-tier": "priority",
+                    "electron:onboarding-workspace-autolaunch-applied": true,
+                    "heartbeat-thread-permissions-by-id": {"thread-1": "do-not-copy"},
+                    "prompt-history": ["do-not-copy"]
+                },
+                "provider-token-cache": "do-not-copy"
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        prepare_codex_app_state_before_provider_switch(&home, "test.before");
+        std::fs::write(
+            &state_path,
+            json!({"electron-saved-workspace-roots": ["D:/fresh/app"]}).to_string(),
+        )
+        .unwrap();
+        finish_codex_app_state_after_provider_switch(&home, "test.after");
+
+        let state: Value =
+            serde_json::from_str(&std::fs::read_to_string(&state_path).unwrap()).unwrap();
+        assert_eq!(
+            state["electron-saved-workspace-roots"],
+            json!(["D:\\fresh\\app", "C:\\work\\app"])
+        );
+        assert_eq!(
+            state["thread-writable-roots"]["thread-1"],
+            json!(["C:/work/app"])
+        );
+        assert_eq!(
+            state["electron-persisted-atom-state"]["default-service-tier"],
+            "priority"
+        );
+        assert_eq!(
+            state["electron-persisted-atom-state"]["electron:onboarding-workspace-autolaunch-applied"],
+            true
+        );
+        assert!(state.get("provider-token-cache").is_none());
+        assert!(
+            state["electron-persisted-atom-state"]
+                .get("heartbeat-thread-permissions-by-id")
+                .is_none()
+        );
+        assert!(
+            state["electron-persisted-atom-state"]
+                .get("prompt-history")
+                .is_none()
+        );
     }
 
     #[test]

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -468,7 +468,7 @@
   const codexThreadServiceTierMaxEntries = 120;
   const codexThreadServiceTierDraftBindWindowMs = 60 * 1000;
   const codexServiceTierRequestOverrideVersion = "3";
-  const codexAppServerModelRequestPatchVersion = "1";
+  const codexAppServerModelRequestPatchVersion = "2";
   const codexPluginMarketplaceUnlockVersion = "12";
   const codexPluginAutoExpandVersion = "1";
   const codexPluginAutoExpandMaxClicks = 80;
@@ -482,6 +482,9 @@
   const codexThreadScrollRouteHooksVersion = "dispatcher:2";
   const codexThreadScrollListenerVersion = "4";
   const codexThreadScrollUserIntentVersion = "dispatcher:2";
+  const codexProjectlessMainWindowVersion = "5";
+  const codexProjectlessMainWindowSetting = { key: "hotkey-window-projectless-default-enabled", default: false };
+  const codexProjectlessMainWindowRetryDelaysMs = [0, 250, 750, 1500, 3000];
   const codexPlusImageOverlayId = "codex-plus-image-overlay";
   window.__codexProjectMoveRuntimeId = (window.__codexProjectMoveRuntimeId || 0) + 1;
   const codexProjectMoveRuntimeId = window.__codexProjectMoveRuntimeId;
@@ -1588,6 +1591,16 @@
     return await codexServiceTierModulePromises.get(namePart);
   }
 
+  async function loadOptionalCodexAppModule(namePart) {
+    try {
+      return await loadCodexAppModule(namePart);
+    } catch (error) {
+      const message = String(error?.message || error);
+      if (message.includes(`未找到 Codex App asset: ${namePart}`)) return null;
+      throw error;
+    }
+  }
+
   async function codexSettingStorageModule() {
     const module = await loadCodexAppModule("setting-storage-");
     if (typeof module.n !== "function" || typeof module.s !== "function") {
@@ -2231,10 +2244,7 @@
         }
         dispatcher.__codexServiceTierOriginalDispatchMessage = dispatcher.dispatchMessage.bind(dispatcher);
         dispatcher.dispatchMessage = (type, payload) => {
-          const message = codexServiceTierRequestOverride({ ...(payload || {}), type });
-          const nextType = message?.type || type;
-          const { type: _type, ...nextPayload } = message || {};
-          return dispatcher.__codexServiceTierOriginalDispatchMessage(nextType, nextPayload);
+          return dispatchCodexPlusMessage(dispatcher, type, payload);
         };
         window.__codexServiceTierRequestOverrideInstalled = codexServiceTierRequestOverrideVersion;
         sendCodexPlusDiagnostic("service_tier_dispatcher_patch_installed", {});
@@ -4681,6 +4691,426 @@
     return await codexStateCall("set-global-state", { params: { key, value } });
   }
 
+  const codexProjectlessMainWindowStateDefaults = {
+    loaded: false,
+    enabled: false,
+    intent: "",
+    source: "",
+    revision: 0,
+    contextRevision: 0,
+    draftContext: null,
+    contextPromise: null,
+    lastGenericBeginAt: 0,
+    homeRouteRevision: -1,
+  };
+  const codexProjectlessMainWindowState = window.__codexProjectlessMainWindowState
+    && typeof window.__codexProjectlessMainWindowState === "object"
+    ? window.__codexProjectlessMainWindowState
+    : {};
+  Object.entries(codexProjectlessMainWindowStateDefaults).forEach(([key, value]) => {
+    if (!Object.prototype.hasOwnProperty.call(codexProjectlessMainWindowState, key)) {
+      codexProjectlessMainWindowState[key] = value;
+    }
+  });
+  window.__codexProjectlessMainWindowState = codexProjectlessMainWindowState;
+
+  function codexProjectlessMainWindowEnabled() {
+    return codexProjectlessMainWindowState.loaded
+      && codexProjectlessMainWindowState.enabled
+      && codexPlusBackendSettings.enhancementsEnabled !== false;
+  }
+
+  function clearCodexProjectlessMainWindowTimers() {
+    (window.__codexProjectlessMainWindowTimers || []).forEach((timer) => clearTimeout(timer));
+    window.__codexProjectlessMainWindowTimers = [];
+  }
+
+  function setCodexProjectlessMainWindowIntent(intent, source) {
+    const normalizedIntent = intent === "generic" || intent === "project" ? intent : "";
+    codexProjectlessMainWindowState.intent = normalizedIntent;
+    codexProjectlessMainWindowState.source = String(source || "");
+    codexProjectlessMainWindowState.revision += 1;
+    codexProjectlessMainWindowState.contextRevision = codexProjectlessMainWindowState.revision;
+    codexProjectlessMainWindowState.draftContext = null;
+    codexProjectlessMainWindowState.contextPromise = null;
+    if (normalizedIntent !== "generic") clearCodexProjectlessMainWindowTimers();
+  }
+
+  function codexProjectlessMainWindowShouldEnforce() {
+    return codexProjectlessMainWindowEnabled()
+      && codexProjectlessMainWindowState.intent === "generic";
+  }
+
+  function codexProjectlessContextValid(context) {
+    return !!context
+      && typeof context === "object"
+      && typeof context.cwd === "string"
+      && context.cwd.trim().length > 0
+      && typeof context.projectlessOutputDirectory === "string"
+      && context.projectlessOutputDirectory.trim().length > 0
+      && Array.isArray(context.workspaceRoots)
+      && context.workspaceRoots.length > 0;
+  }
+
+  function codexProjectlessPromptFromValue(value, visited = new WeakSet(), depth = 0) {
+    if (typeof value === "string") return depth > 0 ? value.trim() : "";
+    if (!value || typeof value !== "object" || depth > 5 || visited.has(value)) return "";
+    visited.add(value);
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item?.type === "text" && typeof item.text === "string" && item.text.trim()) return item.text.trim();
+        const prompt = codexProjectlessPromptFromValue(item, visited, depth + 1);
+        if (prompt) return prompt;
+      }
+      return "";
+    }
+    for (const key of ["input", "prompt", "message", "params", "request", "payload"]) {
+      const prompt = codexProjectlessPromptFromValue(value[key], visited, depth + 1);
+      if (prompt) return prompt;
+    }
+    return "";
+  }
+
+  async function prepareCodexProjectlessDraftContext(prompt = "") {
+    if (!codexProjectlessMainWindowShouldEnforce()) return null;
+    const revision = codexProjectlessMainWindowState.revision;
+    if (codexProjectlessMainWindowState.contextRevision === revision
+        && codexProjectlessContextValid(codexProjectlessMainWindowState.draftContext)) {
+      return codexProjectlessMainWindowState.draftContext;
+    }
+    if (codexProjectlessMainWindowState.contextRevision === revision
+        && codexProjectlessMainWindowState.contextPromise) {
+      return await codexProjectlessMainWindowState.contextPromise;
+    }
+    const contextPromise = Promise.resolve().then(async () => {
+      const module = await loadCodexAppModule("projectless-thread-");
+      if (typeof module.n !== "function") throw new Error("Codex projectless-thread 生成器不可用");
+      const options = String(prompt || "").trim() ? { prompt: String(prompt).trim() } : {};
+      const context = await module.n(["~"], options);
+      if (!codexProjectlessContextValid(context)) throw new Error("Codex projectless-thread 返回了无效目录");
+      return {
+        cwd: context.cwd,
+        projectlessOutputDirectory: context.projectlessOutputDirectory,
+        workspaceRoots: [...context.workspaceRoots],
+      };
+    });
+    codexProjectlessMainWindowState.contextRevision = revision;
+    codexProjectlessMainWindowState.contextPromise = contextPromise;
+    try {
+      const context = await contextPromise;
+      if (revision === codexProjectlessMainWindowState.revision
+          && codexProjectlessMainWindowShouldEnforce()) {
+        codexProjectlessMainWindowState.draftContext = context;
+      }
+      return context;
+    } finally {
+      if (codexProjectlessMainWindowState.contextPromise === contextPromise) {
+        codexProjectlessMainWindowState.contextPromise = null;
+      }
+    }
+  }
+
+  function codexProjectlessStartParams(message) {
+    if (!message || typeof message !== "object") return null;
+    if (message.type === "send-cli-request-for-host" && message.method === "thread/start") return message.params;
+    if ((message.type === "mcp-request" || message.type === "worker-request")
+        && message.request?.method === "thread/start") return message.request.params;
+    if (message.type === "thread-prewarm-start" && message.request?.params) return message.request.params;
+    if (message.type === "prewarm-thread-start-for-host" && message.params) return message.params;
+    if (message.type === "start-conversation" || message.type === "start-thread-for-host") return message;
+    return null;
+  }
+
+  function patchCodexProjectlessStartParams(params, context) {
+    if (!params || typeof params !== "object" || !codexProjectlessContextValid(context)) return params;
+    const next = {
+      ...params,
+      cwd: context.cwd,
+      workspaceRoots: [...context.workspaceRoots],
+      workspaceKind: "projectless",
+      projectlessOutputDirectory: context.projectlessOutputDirectory,
+    };
+    delete next.projectAssignment;
+    if (next.permissions && typeof next.permissions === "object") {
+      const permissions = { ...next.permissions, runtimeWorkspaceRoots: [...context.workspaceRoots] };
+      if (permissions.sandboxPolicy?.type === "workspaceWrite") {
+        permissions.sandboxPolicy = {
+          ...permissions.sandboxPolicy,
+          writableRoots: [...context.workspaceRoots],
+        };
+      }
+      next.permissions = permissions;
+    }
+    return next;
+  }
+
+  function applyCodexProjectlessRequestOverride(message, context) {
+    const params = codexProjectlessStartParams(message);
+    if (!params) return message;
+    const nextParams = patchCodexProjectlessStartParams(params, context);
+    if (nextParams === params) return message;
+    if (message.type === "send-cli-request-for-host") return { ...message, params: nextParams };
+    if (message.type === "mcp-request" || message.type === "worker-request") {
+      return { ...message, request: { ...message.request, params: nextParams } };
+    }
+    if (message.type === "thread-prewarm-start") {
+      return { ...message, request: { ...message.request, params: nextParams } };
+    }
+    if (message.type === "prewarm-thread-start-for-host") return { ...message, params: nextParams };
+    return nextParams;
+  }
+
+  function codexProjectlessRequestNeedsOverride(message) {
+    if (!codexProjectlessMainWindowShouldEnforce()) return false;
+    const params = codexProjectlessStartParams(message);
+    if (!params) return false;
+    return params.workspaceKind !== "projectless"
+      || typeof params.projectlessOutputDirectory !== "string"
+      || !params.projectlessOutputDirectory.trim();
+  }
+
+  function dispatchCodexPlusMessage(dispatcher, type, payload) {
+    const originalMessage = { ...(payload || {}), type };
+    const dispatch = (message) => {
+      const serviceTierMessage = codexServiceTierRequestOverride(message);
+      const nextType = serviceTierMessage?.type || type;
+      const { type: _type, ...nextPayload } = serviceTierMessage || {};
+      return dispatcher.__codexServiceTierOriginalDispatchMessage(nextType, nextPayload);
+    };
+    if (!codexProjectlessRequestNeedsOverride(originalMessage)) return dispatch(originalMessage);
+    const revision = codexProjectlessMainWindowState.revision;
+    const prompt = codexProjectlessPromptFromValue(originalMessage);
+    return prepareCodexProjectlessDraftContext(prompt).then((context) => {
+      if (revision !== codexProjectlessMainWindowState.revision
+          || !codexProjectlessMainWindowShouldEnforce()) {
+        return dispatch(originalMessage);
+      }
+      const message = applyCodexProjectlessRequestOverride(originalMessage, context);
+      sendCodexPlusDiagnostic("projectless_thread_start_overridden", {
+        type: String(type || ""),
+        workspaceRootCount: context.workspaceRoots.length,
+        hasOutputDirectory: !!context.projectlessOutputDirectory,
+      });
+      return dispatch(message);
+    }).catch((error) => {
+      sendCodexPlusDiagnostic("projectless_thread_start_override_failed", {
+        type: String(type || ""),
+        errorName: error?.name || "",
+        errorMessage: error?.message || String(error),
+      });
+      showToast("无项目会话准备失败，请重试", null);
+      throw error;
+    });
+  }
+
+  function codexProjectlessMainWindowLooksLikeHome() {
+    return Array.from(document.querySelectorAll("button, [role='button']")).some((element) => {
+      const label = String(
+        element.getAttribute?.("aria-label")
+        || element.getAttribute?.("title")
+        || element.innerText
+        || element.textContent
+        || ""
+      ).replace(/\s+/g, " ").trim();
+      return /^(select|choose) project$/i.test(label) || /^(选择|选取)项目$/.test(label);
+    });
+  }
+
+  async function navigateCodexProjectlessMainWindowHome(source, revision) {
+    if (!codexProjectlessMainWindowShouldEnforce()
+        || revision !== codexProjectlessMainWindowState.revision
+        || codexProjectlessMainWindowState.homeRouteRevision === revision
+        || !codexProjectlessMainWindowLooksLikeHome()) {
+      return false;
+    }
+    const module = await loadCodexAppModule("vscode-api-");
+    const dispatcher = module?.g;
+    if (!dispatcher || typeof dispatcher.dispatchHostMessage !== "function") {
+      throw new Error("Codex 内部导航接口不可用");
+    }
+    dispatcher.dispatchHostMessage({
+      type: "navigate-to-route",
+      path: "/",
+      state: { focusComposerNonce: Date.now() },
+    });
+    codexProjectlessMainWindowState.homeRouteRevision = revision;
+    sendCodexPlusDiagnostic("projectless_main_window_home_route_cleared", {
+      source: String(source || "runtime"),
+    });
+    return true;
+  }
+
+  async function enforceCodexProjectlessMainWindow(source, revision) {
+    if (!codexProjectlessMainWindowShouldEnforce()) return false;
+    if (revision != null && revision !== codexProjectlessMainWindowState.revision) return false;
+    let changed = false;
+    try {
+      const activeRoots = await getCodexGlobalState("active-workspace-roots").catch(() => null);
+      if (!codexProjectlessMainWindowShouldEnforce()) return false;
+      if (revision != null && revision !== codexProjectlessMainWindowState.revision) return false;
+      if (!Array.isArray(activeRoots) || activeRoots.length > 0) {
+        await setCodexGlobalState("active-workspace-roots", []);
+        sendCodexPlusDiagnostic("projectless_main_window_runtime_prepared", {
+          source: String(source || "runtime"),
+          previousRootCount: Array.isArray(activeRoots) ? activeRoots.length : activeRoots == null ? 0 : 1,
+        });
+        changed = true;
+      }
+      if (await navigateCodexProjectlessMainWindowHome(
+        source,
+        revision == null ? codexProjectlessMainWindowState.revision : revision
+      )) changed = true;
+    } catch (error) {
+      sendCodexPlusDiagnostic("projectless_main_window_runtime_failed", {
+        source: String(source || "runtime"),
+        errorName: error?.name || "",
+        errorMessage: error?.message || String(error),
+      });
+    }
+    return changed;
+  }
+
+  function scheduleCodexProjectlessMainWindowEnforcement(source) {
+    clearCodexProjectlessMainWindowTimers();
+    if (!codexProjectlessMainWindowShouldEnforce()) return;
+    const revision = codexProjectlessMainWindowState.revision;
+    window.__codexProjectlessMainWindowTimers = codexProjectlessMainWindowRetryDelaysMs.map((delay) => setTimeout(() => {
+      void enforceCodexProjectlessMainWindow(source, revision);
+    }, delay));
+  }
+
+  function codexProjectlessMainWindowTriggerKind(target) {
+    if (!target?.closest) return "";
+    const explicitProject = target.closest(
+      'button[aria-label^="Start new chat in "], [data-app-action-sidebar-project-row][data-app-action-sidebar-project-id], [role="menuitem"][data-project-id], [role="menuitem"][data-workspace-root]'
+    );
+    if (explicitProject) return "project";
+    const trigger = target.closest('button, a, [role="button"], [role="menuitem"]');
+    if (!trigger) return "";
+    const labels = [
+      trigger.getAttribute?.("aria-label"),
+      trigger.getAttribute?.("title"),
+      trigger.innerText || trigger.textContent,
+    ].map((value) => String(value || "").replace(/\s+/g, " ").trim().toLowerCase()).filter(Boolean);
+    return labels.some((label) => /^(new (task|chat)|quick chat|新建(任务|对话)|快速对话)(?:\s|ctrl\+|cmd\+|⌘|$)/i.test(label))
+      ? "generic"
+      : "";
+  }
+
+  function beginCodexProjectlessGenericNewTask(source) {
+    const now = Date.now();
+    if (codexProjectlessMainWindowState.intent !== "generic"
+        || now - codexProjectlessMainWindowState.lastGenericBeginAt > 400) {
+      setCodexProjectlessMainWindowIntent("generic", source);
+    } else {
+      codexProjectlessMainWindowState.source = String(source || "");
+    }
+    codexProjectlessMainWindowState.lastGenericBeginAt = now;
+    try {
+      sessionStorage.removeItem(upstreamProjectContextKey);
+    } catch {
+    }
+    scheduleCodexProjectlessMainWindowEnforcement(source);
+  }
+
+  function installCodexProjectlessNewTaskButtons() {
+    if (!codexProjectlessMainWindowEnabled()) return;
+    Array.from(document.querySelectorAll("button, a, [role='button'], [role='menuitem']")).forEach((trigger) => {
+      if (trigger.closest?.('[data-app-action-sidebar-project-row][data-app-action-sidebar-project-id]')) return;
+      if (codexProjectlessMainWindowTriggerKind(trigger) !== "generic") return;
+      if (trigger.dataset?.codexProjectlessMainWindow === codexProjectlessMainWindowVersion) return;
+      if (trigger.dataset) trigger.dataset.codexProjectlessMainWindow = codexProjectlessMainWindowVersion;
+      trigger.addEventListener("click", () => beginCodexProjectlessGenericNewTask("generic-new-task-button"), true);
+    });
+  }
+
+  function handleCodexProjectlessMainWindowNavigation(event) {
+    const target = event?.target?.closest ? event.target : event?.target?.parentElement;
+    const kind = codexProjectlessMainWindowTriggerKind(target);
+    if (kind === "project") {
+      setCodexProjectlessMainWindowIntent("project", "explicit-project");
+      return;
+    }
+    if (kind !== "generic") return;
+    beginCodexProjectlessGenericNewTask("generic-new-task");
+  }
+
+  function installCodexProjectlessMainWindowProtection() {
+    if (window.__codexProjectlessMainWindowProtectionVersion === codexProjectlessMainWindowVersion) return;
+    document.removeEventListener("pointerdown", window.__codexProjectlessMainWindowNavigationHandler, true);
+    document.removeEventListener("click", window.__codexProjectlessMainWindowNavigationHandler, true);
+    window.__codexProjectlessMainWindowNavigationHandler = handleCodexProjectlessMainWindowNavigation;
+    document.addEventListener("pointerdown", window.__codexProjectlessMainWindowNavigationHandler, true);
+    document.addEventListener("click", window.__codexProjectlessMainWindowNavigationHandler, true);
+    window.__codexProjectlessMainWindowProtectionVersion = codexProjectlessMainWindowVersion;
+  }
+
+  async function getCodexProjectlessMainWindowSetting() {
+    try {
+      const settingStorage = await codexSettingStorageModule();
+      return await settingStorage.n(codexProjectlessMainWindowSetting);
+    } catch (error) {
+      if (typeof codexStateCall === "function") {
+        const result = await codexStateCall("get-setting", { params: { key: codexProjectlessMainWindowSetting.key } });
+        return result && Object.prototype.hasOwnProperty.call(result, "value")
+          ? result.value
+          : codexProjectlessMainWindowSetting.default;
+      }
+      throw error;
+    }
+  }
+
+  async function loadCodexProjectlessMainWindowSetting(attempt = 0) {
+    try {
+      codexProjectlessMainWindowState.enabled = (await getCodexProjectlessMainWindowSetting()) === true;
+      codexProjectlessMainWindowState.loaded = true;
+      if (!codexProjectlessMainWindowState.enabled) {
+        setCodexProjectlessMainWindowIntent("", "setting-disabled");
+        return;
+      }
+      if (!codexProjectlessMainWindowState.intent) {
+        setCodexProjectlessMainWindowIntent("generic", "startup");
+      }
+      installAppServerModelRequestPatch();
+      scheduleCodexProjectlessMainWindowEnforcement("startup");
+      installCodexProjectlessNewTaskButtons();
+    } catch (error) {
+      if (attempt < 60) {
+        setTimeout(() => void loadCodexProjectlessMainWindowSetting(attempt + 1), 250);
+        return;
+      }
+      sendCodexPlusDiagnostic("projectless_main_window_setting_failed", {
+        errorName: error?.name || "",
+        errorMessage: error?.message || String(error),
+      });
+    }
+  }
+
+  if (window.__CODEX_PLUS_TEST_PROJECTLESS__) {
+    window.__codexPlusProjectlessTest = {
+      triggerKind: codexProjectlessMainWindowTriggerKind,
+      setEnabled: (enabled) => {
+        codexProjectlessMainWindowState.loaded = true;
+        codexProjectlessMainWindowState.enabled = enabled === true;
+      },
+      setIntent: setCodexProjectlessMainWindowIntent,
+      shouldEnforce: codexProjectlessMainWindowShouldEnforce,
+      requestNeedsOverride: codexProjectlessRequestNeedsOverride,
+      applyRequestOverride: applyCodexProjectlessRequestOverride,
+      appServerRequestNeedsOverride: codexProjectlessAppServerRequestNeedsOverride,
+      applyAppServerRequestOverride: applyCodexProjectlessAppServerRequestOverride,
+      patchAppServerClient: patchAppServerModelRequestClient,
+      contextValid: codexProjectlessContextValid,
+      setDraftContext: (context) => {
+        codexProjectlessMainWindowState.contextRevision = codexProjectlessMainWindowState.revision;
+        codexProjectlessMainWindowState.draftContext = context;
+        codexProjectlessMainWindowState.contextPromise = null;
+      },
+      dispatchMessage: dispatchCodexPlusMessage,
+      state: () => ({ ...codexProjectlessMainWindowState }),
+    };
+  }
+
   function objectGlobalState(value) {
     return value && typeof value === "object" && !Array.isArray(value) ? { ...value } : {};
   }
@@ -5132,16 +5562,85 @@
     return result;
   }
 
+  function codexProjectlessAppServerStartRequest(method, params) {
+    const requestMethod = String(method || "");
+    if (requestMethod === "send-cli-request-for-host"
+        && params?.method === "thread/start"
+        && params.params
+        && typeof params.params === "object") {
+      return {
+        params: params.params,
+        apply: (nextParams) => ({ ...params, params: nextParams }),
+      };
+    }
+    if (requestMethod === "prewarm-thread-start-for-host"
+        && params?.params
+        && typeof params.params === "object") {
+      return {
+        params: params.params,
+        apply: (nextParams) => ({ ...params, params: nextParams }),
+      };
+    }
+    if (requestMethod === "start-conversation"
+        || requestMethod === "start-thread-for-host"
+        || requestMethod === "prewarm-thread-start-for-host"
+        || requestMethod === "thread/start") {
+      return params && typeof params === "object"
+        ? { params, apply: (nextParams) => nextParams }
+        : null;
+    }
+    return null;
+  }
+
+  function codexProjectlessAppServerRequestNeedsOverride(method, params) {
+    if (!codexProjectlessMainWindowShouldEnforce()) return false;
+    const request = codexProjectlessAppServerStartRequest(method, params);
+    if (!request) return false;
+    return request.params.workspaceKind !== "projectless"
+      || typeof request.params.projectlessOutputDirectory !== "string"
+      || !request.params.projectlessOutputDirectory.trim();
+  }
+
+  function applyCodexProjectlessAppServerRequestOverride(method, params, context) {
+    const request = codexProjectlessAppServerStartRequest(method, params);
+    if (!request) return params;
+    return request.apply(patchCodexProjectlessStartParams(request.params, context));
+  }
+
   function patchAppServerModelRequestClient(client) {
     if (!client || typeof client.sendRequest !== "function") return false;
     if (client.__codexPlusModelRequestPatch === codexAppServerModelRequestPatchVersion) return true;
     const originalSendRequest = client.__codexPlusModelOriginalSendRequest || client.sendRequest.bind(client);
     client.__codexPlusModelOriginalSendRequest = originalSendRequest;
     client.sendRequest = async function codexPlusModelPatchedSendRequest(method, params, options) {
-      const result = await originalSendRequest(method, params, options);
+      let nextParams = params;
+      if (codexProjectlessAppServerRequestNeedsOverride(method, params)) {
+        const revision = codexProjectlessMainWindowState.revision;
+        try {
+          const context = await prepareCodexProjectlessDraftContext(codexProjectlessPromptFromValue(params));
+          if (revision === codexProjectlessMainWindowState.revision
+              && codexProjectlessMainWindowShouldEnforce()) {
+            nextParams = applyCodexProjectlessAppServerRequestOverride(method, params, context);
+            sendCodexPlusDiagnostic("projectless_app_server_start_overridden", {
+              method: String(method || ""),
+              workspaceRootCount: context.workspaceRoots.length,
+              hasOutputDirectory: !!context.projectlessOutputDirectory,
+            });
+          }
+        } catch (error) {
+          sendCodexPlusDiagnostic("projectless_app_server_start_override_failed", {
+            method: String(method || ""),
+            errorName: error?.name || "",
+            errorMessage: error?.message || String(error),
+          });
+          showToast("无项目会话准备失败，请重试", null);
+          throw error;
+        }
+      }
+      const result = await originalSendRequest(method, nextParams, options);
       if (!codexPlusModelUnlockEnabled()) return result;
       if (!codexPlusModelNames().length) await loadCodexModelCatalog();
-      return patchAppServerModelResult(appServerModelRequestMethod(String(method || ""), params), result);
+      return patchAppServerModelResult(appServerModelRequestMethod(String(method || ""), nextParams), result);
     };
     client.__codexPlusModelRequestPatch = codexAppServerModelRequestPatchVersion;
     return true;
@@ -5179,29 +5678,50 @@
     if (appServerModelRequestPatchDisabled) return;
     const patch = async () => {
       try {
-        const module = await loadCodexAppModule("app-server-manager-signals-");
-        const candidates = Object.values(module).filter((value) => value && typeof value === "object");
+        const modules = [];
+        for (const assetPrefix of ["use-host-config-", "app-server-manager-signals-"]) {
+          const module = await loadOptionalCodexAppModule(assetPrefix);
+          if (module) modules.push({ assetPrefix, module });
+        }
+        if (modules.length === 0) {
+          window.__codexPlusAppServerModelRequestPatchInstalled = codexAppServerModelRequestPatchVersion;
+          sendCodexPlusDiagnostic("model_app_server_request_patch_skipped", {
+            reason: "app_server_request_assets_missing",
+          });
+          return;
+        }
+        let candidateCount = 0;
         let patchedCount = 0;
-        for (const candidate of candidates) {
-          if (patchAppServerModelRequestClient(candidate)) patchedCount += 1;
-          if (typeof candidate.sendRequest !== "function" && typeof candidate.get === "function") {
-            try {
-              if (patchAppServerModelRequestClient(candidate.get())) patchedCount += 1;
-            } catch {
+        const patchedAssets = [];
+        for (const { assetPrefix, module } of modules) {
+          const candidates = Object.values(module).filter((value) => value && typeof value === "object");
+          candidateCount += candidates.length;
+          let assetPatchedCount = 0;
+          for (const candidate of candidates) {
+            if (patchAppServerModelRequestClient(candidate)) assetPatchedCount += 1;
+            if (typeof candidate.sendRequest !== "function" && typeof candidate.get === "function") {
+              try {
+                if (patchAppServerModelRequestClient(candidate.get())) assetPatchedCount += 1;
+              } catch {
+              }
             }
           }
+          if (assetPatchedCount > 0) patchedAssets.push(assetPrefix);
+          patchedCount += assetPatchedCount;
         }
         if (patchedCount > 0) {
           appServerModelRequestPatchMissCount = 0;
           window.__codexPlusAppServerModelRequestPatchInstalled = codexAppServerModelRequestPatchVersion;
           sendCodexPlusDiagnostic("model_app_server_request_patch_installed", {
-            candidateCount: candidates.length,
+            candidateCount,
             patchedCount,
+            assets: patchedAssets,
           });
         } else {
           noteAppServerModelRequestPatchMiss("model_app_server_request_patch_not_found", {
-            exportCount: Object.keys(module || {}).length,
-            candidateCount: candidates.length,
+            exportCount: modules.reduce((count, entry) => count + Object.keys(entry.module || {}).length, 0),
+            candidateCount,
+            assets: modules.map((entry) => entry.assetPrefix),
           });
         }
       } catch (error) {
@@ -8196,6 +8716,7 @@
   function scanLightweight() {
     installStyle();
     installCodexServiceTierDispatcherPatch();
+    installCodexProjectlessNewTaskButtons();
     installCodexPlusMenu();
     localizeCodexMenus();
     scheduleBackendHeartbeat();
@@ -8921,7 +9442,8 @@
   }
 
   void loadBackendSettingsForStartup();
-  void loadCodexServiceTierState();
+  installCodexProjectlessMainWindowProtection();
+  if (!window.__CODEX_PLUS_TEST_PROJECTLESS__) void loadCodexProjectlessMainWindowSetting();
   installUpstreamBranchDropdownAdapter();
   installUpstreamWorktreeNativeAdapter();
   scan();

--- a/crates/codex-plus-core/src/codex_app_state.rs
+++ b/crates/codex-plus-core/src/codex_app_state.rs
@@ -1,0 +1,724 @@
+use std::collections::{BTreeSet, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Context;
+use serde_json::{Map, Value, json};
+
+const GLOBAL_STATE_FILE: &str = ".codex-global-state.json";
+const GLOBAL_STATE_BACKUP_FILE: &str = ".codex-global-state.json.bak";
+const BACKUP_ROOT: &str = "backups_state/app-state-sync";
+const SNAPSHOT_FILE: &str = "latest-safe-state.json";
+const SNAPSHOT_VERSION: u64 = 1;
+
+const WORKSPACE_PATH_ARRAY_KEYS: &[&str] = &["electron-saved-workspace-roots", "project-order"];
+
+const ACTIVE_WORKSPACE_ROOTS_KEY: &str = "active-workspace-roots";
+
+const WORKSPACE_PATH_MAP_KEYS: &[&str] = &["electron-workspace-root-labels"];
+
+const THREAD_STATE_MAP_KEYS: &[&str] = &[
+    "thread-workspace-root-hints",
+    "thread-projectless-output-directories",
+    "thread-writable-roots",
+];
+
+const THREAD_ID_ARRAY_KEYS: &[&str] = &["projectless-thread-ids"];
+
+const SAFE_TOP_LEVEL_KEYS: &[&str] = &[
+    "electron-avatar-overlay-bounds",
+    "electron-avatar-overlay-open",
+    "electron-main-window-bounds",
+];
+
+const SAFE_ATOM_KEYS: &[&str] = &[
+    "default-service-tier",
+    "avatar-overlay-mascot-width-px",
+    "composer-auto-context-enabled",
+    "diff-filter",
+    "enter-behavior",
+    "first-awake-pet-notification-avatar-ids",
+    "has-seen-codex-mobile-announcement",
+    "has-seen-multi-agent-composer-banner",
+    "has-user-changed-service-tier",
+    "last_completed_onboarding",
+    "preferred-non-full-access-agent-mode-by-host-id",
+    "seen-model-upgrade-list",
+    "sidebar-collapsed-groups",
+    "sidebar-collapsed-sections-v1",
+    "sidebar-width",
+    "thread-summary-panel-section-expanded-progress",
+    "unread-thread-ids-by-host-v1",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppStateSyncResult {
+    pub changed: bool,
+    pub changed_keys: Vec<String>,
+    pub backup_path: Option<PathBuf>,
+    pub snapshot_path: Option<PathBuf>,
+}
+
+pub fn capture_app_state_snapshot(home: &Path) -> anyhow::Result<Option<PathBuf>> {
+    let Some(state) = load_global_state(home)? else {
+        return Ok(None);
+    };
+    let snapshot = safe_snapshot_from_state(&state);
+    let snapshot_state = snapshot
+        .get("state")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    if snapshot_state.is_empty() {
+        return Ok(None);
+    }
+    let path = snapshot_path(home);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    crate::settings::atomic_write(&path, serde_json::to_string_pretty(&snapshot)?.as_bytes())?;
+    Ok(Some(path))
+}
+
+pub fn capture_app_state_snapshot_nonfatal(home: &Path, source: &str) {
+    if let Err(error) = capture_app_state_snapshot(home) {
+        let _ = crate::diagnostic_log::append_diagnostic_log(
+            "codex_app_state.snapshot_failed",
+            json!({
+                "source": source,
+                "error": error.to_string(),
+            }),
+        );
+    }
+}
+
+pub fn sync_app_state_after_provider_switch(home: &Path) -> anyhow::Result<AppStateSyncResult> {
+    let Some(mut state) = load_global_state(home)? else {
+        return Ok(AppStateSyncResult {
+            changed: false,
+            changed_keys: Vec::new(),
+            backup_path: None,
+            snapshot_path: None,
+        });
+    };
+    let original = Value::Object(state.clone());
+    let mut changed_keys = BTreeSet::new();
+
+    normalize_current_state(&mut state, &mut changed_keys);
+    if let Some(snapshot) = load_snapshot(home)? {
+        merge_safe_snapshot(&mut state, &snapshot, &mut changed_keys);
+    }
+
+    let next = Value::Object(state);
+    if next == original {
+        let snapshot_path = capture_app_state_snapshot(home)?;
+        return Ok(AppStateSyncResult {
+            changed: false,
+            changed_keys: Vec::new(),
+            backup_path: None,
+            snapshot_path,
+        });
+    }
+
+    let backup_path = create_backup(home, &original)?;
+    let text = serde_json::to_string_pretty(&next)?;
+    let state_path = state_path(home);
+    crate::settings::atomic_write(&state_path, text.as_bytes())?;
+    if let Some(parent) = state_path.parent() {
+        let _ =
+            crate::settings::atomic_write(&parent.join(GLOBAL_STATE_BACKUP_FILE), text.as_bytes());
+    }
+    let snapshot_path = capture_app_state_snapshot(home)?;
+
+    Ok(AppStateSyncResult {
+        changed: true,
+        changed_keys: changed_keys.into_iter().collect(),
+        backup_path: Some(backup_path),
+        snapshot_path,
+    })
+}
+
+pub fn sync_app_state_after_provider_switch_nonfatal(home: &Path, source: &str) {
+    match sync_app_state_after_provider_switch(home) {
+        Ok(result) => {
+            if result.changed {
+                let _ = crate::diagnostic_log::append_diagnostic_log(
+                    "codex_app_state.synced",
+                    json!({
+                        "source": source,
+                        "changedKeys": result.changed_keys,
+                        "backupPath": result.backup_path.map(|path| path.to_string_lossy().to_string()),
+                        "snapshotPath": result.snapshot_path.map(|path| path.to_string_lossy().to_string()),
+                    }),
+                );
+            }
+        }
+        Err(error) => {
+            let _ = crate::diagnostic_log::append_diagnostic_log(
+                "codex_app_state.sync_failed",
+                json!({
+                    "source": source,
+                    "error": error.to_string(),
+                }),
+            );
+        }
+    }
+}
+
+pub fn prepare_projectless_main_window(home: &Path) -> anyhow::Result<AppStateSyncResult> {
+    if !projectless_startup_requested(home)? {
+        return Ok(AppStateSyncResult {
+            changed: false,
+            changed_keys: Vec::new(),
+            backup_path: None,
+            snapshot_path: None,
+        });
+    }
+    let Some(mut state) = load_global_state(home)? else {
+        return Ok(AppStateSyncResult {
+            changed: false,
+            changed_keys: Vec::new(),
+            backup_path: None,
+            snapshot_path: None,
+        });
+    };
+    let original = Value::Object(state.clone());
+    let mut changed_keys = BTreeSet::new();
+    replace_if_changed(
+        &mut state,
+        ACTIVE_WORKSPACE_ROOTS_KEY,
+        Value::Array(Vec::new()),
+        &mut changed_keys,
+    );
+
+    let mut atom = state
+        .get("electron-persisted-atom-state")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    atom.insert(
+        "electron:onboarding-projectless-completed".to_string(),
+        Value::Bool(true),
+    );
+    atom.insert(
+        "electron:onboarding-workspace-autolaunch-applied".to_string(),
+        Value::Bool(true),
+    );
+    replace_if_changed(
+        &mut state,
+        "electron-persisted-atom-state",
+        Value::Object(atom),
+        &mut changed_keys,
+    );
+
+    let next = Value::Object(state);
+    if next == original {
+        return Ok(AppStateSyncResult {
+            changed: false,
+            changed_keys: Vec::new(),
+            backup_path: None,
+            snapshot_path: None,
+        });
+    }
+
+    let backup_path = create_backup(home, &original)?;
+    let text = serde_json::to_string_pretty(&next)?;
+    let state_path = state_path(home);
+    crate::settings::atomic_write(&state_path, text.as_bytes())?;
+    if let Some(parent) = state_path.parent() {
+        let _ =
+            crate::settings::atomic_write(&parent.join(GLOBAL_STATE_BACKUP_FILE), text.as_bytes());
+    }
+
+    Ok(AppStateSyncResult {
+        changed: true,
+        changed_keys: changed_keys.into_iter().collect(),
+        backup_path: Some(backup_path),
+        snapshot_path: None,
+    })
+}
+
+pub fn prepare_projectless_main_window_nonfatal(home: &Path, source: &str) {
+    match prepare_projectless_main_window(home) {
+        Ok(result) if result.changed => {
+            let _ = crate::diagnostic_log::append_diagnostic_log(
+                "codex_app_state.projectless_main_window_prepared",
+                json!({
+                    "source": source,
+                    "changedKeys": result.changed_keys,
+                    "backupPath": result.backup_path.map(|path| path.to_string_lossy().to_string()),
+                }),
+            );
+        }
+        Ok(_) => {}
+        Err(error) => {
+            let _ = crate::diagnostic_log::append_diagnostic_log(
+                "codex_app_state.projectless_main_window_failed",
+                json!({
+                    "source": source,
+                    "error": error.to_string(),
+                }),
+            );
+        }
+    }
+}
+
+fn load_global_state(home: &Path) -> anyhow::Result<Option<Map<String, Value>>> {
+    let path = state_path(home);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let text =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let value: Value = serde_json::from_str(&text)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    value
+        .as_object()
+        .cloned()
+        .map(Some)
+        .ok_or_else(|| anyhow::anyhow!("{} must be a JSON object", path.display()))
+}
+
+fn projectless_startup_requested(home: &Path) -> anyhow::Result<bool> {
+    let path = home.join("config.toml");
+    if !path.exists() {
+        return Ok(false);
+    }
+    let text =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let config = text
+        .trim_start_matches('\u{feff}')
+        .parse::<toml::Table>()
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    Ok(config
+        .get("desktop")
+        .and_then(toml::Value::as_table)
+        .and_then(|desktop| desktop.get("hotkey-window-projectless-default-enabled"))
+        .and_then(toml::Value::as_bool)
+        .unwrap_or(false))
+}
+
+fn load_snapshot(home: &Path) -> anyhow::Result<Option<Map<String, Value>>> {
+    let path = snapshot_path(home);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let text =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let value: Value = serde_json::from_str(&text)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    let state = value
+        .get("state")
+        .and_then(Value::as_object)
+        .or_else(|| value.as_object())
+        .cloned()
+        .unwrap_or_default();
+    Ok(Some(state))
+}
+
+fn safe_snapshot_from_state(state: &Map<String, Value>) -> Value {
+    let mut safe = Map::new();
+    for key in WORKSPACE_PATH_ARRAY_KEYS {
+        if let Some(value) = state.get(*key) {
+            safe.insert((*key).to_string(), json!(dedupe_paths(path_array(value))));
+        }
+    }
+    if let Some(value) = state.get(ACTIVE_WORKSPACE_ROOTS_KEY) {
+        safe.insert(
+            ACTIVE_WORKSPACE_ROOTS_KEY.to_string(),
+            normalize_active_workspace_roots(value),
+        );
+    }
+    for key in WORKSPACE_PATH_MAP_KEYS {
+        if let Some(value) = state.get(*key).and_then(Value::as_object) {
+            safe.insert(
+                (*key).to_string(),
+                Value::Object(normalize_path_keyed_map(value)),
+            );
+        }
+    }
+    for key in THREAD_STATE_MAP_KEYS {
+        if let Some(value) = state.get(*key).and_then(Value::as_object) {
+            safe.insert(
+                (*key).to_string(),
+                Value::Object(normalize_string_keyed_map(value)),
+            );
+        }
+    }
+    for key in THREAD_ID_ARRAY_KEYS {
+        if let Some(value) = state.get(*key) {
+            safe.insert(
+                (*key).to_string(),
+                json!(dedupe_strings(string_array(value))),
+            );
+        }
+    }
+    for key in SAFE_TOP_LEVEL_KEYS {
+        if let Some(value) = state.get(*key) {
+            safe.insert((*key).to_string(), value.clone());
+        }
+    }
+    if let Some(atom) = state
+        .get("electron-persisted-atom-state")
+        .and_then(Value::as_object)
+    {
+        let atom = safe_atom_state(atom);
+        if !atom.is_empty() {
+            safe.insert(
+                "electron-persisted-atom-state".to_string(),
+                Value::Object(atom),
+            );
+        }
+    }
+    json!({
+        "version": SNAPSHOT_VERSION,
+        "state": safe,
+    })
+}
+
+fn normalize_current_state(state: &mut Map<String, Value>, changed: &mut BTreeSet<String>) {
+    for key in WORKSPACE_PATH_ARRAY_KEYS {
+        if let Some(value) = state.get(*key).cloned() {
+            let next = json!(dedupe_paths(path_array(&value)));
+            replace_if_changed(state, key, next, changed);
+        }
+    }
+    if let Some(value) = state.get(ACTIVE_WORKSPACE_ROOTS_KEY).cloned() {
+        replace_if_changed(
+            state,
+            ACTIVE_WORKSPACE_ROOTS_KEY,
+            normalize_active_workspace_roots(&value),
+            changed,
+        );
+    }
+    for key in WORKSPACE_PATH_MAP_KEYS {
+        if let Some(value) = state.get(*key).and_then(Value::as_object) {
+            let next = Value::Object(normalize_path_keyed_map(value));
+            replace_if_changed(state, key, next, changed);
+        }
+    }
+    for key in THREAD_STATE_MAP_KEYS {
+        if let Some(value) = state.get(*key).and_then(Value::as_object) {
+            let next = Value::Object(normalize_string_keyed_map(value));
+            replace_if_changed(state, key, next, changed);
+        }
+    }
+    for key in THREAD_ID_ARRAY_KEYS {
+        if let Some(value) = state.get(*key).cloned() {
+            let next = json!(dedupe_strings(string_array(&value)));
+            replace_if_changed(state, key, next, changed);
+        }
+    }
+    if let Some(value) = state
+        .get("electron-persisted-atom-state")
+        .and_then(Value::as_object)
+        .cloned()
+    {
+        let mut atom = value;
+        normalize_atom_state(&mut atom);
+        replace_if_changed(
+            state,
+            "electron-persisted-atom-state",
+            Value::Object(atom),
+            changed,
+        );
+    }
+}
+
+fn merge_safe_snapshot(
+    target: &mut Map<String, Value>,
+    snapshot: &Map<String, Value>,
+    changed: &mut BTreeSet<String>,
+) {
+    for key in WORKSPACE_PATH_ARRAY_KEYS {
+        let mut paths = target.get(*key).map(path_array).unwrap_or_default();
+        paths.extend(snapshot.get(*key).map(path_array).unwrap_or_default());
+        if !paths.is_empty() {
+            replace_if_changed(target, key, json!(dedupe_paths(paths)), changed);
+        }
+    }
+    let mut active_paths = target
+        .get(ACTIVE_WORKSPACE_ROOTS_KEY)
+        .map(path_array)
+        .unwrap_or_default();
+    active_paths.extend(
+        snapshot
+            .get(ACTIVE_WORKSPACE_ROOTS_KEY)
+            .map(path_array)
+            .unwrap_or_default(),
+    );
+    let active_paths = dedupe_paths(active_paths);
+    if !active_paths.is_empty() {
+        let target_is_array = target
+            .get(ACTIVE_WORKSPACE_ROOTS_KEY)
+            .is_some_and(Value::is_array);
+        let snapshot_is_array = snapshot
+            .get(ACTIVE_WORKSPACE_ROOTS_KEY)
+            .is_some_and(Value::is_array);
+        let next = if target_is_array || snapshot_is_array || active_paths.len() > 1 {
+            json!(active_paths)
+        } else {
+            json!(active_paths[0])
+        };
+        replace_if_changed(target, ACTIVE_WORKSPACE_ROOTS_KEY, next, changed);
+    }
+    for key in WORKSPACE_PATH_MAP_KEYS {
+        let snapshot_map = snapshot.get(*key).and_then(Value::as_object);
+        let current_map = target.get(*key).and_then(Value::as_object);
+        let merged = merge_path_keyed_maps(snapshot_map, current_map);
+        if !merged.is_empty() {
+            replace_if_changed(target, key, Value::Object(merged), changed);
+        }
+    }
+    for key in THREAD_STATE_MAP_KEYS {
+        let snapshot_map = snapshot.get(*key).and_then(Value::as_object);
+        let current_map = target.get(*key).and_then(Value::as_object);
+        let merged = merge_string_keyed_maps(snapshot_map, current_map);
+        if !merged.is_empty() {
+            replace_if_changed(target, key, Value::Object(merged), changed);
+        }
+    }
+    for key in THREAD_ID_ARRAY_KEYS {
+        let mut ids = target.get(*key).map(string_array).unwrap_or_default();
+        ids.extend(snapshot.get(*key).map(string_array).unwrap_or_default());
+        if !ids.is_empty() {
+            replace_if_changed(target, key, json!(dedupe_strings(ids)), changed);
+        }
+    }
+    for key in SAFE_TOP_LEVEL_KEYS {
+        if let Some(value) = snapshot.get(*key) {
+            replace_if_changed(target, key, value.clone(), changed);
+        }
+    }
+    if let Some(snapshot_atom) = snapshot
+        .get("electron-persisted-atom-state")
+        .and_then(Value::as_object)
+    {
+        let mut atom = target
+            .get("electron-persisted-atom-state")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        for (key, value) in safe_atom_state(snapshot_atom) {
+            atom.insert(key, value);
+        }
+        normalize_atom_state(&mut atom);
+        replace_if_changed(
+            target,
+            "electron-persisted-atom-state",
+            Value::Object(atom),
+            changed,
+        );
+    }
+}
+
+fn replace_if_changed(
+    target: &mut Map<String, Value>,
+    key: &str,
+    value: Value,
+    changed: &mut BTreeSet<String>,
+) {
+    if target.get(key) != Some(&value) {
+        target.insert(key.to_string(), value);
+        changed.insert(key.to_string());
+    }
+}
+
+fn safe_atom_state(atom: &Map<String, Value>) -> Map<String, Value> {
+    atom.iter()
+        .filter(|(key, _)| is_safe_atom_key(key))
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect()
+}
+
+fn normalize_atom_state(atom: &mut Map<String, Value>) {
+    if let Some(value) = atom.remove("service-tier-default") {
+        atom.entry("default-service-tier".to_string())
+            .or_insert(value);
+    }
+}
+
+fn is_safe_atom_key(key: &str) -> bool {
+    SAFE_ATOM_KEYS.contains(&key)
+        || key.starts_with("app-shell:right-panel-width:")
+        || key.starts_with("avatar-overlay-")
+        || key.starts_with("electron:onboarding-")
+        || key.starts_with("first-awake-pet-notification-")
+        || key.starts_with("sidebar-project-expanded-")
+        || key.starts_with("thread-summary-panel-section-expanded-")
+}
+
+fn merge_path_keyed_maps(
+    snapshot: Option<&Map<String, Value>>,
+    current: Option<&Map<String, Value>>,
+) -> Map<String, Value> {
+    let mut merged = Map::new();
+    if let Some(snapshot) = snapshot {
+        for (key, value) in normalize_path_keyed_map(snapshot) {
+            merged.insert(key, value);
+        }
+    }
+    if let Some(current) = current {
+        for (key, value) in normalize_path_keyed_map(current) {
+            merged.insert(key, value);
+        }
+    }
+    merged
+}
+
+fn merge_string_keyed_maps(
+    snapshot: Option<&Map<String, Value>>,
+    current: Option<&Map<String, Value>>,
+) -> Map<String, Value> {
+    let mut merged = Map::new();
+    if let Some(snapshot) = snapshot {
+        for (key, value) in normalize_string_keyed_map(snapshot) {
+            merged.insert(key, value);
+        }
+    }
+    if let Some(current) = current {
+        for (key, value) in normalize_string_keyed_map(current) {
+            merged.insert(key, value);
+        }
+    }
+    merged
+}
+
+fn normalize_path_keyed_map(map: &Map<String, Value>) -> Map<String, Value> {
+    let mut next = Map::new();
+    for (key, value) in map {
+        if let Some(path) = normalize_desktop_path(key) {
+            next.insert(path, value.clone());
+        }
+    }
+    next
+}
+
+fn normalize_string_keyed_map(map: &Map<String, Value>) -> Map<String, Value> {
+    let mut next = Map::new();
+    for (key, value) in map {
+        let key = key.trim();
+        if !key.is_empty() {
+            next.insert(key.to_string(), value.clone());
+        }
+    }
+    next
+}
+
+fn path_array(value: &Value) -> Vec<String> {
+    if let Some(items) = value.as_array() {
+        items
+            .iter()
+            .filter_map(Value::as_str)
+            .filter_map(normalize_desktop_path)
+            .collect()
+    } else if let Some(value) = value.as_str() {
+        normalize_desktop_path(value).into_iter().collect()
+    } else {
+        Vec::new()
+    }
+}
+
+fn normalize_active_workspace_roots(value: &Value) -> Value {
+    let normalized = dedupe_paths(path_array(value));
+    if value.is_array() {
+        json!(normalized)
+    } else if let Some(first) = normalized.first() {
+        json!(first)
+    } else {
+        value.clone()
+    }
+}
+
+fn dedupe_paths(paths: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut result = Vec::new();
+    for path in paths {
+        let comparable = path
+            .replace('/', r"\")
+            .trim_end_matches('\\')
+            .to_ascii_lowercase();
+        if seen.insert(comparable) {
+            result.push(path);
+        }
+    }
+    result
+}
+
+fn string_array(value: &Value) -> Vec<String> {
+    if let Some(items) = value.as_array() {
+        items
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::trim)
+            .filter(|item| !item.is_empty())
+            .map(ToString::to_string)
+            .collect()
+    } else if let Some(value) = value.as_str() {
+        let value = value.trim();
+        if value.is_empty() {
+            Vec::new()
+        } else {
+            vec![value.to_string()]
+        }
+    } else {
+        Vec::new()
+    }
+}
+
+fn dedupe_strings(items: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut result = Vec::new();
+    for item in items {
+        if seen.insert(item.clone()) {
+            result.push(item);
+        }
+    }
+    result
+}
+
+fn normalize_desktop_path(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let mut path = trimmed.replace('/', r"\");
+    while path.len() > 3 && path.ends_with('\\') {
+        path.pop();
+    }
+    Some(path)
+}
+
+fn create_backup(home: &Path, original: &Value) -> anyhow::Result<PathBuf> {
+    let root = home.join(BACKUP_ROOT).join(format!("{}", now_ms()));
+    fs::create_dir_all(&root)?;
+    fs::write(
+        root.join(GLOBAL_STATE_FILE),
+        serde_json::to_string_pretty(original)?,
+    )?;
+    fs::write(
+        root.join("metadata.json"),
+        serde_json::to_string_pretty(&json!({
+            "version": SNAPSHOT_VERSION,
+            "managedBy": "Codex++ app state sync",
+            "createdAtMs": now_ms(),
+        }))?,
+    )?;
+    Ok(root)
+}
+
+fn state_path(home: &Path) -> PathBuf {
+    home.join(GLOBAL_STATE_FILE)
+}
+
+fn snapshot_path(home: &Path) -> PathBuf {
+    home.join(BACKUP_ROOT).join(SNAPSHOT_FILE)
+}
+
+fn now_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -258,8 +258,14 @@ where
     let mut keep_launched_on_error = false;
 
     let result: anyhow::Result<LaunchHandle> = async {
+        let home = crate::relay_config::default_codex_home_dir();
         if settings.provider_sync_enabled {
+            crate::codex_app_state::capture_app_state_snapshot_nonfatal(&home, "launcher.before");
             hooks.run_provider_sync().await?;
+            crate::codex_app_state::sync_app_state_after_provider_switch_nonfatal(
+                &home,
+                "launcher.after_provider_sync",
+            );
         }
         if let Err(error) = hooks.ensure_plugin_marketplace_config(&settings).await {
             let _ = crate::diagnostic_log::append_diagnostic_log(
@@ -272,7 +278,6 @@ where
         if settings.computer_use_guard_enabled {
             hooks.ensure_computer_use_config(&settings).await?;
         }
-        let home = crate::relay_config::default_codex_home_dir();
         match crate::codex_sqlite::sanitize_historical_model_suffixes(&home) {
             Ok(result) if result.updated > 0 => {
                 let _ = crate::diagnostic_log::append_diagnostic_log(
@@ -654,6 +659,13 @@ impl LaunchHooks for DefaultLaunchHooks {
         settings: &BackendSettings,
         extra_args: &[String],
     ) -> anyhow::Result<CodexLaunch> {
+        if settings.enhancements_enabled {
+            let home = crate::relay_config::default_codex_home_dir();
+            crate::codex_app_state::prepare_projectless_main_window_nonfatal(
+                &home,
+                "launcher.prelaunch",
+            );
+        }
         let native_menu_localization_enabled = settings.codex_app_native_menu_localization;
         let native_menu_inspector_port =
             native_menu_localization_enabled.then(|| select_native_menu_inspector_port(debug_port));

--- a/crates/codex-plus-core/src/lib.rs
+++ b/crates/codex-plus-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod assets;
 pub mod bridge;
 pub mod ccs_import;
 pub mod cdp;
+pub mod codex_app_state;
 pub mod codex_home;
 pub mod codex_local_storage;
 pub mod codex_sqlite;

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -1076,7 +1076,10 @@ fn write_codex_live_atomic(
     let config_text = guarded_config_text.as_deref();
 
     let config_text = match config_text {
-        Some(config_text) => Some(preserve_live_marketplace_configs(home, config_text)?),
+        Some(config_text) => {
+            let config_text = preserve_live_desktop_settings(home, config_text)?;
+            Some(preserve_live_marketplace_configs(home, &config_text)?)
+        }
         None => None,
     };
     let config_text = config_text.as_deref();
@@ -1394,6 +1397,42 @@ fn validate_toml_config(config_text: &str, path: &Path) -> anyhow::Result<()> {
 
 fn normalize_config_text_for_write(config_text: &str) -> String {
     config_text.trim_start_matches('\u{feff}').to_string()
+}
+
+fn preserve_live_desktop_settings(home: &Path, config_text: &str) -> anyhow::Result<String> {
+    let normalized = normalize_config_text_for_write(config_text);
+    let live_text = read_optional_text(&home.join("config.toml"))?;
+    if live_text.trim().is_empty() {
+        return Ok(normalized);
+    }
+    let Ok(live_doc) = parse_toml_document(&live_text) else {
+        return Ok(normalized);
+    };
+    let mut target_doc = parse_toml_document(&normalized)?;
+    if let Some(live_desktop) = live_doc.get("desktop").cloned() {
+        if !live_desktop.is_none() {
+            merge_toml_item(&mut target_doc["desktop"], &live_desktop);
+        }
+    }
+    for key in ["sandbox_mode", "approval_policy", "sandbox_workspace_write"] {
+        if let Some(live_value) = live_doc.get(key).cloned() {
+            merge_toml_item(&mut target_doc[key], &live_value);
+        }
+    }
+    let context_usage_configured = target_doc
+        .get("desktop")
+        .and_then(Item::as_table)
+        .and_then(|desktop| desktop.get("show-context-window-usage"))
+        .is_some();
+    if !context_usage_configured {
+        if target_doc.get("desktop").is_none() {
+            target_doc["desktop"] = toml_edit::table();
+        }
+        if let Some(desktop) = target_doc["desktop"].as_table_mut() {
+            desktop["show-context-window-usage"] = toml_edit::value(true);
+        }
+    }
+    Ok(normalize_optional_toml(target_doc))
 }
 
 fn validate_auth_json(auth_bytes: &[u8], path: &Path) -> anyhow::Result<()> {

--- a/crates/codex-plus-core/src/relay_switch.rs
+++ b/crates/codex-plus-core/src/relay_switch.rs
@@ -24,6 +24,7 @@ pub fn switch_relay_profile_in_home(
     if !selected_settings.relay_profiles_enabled {
         anyhow::bail!("供应商配置总开关已关闭，未写入 config.toml / auth.json。");
     }
+    crate::codex_app_state::capture_app_state_snapshot_nonfatal(home, "relay_switch.before");
 
     let original_settings = store.load().unwrap_or_default();
     if !previous_active_relay_id.trim().is_empty()
@@ -38,7 +39,13 @@ pub fn switch_relay_profile_in_home(
     let selected_settings = store.load().context("读取供应商设置失败")?;
 
     match apply_selected_relay_profile(home, &selected_settings) {
-        Ok(result) => Ok(result),
+        Ok(result) => {
+            crate::codex_app_state::sync_app_state_after_provider_switch_nonfatal(
+                home,
+                "relay_switch.after",
+            );
+            Ok(result)
+        }
         Err(error) => {
             let _ = store.save(&original_settings);
             Err(error)

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -1098,6 +1098,241 @@ process.stdout.write(JSON.stringify({{
 }
 
 #[test]
+fn injection_script_applies_projectless_main_window_contract() {
+    let script = assets::injection_script(57321);
+    assert!(script.contains("installCodexProjectlessNewTaskButtons"));
+    assert!(script.contains("codexProjectlessMainWindowVersion = \"5\""));
+    assert!(script.contains("generic-new-task-button"));
+    assert!(script.contains("loadCodexAppModule(\"projectless-thread-\")"));
+    assert!(script.contains("projectless_thread_start_overridden"));
+    assert!(script.contains("projectless_app_server_start_overridden"));
+    assert!(script.contains("projectless_main_window_home_route_cleared"));
+    assert!(script.contains("dispatcher.dispatchHostMessage"));
+    assert!(script.contains("[\"use-host-config-\", \"app-server-manager-signals-\"]"));
+    assert!(script.contains("codexProjectlessMainWindowRetryDelaysMs = [0, 250, 750, 1500, 3000]"));
+    let cases = run_projectless_main_window_contract_harness();
+
+    assert_eq!(cases["englishNewTask"], "generic");
+    assert_eq!(cases["chineseNewTask"], "generic");
+    assert_eq!(cases["compactChineseNewTask"], "generic");
+    assert_eq!(cases["quickChat"], "generic");
+    assert_eq!(cases["explicitProject"], "project");
+    assert_eq!(cases["projectRow"], "project");
+    assert_eq!(cases["unrelated"], "");
+    assert_eq!(cases["genericEnabled"], true);
+    assert_eq!(cases["projectRequestNeedsOverride"], true);
+    assert_eq!(cases["nativeProjectlessNeedsOverride"], false);
+    assert_eq!(cases["patchedWorkspaceKind"], "projectless");
+    assert_eq!(cases["patchedCwd"], "C:/generated/work");
+    assert_eq!(cases["patchedOutputDirectory"], "C:/generated/outputs");
+    assert_eq!(cases["patchedWorkspaceRoots"], json!(["C:/generated/work"]));
+    assert_eq!(
+        cases["patchedPermissionRoots"],
+        json!(["C:/generated/work"])
+    );
+    assert_eq!(cases["patchedWritableRoots"], json!(["C:/generated/work"]));
+    assert_eq!(cases["patchedHasProjectAssignment"], false);
+    assert_eq!(cases["dispatchResult"], "sent");
+    assert_eq!(cases["dispatchedCount"], 1);
+    assert_eq!(cases["dispatchedType"], "start-conversation");
+    assert_eq!(cases["dispatchedWorkspaceKind"], "projectless");
+    assert_eq!(cases["dispatchedCwd"], "C:/generated/work");
+    assert_eq!(cases["appServerRequestNeedsOverride"], true);
+    assert_eq!(cases["appServerPatchedWorkspaceKind"], "projectless");
+    assert_eq!(cases["appServerPatchedCwd"], "C:/generated/work");
+    assert_eq!(cases["appServerPatchedHasProjectAssignment"], false);
+    assert_eq!(cases["nestedAppServerWorkspaceKind"], "projectless");
+    assert_eq!(cases["nestedAppServerCwd"], "C:/generated/work");
+    assert_eq!(cases["appServerSentCount"], 1);
+    assert_eq!(cases["appServerSentMethod"], "start-conversation");
+    assert_eq!(cases["appServerSentWorkspaceKind"], "projectless");
+    assert_eq!(cases["appServerSentCwd"], "C:/generated/work");
+    assert_eq!(cases["explicitProjectWins"], false);
+    assert_eq!(cases["explicitProjectRequestIsUntouched"], false);
+    assert_eq!(cases["disabledIsNoop"], false);
+}
+
+fn run_projectless_main_window_contract_harness() -> serde_json::Value {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let script_path = temp.path().join("renderer-inject.js");
+    let harness_path = temp.path().join("projectless-main-window-harness.cjs");
+    std::fs::write(&script_path, assets::injection_script(57321))
+        .expect("injection script should be written");
+    let mut harness = std::fs::File::create(&harness_path).expect("harness should be created");
+    write!(
+        harness,
+        r#"
+const scriptPath = {script_path};
+const store = new Map();
+function node() {{
+  return {{
+    appendChild() {{}}, prepend() {{}}, remove() {{}}, setAttribute() {{}}, removeAttribute() {{}},
+    addEventListener() {{}}, querySelector() {{ return null; }}, querySelectorAll() {{ return []; }},
+    closest() {{ return null; }},
+    classList: {{ add() {{}}, remove() {{}}, toggle() {{}}, contains() {{ return false; }} }},
+    dataset: {{}}, style: {{}}, children: [], isConnected: true, textContent: "", innerHTML: "",
+  }};
+}}
+function trigger(label, kind = "generic") {{
+  const value = {{
+    textContent: label,
+    getAttribute(name) {{ return name === "aria-label" ? label : null; }},
+    closest(selector) {{
+      if (selector.includes('Start new chat in') || selector.includes('data-app-action-sidebar-project-row')) {{
+        return kind === "project-button" || kind === "project-row" ? value : null;
+      }}
+      if (selector === 'button, a, [role="button"], [role="menuitem"]') return value;
+      return null;
+    }},
+  }};
+  return value;
+}}
+globalThis.window = globalThis;
+window.__CODEX_PLUS_TEST_PROJECTLESS__ = true;
+window.addEventListener = () => {{}};
+window.removeEventListener = () => {{}};
+window.dispatchEvent = () => true;
+globalThis.Element = class Element {{}};
+globalThis.HTMLElement = class HTMLElement extends Element {{}};
+globalThis.HTMLAnchorElement = class HTMLAnchorElement extends HTMLElement {{}};
+globalThis.MutationObserver = class MutationObserver {{ observe() {{}} disconnect() {{}} }};
+globalThis.ResizeObserver = class ResizeObserver {{ observe() {{}} disconnect() {{}} }};
+globalThis.requestAnimationFrame = () => 0;
+globalThis.cancelAnimationFrame = () => {{}};
+globalThis.document = {{
+  scripts: [], documentElement: node(), body: node(), createElement: () => node(),
+  getElementById: () => null, querySelector: () => null, querySelectorAll: () => [],
+  addEventListener() {{}}, removeEventListener() {{}},
+}};
+globalThis.localStorage = {{
+  getItem: (key) => store.has(key) ? store.get(key) : null,
+  setItem: (key, value) => store.set(key, String(value)), removeItem: (key) => store.delete(key),
+}};
+store.set("codexPlusSettings", JSON.stringify({{ modelWhitelistUnlock: false }}));
+globalThis.sessionStorage = globalThis.localStorage;
+globalThis.location = {{ href: "https://codex.test/index.html", pathname: "/index.html", search: "", hash: "" }};
+window.location = globalThis.location;
+globalThis.navigator = {{ userAgent: "node-test" }};
+globalThis.performance = {{ getEntriesByType: () => [] }};
+require(scriptPath);
+void (async () => {{
+const api = window.__codexPlusProjectlessTest;
+const englishNewTask = api.triggerKind(trigger("New task"));
+const chineseNewTask = api.triggerKind(trigger("新建任务\nCtrl+N"));
+const compactChineseNewTask = api.triggerKind(trigger("新建任务Ctrl+N"));
+const quickChat = api.triggerKind(trigger("Quick Chat"));
+const explicitProject = api.triggerKind(trigger("Start new chat in Demo", "project-button"));
+const projectRow = api.triggerKind(trigger("Demo", "project-row"));
+const unrelated = api.triggerKind(trigger("Settings"));
+api.setEnabled(true);
+api.setIntent("generic", "test");
+const genericEnabled = api.shouldEnforce();
+const context = {{ cwd: "C:/generated/work", projectlessOutputDirectory: "C:/generated/outputs", workspaceRoots: ["C:/generated/work"] }};
+const projectRequest = {{
+  type: "start-conversation",
+  cwd: "C:/recent-project",
+  workspaceRoots: ["C:/recent-project"],
+  workspaceKind: "project",
+  projectAssignment: {{ projectKind: "local", projectId: "C:/recent-project" }},
+  permissions: {{
+    runtimeWorkspaceRoots: ["C:/recent-project"],
+    sandboxPolicy: {{ type: "workspaceWrite", writableRoots: ["C:/recent-project"] }},
+  }},
+}};
+const projectRequestNeedsOverride = api.requestNeedsOverride(projectRequest);
+const patchedRequest = api.applyRequestOverride(projectRequest, context);
+const nativeProjectlessNeedsOverride = api.requestNeedsOverride({{
+  type: "start-conversation",
+  cwd: "C:/native/work",
+  workspaceRoots: ["C:/native/work"],
+  workspaceKind: "projectless",
+  projectlessOutputDirectory: "C:/native/outputs",
+}});
+const dispatched = [];
+const dispatcher = {{
+  __codexServiceTierOriginalDispatchMessage(type, payload) {{
+    dispatched.push({{ type, payload }});
+    return "sent";
+  }},
+}};
+api.setDraftContext(context);
+const dispatchResult = await api.dispatchMessage(dispatcher, "start-conversation", projectRequest);
+const appServerProjectRequest = {{ ...projectRequest }};
+delete appServerProjectRequest.type;
+const appServerRequestNeedsOverride = api.appServerRequestNeedsOverride("start-conversation", appServerProjectRequest);
+const appServerPatchedRequest = api.applyAppServerRequestOverride("start-conversation", appServerProjectRequest, context);
+const nestedAppServerPatchedRequest = api.applyAppServerRequestOverride("send-cli-request-for-host", {{
+  method: "thread/start",
+  params: appServerProjectRequest,
+}}, context);
+const appServerSent = [];
+const appServerClient = {{
+  async sendRequest(method, params) {{
+    appServerSent.push({{ method, params }});
+    return {{ ok: true }};
+  }},
+}};
+api.patchAppServerClient(appServerClient);
+await appServerClient.sendRequest("start-conversation", appServerProjectRequest);
+api.setIntent("project", "test");
+const explicitProjectWins = api.shouldEnforce();
+const explicitProjectRequestIsUntouched = api.requestNeedsOverride(projectRequest);
+api.setEnabled(false);
+api.setIntent("generic", "test");
+const disabledIsNoop = api.shouldEnforce();
+process.stdout.write(JSON.stringify({{
+  englishNewTask, chineseNewTask, compactChineseNewTask, quickChat, explicitProject, projectRow, unrelated,
+  genericEnabled, projectRequestNeedsOverride, nativeProjectlessNeedsOverride,
+  patchedWorkspaceKind: patchedRequest.workspaceKind,
+  patchedCwd: patchedRequest.cwd,
+  patchedOutputDirectory: patchedRequest.projectlessOutputDirectory,
+  patchedWorkspaceRoots: patchedRequest.workspaceRoots,
+  patchedPermissionRoots: patchedRequest.permissions.runtimeWorkspaceRoots,
+  patchedWritableRoots: patchedRequest.permissions.sandboxPolicy.writableRoots,
+  patchedHasProjectAssignment: Object.hasOwn(patchedRequest, "projectAssignment"),
+  dispatchResult,
+  dispatchedCount: dispatched.length,
+  dispatchedType: dispatched[0]?.type,
+  dispatchedWorkspaceKind: dispatched[0]?.payload?.workspaceKind,
+  dispatchedCwd: dispatched[0]?.payload?.cwd,
+  appServerRequestNeedsOverride,
+  appServerPatchedWorkspaceKind: appServerPatchedRequest.workspaceKind,
+  appServerPatchedCwd: appServerPatchedRequest.cwd,
+  appServerPatchedHasProjectAssignment: Object.hasOwn(appServerPatchedRequest, "projectAssignment"),
+  nestedAppServerWorkspaceKind: nestedAppServerPatchedRequest.params.workspaceKind,
+  nestedAppServerCwd: nestedAppServerPatchedRequest.params.cwd,
+  appServerSentCount: appServerSent.length,
+  appServerSentMethod: appServerSent[0]?.method,
+  appServerSentWorkspaceKind: appServerSent[0]?.params?.workspaceKind,
+  appServerSentCwd: appServerSent[0]?.params?.cwd,
+  explicitProjectWins, explicitProjectRequestIsUntouched, disabledIsNoop,
+}}));
+process.exit(0);
+}})().catch((error) => {{
+  console.error(error);
+  process.exit(1);
+}});
+"#,
+        script_path = serde_json::to_string(&script_path.to_string_lossy().to_string())
+            .expect("script path should serialize")
+    )
+    .expect("harness should be written");
+    drop(harness);
+
+    let output = Command::new("node")
+        .arg(&harness_path)
+        .output()
+        .expect("node should run projectless main-window harness");
+    assert!(
+        output.status.success(),
+        "node harness failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("harness stdout should be JSON")
+}
+
+#[test]
 fn injection_script_restores_thread_scroll_positions() {
     let script = assets::injection_script(57321);
 

--- a/crates/codex-plus-core/tests/codex_app_state.rs
+++ b/crates/codex-plus-core/tests/codex_app_state.rs
@@ -1,0 +1,310 @@
+use codex_plus_core::codex_app_state::{
+    capture_app_state_snapshot, prepare_projectless_main_window,
+    sync_app_state_after_provider_switch,
+};
+use serde_json::{Value, json};
+
+#[test]
+fn app_state_sync_restores_safe_state_and_ignores_sensitive_snapshot_keys() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path();
+    let state_path = home.join(".codex-global-state.json");
+    std::fs::write(
+        &state_path,
+        json!({
+            "electron-saved-workspace-roots": ["C:/work/app", "C:\\work\\app\\"],
+            "project-order": ["C:/work/app"],
+            "active-workspace-roots": "C:/work/app",
+            "electron-workspace-root-labels": {
+                "C:/work/app/": "App"
+            },
+            "electron-avatar-overlay-bounds": {
+                "x": 20,
+                "y": 30,
+                "width": 320,
+                "height": 240
+            },
+            "electron-avatar-overlay-open": true,
+            "electron-main-window-bounds": {
+                "x": 10,
+                "y": 10,
+                "width": 1280,
+                "height": 800
+            },
+            "thread-workspace-root-hints": {
+                "thread-1": "C:/work/app",
+                "local:thread-2": {
+                    "workspaceRoot": "D:/work/other"
+                }
+            },
+            "thread-projectless-output-directories": {
+                "thread-1": "C:/work/app/out"
+            },
+            "thread-writable-roots": {
+                "thread-1": ["C:/work/app"]
+            },
+            "projectless-thread-ids": ["thread-1", "thread-1"],
+            "electron-persisted-atom-state": {
+                "app-shell:right-panel-width:v2:/": 420,
+                "avatar-overlay-mascot-width-px": 160,
+                "composer-auto-context-enabled": false,
+                "default-service-tier": "priority",
+                "diff-filter": "all",
+                "enter-behavior": "cmdAlways",
+                "first-awake-pet-notification-avatar-ids": ["otter"],
+                "has-seen-multi-agent-composer-banner": true,
+                "electron:onboarding-workspace-autolaunch-applied": true,
+                "sidebar-collapsed-sections-v1": ["cloud"],
+                "sidebar-project-expanded-v1-codex:C:/work/app": true,
+                "sidebar-width": 296,
+                "thread-summary-panel-section-expanded-progress": false,
+                "thread-client-id-v1:thread-1": "do-not-copy",
+                "heartbeat-thread-permissions-by-id": {
+                    "thread-1": "do-not-copy"
+                },
+                "prompt-history": ["secret"],
+                "OPENAI_API_KEY": "do-not-copy",
+                "provider-token-cache": "do-not-copy"
+            },
+            "prompt-history": ["secret"],
+            "provider-token-cache": "secret"
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let snapshot_path = capture_app_state_snapshot(home)
+        .unwrap()
+        .expect("snapshot should be created");
+    assert!(snapshot_path.is_file());
+
+    std::fs::write(
+        &state_path,
+        json!({
+            "electron-saved-workspace-roots": ["D:/fresh/app"],
+            "active-workspace-roots": "D:/fresh/app",
+            "thread-workspace-root-hints": {
+                "thread-3": "D:/fresh/app"
+            },
+            "electron-persisted-atom-state": {
+                "service-tier-default": "standard"
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let result = sync_app_state_after_provider_switch(home).unwrap();
+    let state: Value =
+        serde_json::from_str(&std::fs::read_to_string(&state_path).unwrap()).unwrap();
+
+    assert!(result.changed);
+    assert!(result.backup_path.as_deref().unwrap().is_dir());
+    assert!(result.snapshot_path.as_deref().unwrap().is_file());
+    assert_eq!(
+        state["electron-saved-workspace-roots"],
+        json!(["D:\\fresh\\app", "C:\\work\\app"])
+    );
+    assert_eq!(
+        state["active-workspace-roots"],
+        json!(["D:\\fresh\\app", "C:\\work\\app"])
+    );
+    assert_eq!(
+        state["electron-workspace-root-labels"],
+        json!({"C:\\work\\app": "App"})
+    );
+    assert_eq!(state["electron-avatar-overlay-open"], true);
+    assert_eq!(state["electron-avatar-overlay-bounds"]["width"], 320);
+    assert_eq!(state["electron-main-window-bounds"]["height"], 800);
+    assert_eq!(
+        state["thread-workspace-root-hints"]["thread-1"],
+        "C:/work/app"
+    );
+    assert_eq!(
+        state["thread-workspace-root-hints"]["thread-3"],
+        "D:/fresh/app"
+    );
+    assert_eq!(
+        state["thread-projectless-output-directories"]["thread-1"],
+        "C:/work/app/out"
+    );
+    assert_eq!(
+        state["thread-writable-roots"]["thread-1"],
+        json!(["C:/work/app"])
+    );
+    assert_eq!(state["projectless-thread-ids"], json!(["thread-1"]));
+    assert_eq!(
+        state["electron-persisted-atom-state"]["default-service-tier"],
+        "priority"
+    );
+    assert_eq!(
+        state["electron-persisted-atom-state"]["composer-auto-context-enabled"],
+        false
+    );
+    assert_eq!(
+        state["electron-persisted-atom-state"]["enter-behavior"],
+        "cmdAlways"
+    );
+    assert_eq!(
+        state["electron-persisted-atom-state"]["avatar-overlay-mascot-width-px"],
+        160
+    );
+    assert_eq!(state["electron-persisted-atom-state"]["sidebar-width"], 296);
+    assert_eq!(
+        state["electron-persisted-atom-state"]["app-shell:right-panel-width:v2:/"],
+        420
+    );
+    assert_eq!(
+        state["electron-persisted-atom-state"]["sidebar-project-expanded-v1-codex:C:/work/app"],
+        true
+    );
+    assert_eq!(
+        state["electron-persisted-atom-state"]["has-seen-multi-agent-composer-banner"],
+        true
+    );
+    assert_eq!(
+        state["electron-persisted-atom-state"]["electron:onboarding-workspace-autolaunch-applied"],
+        true
+    );
+    assert!(state.get("prompt-history").is_none());
+    assert!(state.get("provider-token-cache").is_none());
+    assert!(
+        state["electron-persisted-atom-state"]
+            .get("prompt-history")
+            .is_none()
+    );
+    assert!(
+        state["electron-persisted-atom-state"]
+            .get("thread-client-id-v1:thread-1")
+            .is_none()
+    );
+    assert!(
+        state["electron-persisted-atom-state"]
+            .get("heartbeat-thread-permissions-by-id")
+            .is_none()
+    );
+    assert!(
+        state["electron-persisted-atom-state"]
+            .get("OPENAI_API_KEY")
+            .is_none()
+    );
+    assert!(
+        state["electron-persisted-atom-state"]
+            .get("provider-token-cache")
+            .is_none()
+    );
+}
+
+#[test]
+fn app_state_sync_normalizes_current_state_and_writes_backup_before_change() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path();
+    let state_path = home.join(".codex-global-state.json");
+    std::fs::write(
+        &state_path,
+        json!({
+            "electron-saved-workspace-roots": ["C:/work/app", "C:\\work\\app\\"],
+            "active-workspace-roots": "C:/work/app/",
+            "projectless-thread-ids": ["thread-1", "thread-1"]
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let result = sync_app_state_after_provider_switch(home).unwrap();
+    let backup_path = result
+        .backup_path
+        .expect("normalization should create backup");
+    let state: Value =
+        serde_json::from_str(&std::fs::read_to_string(&state_path).unwrap()).unwrap();
+    let backup: Value = serde_json::from_str(
+        &std::fs::read_to_string(backup_path.join(".codex-global-state.json")).unwrap(),
+    )
+    .unwrap();
+
+    assert!(result.changed);
+    assert_eq!(
+        state["electron-saved-workspace-roots"],
+        json!(["C:\\work\\app"])
+    );
+    assert_eq!(state["active-workspace-roots"], json!("C:\\work\\app"));
+    assert_eq!(state["projectless-thread-ids"], json!(["thread-1"]));
+    assert_eq!(
+        backup["electron-saved-workspace-roots"],
+        json!(["C:/work/app", "C:\\work\\app\\"])
+    );
+}
+
+#[test]
+fn projectless_main_window_preparation_keeps_saved_projects_and_clears_active_root() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path();
+    std::fs::write(
+        home.join("config.toml"),
+        r#"[desktop]
+hotkey-window-projectless-default-enabled = true
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        home.join(".codex-global-state.json"),
+        json!({
+            "electron-saved-workspace-roots": ["C:/work/app"],
+            "active-workspace-roots": ["C:/work/app"],
+            "electron-persisted-atom-state": {
+                "electron:onboarding-projectless-completed": false
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let result = prepare_projectless_main_window(home).unwrap();
+    let state: Value = serde_json::from_str(
+        &std::fs::read_to_string(home.join(".codex-global-state.json")).unwrap(),
+    )
+    .unwrap();
+
+    assert!(result.changed);
+    assert!(result.backup_path.as_deref().unwrap().is_dir());
+    assert_eq!(
+        state["electron-saved-workspace-roots"],
+        json!(["C:/work/app"])
+    );
+    assert_eq!(state["active-workspace-roots"], json!([]));
+    assert_eq!(
+        state["electron-persisted-atom-state"]["electron:onboarding-projectless-completed"],
+        true
+    );
+    assert_eq!(
+        state["electron-persisted-atom-state"]["electron:onboarding-workspace-autolaunch-applied"],
+        true
+    );
+}
+
+#[test]
+fn projectless_main_window_preparation_respects_disabled_preference() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path();
+    std::fs::write(
+        home.join("config.toml"),
+        r#"[desktop]
+hotkey-window-projectless-default-enabled = false
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        home.join(".codex-global-state.json"),
+        json!({"active-workspace-roots": ["C:/work/app"]}).to_string(),
+    )
+    .unwrap();
+
+    let result = prepare_projectless_main_window(home).unwrap();
+    let state: Value = serde_json::from_str(
+        &std::fs::read_to_string(home.join(".codex-global-state.json")).unwrap(),
+    )
+    .unwrap();
+
+    assert!(!result.changed);
+    assert_eq!(state["active-workspace-roots"], json!(["C:/work/app"]));
+}

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -405,6 +405,15 @@ fn launcher_does_not_override_codex_app_environment() {
 }
 
 #[test]
+fn launcher_prepares_projectless_main_window_when_enhancements_are_enabled() {
+    let source = include_str!("../src/launcher.rs");
+
+    assert!(source.contains("if settings.enhancements_enabled"));
+    assert!(source.contains("prepare_projectless_main_window_nonfatal"));
+    assert!(source.contains("launcher.prelaunch"));
+}
+
+#[test]
 fn launcher_windows_process_wait_uses_platform_cfg_guards() {
     let source = include_str!("../src/launcher.rs").replace("\r\n", "\n");
 

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -558,6 +558,100 @@ experimental_bearer_token = "sk-a"
 }
 
 #[test]
+fn apply_relay_files_preserves_live_desktop_personalization_settings() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("config.toml"),
+        r#"model = "old"
+sandbox_mode = "danger-full-access"
+approval_policy = "never"
+sandbox_workspace_write = ["C:/workspace"]
+
+[desktop]
+composerEnterBehavior = "cmdAlways"
+followUpQueueMode = "queue"
+selected-avatar-id = "avatar-local"
+"#,
+    )
+    .unwrap();
+
+    apply_relay_files_to_home(
+        temp.path(),
+        r#"model_provider = "custom"
+sandbox_mode = "read-only"
+approval_policy = "on-request"
+sandbox_workspace_write = []
+
+[desktop]
+composerEnterBehavior = "enter"
+selected-avatar-id = "avatar-from-profile"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay-a.example/v1"
+experimental_bearer_token = "sk-a"
+"#,
+        r#"{"OPENAI_API_KEY":"sk-a"}"#,
+    )
+    .unwrap();
+
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    let parsed: toml::Value = config.parse().unwrap();
+    assert_eq!(
+        parsed["desktop"]["composerEnterBehavior"].as_str(),
+        Some("cmdAlways")
+    );
+    assert_eq!(
+        parsed["desktop"]["followUpQueueMode"].as_str(),
+        Some("queue")
+    );
+    assert_eq!(
+        parsed["desktop"]["selected-avatar-id"].as_str(),
+        Some("avatar-local")
+    );
+    assert_eq!(parsed["sandbox_mode"].as_str(), Some("danger-full-access"));
+    assert_eq!(parsed["approval_policy"].as_str(), Some("never"));
+    assert_eq!(
+        parsed["sandbox_workspace_write"].as_array().unwrap(),
+        &[toml::Value::String("C:/workspace".to_string())]
+    );
+    assert_eq!(
+        parsed["model_providers"]["custom"]["base_url"].as_str(),
+        Some("https://relay-a.example/v1")
+    );
+}
+
+#[test]
+fn apply_relay_files_enables_context_usage_when_neither_config_has_a_preference() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("config.toml"), r#"model = "old""#).unwrap();
+
+    apply_relay_files_to_home(
+        temp.path(),
+        r#"model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay-a.example/v1"
+experimental_bearer_token = "sk-a"
+"#,
+        r#"{"OPENAI_API_KEY":"sk-a"}"#,
+    )
+    .unwrap();
+
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    let parsed: toml::Value = config.parse().unwrap();
+    assert_eq!(
+        parsed["desktop"]["show-context-window-usage"].as_bool(),
+        Some(true)
+    );
+}
+
+#[test]
 fn apply_relay_files_allows_empty_isolated_auth_json() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::write(temp.path().join("auth.json"), r#"{"OPENAI_API_KEY":"old"}"#).unwrap();

--- a/crates/codex-plus-core/tests/relay_switch.rs
+++ b/crates/codex-plus-core/tests/relay_switch.rs
@@ -221,6 +221,67 @@ goals = true
     assert!(returned.api_key.is_empty());
 }
 
+#[test]
+fn switch_captures_safe_app_state_before_writing_provider_config() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path().join("codex");
+    std::fs::create_dir(&home).unwrap();
+    std::fs::write(
+        home.join(".codex-global-state.json"),
+        serde_json::json!({
+            "electron-saved-workspace-roots": ["C:/work/app"],
+            "prompt-history": ["do-not-copy"],
+            "electron-persisted-atom-state": {
+                "default-service-tier": "priority",
+                "provider-token-cache": "do-not-copy"
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let store = SettingsStore::new(temp.path().join("settings.json"));
+    let original = BackendSettings {
+        active_relay_id: "a".to_string(),
+        relay_profiles: vec![
+            pure_profile("a", "https://a.example/v1", "sk-a"),
+            pure_profile("b", "https://b.example/v1", "sk-b"),
+        ],
+        ..BackendSettings::default()
+    };
+    store.save(&original).unwrap();
+    let next = BackendSettings {
+        active_relay_id: "b".to_string(),
+        relay_profiles: original.relay_profiles.clone(),
+        ..BackendSettings::default()
+    };
+
+    switch_relay_profile_in_home(&store, &home, next, "a").unwrap();
+
+    let snapshot: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(
+            home.join("backups_state")
+                .join("app-state-sync")
+                .join("latest-safe-state.json"),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        snapshot["state"]["electron-saved-workspace-roots"],
+        serde_json::json!(["C:\\work\\app"])
+    );
+    assert_eq!(
+        snapshot["state"]["electron-persisted-atom-state"]["default-service-tier"],
+        "priority"
+    );
+    assert!(snapshot["state"].get("prompt-history").is_none());
+    assert!(
+        snapshot["state"]["electron-persisted-atom-state"]
+            .get("provider-token-cache")
+            .is_none()
+    );
+}
+
 fn pure_profile(id: &str, base_url: &str, key: &str) -> RelayProfile {
     RelayProfile {
         id: id.to_string(),


### PR DESCRIPTION
## 中文说明

### 为什么需要这个修复

Codex++ 的主要使用场景之一，是让 API Key 用户在多个供应商之间切换。Codex App 不只把状态保存在 `config.toml` 和 `auth.json` 中，还会把桌面端设置、工作区提示、线程目录、沙盒状态和服务档位等信息保存在 `.codex-global-state.json`。

此前切换供应商时，会话数据库中的 `model_provider` 可以同步，但这些 App 状态没有形成同一套切换契约，因而可能出现以下问题：

- 用户一直使用 `Ctrl+Enter` 提交、`Enter` 换行，切换供应商后设置恢复默认；下一次按习惯输入换行时，消息可能被直接提交。
- 外观、桌宠、布局、上下文占用显示等个性化设置回退。
- 工作区根目录、线程可写目录、沙盒配置和 projectless 输出目录丢失或被旧供应商状态覆盖。
- 切换后需要重新选择工作区，或者原本可写的任务显示为只读。

另一个独立但相关的问题来自 Codex App 本身：即使已经开启“无需项目创建对话”，启动主页或从项目任务返回“新建任务”时，App 仍可能自动带入最近使用的项目。早期方案只清除了界面上的项目选择，看起来已经无项目，但首次消息仍可能创建为项目任务。

这不是 Codex++ 丢失了该设置，而是当前 Codex App 的主页路由、草稿状态与最终 `start-conversation` 请求没有始终遵守已保存的 projectless 选项。本 PR 在 Codex++ 侧增加了兼容兜底。

### 修改内容

- 在供应商写入前保存允许同步的 Codex App 安全状态，并在写入完成后恢复和归一。
- 同步工作区根目录、线程工作区提示、projectless 输出目录、沙盒和工作区写入权限。
- 保留 Enter/Ctrl+Enter 行为、外观、桌宠、布局、onboarding、service tier 等桌面端个性化状态。
- 所有 App 状态写入前创建回滚备份；敏感或供应商专属字段不会进入安全快照。
- 保留用户显式设置的“显示上下文占用”；新配置没有该字段时默认开启显示。
- 对“无需项目创建对话”增加运行时兜底：
  - 仅处理主页、通用“新建任务 / New task / Quick Chat”等 projectless 场景。
  - 使用 App 自己的 `projectless-thread-*` 生成器获取 cwd、workspace roots 和输出目录。
  - 在真实 `start-conversation`、`start-thread-for-host`、预热和嵌套 `thread/start` 请求发送前写入 `workspaceKind: "projectless"`，并移除旧 `projectAssignment`。
  - 用户显式选择项目时保持原生项目行为；关闭该选项时不做 projectless 覆盖。
- Fast/service-tier 状态不再在后端设置加载前抢跑读取，避免把未加载误判为不可用。本 PR 不包含 GPT-5.6 元数据或 Fast 按钮功能扩展。

### 边界

- 本 PR 不修改 Codex App 包体，不修改用户图片或宠物素材。
- 不复制 `auth.json`、API Key、prompt history 等敏感内容到 App 状态快照。
- Browser/Chrome/Computer Use 的 marketplace/cache 恢复，以及模型目录/Fast 入口稳定性，将作为后续独立 PR 提交。
- projectless 兜底针对 Codex App 当前行为漂移；如果上游未来完整修复并稳定遵守该设置，可以单独移除运行时兼容层。

### 验证

- `node --check assets/inject/renderer-inject.js`
- `cargo fmt --all -- --check`
- Codex core：CDP `78/78`、App state `4/4`、launcher `66/66`、relay config `97/97`、relay switch `5/5`
- Codex++ manager：单测 `32/32`、Windows assertions `22/22`
- `npm run check`
- `npm run vite:build`
- 已在真实 Windows Codex App 中验证：开启时，冷启动主页和从项目任务返回通用“新建任务”都能创建真正的 projectless 任务；显式项目入口仍创建项目任务；关闭选项后恢复最近项目行为。

---

## English

### Why this fix is needed

A primary Codex++ workflow is switching API-key users between multiple providers. Codex App stores much more than `config.toml` and `auth.json`: desktop preferences, workspace hints, thread directories, sandbox state, and service-tier preferences also live in `.codex-global-state.json`.

Provider switching previously synchronized conversation `model_provider` values but did not treat this App state as one coherent switching contract. This could reset Enter/Ctrl+Enter behavior, appearance and pet choices, workspace roots, writable directories, sandbox settings, context-usage visibility, and other desktop preferences.

There is also a native Codex App issue: the saved “allow chats without a project” option can be enabled while the home screen or generic New Task flow still reuses the most recent project. Earlier mitigation could hide the project selector without changing the real first-message request, producing a task that looked projectless but was still persisted under a project.

This is not a failure to preserve the setting value. The current App route, draft state, and final `start-conversation` path do not consistently honor that saved option. This PR adds a Codex++ compatibility fallback.

### What changed

- Capture an allowlisted, non-sensitive Codex App state snapshot before provider writes, then normalize and restore it afterward.
- Preserve workspace roots, thread workspace hints, projectless output directories, sandbox state, and workspace-write permissions.
- Preserve Enter behavior, appearance, pet/layout choices, onboarding state, service-tier preferences, and context-usage visibility.
- Create rollback backups before App-state writes and exclude provider-specific or sensitive fields.
- Add a runtime projectless fallback for generic home/New Task/Quick Chat flows.
- Use the App's native `projectless-thread-*` generator and patch the real `start-conversation`, host thread-start, prewarm, and nested `thread/start` requests with `workspaceKind: "projectless"`, generated directories, writable roots, and no stale `projectAssignment`.
- Keep explicit project actions authoritative and leave native project behavior unchanged when the option is disabled.
- Defer Fast/service-tier state loading until backend settings are ready, avoiding a false unavailable state. This PR does not add GPT-5.6 metadata or new Fast capabilities.

### Scope boundaries

- No Codex App package repacking and no modification of user images or pet assets.
- No API keys, `auth.json`, or prompt history are copied into the safe App-state snapshot.
- Browser/Chrome/Computer Use marketplace recovery and model-catalog/Fast UI stability remain separate follow-up PRs.
- The projectless layer is a compatibility fallback for current App behavior and can be retired independently once the upstream App reliably honors its own setting.

### Validation

- Renderer syntax and Rust formatting checks passed.
- Core tests passed: CDP `78/78`, App state `4/4`, launcher `66/66`, relay config `97/97`, relay switch `5/5`.
- Manager tests passed: unit tests `32/32`, Windows assertions `22/22`.
- TypeScript check and Vite production build passed.
- Human-tested on Windows Codex App: enabled cold-start and generic New Task flows create genuinely projectless tasks; explicit project actions remain project-bound; disabling the option restores recent-project behavior.
