### PR TITLE
feat: support custom companion images beside the composer

### DIFF
--- a/apps/codex-plus-manager/src/dream-skin.test.ts
+++ b/apps/codex-plus-manager/src/dream-skin.test.ts
@@ -70,6 +70,11 @@ describe("dream skin theme helpers", () => {
       promoTitle: "Sponsor",
       promoSub: "sponsor.example",
       promoUrl: "https://sponsor.example",
+      companion: {
+        dataUrl: "data:image/webp;base64,UklGRg==",
+        width: 96,
+        side: "right",
+      },
       customTargetField: { nested: true },
     });
 
@@ -77,7 +82,22 @@ describe("dream skin theme helpers", () => {
     assert.equal(theme.stylePreset, undefined);
     assert.deepEqual(theme.art, { focusX: 0.72, focusY: 0.45, safeArea: "left", taskMode: "ambient" });
     assert.deepEqual(theme.palette, { accent: "#123456", custom: "keep" });
+    assert.deepEqual(theme.companion, {
+      dataUrl: "data:image/webp;base64,UklGRg==",
+      width: 96,
+      side: "right",
+    });
     assert.deepEqual(theme.customTargetField, { nested: true });
+  });
+
+  it("renders an optional image companion beside the visible composer", async () => {
+    const renderer = await readFile(new URL("../../../assets/inject/renderer-inject.js", import.meta.url), "utf8");
+
+    assert.match(renderer, /codex-dream-skin-companion/);
+    assert.match(renderer, /theme\.companion/);
+    assert.match(renderer, /\.composer-footer/);
+    assert.match(renderer, /data:image\/(?:png|jpeg|webp|gif);base64/);
+    assert.match(renderer, /removeDreamSkinCompanion/);
   });
 
   it("detects text, color, and image draft changes", () => {

--- a/apps/codex-plus-manager/src/dream-skin.ts
+++ b/apps/codex-plus-manager/src/dream-skin.ts
@@ -40,6 +40,13 @@ export type DreamSkinThemeConfig = {
   promoSub?: string;
   promoUrl?: string;
   image?: string;
+  companion?: {
+    dataUrl: string;
+    width?: number;
+    side?: "auto" | "left" | "right";
+    offsetX?: number;
+    offsetY?: number;
+  };
   [key: string]: unknown;
 };
 

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -1621,6 +1621,106 @@
     };
   }
 
+  const dreamSkinCompanionId = "codex-dream-skin-companion";
+  const dreamSkinCompanionDataUrlPrefixes = [
+    "data:image/png;base64,",
+    "data:image/jpeg;base64,",
+    "data:image/webp;base64,",
+    "data:image/gif;base64,",
+  ];
+  const dreamSkinCompanionBase64Pattern = /^[a-z0-9+/=\s]+$/i;
+
+  function removeDreamSkinCompanion() {
+    document.getElementById(dreamSkinCompanionId)?.remove();
+  }
+
+  function dreamSkinCompanionConfig(theme) {
+    const companion = theme && theme.companion;
+    if (!companion || typeof companion !== "object") return null;
+    const dataUrl = typeof companion.dataUrl === "string" ? companion.dataUrl.trim() : "";
+    const prefix = dreamSkinCompanionDataUrlPrefixes.find((candidate) =>
+      dataUrl.toLowerCase().startsWith(candidate));
+    if (
+      !dataUrl
+      || dataUrl.length > 240_000
+      || !prefix
+      || !dreamSkinCompanionBase64Pattern.test(dataUrl.slice(prefix.length))
+    ) {
+      return null;
+    }
+    const width = Math.max(48, Math.min(Number(companion.width) || 96, 160));
+    const side = ["left", "right"].includes(companion.side) ? companion.side : "auto";
+    const offsetX = Math.max(-48, Math.min(Number(companion.offsetX) || 0, 48));
+    const offsetY = Math.max(-48, Math.min(Number(companion.offsetY) || 0, 48));
+    return { dataUrl, width, side, offsetX, offsetY };
+  }
+
+  function visibleDreamSkinComposer() {
+    return [...document.querySelectorAll(".composer-footer")]
+      .map((node) => ({ node, rect: node.getBoundingClientRect?.() }))
+      .filter(({ rect }) => rect && rect.width > 200 && rect.height > 0)
+      .sort((left, right) => right.rect.bottom - left.rect.bottom)[0] || null;
+  }
+
+  function ensureDreamSkinCompanion(theme) {
+    const config = dreamSkinCompanionConfig(theme);
+    const composer = visibleDreamSkinComposer();
+    if (!config || !composer) {
+      removeDreamSkinCompanion();
+      return;
+    }
+
+    let companion = document.getElementById(dreamSkinCompanionId);
+    if (!companion) {
+      companion = document.createElement("img");
+      companion.id = dreamSkinCompanionId;
+      companion.alt = "";
+      companion.setAttribute("aria-hidden", "true");
+      Object.assign(companion.style, {
+        position: "fixed",
+        zIndex: "39",
+        height: "auto",
+        maxHeight: "160px",
+        objectFit: "contain",
+        pointerEvents: "none",
+        userSelect: "none",
+        filter: "drop-shadow(0 8px 14px rgba(0, 0, 0, .18))",
+        transition: "left 160ms ease, top 160ms ease, opacity 160ms ease",
+      });
+      document.body.appendChild(companion);
+    }
+    if (companion.src !== config.dataUrl) companion.src = config.dataUrl;
+
+    const gap = 12;
+    const edge = 8;
+    const right = composer.rect.right + gap + config.offsetX;
+    const left = composer.rect.left - config.width - gap + config.offsetX;
+    const fitsRight = right + config.width <= window.innerWidth - edge;
+    const fitsLeft = left >= edge;
+    const useRight = config.side === "right"
+      ? fitsRight
+      : config.side === "left"
+        ? !fitsLeft && fitsRight
+        : fitsRight || !fitsLeft;
+
+    if (!fitsRight && !fitsLeft) {
+      companion.style.opacity = "0";
+      return;
+    }
+
+    const top = Math.max(
+      edge,
+      Math.min(
+        composer.rect.bottom - config.width + config.offsetY,
+        window.innerHeight - config.width - edge,
+      ),
+    );
+    companion.style.width = `${config.width}px`;
+    companion.style.left = `${Math.round(useRight ? right : left)}px`;
+    companion.style.top = `${Math.round(top)}px`;
+    companion.style.opacity = "1";
+  }
+
   function clearDreamSkinPresentation() {
     const root = document.documentElement;
     for (const className of [...(root?.classList || [])]) {
@@ -1678,6 +1778,7 @@
     document.getElementById("codex-dream-skin-chrome")?.remove();
     document.getElementById("codex-glass-vision-skin-chrome")?.remove();
     document.getElementById("codex-theme-chrome")?.remove();
+    removeDreamSkinCompanion();
     const state = window.__CODEX_DREAM_SKIN_STATE__;
     const descriptor = state?.descriptor;
     if (descriptor) {
@@ -1832,6 +1933,7 @@
       root.setAttribute("data-dream-shell", shell);
       applyIndependentThemeVariables(root, shell, theme, descriptor, artSource);
       ensureStyle(root);
+      ensureDreamSkinCompanion(theme);
 
       const homeIndicator = document.querySelector('[data-testid="home-icon"]');
       const home = homeIndicator?.closest('[role="main"]')

--- a/crates/codex-plus-core/src/assets.rs
+++ b/crates/codex-plus-core/src/assets.rs
@@ -49,7 +49,7 @@ const STEPWISE_SCRIPT: &str = include_str!("../../../assets/inject/stepwise-inje
 const SPONSOR_ALIPAY: &[u8] = include_bytes!("../../../assets/images/sponsor-alipay.jpg");
 const SPONSOR_WECHAT: &[u8] = include_bytes!("../../../assets/images/sponsor-wechat.jpg");
 pub const DIAGNOSTIC_BUILD_ID: &str = "diag-20260518-1";
-const DREAM_SKIN_RENDERER_REVISION: &str = "14";
+const DREAM_SKIN_RENDERER_REVISION: &str = "15";
 
 pub fn renderer_script() -> &'static str {
     RENDERER_SCRIPT

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -381,7 +381,7 @@ fn rejects_cdp_websocket_with_wrong_scheme_or_missing_port() {
 
 #[test]
 fn injection_script_installs_dream_skin_from_backend_settings() {
-    let settings = codex_plus_core::settings::BackendSettings {
+    let mut settings = codex_plus_core::settings::BackendSettings {
         codex_app_dream_skin_enabled: true,
         codex_app_dream_skin_paused: false,
         codex_app_dream_skin_theme_config: codex_plus_core::settings::DreamSkinThemeConfig {
@@ -390,6 +390,17 @@ fn injection_script_installs_dream_skin_from_backend_settings() {
         },
         ..Default::default()
     };
+    settings
+        .codex_app_dream_skin_theme_config
+        .extra_fields
+        .insert(
+            "companion".to_string(),
+            serde_json::json!({
+                "dataUrl": "data:image/webp;base64,UklGRg==",
+                "width": 96,
+                "side": "right"
+            }),
+        );
     let script = assets::injection_script_with_settings(57321, &settings);
 
     assert!(script.contains("dreamSkinEnabled: \"codexAppDreamSkinEnabled\""));
@@ -418,6 +429,9 @@ fn injection_script_installs_dream_skin_from_backend_settings() {
     assert!(script.contains("state.observer?.disconnect?.()"));
     assert!(script.contains("window.__CODEX_PLUS_DREAM_SKIN_PAYLOAD_SIGNATURE__"));
     assert!(script.contains("window.__CODEX_PLUS_DREAM_SKIN_THEME__"));
+    assert!(script.contains("data:image/webp;base64,UklGRg=="));
+    assert!(script.contains("codex-dream-skin-companion"));
+    assert!(script.contains("removeDreamSkinCompanion"));
     if cfg!(windows) {
         assert!(script.contains(":root.codex-dream-skin"));
         assert!(!script.contains("薛凯琪专属定制皮肤"));


### PR DESCRIPTION
## Summary

- add an optional `companion` field to Dream Skin themes
- render a theme-provided custom image beside the visible composer/input box
- support configurable width, preferred side, and x/y offsets
- validate image data URLs and remove the companion when the theme is restored or disabled

## Motivation

Some themes include a small photo or character next to the input box. This change makes that decoration a reusable theme capability instead of hard-coding a specific asset into Codex++. Theme authors can provide their own image through `companion.dataUrl` and control its placement.

Example:

```json
{
  "companion": {
    "dataUrl": "data:image/webp;base64,...",
    "width": 96,
    "side": "right",
    "offsetX": 0,
    "offsetY": 4
  }
}
```

The renderer accepts PNG, JPEG, WebP, and GIF base64 data URLs, applies size and offset bounds, falls back to the opposite side when necessary, and hides the image when neither side has enough room.

## Verification

- `npm test` - 32/32 passed
- `npm run check` - passed
- `npm run vite:build` - passed
- `node --check assets/inject/renderer-inject.js` - passed

Rust tests were not run locally because the Rust toolchain is not installed on the development machine.