### PR TITLE
修复 Custom Responses 新任务缺失 Web Search / Restore Web Search for custom Responses tasks

### DIFF
--- a/crates/codex-plus-core/src/model_suffix.rs
+++ b/crates/codex-plus-core/src/model_suffix.rs
@@ -204,7 +204,7 @@ pub fn build_model_catalog_json(
     entries: &[ModelCatalogEntry],
     fallback_window: Option<u64>,
 ) -> String {
-    build_model_catalog_json_with_template(entries, fallback_window, None)
+    build_model_catalog_json_with_capabilities(entries, fallback_window, None, None)
 }
 
 /// 使用指定模板（或内置 bundled 模板）构建 catalog。
@@ -213,6 +213,18 @@ pub fn build_model_catalog_json_with_template(
     entries: &[ModelCatalogEntry],
     fallback_window: Option<u64>,
     template: Option<&Value>,
+) -> String {
+    build_model_catalog_json_with_capabilities(entries, fallback_window, template, None)
+}
+
+/// 使用显式 provider capability 构建 catalog。
+/// `use_responses_lite_override` 仅由明确知道 provider wire capability 的调用方传入；
+/// 通用 builder 默认保留模板中的原始 Lite 行为。
+pub(crate) fn build_model_catalog_json_with_capabilities(
+    entries: &[ModelCatalogEntry],
+    fallback_window: Option<u64>,
+    template: Option<&Value>,
+    use_responses_lite_override: Option<bool>,
 ) -> String {
     let models: Vec<Value> = entries
         .iter()
@@ -241,9 +253,9 @@ pub fn build_model_catalog_json_with_template(
             model["priority"] = json!(1000 + index);
             model["visibility"] = json!("list");
             model["supported_in_api"] = json!(true);
-            // Third-party provider catalogs use the public Responses wire format. Responses Lite
-            // moves tools into an internal input item and suppresses hosted tools such as web_search.
-            model["use_responses_lite"] = json!(false);
+            if let Some(use_responses_lite) = use_responses_lite_override {
+                model["use_responses_lite"] = json!(use_responses_lite);
+            }
             if !has_model_metadata {
                 model["additional_speed_tiers"] = json!([]);
                 model["service_tiers"] = json!([]);

--- a/crates/codex-plus-core/src/model_suffix.rs
+++ b/crates/codex-plus-core/src/model_suffix.rs
@@ -241,6 +241,9 @@ pub fn build_model_catalog_json_with_template(
             model["priority"] = json!(1000 + index);
             model["visibility"] = json!("list");
             model["supported_in_api"] = json!(true);
+            // Third-party provider catalogs use the public Responses wire format. Responses Lite
+            // moves tools into an internal input item and suppresses hosted tools such as web_search.
+            model["use_responses_lite"] = json!(false);
             if !has_model_metadata {
                 model["additional_speed_tiers"] = json!([]);
                 model["service_tiers"] = json!([]);

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -1514,11 +1514,12 @@ fn apply_model_catalog_to_config(
         "model-catalogs/{}.json",
         sanitize_catalog_filename(&profile.id)
     );
+    let custom_responses = custom_responses_provider(config_text);
     // 用户已手写 model_catalog_json 指针时保留，不覆盖（保 preserves_user_model_catalog_json 测试）
     // 仅当现有指针指向本 profile 自己生成的 catalog 时才重新生成。
     if let Some(existing) = root_key_string(config_text, "model_catalog_json") {
         if existing != catalog_relative {
-            if custom_responses_provider(config_text)
+            if custom_responses
                 && copy_standard_responses_catalog(home, &existing, &catalog_relative)?
             {
                 let mut doc = parse_toml_document(config_text)?;
@@ -1530,7 +1531,7 @@ fn apply_model_catalog_to_config(
     }
     if let Some(external_catalog) = live_external_model_catalog(home) {
         let mut doc = parse_toml_document(config_text)?;
-        if custom_responses_provider(config_text)
+        if custom_responses
             && copy_standard_responses_catalog(home, &external_catalog, &catalog_relative)?
         {
             doc["model_catalog_json"] = toml_edit::value(catalog_relative);
@@ -1562,7 +1563,14 @@ fn apply_model_catalog_to_config(
     if let Some(parent) = catalog_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let catalog_json = crate::model_suffix::build_model_catalog_json(&entries, fallback);
+    // Only custom Responses providers need the standard Responses tool wire format. Official
+    // profiles and custom Chat Completions retain the model template's original Lite behavior.
+    let catalog_json = crate::model_suffix::build_model_catalog_json_with_capabilities(
+        &entries,
+        fallback,
+        None,
+        custom_responses.then_some(false),
+    );
     std::fs::write(&catalog_path, catalog_json)?;
     let mut doc = parse_toml_document(config_text)?;
     doc["model_catalog_json"] = toml_edit::value(catalog_relative);

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -1518,12 +1518,25 @@ fn apply_model_catalog_to_config(
     // 仅当现有指针指向本 profile 自己生成的 catalog 时才重新生成。
     if let Some(existing) = root_key_string(config_text, "model_catalog_json") {
         if existing != catalog_relative {
+            if custom_responses_provider(config_text)
+                && copy_standard_responses_catalog(home, &existing, &catalog_relative)?
+            {
+                let mut doc = parse_toml_document(config_text)?;
+                doc["model_catalog_json"] = toml_edit::value(catalog_relative);
+                return Ok(normalize_optional_toml(doc));
+            }
             return Ok(config_text.to_string());
         }
     }
     if let Some(external_catalog) = live_external_model_catalog(home) {
         let mut doc = parse_toml_document(config_text)?;
-        doc["model_catalog_json"] = toml_edit::value(external_catalog);
+        if custom_responses_provider(config_text)
+            && copy_standard_responses_catalog(home, &external_catalog, &catalog_relative)?
+        {
+            doc["model_catalog_json"] = toml_edit::value(catalog_relative);
+        } else {
+            doc["model_catalog_json"] = toml_edit::value(external_catalog);
+        }
         return Ok(normalize_optional_toml(doc));
     }
     let (model_list, model_windows): (String, std::collections::HashMap<String, String>) =
@@ -1554,6 +1567,66 @@ fn apply_model_catalog_to_config(
     let mut doc = parse_toml_document(config_text)?;
     doc["model_catalog_json"] = toml_edit::value(catalog_relative);
     Ok(normalize_optional_toml(doc))
+}
+
+fn custom_responses_provider(config_text: &str) -> bool {
+    let Ok(doc) = parse_toml_document(config_text) else {
+        return false;
+    };
+    let Some(provider_id) = active_provider_id(&doc) else {
+        return false;
+    };
+    if !is_custom_provider_id(&provider_id) {
+        return false;
+    }
+    doc.get("model_providers")
+        .and_then(Item::as_table)
+        .and_then(|providers| providers.get(&provider_id))
+        .and_then(Item::as_table_like)
+        .and_then(|provider| provider.get("wire_api"))
+        .and_then(Item::as_str)
+        .is_some_and(|wire_api| wire_api.trim().eq_ignore_ascii_case("responses"))
+}
+
+fn copy_standard_responses_catalog(
+    home: &Path,
+    source: &str,
+    target_relative: &str,
+) -> anyhow::Result<bool> {
+    let source_path = {
+        let path = Path::new(source);
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            home.join(path)
+        }
+    };
+    let Ok(contents) = std::fs::read_to_string(source_path) else {
+        return Ok(false);
+    };
+    let Ok(mut catalog) = serde_json::from_str::<Value>(&contents) else {
+        return Ok(false);
+    };
+    let Some(models) = catalog.get_mut("models").and_then(Value::as_array_mut) else {
+        return Ok(false);
+    };
+    let mut changed = false;
+    for model in models {
+        if model.get("use_responses_lite").and_then(Value::as_bool) == Some(true) {
+            model["use_responses_lite"] = Value::Bool(false);
+            changed = true;
+        }
+    }
+    if !changed {
+        return Ok(false);
+    }
+
+    let target = home.join(target_relative);
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(target, serde_json::to_string_pretty(&catalog)?)?;
+    Ok(true)
 }
 
 fn live_external_model_catalog(home: &Path) -> Option<String> {
@@ -2723,6 +2796,11 @@ fn unquote_toml_string(value: &str) -> String {
     value
         .strip_prefix('"')
         .and_then(|value| value.strip_suffix('"'))
+        .or_else(|| {
+            value
+                .strip_prefix('\'')
+                .and_then(|value| value.strip_suffix('\''))
+        })
         .unwrap_or(value)
         .to_string()
 }

--- a/crates/codex-plus-core/tests/model_suffix.rs
+++ b/crates/codex-plus-core/tests/model_suffix.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use codex_plus_core::model_suffix::{
-    build_model_catalog_json, collect_catalog_entries, model_ui_metadata, parse_model_suffix,
+    build_model_catalog_json, build_model_catalog_json_with_template, collect_catalog_entries,
+    model_ui_metadata, parse_model_suffix,
 };
 
 #[test]
@@ -142,8 +143,27 @@ fn build_catalog_json_uses_runtime_compatible_gpt56_metadata() {
         assert_eq!(model["additional_speed_tiers"], serde_json::json!(["fast"]));
         assert_eq!(model["service_tiers"][0]["id"], "priority");
         assert_eq!(model["supports_search_tool"], true);
-        assert_eq!(model["use_responses_lite"], false);
+        assert_eq!(model["use_responses_lite"], true);
     }
+}
+
+#[test]
+fn build_catalog_json_preserves_template_responses_lite_behavior() {
+    let entries = collect_catalog_entries("official-model", &HashMap::new(), "official-model");
+    let template = serde_json::json!({
+        "slug": "official-template",
+        "supports_search_tool": true,
+        "use_responses_lite": true
+    });
+    let catalog: serde_json::Value = serde_json::from_str(&build_model_catalog_json_with_template(
+        &entries,
+        None,
+        Some(&template),
+    ))
+    .unwrap();
+
+    assert_eq!(catalog["models"][0]["use_responses_lite"], true);
+    assert_eq!(catalog["models"][0]["supports_search_tool"], true);
 }
 
 #[test]

--- a/crates/codex-plus-core/tests/model_suffix.rs
+++ b/crates/codex-plus-core/tests/model_suffix.rs
@@ -141,6 +141,8 @@ fn build_catalog_json_uses_runtime_compatible_gpt56_metadata() {
         assert!(!efforts.contains(&"minimal"));
         assert_eq!(model["additional_speed_tiers"], serde_json::json!(["fast"]));
         assert_eq!(model["service_tiers"][0]["id"], "priority");
+        assert_eq!(model["supports_search_tool"], true);
+        assert_eq!(model["use_responses_lite"], false);
     }
 }
 

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -3247,6 +3247,76 @@ experimental_bearer_token = "sk-new"
     assert_eq!(sol["context_window"], 272_000);
     assert_eq!(sol["default_reasoning_level"], "low");
     assert_eq!(sol["service_tiers"][0]["id"], "priority");
+    assert_eq!(sol["supports_search_tool"], true);
+    assert_eq!(sol["use_responses_lite"], false);
+}
+
+#[test]
+fn apply_relay_profile_copies_external_lite_catalog_for_standard_responses() {
+    let temp = tempfile::tempdir().unwrap();
+    let external_dir = temp.path().join("external");
+    std::fs::create_dir_all(&external_dir).unwrap();
+    let external_catalog = external_dir.join("gpt56.json");
+    std::fs::write(
+        &external_catalog,
+        r#"{
+  "models": [
+    {
+      "slug": "gpt-5.6-sol",
+      "supports_search_tool": true,
+      "web_search_tool_type": "text_and_image",
+      "use_responses_lite": true
+    }
+  ]
+}"#,
+    )
+    .unwrap();
+    let external_absolute = external_catalog.to_string_lossy();
+    let profile = RelayProfile {
+        id: "relay-gpt56-external".to_string(),
+        model: "gpt-5.6-sol".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: format!(
+            r#"model = "gpt-5.6-sol"
+model_catalog_json = '{external_absolute}'
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example/v1"
+experimental_bearer_token = "sk-new"
+"#
+        ),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        model_list: "gpt-5.6-sol".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(config.contains(r#"model_catalog_json = "model-catalogs/relay-gpt56-external.json""#));
+    let copied: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(
+            temp.path()
+                .join("model-catalogs")
+                .join("relay-gpt56-external.json"),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(copied["models"][0]["supports_search_tool"], true);
+    assert_eq!(
+        copied["models"][0]["web_search_tool_type"],
+        "text_and_image"
+    );
+    assert_eq!(copied["models"][0]["use_responses_lite"], false);
+
+    let original: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(external_catalog).unwrap()).unwrap();
+    assert_eq!(original["models"][0]["use_responses_lite"], true);
 }
 
 #[test]

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -3252,6 +3252,43 @@ experimental_bearer_token = "sk-new"
 }
 
 #[test]
+fn apply_custom_chat_profile_preserves_generated_catalog_lite_behavior() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = RelayProfile {
+        id: "relay-gpt56-chat".to_string(),
+        model: "gpt-5.6-sol".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model = "gpt-5.6-sol"
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "chat"
+requires_openai_auth = true
+base_url = "https://relay.example/v1"
+experimental_bearer_token = "sk-new"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        model_list: "gpt-5.6-sol".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+
+    let catalog: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(
+            temp.path()
+                .join("model-catalogs")
+                .join("relay-gpt56-chat.json"),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(catalog["models"][0]["use_responses_lite"], true);
+}
+
+#[test]
 fn apply_relay_profile_copies_external_lite_catalog_for_standard_responses() {
     let temp = tempfile::tempdir().unwrap();
     let external_dir = temp.path().join("external");


### PR DESCRIPTION
## 中文

### 问题与影响

Codex App `26.715.2305.0` 内置的 Codex CLI `0.144.1` 开始实际遵循 GPT-5.6 catalog 中的 `use_responses_lite=true`。在 Responses Lite 模式下，Codex 不会注册托管的 `web_search`，而是依赖另一套独立的 `web.run` executor。

这对官方运行环境可能成立，但 Codex++ 的主要用户场景是使用第三方 URL 与 API Key 接入标准 Responses API。这类供应商通常支持 OpenAI 托管 Web Search，却没有 Codex 内部的 `web.run` executor。最终会出现：

- catalog 明确声明 `supports_search_tool=true`；
- 相同 URL、Key 和模型在其他客户端可以联网；
- 但从 Codex++ 启动的新任务完全没有暴露 `web_search` 工具。

这是新版 App/CLI 更新带来的静默能力回归。请求本身不会明显报错，用户只会发现模型突然无法联网，因此很容易被误判为供应商、模型或 Key 的问题。

### 修复方式

- Codex++ 为第三方供应商生成的模型 catalog 强制使用标准 Responses：`use_responses_lite=false`。
- 保留 `supports_search_tool` 和 `web_search_tool_type` 等搜索元数据。
- 当用户已经配置外部 Lite catalog 时，不原地修改用户文件；复制为 `model-catalogs/<profile>.json` 管理副本，只在副本中关闭 Lite，并更新当前 profile 指针。
- 仅对自定义供应商且 `wire_api="responses"` 的配置执行迁移；官方模型和官方登录路径保持不变。
- 同时兼容 TOML 双引号基础字符串与单引号字面量字符串。后者对 Windows 绝对路径尤其重要，例如：

  ```toml
  model_catalog_json = 'C:\Users\name\.codex\gpt56-model-catalog.json'
  ```

### 为什么不能只修改原 catalog

外部 catalog 可能由用户、其他工具或 Codex App 自身维护。原地修改会破坏所有权边界，也可能在下次更新时被覆盖。本 PR 使用 Codex++ 管理副本，使迁移可回滚、按供应商隔离，并保留原始文件作为来源。

### 验证

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codex-plus-core --test model_suffix -j 2`：`14/14`
- `cargo test -p codex-plus-core --test relay_config -j 2`：`102/102`
- 回归覆盖单引号绝对路径、管理副本写入、原文件不变、搜索元数据保留。
- 已在 Codex App `26.715.2305.0` 的 API Key / Custom Responses 真人环境验证：重新启动并创建新任务后，联网工具成功恢复并暴露。

希望尽快合并。若不处理，使用第三方 Responses API 的用户会在新版 App 中静默失去 Web Search，即使供应商和模型本身完全支持联网。

---

## English

### Problem and impact

The Codex CLI `0.144.1` bundled with Codex App `26.715.2305.0` now honors `use_responses_lite=true` from the GPT-5.6 catalog. In Responses Lite mode, Codex does not register hosted `web_search`; it expects a separate internal `web.run` executor instead.

That assumption may hold in the official runtime, but the primary Codex++ use case is connecting to a third-party URL with an API key through the standard Responses API. These providers can support hosted OpenAI Web Search while not providing Codex's internal `web.run` executor. The result is:

- the catalog still declares `supports_search_tool=true`;
- the same URL, key, and model can browse in another client;
- a new task launched through Codex++ exposes no `web_search` tool at all.

This is a silent capability regression introduced by the newer App/CLI behavior. Requests do not necessarily fail with an obvious error, so users can easily misdiagnose the provider, model, or API key.

### Fix

- Codex++ generated catalogs for third-party providers now use standard Responses with `use_responses_lite=false`.
- Search metadata such as `supports_search_tool` and `web_search_tool_type` is retained.
- Existing external Lite catalogs are never modified in place. Codex++ copies them to a managed `model-catalogs/<profile>.json`, disables Lite only in that copy, and updates the active profile pointer.
- Migration is limited to custom providers using `wire_api="responses"`; official models and official-login behavior remain unchanged.
- Both TOML basic strings and literal strings are supported, including single-quoted absolute Windows catalog paths.

### Why not edit the original catalog

An external catalog may be owned by the user, another tool, or the Codex App. Editing it in place would violate that ownership boundary and could be overwritten by a later update. A Codex++ managed copy keeps the migration reversible and isolated per provider while preserving the original source file.

### Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p codex-plus-core --test model_suffix -j 2`: `14/14`
- `cargo test -p codex-plus-core --test relay_config -j 2`: `102/102`
- Regression coverage verifies literal-string absolute paths, managed-copy creation, unchanged source files, and preserved search metadata.
- Human validation passed on Codex App `26.715.2305.0` with an API-key Custom Responses provider: after restart, a new task exposed the browsing tool again.

An expedited merge would prevent third-party Responses users from silently losing Web Search on the newer Codex App even when their provider and model fully support it.
