### PR TITLE
修复管理工具窗口关闭与居中问题

### DIFF
--- a/apps/codex-plus-manager/src-tauri/src/lib.rs
+++ b/apps/codex-plus-manager/src-tauri/src/lib.rs
@@ -51,6 +51,7 @@ pub fn run() {
             let mut main_window_builder =
                 tauri::WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::App(url.into()))
                     .title("Codex++ 管理工具")
+                    .center()
                     .inner_size(1180.0, 820.0)
                     .min_inner_size(960.0, 720.0);
             if let Some(icon) = app.default_window_icon().cloned() {
@@ -220,21 +221,48 @@ fn register_main_window_events<R: tauri::Runtime>(window: tauri::WebviewWindow<R
     let close_event_window = event_window.clone();
 
     event_window.on_window_event(move |event| match event {
-        WindowEvent::Resized(_) => {
-            if matches!(minimized_window.is_minimized(), Ok(true)) {
-                let _ = minimized_window.hide();
+        WindowEvent::Resized(_) => match minimized_window.is_minimized() {
+            Ok(true) => {
+                record_window_operation_result("minimize.hide_to_tray", minimized_window.hide());
             }
-        }
+            Ok(false) => {}
+            Err(error) => record_window_operation_error("minimize.read_state", error),
+        },
         WindowEvent::CloseRequested { api, .. } => {
             if APP_EXITING.load(Ordering::SeqCst) {
                 return;
             }
 
             api.prevent_close();
-            let _ = close_event_window.hide();
+            if !record_window_operation_result("close.hide_to_tray", close_event_window.hide()) {
+                record_window_operation_result(
+                    "close.minimize_fallback",
+                    close_event_window.minimize(),
+                );
+            }
         }
         _ => {}
     });
+}
+
+fn record_window_operation_result(operation: &str, result: tauri::Result<()>) -> bool {
+    match result {
+        Ok(()) => true,
+        Err(error) => {
+            record_window_operation_error(operation, error);
+            false
+        }
+    }
+}
+
+fn record_window_operation_error(operation: &str, error: tauri::Error) {
+    let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+        "manager.window_operation_failed",
+        serde_json::json!({
+            "operation": operation,
+            "error": error.to_string()
+        }),
+    );
 }
 
 #[tauri::command]
@@ -245,7 +273,7 @@ fn manager_exit_app<R: tauri::Runtime>(app: tauri::AppHandle<R>) {
 
 #[tauri::command]
 fn manager_hide_to_tray<R: tauri::Runtime>(window: tauri::WebviewWindow<R>) {
-    let _ = window.hide();
+    record_window_operation_result("command.hide_to_tray", window.hide());
 }
 
 #[tauri::command]
@@ -316,9 +344,9 @@ fn record_tray_dream_skin_result(action: &str, result: anyhow::Result<()>) {
 
 fn show_main_window<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>) {
     if let Some(window) = app_handle.get_webview_window("main") {
-        let _ = window.unminimize();
-        let _ = window.show();
-        let _ = window.set_focus();
+        record_window_operation_result("restore.unminimize", window.unminimize());
+        record_window_operation_result("restore.show", window.show());
+        record_window_operation_result("restore.focus", window.set_focus());
     }
 }
 

--- a/apps/codex-plus-manager/src-tauri/tests/windows_subsystem.rs
+++ b/apps/codex-plus-manager/src-tauri/tests/windows_subsystem.rs
@@ -61,10 +61,21 @@ fn manager_close_minimizes_to_tray_without_confirmation() {
     assert!(!lib_rs.contains("MessageDialogButtons"));
     assert!(!lib_rs.contains(".dialog()"));
     assert!(!lib_rs.contains("manager://close-requested"));
-    assert!(lib_rs.contains("let _ = close_event_window.hide();"));
+    assert!(lib_rs.contains("\"close.hide_to_tray\""));
+    assert!(lib_rs.contains("\"close.minimize_fallback\""));
+    assert!(lib_rs.contains("manager.window_operation_failed"));
     assert!(!app_tsx.contains("CloseConfirmDialog"));
     assert!(app_tsx.contains("manager_exit_app"));
     assert!(app_tsx.contains("manager_hide_to_tray"));
+}
+
+#[test]
+fn manager_centers_window_on_startup() {
+    let lib_rs = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/src/lib.rs"))
+        .expect("read manager lib.rs");
+
+    assert!(lib_rs.contains(".center()"));
+    assert!(!lib_rs.contains("\"restore.center\""));
 }
 
 #[test]


### PR DESCRIPTION
基于 v1.2.42 重新提交，替代 #1598。

## 问题

管理工具关闭/最小化偶发无响应，首次启动时窗口位置不居中。

## 修改

- 首次启动时居中窗口；托盘恢复保留用户原位置
- 记录窗口操作错误
- 隐藏到托盘失败时降级为最小化

以上均使用 Tauri 桌面端通用 API，不包含 Windows 专属实现。

## 验证

- Rust：41 项单元测试、23 项窗口测试通过
- 前端：类型检查、32 项测试、生产构建通过
