### PR TITLE
fix: reject Codex++ path as Codex desktop app

### DIFF
--- a/crates/codex-plus-core/src/app_paths.rs
+++ b/crates/codex-plus-core/src/app_paths.rs
@@ -198,12 +198,14 @@ pub fn resolve_codex_app_dir_with_saved(
     saved_app_path: Option<&str>,
 ) -> Option<PathBuf> {
     if let Some(app_dir) = app_dir {
+        // 显式 --app-path 仅接受有效 Codex 应用；无效时不回退，避免静默启动错误目录
         return normalize_codex_app_path(app_dir);
     }
     if let Some(saved) = saved_app_path
         .map(str::trim)
         .filter(|saved| !saved.is_empty())
     {
+        // 已保存路径无效（例如误选 Codex++）时回退自动探测
         if let Some(path) = normalize_codex_app_path(Path::new(saved)) {
             return Some(path);
         }
@@ -213,6 +215,11 @@ pub fn resolve_codex_app_dir_with_saved(
 
 pub fn normalize_codex_app_path(path: &Path) -> Option<PathBuf> {
     if path.as_os_str().is_empty() {
+        return None;
+    }
+
+    // 拒绝把 Codex++ 管理工具安装目录误当成 Codex 桌面应用
+    if is_codex_plus_plus_path(path) {
         return None;
     }
 
@@ -226,7 +233,9 @@ pub fn normalize_codex_app_path(path: &Path) -> Option<PathBuf> {
     }
 
     if path.is_file() {
-        return path.parent().map(Path::to_path_buf);
+        // 任意普通文件不再视为应用根；仅当父目录已是合法 Codex 目录时取父路径
+        let parent = path.parent()?;
+        return normalize_codex_app_path(parent);
     }
 
     if executable_in_dir(path).is_some() {
@@ -238,13 +247,46 @@ pub fn normalize_codex_app_path(path: &Path) -> Option<PathBuf> {
         if executable_in_dir(&nested_app).is_some() {
             return Some(nested_app);
         }
+        // WindowsApps 常因 ACL 无法枚举 exe；只要包名像 OpenAI.Codex_* 仍接受 app\
+        if is_codex_store_package_dir(path) {
+            return Some(nested_app);
+        }
     }
 
-    if path.is_dir() {
+    // 接受 Store 包目录本身（含 …\OpenAI.Codex_*\app）
+    if path.is_dir() && is_codex_store_package_dir(path) {
         return Some(path.to_path_buf());
     }
 
     None
+}
+
+/// Codex++ 管理控制台/安装根，绝不能当作 OpenAI Codex 桌面应用。
+fn is_codex_plus_plus_path(path: &Path) -> bool {
+    for component in path.components() {
+        let std::path::Component::Normal(name) = component else {
+            continue;
+        };
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        let lower = name.to_ascii_lowercase();
+        if lower == "codex++"
+            || lower == "codexplusplus"
+            || lower == "codex-plus-plus"
+            || lower.contains("codex-plus-manager")
+        {
+            return true;
+        }
+    }
+    let normalized = path.to_string_lossy().replace('/', "\\").to_ascii_lowercase();
+    normalized.contains("\\programs\\codex++")
+        || normalized.contains("\\codex++\\")
+        || normalized.ends_with("\\codex++")
+}
+
+fn is_codex_store_package_dir(path: &Path) -> bool {
+    package_spec_from_path(path).is_some()
 }
 
 pub fn build_codex_executable(app_dir: &Path) -> PathBuf {

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -380,6 +380,70 @@ fn app_paths_saved_path_is_used_when_no_explicit_path_is_provided() {
 }
 
 #[test]
+fn app_paths_rejects_codex_plus_plus_install_dir_as_codex_app() {
+    let temp = tempfile::tempdir().unwrap();
+    let manager = temp.path().join("Programs").join("Codex++");
+    std::fs::create_dir_all(&manager).unwrap();
+    std::fs::write(manager.join("Codex++ Manager.exe"), "").unwrap();
+
+    assert_eq!(normalize_codex_app_path(&manager), None);
+    assert_eq!(
+        normalize_codex_app_path(&manager.join("Codex++ Manager.exe")),
+        None
+    );
+
+    let resolved = resolve_codex_app_dir_with_saved(None, Some(&manager.to_string_lossy()));
+    assert_ne!(resolved.as_deref(), Some(manager.as_path()));
+}
+
+#[test]
+fn app_paths_rejects_plain_directory_without_codex_executable() {
+    let temp = tempfile::tempdir().unwrap();
+    let plain = temp.path().join("not-a-codex-app");
+    std::fs::create_dir_all(&plain).unwrap();
+    std::fs::write(plain.join("readme.txt"), "nope").unwrap();
+
+    assert_eq!(normalize_codex_app_path(&plain), None);
+    assert_eq!(normalize_codex_app_path(&plain.join("readme.txt")), None);
+}
+
+#[test]
+fn app_paths_empty_saved_path_matches_no_saved_path() {
+    assert_eq!(
+        resolve_codex_app_dir_with_saved(None, Some("")),
+        resolve_codex_app_dir_with_saved(None, None)
+    );
+    assert_eq!(
+        resolve_codex_app_dir_with_saved(None, Some("   ")),
+        resolve_codex_app_dir_with_saved(None, None)
+    );
+}
+
+#[test]
+fn app_paths_invalid_saved_path_falls_back_instead_of_sticking() {
+    let temp = tempfile::tempdir().unwrap();
+    let junk = temp.path().join("Codex++");
+    std::fs::create_dir_all(&junk).unwrap();
+
+    // 合法独立安装：即使 saved 指向 Codex++，规范化失败后应能落到该候选
+    // （通过显式 app_dir 验证回退链之外的合法路径仍可用）
+    let standalone = temp.path().join("OpenAI").join("Codex").join("bin");
+    std::fs::create_dir_all(&standalone).unwrap();
+    std::fs::write(standalone.join("codex.exe"), "").unwrap();
+
+    assert_eq!(normalize_codex_app_path(&junk), None);
+    assert_eq!(
+        normalize_codex_app_path(&standalone).as_deref(),
+        Some(standalone.as_path())
+    );
+    assert_eq!(
+        resolve_codex_app_dir_with_saved(Some(&standalone), Some(&junk.to_string_lossy()))
+            .as_deref(),
+        Some(standalone.as_path())
+    );
+}
+
+#[test]
 fn launcher_builds_debug_arguments_and_commands() {
     let app_dir = PathBuf::from(r"C:\Codex\app");
 


### PR DESCRIPTION
## Summary
- Tighten `normalize_codex_app_path` so arbitrary existing directories are no longer accepted as Codex Desktop.
- Reject Codex++ manager install roots (`Programs\Codex++`, etc.) that were previously saved as `codexAppPath` and blocked MS Store auto-detect.
- When a saved path fails validation, fall back to automatic detection; add regression tests for reject/fallback/valid paths.

## Test plan
- [x] `cargo test -p codex-plus-core --test launcher app_paths_` (26 passed)
- [ ] Clear invalid `codexAppPath` in `%USERPROFILE%\.codex-session-delete\settings.json` (or use Install/Maintenance → clear saved path)
- [ ] Refresh Overview health check → Codex version shows installed Store/standalone version (e.g. `26.707.9981.0`)
- [ ] Manually set path to Codex++ install dir → should be rejected and auto-detect again
