### PR TITLE
紧急兼容新版 App 的桌宠真实鼠标交互 / Urgent compatibility fix for real-mouse pet interaction

### DIFF
--- a/assets/inject/pet-real-mouse-inject.js
+++ b/assets/inject/pet-real-mouse-inject.js
@@ -1,5 +1,5 @@
 (() => {
-  const runtimeVersion = "4";
+  const runtimeVersion = "5";
   const existing = window.__codexPlusPetRealMouseLook;
   if (existing?.version === runtimeVersion && existing?.isReady?.()) return;
   existing?.stop?.();
@@ -76,12 +76,18 @@
       if (!resolved || typeof resolved.subscribe !== "function") {
         throw new Error("V2 avatar overlay dispatcher unavailable");
       }
-      dispatcher = resolved;
-      unsubscribe = dispatcher.subscribe(eventType, (message) => {
+      if (stopped) throw new Error("pet real-mouse runtime was retired during dispatcher setup");
+      const nextUnsubscribe = resolved.subscribe(eventType, (message) => {
         if (sendingSynthetic) return;
         nativeCursorActive = !!message?.point;
         if (nativeCursorActive) syntheticActive = false;
       });
+      if (stopped) {
+        nextUnsubscribe?.();
+        throw new Error("pet real-mouse runtime was retired during dispatcher subscription");
+      }
+      dispatcher = resolved;
+      unsubscribe = nextUnsubscribe;
       return dispatcher;
     }).catch((error) => {
       dispatcherPromise = null;
@@ -116,6 +122,7 @@
   async function updateScreenPoint(screenPoint) {
     if (stopped || !acceptsUpdates || updateInFlight) return;
     const mascot = document.querySelector(mascotSelector);
+    runtime.mascotHovered = false;
     if (!mascot || document.visibilityState !== "visible" || dragging || nativeCursorActive) {
       if (!nativeCursorActive) clearSyntheticPoint();
       return;
@@ -128,14 +135,16 @@
     updateInFlight = true;
     try {
       const localPoint = { x: screenPoint.x - window.screenX, y: screenPoint.y - window.screenY };
-      const hit = document.elementFromPoint(localPoint.x, localPoint.y);
-      const mascotHovered = mascot.matches(":hover") || !!hit?.closest?.(mascotSelector);
+      const bounds = mascot.getBoundingClientRect();
+      const mascotHovered = localPoint.x >= bounds.left
+        && localPoint.x <= bounds.right
+        && localPoint.y >= bounds.top
+        && localPoint.y <= bounds.bottom;
       runtime.mascotHovered = mascotHovered;
       if (mascotHovered) {
         clearSyntheticPoint();
         return;
       }
-      const bounds = mascot.getBoundingClientRect();
       const centerX = bounds.left + bounds.width / 2;
       const centerY = bounds.top + bounds.height / 2;
       const distance = Math.hypot(localPoint.x - centerX, localPoint.y - centerY);

--- a/assets/inject/pet-real-mouse-inject.js
+++ b/assets/inject/pet-real-mouse-inject.js
@@ -1,5 +1,5 @@
 (() => {
-  const runtimeVersion = "6";
+  const runtimeVersion = "7";
   const existing = window.__codexPlusPetRealMouseLook;
   if (existing?.version === runtimeVersion && existing?.isReady?.()) return;
   existing?.stop?.();
@@ -48,6 +48,12 @@
       },
       cancel(owner) {
         if (state.owner !== owner) return false;
+        const pointerId = state.pointerId;
+        const captureTarget = state.captureTarget;
+        try {
+          if (pointerId != null) captureTarget?.releasePointerCapture?.(pointerId);
+        } catch {
+        }
         state.pointerId = null;
         state.owner = "";
         state.captureTarget = null;
@@ -248,7 +254,8 @@
   function releaseDragging(event) {
     if (!dragging) return;
     if (event) {
-      if (interaction.owns(event, interactionOwner)) interaction.end(event, interactionOwner);
+      if (!interaction.owns(event, interactionOwner)) return;
+      interaction.end(event, interactionOwner);
     } else {
       interaction.cancel(interactionOwner);
     }

--- a/assets/inject/pet-real-mouse-inject.js
+++ b/assets/inject/pet-real-mouse-inject.js
@@ -1,5 +1,5 @@
 (() => {
-  const runtimeVersion = "5";
+  const runtimeVersion = "6";
   const existing = window.__codexPlusPetRealMouseLook;
   if (existing?.version === runtimeVersion && existing?.isReady?.()) return;
   existing?.stop?.();
@@ -9,6 +9,54 @@
   const activationRadius = 480;
   const movementThreshold = 2;
   const movementHoldMs = 1400;
+  const interactionOwner = "real-mouse";
+
+  const interaction = (() => {
+    const key = "__codexPlusPetInteraction";
+    const current = window[key];
+    if (current?.version === 1 && typeof current.begin === "function") return current;
+    const state = { pointerId: null, owner: "", captureTarget: null };
+    const next = {
+      version: 1,
+      begin(event, owner, captureTarget) {
+        if (state.pointerId != null) return state.pointerId === event.pointerId && state.owner === owner;
+        state.pointerId = event.pointerId;
+        state.owner = owner;
+        state.captureTarget = captureTarget || event.target;
+        try {
+          state.captureTarget?.setPointerCapture?.(event.pointerId);
+        } catch {
+        }
+        return true;
+      },
+      owns(event, owner) {
+        return state.pointerId === event.pointerId && state.owner === owner;
+      },
+      active() {
+        return state.pointerId != null;
+      },
+      end(event, owner) {
+        if (!next.owns(event, owner)) return false;
+        try {
+          state.captureTarget?.releasePointerCapture?.(event.pointerId);
+        } catch {
+        }
+        state.pointerId = null;
+        state.owner = "";
+        state.captureTarget = null;
+        return true;
+      },
+      cancel(owner) {
+        if (state.owner !== owner) return false;
+        state.pointerId = null;
+        state.owner = "";
+        state.captureTarget = null;
+        return true;
+      },
+    };
+    window[key] = next;
+    return next;
+  })();
 
   let stopped = false;
   let acceptsUpdates = true;
@@ -123,7 +171,7 @@
     if (stopped || !acceptsUpdates || updateInFlight) return;
     const mascot = document.querySelector(mascotSelector);
     runtime.mascotHovered = false;
-    if (!mascot || document.visibilityState !== "visible" || dragging || nativeCursorActive) {
+    if (!mascot || document.visibilityState !== "visible" || interaction.active() || nativeCursorActive) {
       if (!nativeCursorActive) clearSyntheticPoint();
       return;
     }
@@ -154,7 +202,7 @@
         lastMoveAt = Date.now();
       }
       const active = distance <= activationRadius && Date.now() - lastMoveAt <= movementHoldMs;
-      if (!active || nativeCursorActive || dragging) {
+      if (!active || nativeCursorActive || interaction.active()) {
         clearSyntheticPoint();
         return;
       }
@@ -168,14 +216,51 @@
     }
   }
 
-  function onPointerDown(event) {
-    if (!(event.target instanceof Element) || !event.target.closest(mascotSelector)) return;
-    dragging = true;
-    clearSyntheticPoint();
+  function mascotAtPoint(event) {
+    if (!Number.isFinite(event?.clientX) || !Number.isFinite(event?.clientY)) return null;
+    const mascot = document.querySelector(mascotSelector);
+    if (!mascot) return null;
+    const bounds = mascot.getBoundingClientRect();
+    return event.clientX >= bounds.left
+      && event.clientX <= bounds.right
+      && event.clientY >= bounds.top
+      && event.clientY <= bounds.bottom
+      ? mascot
+      : null;
   }
 
-  function onPointerUp() {
+  function onPointerDown(event) {
+    const target = event.target instanceof Element ? event.target : null;
+    const mascot = target?.closest(mascotSelector) || mascotAtPoint(event);
+    if (!mascot) return;
+    const ownsPointer = interaction.begin(event, interactionOwner, target || mascot);
+    if (!ownsPointer) return;
+    dragging = true;
+    clearSyntheticPoint();
+    event.preventDefault?.();
+  }
+
+  function onPointerMove(event) {
+    if (!dragging || !interaction.owns(event, interactionOwner)) return;
+    event.preventDefault?.();
+  }
+
+  function releaseDragging(event) {
+    if (!dragging) return;
+    if (event) {
+      if (interaction.owns(event, interactionOwner)) interaction.end(event, interactionOwner);
+    } else {
+      interaction.cancel(interactionOwner);
+    }
     dragging = false;
+  }
+
+  function onPointerUp(event) {
+    releaseDragging(event);
+  }
+
+  function onWindowBlur() {
+    releaseDragging();
   }
 
   function stop() {
@@ -195,10 +280,12 @@
     }
     syntheticActive = false;
     document.removeEventListener("pointerdown", onPointerDown, true);
+    document.removeEventListener("pointermove", onPointerMove, true);
     document.removeEventListener("pointerup", onPointerUp, true);
     document.removeEventListener("pointercancel", onPointerUp, true);
     document.removeEventListener("lostpointercapture", onPointerUp, true);
-    window.removeEventListener("blur", onPointerUp);
+    window.removeEventListener("blur", onWindowBlur);
+    interaction.cancel(interactionOwner);
     unsubscribe?.();
     if (window.__codexPlusPetRealMouseLook?.version === runtimeVersion) {
       delete window.__codexPlusPetRealMouseLook;
@@ -206,10 +293,11 @@
   }
 
   document.addEventListener("pointerdown", onPointerDown, true);
+  document.addEventListener("pointermove", onPointerMove, true);
   document.addEventListener("pointerup", onPointerUp, true);
   document.addEventListener("pointercancel", onPointerUp, true);
   document.addEventListener("lostpointercapture", onPointerUp, true);
-  window.addEventListener("blur", onPointerUp);
+  window.addEventListener("blur", onWindowBlur);
   const runtime = {
     version: runtimeVersion,
     transport: "cdp-push",
@@ -218,6 +306,9 @@
     mascotHovered: false,
     isReady() {
       return !stopped && acceptsUpdates;
+    },
+    isVisualOverrideActive() {
+      return nativeCursorActive || syntheticActive || interaction.active() || this.mascotHovered;
     },
     stop,
     updateScreenPoint(point) {

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -2275,22 +2275,24 @@ async fn confirmed_pet_overlay_targets(
         let Some(websocket_url) = target.web_socket_debugger_url.as_deref() else {
             continue;
         };
-        if pet_overlay_supports_v2_cursor(websocket_url).await {
+        if pet_overlay_supports_v2_cursor(websocket_url)
+            .await
+            .unwrap_or(false)
+        {
             confirmed.push(target);
         }
     }
     Ok(confirmed)
 }
 
-async fn pet_overlay_supports_v2_cursor(websocket_url: &str) -> bool {
-    crate::bridge::evaluate_script_with_await_promise(
+async fn pet_overlay_supports_v2_cursor(websocket_url: &str) -> anyhow::Result<bool> {
+    let result = crate::bridge::evaluate_script_with_await_promise(
         websocket_url,
         &crate::assets::pet_real_mouse_capability_probe_script(),
         true,
     )
-    .await
-    .as_ref()
-    .is_ok_and(runtime_evaluate_result_is_true)
+    .await?;
+    Ok(runtime_evaluate_result_is_true(&result))
 }
 
 async fn sync_pet_real_mouse_overlay(debug_port: u16, _helper_port: u16) -> anyhow::Result<()> {
@@ -2304,8 +2306,17 @@ async fn sync_pet_real_mouse_overlay(debug_port: u16, _helper_port: u16) -> anyh
         let Some(websocket_url) = target.web_socket_debugger_url.as_deref() else {
             continue;
         };
-        let supports_v2 = enabled && pet_overlay_supports_v2_cursor(websocket_url).await;
-        let script = if supports_v2 {
+        let script = if !enabled {
+            crate::assets::pet_real_mouse_stop_script()
+        } else if pet_overlay_supports_v2_cursor(websocket_url)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to probe pet overlay capability in target {} ({})",
+                    target.id, target.url
+                )
+            })?
+        {
             crate::assets::pet_real_mouse_script()
         } else {
             crate::assets::pet_real_mouse_stop_script()
@@ -2353,15 +2364,6 @@ async fn run_pet_real_mouse_cursor_driver(debug_port: u16) {
                 );
             }
         }
-        for target in &targets {
-            if let Some(websocket_url) = target.web_socket_debugger_url.as_deref() {
-                let _ = crate::bridge::evaluate_script(
-                    websocket_url,
-                    crate::assets::pet_real_mouse_stop_script(),
-                )
-                .await;
-            }
-        }
         drivers.abort_all();
         while drivers.join_next().await.is_some() {}
         tokio::time::sleep(std::time::Duration::from_secs(5)).await;
@@ -2399,9 +2401,13 @@ async fn run_pet_real_mouse_target_driver(debug_port: u16, target: crate::cdp::C
     )
     .await;
 
-    let _ =
-        crate::bridge::evaluate_script(websocket_url, crate::assets::pet_real_mouse_stop_script())
-            .await;
+    if result.is_ok() {
+        let _ = crate::bridge::evaluate_script(
+            websocket_url,
+            crate::assets::pet_real_mouse_stop_script(),
+        )
+        .await;
+    }
     match result {
         Ok(()) => {
             PET_CURSOR_DRIVER_FAILED.store(false, Ordering::Relaxed);

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -72,8 +72,9 @@ fn pet_real_mouse_script_uses_cdp_push_and_native_avatar_event() {
     assert!(script.contains("nativeCursorActive"));
     assert!(script.contains("transport: \"cdp-push\""));
     assert!(script.contains("updateScreenPoint(point)"));
-    assert!(script.contains("mascot.matches(\":hover\")"));
-    assert!(script.contains("document.elementFromPoint(localPoint.x, localPoint.y)"));
+    assert!(script.contains("localPoint.x >= bounds.left"));
+    assert!(script.contains("localPoint.y <= bounds.bottom"));
+    assert!(!script.contains("document.elementFromPoint"));
     assert!(script.contains("if (mascotHovered)"));
     assert!(
         script
@@ -87,6 +88,9 @@ fn pet_real_mouse_script_uses_cdp_push_and_native_avatar_event() {
     assert!(!script.contains("/pet/cursor-position"));
     assert!(!script.contains("X-Codex-Plus-Pet-Token"));
     assert!(script.contains("delete window.__codexPlusPetRealMouseLook"));
+    assert!(script.contains("retired during dispatcher setup"));
+    assert!(script.contains("nextUnsubscribe?.()"));
+    assert!(script.contains("const runtimeVersion = \"5\""));
 }
 
 #[test]

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -76,13 +76,18 @@ fn pet_real_mouse_script_uses_cdp_push_and_native_avatar_event() {
     assert!(script.contains("localPoint.y <= bounds.bottom"));
     assert!(!script.contains("document.elementFromPoint"));
     assert!(script.contains("if (mascotHovered)"));
-    assert!(
-        script
-            .contains("document.visibilityState !== \"visible\" || dragging || nativeCursorActive")
-    );
+    assert!(script.contains(
+        "document.visibilityState !== \"visible\" || interaction.active() || nativeCursorActive"
+    ));
     assert!(script.contains("sendPoint(null).catch(disableUpdates)"));
     assert!(script.contains("void cleared.catch(disableUpdates)"));
     assert!(script.contains("dispatcher.dispatchHostMessage({ type: eventType, point: null })"));
+    assert!(script.contains("__codexPlusPetInteraction"));
+    assert!(script.contains("setPointerCapture"));
+    assert!(script.contains("releasePointerCapture"));
+    assert!(script.contains("mascotAtPoint"));
+    assert!(script.contains("if (!ownsPointer) return"));
+    assert!(script.contains("document.addEventListener(\"pointermove\", onPointerMove, true)"));
     assert!(script.contains("movementHoldMs = 1400"));
     assert!(script.contains("activationRadius = 480"));
     assert!(!script.contains("/pet/cursor-position"));
@@ -90,7 +95,7 @@ fn pet_real_mouse_script_uses_cdp_push_and_native_avatar_event() {
     assert!(script.contains("delete window.__codexPlusPetRealMouseLook"));
     assert!(script.contains("retired during dispatcher setup"));
     assert!(script.contains("nextUnsubscribe?.()"));
-    assert!(script.contains("const runtimeVersion = \"5\""));
+    assert!(script.contains("const runtimeVersion = \"6\""));
 }
 
 #[test]

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -95,7 +95,104 @@ fn pet_real_mouse_script_uses_cdp_push_and_native_avatar_event() {
     assert!(script.contains("delete window.__codexPlusPetRealMouseLook"));
     assert!(script.contains("retired during dispatcher setup"));
     assert!(script.contains("nextUnsubscribe?.()"));
-    assert!(script.contains("const runtimeVersion = \"6\""));
+    assert!(script.contains("const runtimeVersion = \"7\""));
+}
+
+#[test]
+fn pet_real_mouse_cancel_releases_pointer_capture_on_blur_and_stop() {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let script_path = temp.path().join("pet-real-mouse.js");
+    let harness_path = temp.path().join("pet-real-mouse-cancel-harness.cjs");
+    std::fs::write(&script_path, assets::pet_real_mouse_script())
+        .expect("pet real-mouse script should be written");
+    let mut harness = std::fs::File::create(&harness_path).expect("harness should be created");
+    write!(
+        harness,
+        r#"
+const scriptPath = {script_path};
+const documentListeners = new Map();
+const windowListeners = new Map();
+const setCalls = [];
+const releaseCalls = [];
+
+class MockElement {{
+  closest(selector) {{ return selector === '[data-avatar-mascot="true"]' ? this : null; }}
+  getBoundingClientRect() {{ return {{ left: 0, top: 0, right: 100, bottom: 100, width: 100, height: 100 }}; }}
+  setPointerCapture(pointerId) {{ setCalls.push(pointerId); }}
+  releasePointerCapture(pointerId) {{ releaseCalls.push(pointerId); }}
+}}
+
+const mascot = new MockElement();
+globalThis.Element = MockElement;
+globalThis.window = globalThis;
+window.screenX = 0;
+window.screenY = 0;
+window.addEventListener = (type, listener) => windowListeners.set(type, listener);
+window.removeEventListener = (type, listener) => {{
+  if (windowListeners.get(type) === listener) windowListeners.delete(type);
+}};
+globalThis.document = {{
+  scripts: [],
+  visibilityState: "visible",
+  querySelector: (selector) => selector === '[data-avatar-mascot="true"]' ? mascot : null,
+  querySelectorAll: () => [],
+  addEventListener: (type, listener) => documentListeners.set(type, listener),
+  removeEventListener: (type, listener) => {{
+    if (documentListeners.get(type) === listener) documentListeners.delete(type);
+  }},
+}};
+globalThis.performance = {{ getEntriesByType: () => [] }};
+
+require(scriptPath);
+const runtime = window.__codexPlusPetRealMouseLook;
+const pointerEvent = (pointerId) => ({{
+  pointerId,
+  target: mascot,
+  clientX: 50,
+  clientY: 50,
+  preventDefault() {{}},
+}});
+
+documentListeners.get("pointerdown")(pointerEvent(7));
+windowListeners.get("blur")();
+const activeAfterBlur = runtime.isVisualOverrideActive();
+
+documentListeners.get("pointerdown")(pointerEvent(8));
+documentListeners.get("pointerup")(pointerEvent(9));
+const activeAfterForeignPointer = runtime.isVisualOverrideActive();
+runtime.stop();
+
+process.stdout.write(JSON.stringify({{
+  setCalls,
+  releaseCalls,
+  activeAfterBlur,
+  activeAfterForeignPointer,
+  runtimeRemoved: window.__codexPlusPetRealMouseLook == null,
+}}));
+"#,
+        script_path = serde_json::to_string(&script_path.to_string_lossy().to_string())
+            .expect("script path should serialize")
+    )
+    .expect("harness should be written");
+    drop(harness);
+
+    let output = Command::new("node")
+        .arg(&harness_path)
+        .output()
+        .expect("node should run pet pointer-cancel harness");
+    assert!(
+        output.status.success(),
+        "node harness failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let result: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("harness stdout should be JSON");
+    assert_eq!(result["setCalls"], json!([7, 8]));
+    assert_eq!(result["releaseCalls"], json!([7, 8]));
+    assert_eq!(result["activeAfterBlur"], false);
+    assert_eq!(result["activeAfterForeignPointer"], true);
+    assert_eq!(result["runtimeRemoved"], true);
 }
 
 #[test]


### PR DESCRIPTION
## 中文

### 为什么需要这次紧急兼容更新

PR #1455 合并后，Codex++ 已经能够把 V2 桌宠原本由 Computer Use 虚拟光标驱动的视线动作映射到 Windows 真实鼠标。这个功能在当时的 Codex App 中可以正常工作，但 Codex App `26.715.2305.0` 之后更新了 avatar overlay 的页面生命周期、模块加载时序和 execution context 切换方式，原有 runtime 开始出现新的竞态。

真实使用中会出现以下现象：

- 桌宠只响应视线转向，但原生 hover 或拖拽偶尔失效；
- 鼠标放到桌宠上时，点击可能落到桌宠后方的界面元素；
- 刷新开关可以暂时恢复，但页面导航或 runtime 重建后仍可能复发；
- 短暂的 CDP/能力探测失败会被误判为“不支持 V2”，随后旧清理逻辑可能停掉刚刚建立的新 runtime。

后续排查还确认了一个更直接的拖拽根因：原脚本只维护 `dragging` 布尔状态，没有真正建立浏览器 Pointer Capture。指针离开桌宠边界后，后续事件可能被下层页面接收，于是表现为拖不动、拖到一半失去交互，或点击直接穿透到桌宠背后的界面。

这不是 #1455 初始实现时就存在的问题，而是新版 Codex App 改变运行时行为后产生的兼容回归。如果不及时合并，已经进入主干的真实鼠标桌宠功能在新版 App 上会表现为时好时坏，用户只能反复切换开关或重启，并且可能遇到桌宠无法拖拽、点击穿透等明显交互问题。

### 修改内容

- 将真实鼠标 runtime 升级到 v6，确保页面重建后不会继续复用旧 runtime。
- dispatcher 动态导入和订阅完成前后都检查 runtime 是否已经退役；迟到的订阅会立即解除，不会污染替代 runtime。
- 使用桌宠几何边界判断真实鼠标是否位于桌宠区域，优先释放合成视线点，让原生 hover 和拖拽接管交互。
- 新增共享交互所有权锁，防止多个桌宠 runtime 同时争夺同一个拖拽指针。
- 拖拽开始时调用 `setPointerCapture`，结束时调用 `releasePointerCapture`；即使指针移出桌宠边界，拖拽事件仍由桌宠持有。
- 在 `pointercancel`、`lostpointercapture`、窗口失焦、runtime 停止和重新注入时统一清理拖拽所有权，避免残留状态。
- 拖拽期间暂停合成视线更新并阻止事件继续落向下层页面，同时保留几何命中兜底以适配新版 App 的透明命中变化。
- 区分“明确不支持 V2”和“CDP/导航探测失败”。瞬时错误只上报，不再向可能已经切换 execution context 的页面发送 stop。
- 某个 target driver 退出时不再批量停止全部 target；只有设置被正常关闭时，当前 driver 才执行 stop 清理。

### 范围边界

- 仅修改真实鼠标注入脚本、launcher 生命周期和对应测试，共 3 个文件。
- 不修改用户宠物素材。
- 保留现有 V2 能力检测和 Windows 平台限制。
- **本 PR 不包含桌宠持续状态、持续动画、气泡或 notification expiry patch。**

### 验证

- `node --check assets/inject/pet-real-mouse-inject.js`
- `cargo fmt --all -- --check`
- `git diff --check`
- 原完整回归：`cargo test -p codex-plus-core --test cdp_bridge -j 2`，`78/78` 通过
- Pointer Capture 追加合同测试：`1/1` 通过
- `cargo check -p codex-plus-launcher -j 2`
- Codex App `26.715.4045.0` 真人测试通过：桌宠边界外持续拖拽、松开恢复、点击穿透防护、原生 hover 与真实鼠标视线优先级均正常

这是针对已合并功能的新版 App 紧急兼容更新，希望可以尽快审查并合并，避免 #1455 在当前 Codex App 上继续以不稳定状态提供给用户。

---

## English

### Why this urgent compatibility update is needed

After PR #1455 was merged, Codex++ could map the V2 pet gaze animation, which was originally driven by the Computer Use virtual cursor, to the real Windows mouse. The feature worked with the Codex App version available at that time. Codex App releases after `26.715.2305.0` changed the avatar-overlay page lifecycle, module-loading timing, and execution-context transitions, exposing new races in the existing runtime.

Observed symptoms include:

- the pet follows the pointer direction, while native hover or drag intermittently stops working;
- pointer input can reach UI elements behind the pet;
- toggling the setting temporarily recovers the feature, but navigation or runtime recreation can trigger the issue again;
- a transient CDP/capability-probe failure is treated as “V2 unsupported”, after which stale cleanup can stop the newly installed runtime.

Further investigation confirmed a direct drag root cause: the old script tracked only a `dragging` boolean and never established browser Pointer Capture. Once the pointer left the pet bounds, subsequent events could be delivered to the underlying page, causing drag loss or click-through interaction.

This was not an original #1455 defect. It is a compatibility regression caused by newer Codex App runtime behavior. Without this update, the already-merged real-mouse pet feature remains unreliable on current App versions, forcing users to toggle or restart and sometimes leaving the pet non-draggable with click-through interaction.

### Changes

- Bump the real-mouse runtime to v6 so a rebuilt page cannot retain the previous runtime.
- Check runtime retirement before and after dynamic dispatcher subscription; immediately unsubscribe late listeners.
- Use mascot geometry to yield synthetic gaze input whenever the real pointer is inside the pet region, preserving native hover and drag.
- Add shared interaction ownership so multiple pet runtimes cannot claim the same drag pointer.
- Call `setPointerCapture` on drag start and `releasePointerCapture` on completion, retaining drag ownership outside the pet bounds.
- Clean up drag ownership on `pointercancel`, `lostpointercapture`, window blur, runtime shutdown, and reinjection.
- Suspend synthetic gaze updates and suppress underlying-page input while dragging, with a geometry fallback for current transparent hit-testing behavior.
- Distinguish explicit V2 incompatibility from transient CDP/navigation probe errors. Probe failures are reported without sending a stop command into a potentially replaced execution context.
- Do not stop every target when one target driver exits. A target sends the stop script only after an intentional settings shutdown.

### Scope

- Three files only: the real-mouse injection runtime, launcher lifecycle, and regression assertions.
- No user pet assets are modified.
- Existing V2 capability detection and Windows gating remain intact.
- **Persistent pet status, persistent animation, bubbles, and notification-expiry patching are intentionally excluded.**

### Validation

- `node --check assets/inject/pet-real-mouse-inject.js`
- `cargo fmt --all -- --check`
- `git diff --check`
- Previous full regression: `cargo test -p codex-plus-core --test cdp_bridge -j 2`, `78/78` passed
- Added Pointer Capture contract: `1/1` passed
- `cargo check -p codex-plus-launcher -j 2`
- Human-validated on Codex App `26.715.4045.0`: dragging beyond pet bounds, release recovery, click-through prevention, native hover, and real-mouse gaze priority all passed

Because this repairs an already-merged feature broken by newer App lifecycle behavior, an expedited review and merge would prevent #1455 from remaining unreliable for current Codex App users.
