### PR TITLE
[codex] fix user script runtime status reporting

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -526,6 +526,14 @@ impl BridgeRuntimeService for LauncherRuntimeService {
         self.user_scripts.inventory()
     }
 
+    async fn user_script_inventory_with_runtime_status(
+        &self,
+        payload: Value,
+    ) -> anyhow::Result<Value> {
+        self.user_scripts
+            .inventory_with_runtime_status(payload.get("runtime_status"))
+    }
+
     async fn set_user_scripts_enabled(&self, enabled: bool) -> anyhow::Result<Value> {
         self.user_scripts.set_global_enabled(enabled)?;
         self.user_scripts.inventory()

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -3148,7 +3148,10 @@
   }
 
   async function loadUserScripts(path = "/user-scripts/list", payload = {}) {
-    const result = await postJson(path, payload);
+    const requestPayload = path === "/user-scripts/list"
+      ? { ...payload, runtime_status: window.__codexPlusUserScripts?.scripts || {} }
+      : payload;
+    const result = await postJson(path, requestPayload);
     if (result?.scripts) {
       codexPlusUserScripts = result;
       renderUserScripts();

--- a/crates/codex-plus-core/src/routes.rs
+++ b/crates/codex-plus-core/src/routes.rs
@@ -70,6 +70,12 @@ pub trait BridgeSettingsService: Send + Sync {
 #[async_trait]
 pub trait BridgeRuntimeService: Send + Sync {
     async fn user_script_inventory(&self) -> anyhow::Result<Value>;
+    async fn user_script_inventory_with_runtime_status(
+        &self,
+        _payload: Value,
+    ) -> anyhow::Result<Value> {
+        self.user_script_inventory().await
+    }
     async fn set_user_scripts_enabled(&self, enabled: bool) -> anyhow::Result<Value>;
     async fn set_user_script_enabled(&self, key: String, enabled: bool) -> anyhow::Result<Value>;
     async fn delete_user_script(&self, key: String) -> anyhow::Result<Value>;
@@ -132,7 +138,11 @@ pub async fn handle_bridge_request(
         "/settings/set" => {
             settings_value(&ctx, ctx.settings.set_settings(payload.clone()).await).await
         }
-        "/user-scripts/list" => ctx.runtime.user_script_inventory().await,
+        "/user-scripts/list" => {
+            ctx.runtime
+                .user_script_inventory_with_runtime_status(payload.clone())
+                .await
+        }
         "/user-scripts/set-enabled" => {
             let enabled = payload
                 .get("enabled")

--- a/crates/codex-plus-core/src/user_scripts.rs
+++ b/crates/codex-plus-core/src/user_scripts.rs
@@ -176,8 +176,19 @@ impl UserScriptManager {
     }
 
     pub fn inventory(&self) -> anyhow::Result<Value> {
+        self.inventory_with_runtime_status(None)
+    }
+
+    /// Build the script inventory and, when available, merge the status recorded
+    /// by the renderer-side loader. The filesystem scan alone cannot tell
+    /// whether a script was actually evaluated, so callers that have access to
+    /// the live page should provide `window.__codexPlusUserScripts.scripts`.
+    pub fn inventory_with_runtime_status(
+        &self,
+        runtime_status: Option<&Value>,
+    ) -> anyhow::Result<Value> {
         let config = self.load_config();
-        let scripts = self.scan_scripts(&config)?;
+        let scripts = self.scan_scripts(&config, runtime_status)?;
         Ok(json!({
             "enabled": config.enabled,
             "builtin_dir": self.builtin_dir.to_string_lossy(),
@@ -203,16 +214,36 @@ impl UserScriptManager {
         Ok(blocks.join("\n"))
     }
 
-    fn scan_scripts(&self, config: &UserScriptConfig) -> anyhow::Result<Vec<Value>> {
+    fn scan_scripts(
+        &self,
+        config: &UserScriptConfig,
+        runtime_status: Option<&Value>,
+    ) -> anyhow::Result<Vec<Value>> {
+        let runtime_scripts = runtime_status
+            .and_then(|value| value.get("scripts").or(Some(value)))
+            .and_then(Value::as_object);
         Ok(self
             .scan_script_files(config)?
             .into_iter()
             .map(|script| {
                 let market = config.market.get(&script.key);
-                let status = if !config.enabled || !script.enabled {
+                let fallback_status = if !config.enabled || !script.enabled {
                     "disabled"
                 } else {
                     "not_loaded"
+                };
+                let live = runtime_scripts.and_then(|items| items.get(&script.key));
+                let status = if fallback_status == "disabled" {
+                    fallback_status
+                } else {
+                    live.and_then(|item| item.get("status").and_then(Value::as_str))
+                        .unwrap_or(fallback_status)
+                };
+                let error = if fallback_status == "disabled" {
+                    ""
+                } else {
+                    live.and_then(|item| item.get("error").and_then(Value::as_str))
+                        .unwrap_or("")
                 };
                 json!({
                     "key": script.key,
@@ -220,7 +251,7 @@ impl UserScriptManager {
                     "source": script.source,
                     "enabled": script.enabled,
                     "status": status,
-                    "error": "",
+                    "error": error,
                     "market_id": market.as_ref().map(|item| item.id.as_str()).unwrap_or(""),
                     "version": market.as_ref().map(|item| item.version.as_str()).unwrap_or(""),
                     "installed": market.is_some(),

--- a/crates/codex-plus-core/tests/bridge_routes.rs
+++ b/crates/codex-plus-core/tests/bridge_routes.rs
@@ -626,6 +626,41 @@ async fn user_script_manager_scans_and_persists_inventory_shape() {
 }
 
 #[tokio::test]
+async fn user_script_inventory_merges_renderer_runtime_status() {
+    let temp = tempfile::tempdir().unwrap();
+    let builtin_dir = temp.path().join("builtin");
+    let user_dir = temp.path().join("user");
+    std::fs::create_dir_all(&builtin_dir).unwrap();
+    std::fs::create_dir_all(&user_dir).unwrap();
+    std::fs::write(user_dir.join("loaded.js"), "window.loaded = true;").unwrap();
+    std::fs::write(user_dir.join("failed.js"), "throw new Error('boom');").unwrap();
+    let manager =
+        UserScriptManager::new(builtin_dir, user_dir, temp.path().join("user_scripts.json"));
+    let runtime_status = json!({
+        "user:loaded.js": {"status": "loaded", "error": ""},
+        "user:failed.js": {"status": "failed", "error": "boom"}
+    });
+
+    let inventory = manager
+        .inventory_with_runtime_status(Some(&runtime_status))
+        .unwrap();
+    let scripts = inventory["scripts"].as_array().unwrap();
+    let loaded = scripts
+        .iter()
+        .find(|script| script["key"] == "user:loaded.js")
+        .unwrap();
+    let failed = scripts
+        .iter()
+        .find(|script| script["key"] == "user:failed.js")
+        .unwrap();
+
+    assert_eq!(loaded["status"], "loaded");
+    assert_eq!(loaded["error"], "");
+    assert_eq!(failed["status"], "failed");
+    assert_eq!(failed["error"], "boom");
+}
+
+#[tokio::test]
 async fn user_script_manager_deletes_market_script_metadata_and_rejects_builtin_delete() {
     let temp = tempfile::tempdir().unwrap();
     let builtin_dir = temp.path().join("builtin");


### PR DESCRIPTION
## What changed

Fix false `not_loaded` statuses in the user-script manager by forwarding the renderer's live `window.__codexPlusUserScripts.scripts` snapshot with `/user-scripts/list` and merging it into the filesystem inventory.

## Why

Enabled scripts were executing successfully, but the backend inventory always used the static `not_loaded` fallback. This made the Codex++ manager report scripts as unloaded even when their runtime status was `loaded` (or `failed` with a real error).

The runtime snapshot is passed through the existing bridge request rather than opening a nested CDP connection while handling a bridge call.

## Validation

- `cargo test -p codex-plus-core --test bridge_routes` (26 passed)
- `cargo test -p codex-plus-launcher` (4 passed)
- `cargo build -p codex-plus-launcher --release`
- Verified on Windows that all three enabled user scripts report `loaded` in both the runtime registry and `/user-scripts/list`.

Related: #1581 (related user-script loading symptoms, but this PR fixes status reporting after successful injection)
