### PR TITLE
切换供应商时保留 Hook 状态与原生项目语义 / Preserve Hook state and native project semantics

### DIFF
--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -1192,7 +1192,7 @@ fn write_codex_live_atomic(
 
     let config_text = match config_text {
         Some(config_text) => {
-            let config_text = preserve_live_desktop_settings(home, config_text)?;
+            let config_text = preserve_live_app_settings(home, config_text)?;
             Some(preserve_live_marketplace_configs(home, &config_text)?)
         }
         None => None,
@@ -1558,7 +1558,7 @@ fn normalize_config_text_for_write(config_text: &str) -> String {
     config_text.trim_start_matches('\u{feff}').to_string()
 }
 
-fn preserve_live_desktop_settings(home: &Path, config_text: &str) -> anyhow::Result<String> {
+fn preserve_live_app_settings(home: &Path, config_text: &str) -> anyhow::Result<String> {
     let normalized = normalize_config_text_for_write(config_text);
     let mut target_doc = parse_toml_document(&normalized)?;
     remove_unsupported_approval_policies(&mut target_doc);
@@ -1580,6 +1580,7 @@ fn preserve_live_desktop_settings(home: &Path, config_text: &str) -> anyhow::Res
         }
     }
     remove_unsupported_approval_policies(&mut target_doc);
+    preserve_live_hook_state(&mut target_doc, &live_doc);
     let context_usage_configured = target_doc
         .get("desktop")
         .and_then(Item::as_table)
@@ -1594,6 +1595,41 @@ fn preserve_live_desktop_settings(home: &Path, config_text: &str) -> anyhow::Res
         }
     }
     Ok(normalize_optional_toml(target_doc))
+}
+
+fn preserve_live_hook_state(target_doc: &mut DocumentMut, live_doc: &DocumentMut) {
+    let live_state = live_doc
+        .get("hooks")
+        .and_then(Item::as_table_like)
+        .and_then(|hooks| hooks.get("state"))
+        .cloned();
+
+    if let Some(live_state) = live_state {
+        if target_doc
+            .get("hooks")
+            .and_then(Item::as_table_like)
+            .is_none()
+        {
+            target_doc["hooks"] = toml_edit::table();
+        }
+        let hooks = target_doc["hooks"]
+            .as_table_like_mut()
+            .expect("hooks was initialized as a table");
+        hooks.insert("state", live_state);
+    } else if let Some(hooks) = target_doc
+        .get_mut("hooks")
+        .and_then(Item::as_table_like_mut)
+    {
+        hooks.remove("state");
+    }
+
+    let remove_empty_hooks = target_doc
+        .get("hooks")
+        .and_then(Item::as_table_like)
+        .is_some_and(|hooks| hooks.is_empty());
+    if remove_empty_hooks {
+        target_doc.as_table_mut().remove("hooks");
+    }
 }
 
 fn remove_unsupported_approval_policies(doc: &mut DocumentMut) -> bool {

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -1893,6 +1893,27 @@ fn injection_script_applies_fast_service_tier_contract() {
     );
 
     assert_eq!(cases["startConversation"]["serviceTier"], "priority");
+    assert_eq!(
+        cases["explicitProjectStartConversation"]["workspaceKind"],
+        "project"
+    );
+    assert_eq!(
+        cases["explicitProjectStartConversation"]["projectAssignment"]["projectId"],
+        "C:/projects/explicit"
+    );
+    assert_eq!(
+        cases["projectlessStartConversation"]["workspaceKind"],
+        "projectless"
+    );
+    assert_eq!(
+        cases["projectlessStartConversation"]["projectlessOutputDirectory"],
+        "C:/projectless/outputs"
+    );
+    assert!(
+        cases["projectlessStartConversation"]
+            .get("projectAssignment")
+            .is_none()
+    );
     assert_eq!(cases["fetchStartConversation"]["serviceTier"], "priority");
     assert_eq!(
         cases["fetchSendCliRequest"]["params"]["serviceTier"],
@@ -1921,7 +1942,8 @@ fn injection_script_applies_fast_service_tier_contract() {
     assert_eq!(cases["legacyStateApi"], true);
     assert_eq!(cases["currentStateApi"], true);
     assert_eq!(cases["appServerParamsUnchanged"], true);
-    assert_eq!(cases["appServerSentCount"], 6);
+    assert_eq!(cases["appServerProjectlessParamsUnchanged"], true);
+    assert_eq!(cases["appServerSentCount"], 7);
     assert_eq!(
         cases["providerFromMissing"]["modelProvider"],
         "vendor_alpha"
@@ -2112,6 +2134,24 @@ const startConversation = api.requestOverride({{
   threadId: "thread-12345678",
   model: "gpt-5.5",
 }});
+const explicitProjectStartConversation = api.requestOverride({{
+  type: "start-conversation",
+  threadId: "thread-explicit-project",
+  model: "gpt-5.5",
+  cwd: "C:/projects/explicit",
+  workspaceRoots: ["C:/projects/explicit"],
+  workspaceKind: "project",
+  projectAssignment: {{ projectKind: "local", projectId: "C:/projects/explicit" }},
+}});
+const projectlessStartConversation = api.requestOverride({{
+  type: "start-conversation",
+  threadId: "thread-projectless",
+  model: "gpt-5.5",
+  cwd: "C:/projectless/work",
+  workspaceRoots: ["C:/projectless/work"],
+  workspaceKind: "projectless",
+  projectlessOutputDirectory: "C:/projectless/outputs",
+}});
 const fetchStartConversationEnvelope = api.requestOverride({{
   type: "fetch",
   url: "vscode://codex/start-conversation",
@@ -2232,6 +2272,12 @@ const nativeAppServerParams = {{
   workspaceKind: "project",
   projectAssignment: {{ projectKind: "local", projectId: "C:/native/work" }},
 }};
+const nativeProjectlessAppServerParams = {{
+  cwd: "C:/native/projectless-work",
+  workspaceRoots: ["C:/native/projectless-work"],
+  workspaceKind: "projectless",
+  projectlessOutputDirectory: "C:/native/projectless-outputs",
+}};
 const appServerCalls = [];
 const appServerClient = {{
   async sendRequest(method, params, options) {{
@@ -2242,6 +2288,11 @@ const appServerClient = {{
 api.patchAppServerClient(appServerClient);
 
 appServerClient.sendRequest("start-conversation", nativeAppServerParams, {{ signal: "native" }}).then(async () => {{
+await appServerClient.sendRequest(
+  "thread/start",
+  nativeProjectlessAppServerParams,
+  {{ signal: "native-projectless" }}
+);
 api.setModelCatalog({{ status: "ok", model: "gpt-5.4", default_model: "gpt-5.4", models: ["gpt-5.4"], service_tier: "fast" }});
 const resolvedConfigTomlTier = await api.resolveInheritedServiceTier();
 api.setModelCatalog({{ status: "ok", model: "gpt-5.4", default_model: "gpt-5.4", models: ["gpt-5.4"] }});
@@ -2258,6 +2309,11 @@ const appServerParamsUnchanged = appServerCalls[0]?.params === nativeAppServerPa
   && appServerCalls[0]?.params?.workspaceKind === "project"
   && appServerCalls[0]?.params?.cwd === "C:/native/work"
   && appServerCalls[0]?.params?.projectAssignment?.projectId === "C:/native/work";
+const appServerProjectlessParamsUnchanged = appServerCalls[1]?.params === nativeProjectlessAppServerParams
+  && appServerCalls[1]?.params?.workspaceKind === "projectless"
+  && appServerCalls[1]?.params?.cwd === "C:/native/projectless-work"
+  && appServerCalls[1]?.params?.projectlessOutputDirectory === "C:/native/projectless-outputs"
+  && !Object.hasOwn(appServerCalls[1]?.params || {{}}, "projectAssignment");
 api.setBackendSettings({{
   relayProfilesEnabled: true,
   activeRelayId: "custom-relay",
@@ -2286,7 +2342,7 @@ const providerWithServiceTierControlsDisabled = api.requestOverride({{
   modelProvider: "openai",
 }});
 await appServerClient.sendRequest("thread/start", {{ cwd: "C:/mobile", modelProvider: "openai" }}, {{ signal: "mobile" }});
-const appServerProviderOverride = appServerCalls[1]?.params?.modelProvider;
+const appServerProviderOverride = appServerCalls[2]?.params?.modelProvider;
 const directThreadStartedId = api.remoteSessionStartedThreadId({{
   method: "thread/started",
   params: {{ thread: {{ id: "thread-mobile-direct" }} }},
@@ -2567,6 +2623,8 @@ process.stdout.write(JSON.stringify({{
   resolvedUnsetTier,
   inheritedConfigFastBlocked,
   startConversation,
+  explicitProjectStartConversation,
+  projectlessStartConversation,
   fetchStartConversation,
   fetchSendCliRequest,
   solFastAvailability,
@@ -2580,6 +2638,7 @@ process.stdout.write(JSON.stringify({{
   legacyStateApi,
   currentStateApi,
   appServerParamsUnchanged,
+  appServerProjectlessParamsUnchanged,
   appServerSentCount: appServerCalls.length,
   providerFromMissing,
   providerFromOpenAi,

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -1106,6 +1106,16 @@ sandbox_workspace_write = ["C:/workspace"]
 composerEnterBehavior = "cmdAlways"
 followUpQueueMode = "queue"
 selected-avatar-id = "avatar-local"
+
+[hooks]
+live_only_setting = "do-not-copy"
+
+[hooks.state."plugin-a@personal:hooks/hooks.json:pre_tool_use:0:0"]
+trusted_hash = "live-a-hash"
+
+[hooks.state."plugin-b@openai-bundled:hooks/hooks.json:user_prompt_submit:1:0"]
+trusted_hash = "live-b-hash"
+enabled = false
 "#,
     )
     .unwrap();
@@ -1120,6 +1130,15 @@ sandbox_workspace_write = []
 [desktop]
 composerEnterBehavior = "enter"
 selected-avatar-id = "avatar-from-profile"
+
+[hooks]
+target_only_setting = "keep-me"
+
+[hooks.state."plugin-a@personal:hooks/hooks.json:pre_tool_use:0:0"]
+trusted_hash = "stale-a-hash"
+
+[hooks.state."profile-only-hook"]
+trusted_hash = "stale-profile-only-hash"
 
 [model_providers.custom]
 name = "custom"
@@ -1153,9 +1172,68 @@ experimental_bearer_token = "sk-a"
         &[toml::Value::String("C:/workspace".to_string())]
     );
     assert_eq!(
+        parsed["hooks"]["state"]["plugin-a@personal:hooks/hooks.json:pre_tool_use:0:0"]
+            ["trusted_hash"]
+            .as_str(),
+        Some("live-a-hash")
+    );
+    assert_eq!(
+        parsed["hooks"]["state"]["plugin-b@openai-bundled:hooks/hooks.json:user_prompt_submit:1:0"]
+            ["trusted_hash"]
+            .as_str(),
+        Some("live-b-hash")
+    );
+    assert_eq!(
+        parsed["hooks"]["state"]["plugin-b@openai-bundled:hooks/hooks.json:user_prompt_submit:1:0"]
+            ["enabled"]
+            .as_bool(),
+        Some(false)
+    );
+    assert!(parsed["hooks"]["state"].get("profile-only-hook").is_none());
+    assert_eq!(
+        parsed["hooks"]["target_only_setting"].as_str(),
+        Some("keep-me")
+    );
+    assert!(parsed["hooks"].get("live_only_setting").is_none());
+    assert_eq!(
         parsed["model_providers"]["custom"]["base_url"].as_str(),
         Some("https://relay-a.example/v1")
     );
+}
+
+#[test]
+fn apply_relay_files_removes_stale_profile_hook_state_when_live_config_has_none() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(temp.path().join("config.toml"), "model = \"old\"\n").unwrap();
+
+    apply_relay_files_to_home(
+        temp.path(),
+        r#"model_provider = "custom"
+
+[hooks]
+target_only_setting = "keep-me"
+
+[hooks.state."stale-profile-hook"]
+trusted_hash = "stale-hash"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay-a.example/v1"
+experimental_bearer_token = "sk-a"
+"#,
+        r#"{"OPENAI_API_KEY":"sk-a"}"#,
+    )
+    .unwrap();
+
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    let parsed: toml::Value = config.parse().unwrap();
+    assert_eq!(
+        parsed["hooks"]["target_only_setting"].as_str(),
+        Some("keep-me")
+    );
+    assert!(parsed["hooks"].get("state").is_none());
 }
 
 #[test]

--- a/crates/codex-plus-core/tests/relay_switch.rs
+++ b/crates/codex-plus-core/tests/relay_switch.rs
@@ -69,19 +69,23 @@ fn switch_rolls_back_live_files_when_post_write_status_check_fails() {
     let temp = tempfile::tempdir().unwrap();
     let home = temp.path().join("codex");
     std::fs::create_dir(&home).unwrap();
-    std::fs::write(home.join("auth.json"), r#"{"OPENAI_API_KEY":"sk-a"}"#).unwrap();
-    std::fs::write(
-        home.join("config.toml"),
-        r#"model_provider = "custom"
+    let original_auth = r#"{"OPENAI_API_KEY":"sk-a"}"#;
+    let original_config = r#"model_provider = "custom"
+
+[hooks.state."plugin-a@personal:hooks/hooks.json:pre_tool_use:0:0"]
+trusted_hash = "live-a-hash"
+
+[hooks.state."plugin-b@openai-bundled:hooks/hooks.json:user_prompt_submit:1:0"]
+trusted_hash = "live-b-hash"
 
 [model_providers.custom]
 name = "custom"
 wire_api = "responses"
 requires_openai_auth = true
 base_url = "https://a.example/v1"
-"#,
-    )
-    .unwrap();
+"#;
+    std::fs::write(home.join("auth.json"), original_auth).unwrap();
+    std::fs::write(home.join("config.toml"), original_config).unwrap();
     let store = SettingsStore::new(temp.path().join("settings.json"));
     let original = BackendSettings {
         active_relay_id: "a".to_string(),
@@ -89,6 +93,8 @@ base_url = "https://a.example/v1"
         ..BackendSettings::default()
     };
     store.save(&original).unwrap();
+    let persisted_original = store.load().unwrap();
+    let original_settings_bytes = std::fs::read(temp.path().join("settings.json")).unwrap();
     let next = BackendSettings {
         active_relay_id: "b".to_string(),
         relay_profiles: vec![
@@ -121,15 +127,18 @@ base_url = "https://b.example/v1"
             .to_string()
             .contains("纯 API 配置写入后未检测到完整 custom provider")
     );
-    assert_eq!(store.load().unwrap().active_relay_id, "a");
-    assert!(
-        std::fs::read_to_string(home.join("config.toml"))
-            .unwrap()
-            .contains("https://a.example/v1")
+    assert_eq!(store.load().unwrap(), persisted_original);
+    assert_eq!(
+        std::fs::read(temp.path().join("settings.json")).unwrap(),
+        original_settings_bytes
+    );
+    assert_eq!(
+        std::fs::read_to_string(home.join("config.toml")).unwrap(),
+        original_config
     );
     assert_eq!(
         std::fs::read_to_string(home.join("auth.json")).unwrap(),
-        r#"{"OPENAI_API_KEY":"sk-a"}"#
+        original_auth
     );
 }
 
@@ -144,6 +153,12 @@ fn switch_backfills_previous_profile_from_live_before_selecting_target() {
 model_provider = "manual_a"
 model_context_window = 1000000
 model_auto_compact_token_limit = 900000
+
+[hooks.state."plugin-a@personal:hooks/hooks.json:pre_tool_use:0:0"]
+trusted_hash = "live-a-hash"
+
+[hooks.state."plugin-b@openai-bundled:hooks/hooks.json:user_prompt_submit:1:0"]
+trusted_hash = "live-b-hash"
 
 [model_providers.manual_a]
 name = "manual_a"
@@ -188,6 +203,22 @@ base_url = "https://edited-a.example/v1"
     assert_eq!(previous.auto_compact_limit, "900000");
     assert_eq!(stored.active_relay_id, "b");
     assert_eq!(stored.launch_mode, LaunchMode::Patch);
+    let live: toml::Value = std::fs::read_to_string(home.join("config.toml"))
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert_eq!(
+        live["hooks"]["state"]["plugin-a@personal:hooks/hooks.json:pre_tool_use:0:0"]
+            ["trusted_hash"]
+            .as_str(),
+        Some("live-a-hash")
+    );
+    assert_eq!(
+        live["hooks"]["state"]["plugin-b@openai-bundled:hooks/hooks.json:user_prompt_submit:1:0"]
+            ["trusted_hash"]
+            .as_str(),
+        Some("live-b-hash")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## 背景 / Background

本 PR 已按维护者意见 rebase 到 `main` 的 `7385664`。

当前上游已经移除旧的 Codex++ projectless runtime，并把新线程创建交回 Codex App 原生流程。本 PR 不恢复旧 runtime，也不改 renderer 生产代码；显式项目与无项目请求继续由 App 原生语义决定。

供应商切换仍会用目标 profile 快照替换 `config.toml`。其中 `[hooks.state]` 是当前 App 已加载 Hook 的信任、启用等运行状态，不应因为切换供应商而回退到旧快照。

## 改动 / Changes

- 切换供应商写入配置时，用当前 live `config.toml` 的完整 `[hooks.state]` 替换目标快照中的 Hook 状态。
- 作用域是 live 配置里已经存在的全部 Hook state，不使用插件名称白名单，也不发现、安装或合成插件。
- live 配置没有 `[hooks.state]` 时，移除目标快照里的陈旧 Hook state。
- 目标 `[hooks]` 下除 `state` 外的其他配置保持不变；live 的非 state Hook 配置不会被额外复制。
- 保留最新 `main` 的 provider switch 事务：切换后校验失败时同时恢复 `settings.json`、`config.toml` 与 `auth.json`。
- 删除旧 PR 中已经过时的 projectless 注入提交；renderer 保持最新上游实现。

## 测试 / Tests

- `cargo test -p codex-plus-core --test relay_config -j 2`：135 passed
- `cargo test -p codex-plus-core --test relay_switch -j 2`：6 passed
- `cargo test -p codex-plus-core --test cdp_bridge -j 2`：113 passed
- `cargo check -p codex-plus-core -j 2`
- `node --check assets/inject/renderer-inject.js`
- focused `rustfmt`（Rust 2024）
- `git diff --check`

新增回归覆盖：

- 多个不同插件的完整 Hook state 一并保留，不再把 Windows Attention 当成特殊作用域。
- live 缺少 Hook state 时只清理陈旧 state，保留目标 Hook 的其他配置。
- 显式项目 `projectAssignment` / `workspaceKind = "project"` 经 dispatcher 与 AppServer 包装后保持不变。
- 原生无项目 `workspaceKind = "projectless"` / `projectlessOutputDirectory` 保持不变。
- provider 写入成功但写后校验失败时，三份持久化文件恢复到切换前字节内容。