### PR TITLE
修复：提升管理工具窗口生命周期的可靠性

### DIFF
--- a/apps/codex-plus-manager/src-tauri/src/lib.rs
+++ b/apps/codex-plus-manager/src-tauri/src/lib.rs
@@ -51,6 +51,7 @@ pub fn run() {
             let mut main_window_builder =
                 tauri::WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::App(url.into()))
                     .title("Codex++ 管理工具")
+                    .center()
                     .inner_size(1180.0, 820.0)
                     .min_inner_size(960.0, 720.0);
             if let Some(icon) = app.default_window_icon().cloned() {
@@ -220,21 +221,48 @@ fn register_main_window_events<R: tauri::Runtime>(window: tauri::WebviewWindow<R
     let close_event_window = event_window.clone();
 
     event_window.on_window_event(move |event| match event {
-        WindowEvent::Resized(_) => {
-            if matches!(minimized_window.is_minimized(), Ok(true)) {
-                let _ = minimized_window.hide();
+        WindowEvent::Resized(_) => match minimized_window.is_minimized() {
+            Ok(true) => {
+                record_window_operation_result("minimize.hide_to_tray", minimized_window.hide());
             }
-        }
+            Ok(false) => {}
+            Err(error) => record_window_operation_error("minimize.read_state", error),
+        },
         WindowEvent::CloseRequested { api, .. } => {
             if APP_EXITING.load(Ordering::SeqCst) {
                 return;
             }
 
             api.prevent_close();
-            let _ = close_event_window.hide();
+            if !record_window_operation_result("close.hide_to_tray", close_event_window.hide()) {
+                record_window_operation_result(
+                    "close.minimize_fallback",
+                    close_event_window.minimize(),
+                );
+            }
         }
         _ => {}
     });
+}
+
+fn record_window_operation_result(operation: &str, result: tauri::Result<()>) -> bool {
+    match result {
+        Ok(()) => true,
+        Err(error) => {
+            record_window_operation_error(operation, error);
+            false
+        }
+    }
+}
+
+fn record_window_operation_error(operation: &str, error: tauri::Error) {
+    let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+        "manager.window_operation_failed",
+        serde_json::json!({
+            "operation": operation,
+            "error": error.to_string()
+        }),
+    );
 }
 
 #[tauri::command]
@@ -245,7 +273,7 @@ fn manager_exit_app<R: tauri::Runtime>(app: tauri::AppHandle<R>) {
 
 #[tauri::command]
 fn manager_hide_to_tray<R: tauri::Runtime>(window: tauri::WebviewWindow<R>) {
-    let _ = window.hide();
+    record_window_operation_result("command.hide_to_tray", window.hide());
 }
 
 #[tauri::command]
@@ -316,9 +344,10 @@ fn record_tray_dream_skin_result(action: &str, result: anyhow::Result<()>) {
 
 fn show_main_window<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>) {
     if let Some(window) = app_handle.get_webview_window("main") {
-        let _ = window.unminimize();
-        let _ = window.show();
-        let _ = window.set_focus();
+        record_window_operation_result("restore.unminimize", window.unminimize());
+        record_window_operation_result("restore.show", window.show());
+        record_window_operation_result("restore.center", window.center());
+        record_window_operation_result("restore.focus", window.set_focus());
     }
 }
 

--- a/apps/codex-plus-manager/src-tauri/tests/windows_subsystem.rs
+++ b/apps/codex-plus-manager/src-tauri/tests/windows_subsystem.rs
@@ -61,10 +61,21 @@ fn manager_close_minimizes_to_tray_without_confirmation() {
     assert!(!lib_rs.contains("MessageDialogButtons"));
     assert!(!lib_rs.contains(".dialog()"));
     assert!(!lib_rs.contains("manager://close-requested"));
-    assert!(lib_rs.contains("let _ = close_event_window.hide();"));
+    assert!(lib_rs.contains("\"close.hide_to_tray\""));
+    assert!(lib_rs.contains("\"close.minimize_fallback\""));
+    assert!(lib_rs.contains("manager.window_operation_failed"));
     assert!(!app_tsx.contains("CloseConfirmDialog"));
     assert!(app_tsx.contains("manager_exit_app"));
     assert!(app_tsx.contains("manager_hide_to_tray"));
+}
+
+#[test]
+fn manager_centers_window_on_startup_and_tray_restore() {
+    let lib_rs = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/lib.rs"))
+        .expect("read manager lib.rs");
+
+    assert!(lib_rs.contains(".center()"));
+    assert!(lib_rs.contains("\"restore.center\", window.center()"));
 }
 
 #[test]


### PR DESCRIPTION
## 修改内容

- 管理工具窗口首次创建时自动居中
- 从系统托盘恢复窗口时重新居中
- 不再静默忽略 Tauri 窗口操作错误，将失败信息写入诊断日志
- 点击关闭但隐藏到托盘失败时，自动降级为最小化
- 添加启动/托盘恢复居中及关闭兜底行为的集成测试

## 问题原因

管理工具只设置了固定窗口大小，没有指定启动位置，因此初始位置由 Windows 自行决定。关闭或最小化时，原代码还会直接丢弃 `hide()` 返回的错误（`let _ = ...`），导致隐藏失败时看起来像右上角按钮完全没有响应，同时日志中也没有任何排查线索。

## 用户影响

修改后，管理工具会以可预测的居中位置打开。从托盘恢复时也会重新居中。如果关闭或最小化到托盘失败，错误将记录到 `codex-plus.log`；关闭操作还会尝试最小化作为兜底，不再表现为毫无反应。

## 验证结果

- `cargo fmt --all -- --check`
- 管理员权限运行 `cargo test -p codex-plus-manager`：完整通过
  - 41 项库测试通过
  - GUI 测试壳成功启动
  - 23 项窗口集成测试通过
  - 文档测试通过
- `npm run check`：通过
- `npm test`：31 项通过
- `npm run vite:build`：通过

`cargo clippy -p codex-plus-manager --all-targets -- -D warnings` 仍被 `codex-plus-core` 中 107 个既有警告阻断，本次差异没有引入这些警告。由于 `-D warnings` 会把依赖链中的全部警告升级为错误，这些上游既有警告需要单独清理，不属于本次窗口修复范围。
