### PR TITLE
fix: 确认弹窗内容过长时按钮被遮挡无法操作

### DIFF
--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -6610,15 +6610,17 @@ function ConfirmDialog({
 }) {
   return (
     <div className="modal-backdrop" role="dialog" aria-modal="true">
-      <div className="modal-card">
+      <div className="modal-card confirm-modal">
         <div className="modal-head">
           <div>
             <h2>{confirm.title}</h2>
-            <p className="modal-message">{confirm.message}</p>
           </div>
           <button className="toast-close" onClick={onCancel} type="button">×</button>
         </div>
-        <Toolbar>
+        <div className="confirm-modal-body">
+          <p className="modal-message">{confirm.message}</p>
+        </div>
+        <Toolbar className="confirm-modal-actions">
           <Button onClick={onConfirm}>
             <Trash2 className="h-4 w-4" />
             {confirm.confirmText}

--- a/apps/codex-plus-manager/src/styles.css
+++ b/apps/codex-plus-manager/src/styles.css
@@ -2284,6 +2284,27 @@ body {
   overflow-wrap: anywhere;
 }
 
+.confirm-modal {
+  max-height: min(760px, calc(100vh - 48px));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.confirm-modal-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  margin-bottom: 14px;
+}
+
+.confirm-modal-actions {
+  flex: 0 0 auto;
+  margin-top: 0;
+  padding-top: 14px;
+  border-top: 1px solid hsl(var(--border));
+}
+
 .session-index-cleanup-modal {
   max-height: min(760px, calc(100vh - 48px));
   overflow: hidden;


### PR DESCRIPTION
## 问题

在「会话管理」模块中删除已归档会话时，如果会话内容（系统提示词等）过长，确认弹窗中的「确认删除」/「取消」按钮会被撑出视口之外，无法点击操作，导致删除流程卡住。

## 修复方案

将 ConfirmDialog 组件的结构调整为三段式 flex 布局：

- **标题区域** (modal-head)：固定在顶部
- **内容区域** (confirm-modal-body)：lex: 1 1 auto，独立滚动
- **按钮区域** (confirm-modal-actions)：lex: 0 0 auto，固定在底部

弹窗整体设置 max-height: calc(100vh - 48px)，确保不超出视口。即使消息内容非常长，按钮始终可见可点击。

## 改动文件

- pps/codex-plus-manager/src/App.tsx — ConfirmDialog 组件结构调整
- pps/codex-plus-manager/src/styles.css — 新增 .confirm-modal / .confirm-modal-body / .confirm-modal-actions 样式

## 验证

- Vite 前端构建通过
- 浏览器中注入超长内容测试，确认按钮固定在视口内可见（actionsBottom 540px < viewportHeight 600px），内容区域可独立滚动