### PR TITLE
feat: support Anthropic Messages protocol proxy

### DIFF
--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -3198,6 +3198,9 @@ pub async fn diagnose_relay_profile(profile: RelayProfile) -> CommandResult<Prov
             match profile.protocol {
                 codex_plus_core::settings::RelayProtocol::Responses => "Responses API",
                 codex_plus_core::settings::RelayProtocol::ChatCompletions => "Chat Completions",
+                codex_plus_core::settings::RelayProtocol::AnthropicMessages => {
+                    "Claude Messages"
+                }
             }
         ),
     });

--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -309,7 +309,7 @@ type CodexContextEntries = {
   plugins: CodexContextEntry[];
 };
 
-type RelayProtocol = "responses" | "chatCompletions";
+type RelayProtocol = "responses" | "chatCompletions" | "anthropicMessages";
 type RelayMode = "official" | "mixedApi" | "pureApi" | "aggregate";
 const PROTOCOL_PROXY_BASE_URL = "http://127.0.0.1:57321/v1";
 const CHAT_UPSTREAM_BASE_URL_KEY = "codex_plus_chat_base_url";
@@ -5678,6 +5678,13 @@ function RelayProfileEditor({
                 >
                   Chat Completions
                 </button>
+                <button
+                  className={`protocol-option ${profile.protocol === "anthropicMessages" ? "active" : ""}`}
+                  onClick={() => updateDraft({ protocol: "anthropicMessages" })}
+                  type="button"
+                >
+                  Claude Messages
+                </button>
               </div>
             </Field>
           </div>
@@ -5826,7 +5833,7 @@ function RelayProfileEditor({
           </Field>
         ) : null}
       </div>
-      {showApiFields && profile.protocol === "chatCompletions" ? (
+      {showApiFields && profile.protocol !== "responses" ? (
         <div className="hint-line relay-protocol-hint">
           <MessageCircle className="h-4 w-4" />
           <span>{t("此上游会通过本地 127.0.0.1:57321 转成 Responses API，需要从 Codex++ 启动 Codex。")}</span>
@@ -7704,7 +7711,10 @@ function normalizeRelayProfile(profile: RelayProfile, defaultContextSelection = 
     baseUrl: profile.baseUrl || defaultSettings.relayBaseUrl,
     upstreamBaseUrl: profile.upstreamBaseUrl || profile.baseUrl || "",
     apiKey: profile.apiKey || "",
-    protocol: profile.protocol === "chatCompletions" ? "chatCompletions" : "responses",
+    protocol:
+      profile.protocol === "chatCompletions" || profile.protocol === "anthropicMessages"
+        ? profile.protocol
+        : "responses",
     relayMode,
     officialMixApiKey,
     testModel: profile.testModel || "",
@@ -7750,7 +7760,9 @@ function activeRelayProfile(settings: BackendSettings): RelayProfile {
 }
 
 function relayProtocolLabel(protocol: RelayProtocol): string {
-  return protocol === "chatCompletions" ? t("Chat Completions 转 Responses") : "Responses API";
+  if (protocol === "chatCompletions") return t("Chat Completions 转 Responses");
+  if (protocol === "anthropicMessages") return t("Claude Messages 转 Responses");
+  return "Responses API";
 }
 
 function ccsProviderSummary(result: CcsProvidersResult | null): string {
@@ -7794,6 +7806,14 @@ function providerImportWireApiLabel(value: string): string {
   const normalized = value.trim().toLowerCase();
   if (normalized === "chat" || normalized === "chat_completions" || normalized === "chat-completions") {
     return "Chat Completions";
+  }
+  if (
+    normalized === "anthropic" ||
+    normalized === "messages" ||
+    normalized === "anthropic_messages" ||
+    normalized === "anthropic-messages"
+  ) {
+    return "Claude Messages";
   }
   return "Responses";
 }
@@ -7891,7 +7911,7 @@ function buildRelayConfigToml(
   profile: Pick<RelayProfile, "model" | "baseUrl" | "upstreamBaseUrl" | "apiKey" | "protocol">,
   options: { includeBearerToken: boolean },
 ): string {
-  const baseUrl = profile.protocol === "chatCompletions" ? PROTOCOL_PROXY_BASE_URL : profile.baseUrl.trim();
+  const baseUrl = profile.protocol !== "responses" ? PROTOCOL_PROXY_BASE_URL : profile.baseUrl.trim();
   const apiKey = profile.apiKey.trim();
   const rootLines = [
     profile.model.trim() ? `model = "${tomlString(profile.model.trim())}"` : null,
@@ -7994,7 +8014,7 @@ function applyRelayProfilePatchToFiles(
     next.baseUrl = patch.upstreamBaseUrl || "";
   }
   if ("baseUrl" in patch || "upstreamBaseUrl" in patch || "protocol" in patch) {
-    const baseUrlForConfig = next.protocol === "chatCompletions" ? PROTOCOL_PROXY_BASE_URL : next.upstreamBaseUrl || next.baseUrl;
+    const baseUrlForConfig = next.protocol !== "responses" ? PROTOCOL_PROXY_BASE_URL : next.upstreamBaseUrl || next.baseUrl;
     next.configContents = setCodexProviderStringKey(next.configContents, "base_url", baseUrlForConfig);
     next.configContents = removeRootTomlKey(next.configContents, CHAT_UPSTREAM_BASE_URL_KEY);
   }

--- a/apps/codex-plus-manager/src/i18n-en.ts
+++ b/apps/codex-plus-manager/src/i18n-en.ts
@@ -9,6 +9,7 @@ export const EN_PLAIN: Record<string, string> = {
     "Expands plugin marketplace requests in API Key mode to show the full plugin list. Usually unnecessary in official/mixed mode.",
   "API Key 环境变量": "API Key environment variable",
   "Chat Completions 转 Responses": "Chat Completions to Responses",
+  "Claude Messages 转 Responses": "Claude Messages to Responses",
   "Codex 启动参数": "Codex launch arguments",
   "Codex 工具与插件": "Codex tools & plugins",
   "Codex 应用": "Codex app",

--- a/apps/codex-plus-manager/src/presets.ts
+++ b/apps/codex-plus-manager/src/presets.ts
@@ -9,7 +9,7 @@
 
 export type PresetCategory = "official" | "aggregator" | "third_party" | "cn_official";
 
-export type RelayProtocol = "responses" | "chatCompletions";
+export type RelayProtocol = "responses" | "chatCompletions" | "anthropicMessages";
 
 export interface ProviderPreset {
   id: string;
@@ -27,7 +27,7 @@ export interface ProviderPreset {
  * 预设列表。选择任一预设会自动填充：
  * - name     → 供应商名称
  * - baseUrl  → API 端点
- * - protocol → responses / chatCompletions（根据上游实际协议）
+ * - protocol → responses / chatCompletions / anthropicMessages（根据上游实际协议）
  * - model    → 默认模型名
  * - modelList → 可选模型清单（换行分隔）
  */

--- a/crates/codex-plus-core/src/ccs_import.rs
+++ b/crates/codex-plus-core/src/ccs_import.rs
@@ -167,6 +167,9 @@ fn extract_api_key(config: &Value) -> Option<String> {
 
 fn extract_protocol(config: &Value) -> RelayProtocol {
     if let Some(api_format) = string_at(config, &["api_format", "apiFormat"]) {
+        if is_anthropic_protocol(&api_format) {
+            return RelayProtocol::AnthropicMessages;
+        }
         if is_chat_protocol(&api_format) {
             return RelayProtocol::ChatCompletions;
         }
@@ -176,9 +179,18 @@ fn extract_protocol(config: &Value) -> RelayProtocol {
         .and_then(Value::as_str)
         .and_then(extract_toml_wire_api)
     {
+        if is_anthropic_protocol(&wire_api) {
+            return RelayProtocol::AnthropicMessages;
+        }
         if is_chat_protocol(&wire_api) {
             return RelayProtocol::ChatCompletions;
         }
+    }
+    if extract_base_url(config)
+        .map(|value| value.to_ascii_lowercase().ends_with("/messages"))
+        .unwrap_or(false)
+    {
+        return RelayProtocol::AnthropicMessages;
     }
     if extract_base_url(config)
         .map(|value| value.to_ascii_lowercase().ends_with("/chat/completions"))
@@ -225,6 +237,13 @@ fn is_chat_protocol(value: &str) -> bool {
     )
 }
 
+fn is_anthropic_protocol(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "anthropic" | "messages" | "anthropic_messages" | "anthropic-messages" | "claude"
+    )
+}
+
 fn extract_toml_base_url(text: &str) -> Option<String> {
     extract_toml_string_value(text, "base_url")
 }
@@ -259,6 +278,7 @@ fn build_config_toml(base_url: &str, api_key: &str, protocol: RelayProtocol) -> 
     let wire_api = match protocol {
         RelayProtocol::Responses => "responses",
         RelayProtocol::ChatCompletions => "chat",
+        RelayProtocol::AnthropicMessages => "responses",
     };
     [
         "model_provider = \"CodexPlusPlus\"".to_string(),

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -1422,10 +1422,10 @@ async fn handle_protocol_proxy_connection(
             stream.shutdown().await?;
             return Ok(());
         }
-        let mut converter = request_json
-            .as_ref()
-            .map(crate::protocol_proxy::ChatSseToResponsesConverter::with_request)
-            .unwrap_or_default();
+        let mut converter = crate::protocol_proxy::UpstreamSseToResponsesConverter::with_request(
+            upstream.wire_api,
+            request_json.as_ref().unwrap_or(&serde_json::Value::Null),
+        );
         let mut bytes_stream = upstream.response.bytes_stream();
         let mut stream_failed = false;
         while let Some(chunk) = bytes_stream.next().await {
@@ -1488,11 +1488,28 @@ async fn handle_protocol_proxy_connection(
         stream.shutdown().await?;
         return Ok(());
     }
-    let chat_json: serde_json::Value = serde_json::from_slice(&upstream_body)?;
-    let response_json = if let Some(request_json) = request_json.as_ref() {
-        crate::protocol_proxy::chat_completion_to_response_with_request(chat_json, request_json)?
-    } else {
-        crate::protocol_proxy::chat_completion_to_response(chat_json)?
+    let upstream_json: serde_json::Value = serde_json::from_slice(&upstream_body)?;
+    let response_json = match upstream.wire_api {
+        crate::protocol_proxy::UpstreamWireApi::AnthropicMessages => {
+            if let Some(request_json) = request_json.as_ref() {
+                crate::protocol_proxy::anthropic_message_to_response_with_request(
+                    upstream_json,
+                    request_json,
+                )?
+            } else {
+                crate::protocol_proxy::anthropic_message_to_response(upstream_json)?
+            }
+        }
+        _ => {
+            if let Some(request_json) = request_json.as_ref() {
+                crate::protocol_proxy::chat_completion_to_response_with_request(
+                    upstream_json,
+                    request_json,
+                )?
+            } else {
+                crate::protocol_proxy::chat_completion_to_response(upstream_json)?
+            }
+        }
     };
     let body = serde_json::to_vec(&response_json)?;
     write_http_response(stream, "200 OK", "application/json; charset=utf-8", &body).await?;

--- a/crates/codex-plus-core/src/protocol_proxy.rs
+++ b/crates/codex-plus-core/src/protocol_proxy.rs
@@ -1,6 +1,4 @@
-//! Codex Responses API 与 OpenAI Chat Completions 的本地协议转换。
-//!
-//! Codex Chat 与 Responses 协议之间的转换实现。
+//! Codex Responses API 与 Chat Completions、Claude Messages 的本地协议转换。
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
@@ -16,6 +14,7 @@ pub const DEFAULT_PROTOCOL_PROXY_PORT: u16 = 57321;
 const UPSTREAM_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const UPSTREAM_HEADER_TIMEOUT: Duration = Duration::from_secs(30);
 const UPSTREAM_STREAM_HEADER_TIMEOUT: Duration = Duration::from_secs(120);
+const DEFAULT_ANTHROPIC_MAX_TOKENS: u64 = 8192;
 const THINK_OPEN_TAG: &str = "<think>";
 const THINK_CLOSE_TAG: &str = "</think>";
 const EXTRA_CHAT_PASSTHROUGH_FIELDS: &[&str] = &[
@@ -217,6 +216,332 @@ pub fn responses_to_chat_completions(body: Value) -> anyhow::Result<Value> {
     Ok(result)
 }
 
+pub fn responses_to_anthropic_messages(body: Value) -> anyhow::Result<Value> {
+    let original_request = body.clone();
+    let chat_body = responses_to_chat_completions(body)?;
+    chat_completions_to_anthropic_messages(chat_body, &original_request)
+}
+
+fn chat_completions_to_anthropic_messages(
+    chat_body: Value,
+    original_request: &Value,
+) -> anyhow::Result<Value> {
+    let model = chat_body
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let adaptive_thinking = anthropic_uses_adaptive_thinking(model);
+    let mut reasoning_signatures = responses_reasoning_signatures(original_request).into_iter();
+    let mut result = json!({
+        "model": model,
+        "max_tokens": chat_body
+            .get("max_tokens")
+            .or_else(|| chat_body.get("max_completion_tokens"))
+            .cloned()
+            .unwrap_or_else(|| json!(DEFAULT_ANTHROPIC_MAX_TOKENS))
+    });
+
+    let mut system_parts = Vec::new();
+    let mut messages = Vec::new();
+    for message in chat_body
+        .get("messages")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let role = message
+            .get("role")
+            .and_then(Value::as_str)
+            .unwrap_or("user");
+        if matches!(role, "system" | "developer") {
+            let text = instruction_text(message.get("content").unwrap_or(&Value::Null));
+            if !text.is_empty() {
+                system_parts.push(text);
+            }
+            continue;
+        }
+
+        let mut content =
+            chat_content_to_anthropic_blocks(message.get("content").unwrap_or(&Value::Null));
+        match role {
+            "assistant" => {
+                if let Some(thinking) = message
+                    .get("reasoning_content")
+                    .and_then(Value::as_str)
+                    .filter(|thinking| !thinking.is_empty())
+                {
+                    let mut block = json!({ "type": "thinking", "thinking": thinking });
+                    if let Some(Some(signature)) = reasoning_signatures.next() {
+                        block["signature"] = json!(signature);
+                    }
+                    content.insert(0, block);
+                }
+                for tool_call in message
+                    .get("tool_calls")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                {
+                    let function = tool_call.get("function").unwrap_or(&Value::Null);
+                    let arguments = function
+                        .get("arguments")
+                        .and_then(Value::as_str)
+                        .and_then(|arguments| serde_json::from_str::<Value>(arguments).ok())
+                        .unwrap_or_else(|| json!({}));
+                    content.push(json!({
+                        "type": "tool_use",
+                        "id": tool_call
+                            .get("id")
+                            .and_then(Value::as_str)
+                            .unwrap_or("call_0"),
+                        "name": function
+                            .get("name")
+                            .and_then(Value::as_str)
+                            .unwrap_or("unknown_tool"),
+                        "input": arguments
+                    }));
+                }
+                push_anthropic_message(&mut messages, "assistant", content);
+            }
+            "tool" => {
+                let tool_use_id = message
+                    .get("tool_call_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default();
+                if !tool_use_id.is_empty() {
+                    push_anthropic_message(
+                        &mut messages,
+                        "user",
+                        vec![json!({
+                            "type": "tool_result",
+                            "tool_use_id": tool_use_id,
+                            "content": response_output_text(
+                                message.get("content").unwrap_or(&Value::Null)
+                            )
+                        })],
+                    );
+                }
+            }
+            _ => push_anthropic_message(&mut messages, "user", content),
+        }
+    }
+    if !system_parts.is_empty() {
+        result["system"] = json!(system_parts.join("\n\n"));
+    }
+    result["messages"] = json!(messages);
+
+    if let Some(tools) = chat_body.get("tools").and_then(Value::as_array) {
+        let tools = tools
+            .iter()
+            .filter_map(chat_tool_to_anthropic_tool)
+            .collect::<Vec<_>>();
+        if !tools.is_empty() {
+            result["tools"] = json!(tools);
+            if let Some(tool_choice) = chat_body
+                .get("tool_choice")
+                .and_then(|choice| chat_tool_choice_to_anthropic(choice, &chat_body))
+            {
+                result["tool_choice"] =
+                    compatible_anthropic_tool_choice(tool_choice, adaptive_thinking);
+            }
+        }
+    }
+
+    for key in ["temperature", "top_p", "stream"] {
+        if let Some(value) = chat_body.get(key) {
+            result[key] = value.clone();
+        }
+    }
+    if let Some(stop) = chat_body.get("stop") {
+        result["stop_sequences"] = if stop.is_array() {
+            stop.clone()
+        } else {
+            json!([stop])
+        };
+    }
+    if let Some(effort) = original_request
+        .pointer("/reasoning/effort")
+        .and_then(Value::as_str)
+        .and_then(anthropic_effort)
+    {
+        result["output_config"] = json!({ "effort": effort });
+    }
+    if adaptive_thinking {
+        result["thinking"] = json!({ "type": "adaptive" });
+    }
+
+    Ok(result)
+}
+
+fn chat_content_to_anthropic_blocks(content: &Value) -> Vec<Value> {
+    match content {
+        Value::String(text) if !text.is_empty() => vec![json!({ "type": "text", "text": text })],
+        Value::Array(parts) => parts
+            .iter()
+            .filter_map(|part| match part.get("type").and_then(Value::as_str) {
+                Some("text" | "input_text" | "output_text") => part
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .filter(|text| !text.is_empty())
+                    .map(|text| json!({ "type": "text", "text": text })),
+                Some("image_url") => anthropic_image_block(part.get("image_url")?),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn anthropic_image_block(image_url: &Value) -> Option<Value> {
+    let url = image_url
+        .as_str()
+        .or_else(|| image_url.get("url").and_then(Value::as_str))?;
+    if let Some(data_url) = url.strip_prefix("data:") {
+        let (metadata, data) = data_url.split_once(',')?;
+        let media_type = metadata.strip_suffix(";base64")?;
+        return Some(json!({
+            "type": "image",
+            "source": { "type": "base64", "media_type": media_type, "data": data }
+        }));
+    }
+    Some(json!({
+        "type": "image",
+        "source": { "type": "url", "url": url }
+    }))
+}
+
+fn push_anthropic_message(messages: &mut Vec<Value>, role: &str, content: Vec<Value>) {
+    if content.is_empty() {
+        return;
+    }
+    if let Some(last) = messages.last_mut()
+        && last.get("role").and_then(Value::as_str) == Some(role)
+        && let Some(parts) = last.get_mut("content").and_then(Value::as_array_mut)
+    {
+        parts.extend(content);
+        return;
+    }
+    messages.push(json!({ "role": role, "content": content }));
+}
+
+fn chat_tool_to_anthropic_tool(tool: &Value) -> Option<Value> {
+    let function = tool.get("function")?;
+    let name = function.get("name").and_then(Value::as_str)?;
+    let mut converted = json!({
+        "name": name,
+        "input_schema": function
+            .get("parameters")
+            .cloned()
+            .unwrap_or_else(|| json!({ "type": "object", "properties": {} }))
+    });
+    if let Some(description) = function.get("description") {
+        converted["description"] = description.clone();
+    }
+    Some(converted)
+}
+
+fn chat_tool_choice_to_anthropic(choice: &Value, chat_body: &Value) -> Option<Value> {
+    let disable_parallel_tool_use = chat_body
+        .get("parallel_tool_calls")
+        .and_then(Value::as_bool)
+        .map(|enabled| !enabled);
+    let mut converted = match choice {
+        Value::String(value) => match value.as_str() {
+            "auto" => json!({ "type": "auto" }),
+            "required" => json!({ "type": "any" }),
+            "none" => json!({ "type": "none" }),
+            _ => return None,
+        },
+        Value::Object(object) => {
+            let choice_type = object
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            if matches!(choice_type, "auto" | "any" | "none") {
+                json!({ "type": choice_type })
+            } else {
+                let name = object
+                    .get("function")
+                    .and_then(|function| function.get("name"))
+                    .or_else(|| object.get("name"))
+                    .and_then(Value::as_str)?;
+                json!({ "type": "tool", "name": name })
+            }
+        }
+        _ => return None,
+    };
+    if let Some(disabled) = disable_parallel_tool_use {
+        converted["disable_parallel_tool_use"] = json!(disabled);
+    }
+    Some(converted)
+}
+
+fn anthropic_effort(effort: &str) -> Option<&'static str> {
+    match effort.trim().to_ascii_lowercase().as_str() {
+        "none" | "off" | "disabled" | "minimal" | "low" => Some("low"),
+        "medium" => Some("medium"),
+        "high" => Some("high"),
+        "xhigh" => Some("xhigh"),
+        "max" => Some("max"),
+        _ => None,
+    }
+}
+
+fn anthropic_uses_adaptive_thinking(model: &str) -> bool {
+    let model = model.trim().to_ascii_lowercase();
+    [
+        "fable-5",
+        "mythos-5",
+        "mythos-preview",
+        "opus-4-6",
+        "opus-4-7",
+        "opus-4-8",
+        "sonnet-4-6",
+        "sonnet-5",
+    ]
+    .iter()
+    .any(|name| model.contains(name))
+}
+
+fn compatible_anthropic_tool_choice(mut choice: Value, adaptive_thinking: bool) -> Value {
+    if adaptive_thinking
+        && matches!(
+            choice.get("type").and_then(Value::as_str),
+            Some("any" | "tool")
+        )
+    {
+        choice["type"] = json!("auto");
+        if let Some(choice) = choice.as_object_mut() {
+            choice.remove("name");
+        }
+    }
+    choice
+}
+
+fn responses_reasoning_signatures(request: &Value) -> Vec<Option<String>> {
+    let mut signatures = Vec::new();
+    let mut push_signature = |item: &Value| {
+        if item.get("type").and_then(Value::as_str) != Some("reasoning")
+            || responses_reasoning_text(item).is_none_or(|text| text.is_empty())
+        {
+            return;
+        }
+        signatures.push(
+            item.get("encrypted_content")
+                .or_else(|| item.get("signature"))
+                .and_then(Value::as_str)
+                .filter(|signature| !signature.is_empty())
+                .map(ToString::to_string),
+        );
+    };
+    match request.get("input") {
+        Some(Value::Array(items)) => items.iter().for_each(&mut push_signature),
+        Some(item @ Value::Object(_)) => push_signature(item),
+        _ => {}
+    }
+    signatures
+}
+
 pub fn chat_completion_to_response(body: Value) -> anyhow::Result<Value> {
     chat_completion_to_response_with_context(body, &CodexToolContext::default(), None)
 }
@@ -276,6 +601,136 @@ fn chat_completion_to_response_with_context(
     Ok(response)
 }
 
+pub fn anthropic_message_to_response(body: Value) -> anyhow::Result<Value> {
+    let chat_body = anthropic_message_to_chat_completion(body)?;
+    chat_completion_to_response(chat_body)
+}
+
+pub fn anthropic_message_to_response_with_request(
+    body: Value,
+    original_request: &Value,
+) -> anyhow::Result<Value> {
+    let chat_body = anthropic_message_to_chat_completion(body)?;
+    chat_completion_to_response_with_request(chat_body, original_request)
+}
+
+fn anthropic_message_to_chat_completion(body: Value) -> anyhow::Result<Value> {
+    let content = body
+        .get("content")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("Anthropic message response missing content"))?;
+    let mut text = String::new();
+    let mut reasoning = String::new();
+    let mut reasoning_signature = None;
+    let mut tool_calls = Vec::new();
+    for block in content {
+        match block
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+        {
+            "text" => {
+                if let Some(value) = block.get("text").and_then(Value::as_str) {
+                    text.push_str(value);
+                }
+            }
+            "thinking" => {
+                if let Some(value) = block.get("thinking").and_then(Value::as_str) {
+                    reasoning.push_str(value);
+                }
+                if reasoning_signature.is_none() {
+                    reasoning_signature = block
+                        .get("signature")
+                        .and_then(Value::as_str)
+                        .filter(|signature| !signature.is_empty())
+                        .map(ToString::to_string);
+                }
+            }
+            "tool_use" => {
+                tool_calls.push(json!({
+                    "id": block.get("id").and_then(Value::as_str).unwrap_or("call_0"),
+                    "type": "function",
+                    "function": {
+                        "name": block
+                            .get("name")
+                            .and_then(Value::as_str)
+                            .unwrap_or("unknown_tool"),
+                        "arguments": canonical_json_string(
+                            block.get("input").unwrap_or(&json!({}))
+                        )
+                    }
+                }));
+            }
+            _ => {}
+        }
+    }
+
+    let stop_reason = body
+        .get("stop_reason")
+        .and_then(Value::as_str)
+        .unwrap_or("end_turn");
+    let mut message = json!({
+        "role": "assistant",
+        "content": text
+    });
+    if !reasoning.is_empty() {
+        message["reasoning_content"] = json!(reasoning);
+    }
+    if let Some(signature) = reasoning_signature {
+        message["reasoning_signature"] = json!(signature);
+    }
+    if !tool_calls.is_empty() {
+        message["tool_calls"] = json!(tool_calls);
+    }
+    if stop_reason == "refusal" {
+        message["refusal"] = json!(anthropic_refusal_text(&body));
+    }
+
+    Ok(json!({
+        "id": body.get("id").and_then(Value::as_str).unwrap_or("msg_compat"),
+        "object": "chat.completion",
+        "created": 0,
+        "model": body.get("model").and_then(Value::as_str).unwrap_or(""),
+        "choices": [{
+            "index": 0,
+            "message": message,
+            "finish_reason": anthropic_stop_reason_to_chat(stop_reason)
+        }],
+        "usage": anthropic_usage_to_chat_usage(body.get("usage"))
+    }))
+}
+
+fn anthropic_refusal_text(body: &Value) -> String {
+    body.pointer("/stop_details/explanation")
+        .or_else(|| body.pointer("/stop_details/category"))
+        .and_then(Value::as_str)
+        .filter(|text| !text.is_empty())
+        .unwrap_or("Request refused by upstream model")
+        .to_string()
+}
+
+fn anthropic_stop_reason_to_chat(stop_reason: &str) -> &'static str {
+    match stop_reason {
+        "max_tokens" | "model_context_window_exceeded" => "length",
+        "tool_use" => "tool_calls",
+        _ => "stop",
+    }
+}
+
+fn anthropic_usage_to_chat_usage(usage: Option<&Value>) -> Value {
+    let Some(usage) = usage.filter(|usage| usage.is_object()) else {
+        return json!({});
+    };
+    let mut converted = usage.clone();
+    if let Some(value) = usage.pointer("/cache_creation/ephemeral_5m_input_tokens") {
+        converted["cache_creation_5m_input_tokens"] = value.clone();
+    }
+    if let Some(value) = usage.pointer("/cache_creation/ephemeral_1h_input_tokens") {
+        converted["cache_creation_1h_input_tokens"] = value.clone();
+    }
+    converted
+}
+
 pub struct ProxyHttpResponse {
     pub status: String,
     pub content_type: String,
@@ -294,6 +749,7 @@ pub struct UpstreamProxyResponse {
 pub enum UpstreamWireApi {
     Responses,
     ChatCompletions,
+    AnthropicMessages,
     AudioTranscriptions,
 }
 
@@ -443,6 +899,323 @@ impl ChatSseToResponsesConverter {
     }
 }
 
+pub struct AnthropicSseToResponsesConverter {
+    buffer: String,
+    utf8_remainder: Vec<u8>,
+    state: AnthropicSseState,
+    failed: bool,
+}
+
+impl Default for AnthropicSseToResponsesConverter {
+    fn default() -> Self {
+        Self {
+            buffer: String::new(),
+            utf8_remainder: Vec::new(),
+            state: AnthropicSseState::default(),
+            failed: false,
+        }
+    }
+}
+
+impl AnthropicSseToResponsesConverter {
+    pub fn with_request(original_request: &Value) -> Self {
+        Self {
+            state: AnthropicSseState::with_request(original_request),
+            ..Self::default()
+        }
+    }
+
+    pub fn push_bytes(&mut self, bytes: &[u8]) -> Vec<u8> {
+        append_utf8_safe(&mut self.buffer, &mut self.utf8_remainder, bytes);
+        let mut output = String::new();
+        while let Some(block) = take_sse_block(&mut self.buffer) {
+            if block.trim().is_empty() {
+                continue;
+            }
+            self.handle_block(&block, &mut output);
+            if self.failed {
+                break;
+            }
+        }
+        output.into_bytes()
+    }
+
+    pub fn finish(&mut self) -> Vec<u8> {
+        if !self.utf8_remainder.is_empty() {
+            self.buffer
+                .push_str(&String::from_utf8_lossy(&self.utf8_remainder));
+            self.utf8_remainder.clear();
+        }
+        let mut output = String::new();
+        if !self.failed {
+            self.state.chat.finalize_into(&mut output);
+        }
+        output.into_bytes()
+    }
+
+    pub fn fail(&mut self, message: String, error_type: Option<String>) -> Vec<u8> {
+        let mut output = String::new();
+        self.state
+            .chat
+            .failed_into(&mut output, message, error_type);
+        self.failed = true;
+        output.into_bytes()
+    }
+
+    fn handle_block(&mut self, block: &str, output: &mut String) {
+        let data = block
+            .lines()
+            .filter_map(|line| strip_sse_field(line, "data"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        if data.is_empty() {
+            return;
+        }
+        if data.trim() == "[DONE]" {
+            self.state.chat.finalize_into(output);
+            return;
+        }
+        let Ok(event) = serde_json::from_str::<Value>(&data) else {
+            return;
+        };
+        if event.get("type").and_then(Value::as_str) == Some("error")
+            || event.get("error").is_some()
+        {
+            let (message, error_type) = extract_chat_sse_error(&event);
+            self.state.chat.failed_into(output, message, error_type);
+            self.failed = true;
+            return;
+        }
+        self.state.handle_event_into(&event, output);
+    }
+}
+
+pub enum UpstreamSseToResponsesConverter {
+    Chat(ChatSseToResponsesConverter),
+    Anthropic(AnthropicSseToResponsesConverter),
+}
+
+impl UpstreamSseToResponsesConverter {
+    pub fn with_request(wire_api: UpstreamWireApi, original_request: &Value) -> Self {
+        match wire_api {
+            UpstreamWireApi::AnthropicMessages => Self::Anthropic(
+                AnthropicSseToResponsesConverter::with_request(original_request),
+            ),
+            _ => Self::Chat(ChatSseToResponsesConverter::with_request(original_request)),
+        }
+    }
+
+    pub fn push_bytes(&mut self, bytes: &[u8]) -> Vec<u8> {
+        match self {
+            Self::Chat(converter) => converter.push_bytes(bytes),
+            Self::Anthropic(converter) => converter.push_bytes(bytes),
+        }
+    }
+
+    pub fn finish(&mut self) -> Vec<u8> {
+        match self {
+            Self::Chat(converter) => converter.finish(),
+            Self::Anthropic(converter) => converter.finish(),
+        }
+    }
+
+    pub fn fail(&mut self, message: String, error_type: Option<String>) -> Vec<u8> {
+        match self {
+            Self::Chat(converter) => converter.fail(message, error_type),
+            Self::Anthropic(converter) => converter.fail(message, error_type),
+        }
+    }
+}
+
+struct AnthropicSseState {
+    chat: ChatSseState,
+    usage: Value,
+}
+
+impl Default for AnthropicSseState {
+    fn default() -> Self {
+        Self {
+            chat: ChatSseState::default(),
+            usage: json!({}),
+        }
+    }
+}
+
+impl AnthropicSseState {
+    fn with_request(original_request: &Value) -> Self {
+        Self {
+            chat: ChatSseState::with_request(original_request),
+            ..Self::default()
+        }
+    }
+
+    fn handle_event_into(&mut self, event: &Value, output: &mut String) {
+        match event
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+        {
+            "message_start" => {
+                let message = event.get("message").unwrap_or(&Value::Null);
+                self.merge_usage(message.get("usage"));
+                self.chat.handle_chat_chunk_into(
+                    &json!({
+                        "id": message.get("id").and_then(Value::as_str).unwrap_or("msg_compat"),
+                        "model": message.get("model").and_then(Value::as_str).unwrap_or(""),
+                        "choices": [],
+                        "usage": anthropic_usage_to_chat_usage(Some(&self.usage))
+                    }),
+                    output,
+                );
+                for (index, block) in message
+                    .get("content")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                    .enumerate()
+                {
+                    self.handle_content_block_start(index, block, output);
+                }
+            }
+            "content_block_start" => {
+                let index = event.get("index").and_then(Value::as_u64).unwrap_or(0) as usize;
+                self.handle_content_block_start(
+                    index,
+                    event.get("content_block").unwrap_or(&Value::Null),
+                    output,
+                );
+            }
+            "content_block_delta" => {
+                let index = event.get("index").and_then(Value::as_u64).unwrap_or(0) as usize;
+                let delta = event.get("delta").unwrap_or(&Value::Null);
+                let chat_delta = match delta.get("type").and_then(Value::as_str) {
+                    Some("text_delta") => {
+                        json!({ "content": delta.get("text").and_then(Value::as_str).unwrap_or("") })
+                    }
+                    Some("thinking_delta") => json!({
+                        "reasoning_content": delta
+                            .get("thinking")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                    }),
+                    Some("signature_delta") => {
+                        if let Some(signature) = delta.get("signature").and_then(Value::as_str) {
+                            self.chat.reasoning.encrypted_content.push_str(signature);
+                        }
+                        return;
+                    }
+                    Some("input_json_delta") => json!({
+                        "tool_calls": [{
+                            "index": index,
+                            "function": {
+                                "arguments": delta
+                                    .get("partial_json")
+                                    .and_then(Value::as_str)
+                                    .unwrap_or("")
+                            }
+                        }]
+                    }),
+                    _ => return,
+                };
+                self.chat.handle_chat_chunk_into(
+                    &json!({ "choices": [{ "index": 0, "delta": chat_delta }] }),
+                    output,
+                );
+            }
+            "message_delta" => {
+                self.merge_usage(event.get("usage"));
+                let delta = event.get("delta").unwrap_or(&Value::Null);
+                let stop_reason = delta
+                    .get("stop_reason")
+                    .and_then(Value::as_str)
+                    .unwrap_or("end_turn");
+                if stop_reason == "refusal" && !self.chat.text.added {
+                    let refusal = delta
+                        .pointer("/stop_details/explanation")
+                        .or_else(|| delta.pointer("/stop_details/category"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("Request refused by upstream model");
+                    self.chat.handle_chat_chunk_into(
+                        &json!({ "choices": [{ "index": 0, "delta": { "content": refusal } }] }),
+                        output,
+                    );
+                }
+                self.chat.handle_chat_chunk_into(
+                    &json!({
+                        "choices": [{
+                            "index": 0,
+                            "delta": {},
+                            "finish_reason": anthropic_stop_reason_to_chat(stop_reason)
+                        }],
+                        "usage": anthropic_usage_to_chat_usage(Some(&self.usage))
+                    }),
+                    output,
+                );
+            }
+            "message_stop" => self.chat.finalize_into(output),
+            _ => {}
+        }
+    }
+
+    fn handle_content_block_start(&mut self, index: usize, block: &Value, output: &mut String) {
+        let delta = match block.get("type").and_then(Value::as_str) {
+            Some("text") => {
+                json!({ "content": block.get("text").and_then(Value::as_str).unwrap_or("") })
+            }
+            Some("thinking") => {
+                if let Some(signature) = block
+                    .get("signature")
+                    .and_then(Value::as_str)
+                    .filter(|signature| !signature.is_empty())
+                {
+                    self.chat.reasoning.encrypted_content.push_str(signature);
+                }
+                json!({
+                    "reasoning_content": block
+                        .get("thinking")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                })
+            }
+            Some("tool_use") => json!({
+                "tool_calls": [{
+                    "index": index,
+                    "id": block.get("id").and_then(Value::as_str).unwrap_or("call_0"),
+                    "type": "function",
+                    "function": {
+                        "name": block
+                            .get("name")
+                            .and_then(Value::as_str)
+                            .unwrap_or("unknown_tool"),
+                        "arguments": block
+                            .get("input")
+                            .filter(|input| input.as_object().is_some_and(|input| !input.is_empty()))
+                            .map(canonical_json_string)
+                            .unwrap_or_default()
+                    }
+                }]
+            }),
+            _ => return,
+        };
+        self.chat.handle_chat_chunk_into(
+            &json!({ "choices": [{ "index": 0, "delta": delta }] }),
+            output,
+        );
+    }
+
+    fn merge_usage(&mut self, usage: Option<&Value>) {
+        let Some(incoming) = usage.and_then(Value::as_object) else {
+            return;
+        };
+        let Some(current) = self.usage.as_object_mut() else {
+            return;
+        };
+        for (key, value) in incoming {
+            current.insert(key.clone(), value.clone());
+        }
+    }
+}
+
 pub fn is_responses_proxy_path(path: &str) -> bool {
     let path = path.split_once('?').map_or(path, |(path, _)| path);
     matches!(
@@ -552,6 +1325,7 @@ async fn open_responses_proxy_request_with_settings_and_user_agent(
                 relay.api_key.trim(),
                 is_stream,
                 &upstream_body,
+                wire_api,
             ),
             is_stream,
         )
@@ -798,9 +1572,11 @@ async fn upstream_request_parts(
     relay: &crate::settings::RelayProfile,
     request_json: Value,
 ) -> anyhow::Result<(String, Value, UpstreamWireApi)> {
+    let original_request = request_json.clone();
     let mut body = match relay.protocol {
         RelayProtocol::Responses => request_json,
         RelayProtocol::ChatCompletions => responses_to_chat_completions(request_json)?,
+        RelayProtocol::AnthropicMessages => responses_to_chat_completions(request_json)?,
     };
 
     // Image handling (per-model): send-as-is / strip / VLM analysis
@@ -848,14 +1624,20 @@ async fn upstream_request_parts(
         }
     }
 
+    if relay.protocol == RelayProtocol::AnthropicMessages {
+        body = chat_completions_to_anthropic_messages(body, &original_request)?;
+    }
+
     let wire_api = match relay.protocol {
         RelayProtocol::Responses => UpstreamWireApi::Responses,
         RelayProtocol::ChatCompletions => UpstreamWireApi::ChatCompletions,
+        RelayProtocol::AnthropicMessages => UpstreamWireApi::AnthropicMessages,
     };
     Ok((
         match relay.protocol {
             RelayProtocol::Responses => responses_url(&relay.base_url),
             RelayProtocol::ChatCompletions => chat_completions_url(&relay.base_url),
+            RelayProtocol::AnthropicMessages => anthropic_messages_url(&relay.base_url),
         },
         body,
         wire_api,
@@ -868,11 +1650,17 @@ fn upstream_request_builder(
     api_key: &str,
     is_stream: bool,
     upstream_body: &Value,
+    wire_api: UpstreamWireApi,
 ) -> reqwest::RequestBuilder {
     let mut builder = client
         .post(endpoint)
         .bearer_auth(api_key)
         .header(reqwest::header::CONTENT_TYPE, "application/json");
+    if wire_api == UpstreamWireApi::AnthropicMessages {
+        builder = builder
+            .header("x-api-key", api_key)
+            .header("anthropic-version", "2023-06-01");
+    }
     if is_stream {
         builder = builder
             .header(reqwest::header::ACCEPT, "text/event-stream")
@@ -948,15 +1736,26 @@ pub async fn handle_responses_proxy_request(body: &str) -> anyhow::Result<ProxyH
 
     if is_stream {
         let text = String::from_utf8_lossy(&upstream_body);
+        let converted = match wire_api {
+            UpstreamWireApi::AnthropicMessages => {
+                anthropic_sse_to_responses_sse_with_request(&text, &request_json)
+            }
+            _ => chat_sse_to_responses_sse_with_request(&text, &request_json),
+        };
         return Ok(ProxyHttpResponse {
             status: "200 OK".to_string(),
             content_type: "text/event-stream; charset=utf-8".to_string(),
-            body: chat_sse_to_responses_sse_with_request(&text, &request_json).into_bytes(),
+            body: converted.into_bytes(),
         });
     }
 
-    let chat_json: Value = serde_json::from_slice(&upstream_body)?;
-    let response_json = chat_completion_to_response_with_request(chat_json, &request_json)?;
+    let upstream_json: Value = serde_json::from_slice(&upstream_body)?;
+    let response_json = match wire_api {
+        UpstreamWireApi::AnthropicMessages => {
+            anthropic_message_to_response_with_request(upstream_json, &request_json)?
+        }
+        _ => chat_completion_to_response_with_request(upstream_json, &request_json)?,
+    };
     Ok(ProxyHttpResponse {
         status: "200 OK".to_string(),
         content_type: "application/json; charset=utf-8".to_string(),
@@ -977,6 +1776,26 @@ pub fn chat_completions_url(base_url: &str) -> String {
         format!("{base}/chat/completions")
     } else {
         format!("{base}/v1/chat/completions")
+    };
+    while url.contains("/v1/v1") {
+        url = url.replace("/v1/v1", "/v1");
+    }
+    url
+}
+
+pub fn anthropic_messages_url(base_url: &str) -> String {
+    let skip_version_prefix = base_url.trim().ends_with('#');
+    let base = base_url.trim().trim_end_matches('#').trim_end_matches('/');
+    if base.to_ascii_lowercase().ends_with("/messages") {
+        return base.to_string();
+    }
+    let origin_only = base
+        .split_once("://")
+        .map_or(!base.contains('/'), |(_, rest)| !rest.contains('/'));
+    let mut url = if skip_version_prefix || has_version_suffix(base) || !origin_only {
+        format!("{base}/messages")
+    } else {
+        format!("{base}/v1/messages")
     };
     while url.contains("/v1/v1") {
         url = url.replace("/v1/v1", "/v1");
@@ -1034,6 +1853,9 @@ pub fn models_url(base_url: &str) -> String {
     if base.to_ascii_lowercase().ends_with("/chat/completions") {
         base.truncate(base.len() - "/chat/completions".len());
     }
+    if base.to_ascii_lowercase().ends_with("/messages") {
+        base.truncate(base.len() - "/messages".len());
+    }
     if base.to_ascii_lowercase().ends_with("/models") {
         return base;
     }
@@ -1073,6 +1895,23 @@ pub fn chat_sse_to_responses_sse_with_request(input: &str, original_request: &Va
     String::from_utf8(output).unwrap_or_default()
 }
 
+pub fn anthropic_sse_to_responses_sse(input: &str) -> String {
+    let mut converter = AnthropicSseToResponsesConverter::default();
+    let mut output = converter.push_bytes(input.as_bytes());
+    output.extend(converter.finish());
+    String::from_utf8(output).unwrap_or_default()
+}
+
+pub fn anthropic_sse_to_responses_sse_with_request(
+    input: &str,
+    original_request: &Value,
+) -> String {
+    let mut converter = AnthropicSseToResponsesConverter::with_request(original_request);
+    let mut output = converter.push_bytes(input.as_bytes());
+    output.extend(converter.finish());
+    String::from_utf8(output).unwrap_or_default()
+}
+
 pub fn response_id_from_chat_id(id: Option<&str>) -> String {
     let id = id.unwrap_or("compat");
     if id.starts_with("resp_") {
@@ -1104,6 +1943,7 @@ struct ReasoningItemState {
     output_index: Option<u32>,
     item_id: String,
     text: String,
+    encrypted_content: String,
     added: bool,
     done: bool,
 }
@@ -1564,12 +2404,15 @@ impl ChatSseState {
             return;
         }
         let output_index = self.reasoning.output_index.unwrap_or(0);
-        let item = json!({
+        let mut item = json!({
             "id": self.reasoning.item_id,
             "type": "reasoning",
             "reasoning_content": self.reasoning.text,
             "summary": [{ "type": "summary_text", "text": self.reasoning.text }]
         });
+        if !self.reasoning.encrypted_content.is_empty() {
+            item["encrypted_content"] = json!(self.reasoning.encrypted_content);
+        }
         self.output_items.push((output_index, item.clone()));
         self.reasoning.done = true;
         push_sse(
@@ -2976,12 +3819,20 @@ fn chat_reasoning_to_response_output_item(message: &Value, response_id: &str) ->
     if reasoning.is_empty() {
         return None;
     }
-    Some(json!({
+    let mut item = json!({
         "id": format!("rs_{response_id}"),
         "type": "reasoning",
         "reasoning_content": reasoning,
         "summary": [{ "type": "summary_text", "text": reasoning }]
-    }))
+    });
+    if let Some(signature) = message
+        .get("reasoning_signature")
+        .and_then(Value::as_str)
+        .filter(|signature| !signature.is_empty())
+    {
+        item["encrypted_content"] = json!(signature);
+    }
+    Some(item)
 }
 
 fn chat_reasoning_text(message: &Value) -> Option<String> {
@@ -3404,17 +4255,9 @@ fn chat_usage_to_responses_usage(usage: Option<&Value>) -> Value {
         || usage.get("cache_creation_input_tokens").is_some()
         || usage.get("cache_creation_5m_input_tokens").is_some()
         || usage.get("cache_creation_1h_input_tokens").is_some();
-    let has_cache_details = cached_tokens > 0
-        || usage
-            .pointer("/prompt_tokens_details/cached_tokens")
-            .is_some()
-        || usage
-            .pointer("/input_tokens_details/cached_tokens")
-            .is_some();
-
     if let Some(value) = usage.get("input_tokens").and_then(Value::as_u64) {
         input_tokens = value;
-        input_tokens_include_cache = false;
+        input_tokens_include_cache = !has_claude_cache_fields;
     }
     if let Some(cache_read) = usage.get("cache_read_input_tokens").and_then(Value::as_u64) {
         cached_tokens = cache_read;
@@ -3424,46 +4267,47 @@ fn chat_usage_to_responses_usage(usage: Option<&Value>) -> Value {
             .get("cachedContentTokenCount")
             .and_then(Value::as_u64)
             .unwrap_or(0);
-        input_tokens = prompt_tokens.saturating_sub(cached_tokens);
-        input_tokens_include_cache = false;
+        input_tokens = prompt_tokens;
+        input_tokens_include_cache = true;
     }
 
-    let usage_input_tokens = if input_tokens_include_cache {
-        input_tokens.saturating_sub(
-            cached_tokens
-                + effective_cache_creation_tokens(
-                    cache_creation,
-                    cache_creation_5m,
-                    cache_creation_1h,
-                ),
-        )
+    let cache_creation_tokens =
+        effective_cache_creation_tokens(cache_creation, cache_creation_5m, cache_creation_1h);
+    let uncached_input_tokens = if input_tokens_include_cache {
+        input_tokens.saturating_sub(cached_tokens + cache_creation_tokens)
     } else {
         input_tokens
     };
+    let response_input_tokens = uncached_input_tokens + cached_tokens + cache_creation_tokens;
     let should_recalculate_total = usage.get("total_tokens").is_none()
         || cached_tokens > 0
-        || effective_cache_creation_tokens(cache_creation, cache_creation_5m, cache_creation_1h)
-            > 0
+        || cache_creation_tokens > 0
         || usage.get("promptTokenCount").is_some();
     let total_tokens = if should_recalculate_total {
-        usage_input_tokens
-            + output_tokens
-            + cached_tokens
-            + effective_cache_creation_tokens(cache_creation, cache_creation_5m, cache_creation_1h)
+        response_input_tokens + output_tokens
     } else {
         usage
             .get("total_tokens")
             .and_then(Value::as_u64)
-            .unwrap_or(usage_input_tokens + output_tokens)
+            .unwrap_or(response_input_tokens + output_tokens)
     };
     let mut result = json!({
-        "input_tokens": usage_input_tokens,
+        "input_tokens": response_input_tokens,
         "output_tokens": output_tokens,
         "total_tokens": total_tokens
     });
 
-    if !has_claude_cache_fields && has_cache_details && cached_tokens > 0 {
-        result["input_tokens_details"] = json!({ "cached_tokens": cached_tokens });
+    if cached_tokens > 0 || cache_creation_tokens > 0 {
+        let mut details = usage
+            .get("input_tokens_details")
+            .cloned()
+            .filter(Value::is_object)
+            .unwrap_or_else(|| json!({}));
+        details["cached_tokens"] = json!(cached_tokens);
+        if cache_creation_tokens > 0 {
+            details["cache_write_tokens"] = json!(cache_creation_tokens);
+        }
+        result["input_tokens_details"] = details;
     }
     if let Some(details) = usage.get("completion_tokens_details") {
         result["output_tokens_details"] = details.clone();

--- a/crates/codex-plus-core/src/protocol_proxy.rs
+++ b/crates/codex-plus-core/src/protocol_proxy.rs
@@ -398,7 +398,11 @@ fn anthropic_image_block(image_url: &Value) -> Option<Value> {
         .or_else(|| image_url.get("url").and_then(Value::as_str))?;
     if let Some(data_url) = url.strip_prefix("data:") {
         let (metadata, data) = data_url.split_once(',')?;
-        let media_type = metadata.strip_suffix(";base64")?;
+        let mut metadata_parts = metadata.split(';');
+        let media_type = metadata_parts.next().filter(|value| !value.is_empty())?;
+        if !metadata_parts.any(|part| part.eq_ignore_ascii_case("base64")) {
+            return None;
+        }
         return Some(json!({
             "type": "image",
             "source": { "type": "base64", "media_type": media_type, "data": data }
@@ -1654,8 +1658,10 @@ fn upstream_request_builder(
 ) -> reqwest::RequestBuilder {
     let mut builder = client
         .post(endpoint)
-        .bearer_auth(api_key)
         .header(reqwest::header::CONTENT_TYPE, "application/json");
+    if wire_api != UpstreamWireApi::AnthropicMessages {
+        builder = builder.bearer_auth(api_key);
+    }
     if wire_api == UpstreamWireApi::AnthropicMessages {
         builder = builder
             .header("x-api-key", api_key)
@@ -4930,4 +4936,35 @@ fn is_openai_o_series(model: &str) -> bool {
             .as_bytes()
             .get(1)
             .is_some_and(|byte| byte.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn anthropic_request_uses_x_api_key_without_bearer_auth() {
+        let request = upstream_request_builder(
+            reqwest::Client::new(),
+            "https://relay.example/v1/messages",
+            "sk-test",
+            false,
+            &json!({}),
+            UpstreamWireApi::AnthropicMessages,
+        )
+        .build()
+        .unwrap();
+
+        assert!(
+            request
+                .headers()
+                .get(reqwest::header::AUTHORIZATION)
+                .is_none()
+        );
+        assert_eq!(request.headers().get("x-api-key").unwrap(), "sk-test");
+        assert_eq!(
+            request.headers().get("anthropic-version").unwrap(),
+            "2023-06-01"
+        );
+    }
 }

--- a/crates/codex-plus-core/src/provider_import.rs
+++ b/crates/codex-plus-core/src/provider_import.rs
@@ -248,6 +248,9 @@ fn normalize_request(mut request: ProviderImportRequest) -> anyhow::Result<Provi
 fn relay_protocol(value: &str) -> RelayProtocol {
     match value.trim().to_ascii_lowercase().as_str() {
         "chat" | "chat_completions" | "chat-completions" => RelayProtocol::ChatCompletions,
+        "anthropic" | "messages" | "anthropic_messages" | "anthropic-messages" => {
+            RelayProtocol::AnthropicMessages
+        }
         _ => RelayProtocol::Responses,
     }
 }
@@ -265,6 +268,7 @@ fn build_config_toml(base_url: &str, api_key: &str, protocol: RelayProtocol) -> 
     let wire_api = match protocol {
         RelayProtocol::Responses => "responses",
         RelayProtocol::ChatCompletions => "chat",
+        RelayProtocol::AnthropicMessages => "responses",
     };
     [
         "model_provider = \"CodexPlusPlus\"".to_string(),

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -528,6 +528,7 @@ pub async fn test_relay_profile(
     let endpoint = match profile.protocol {
         RelayProtocol::Responses => format!("{base_url}/responses"),
         RelayProtocol::ChatCompletions => format!("{base_url}/chat/completions"),
+        RelayProtocol::AnthropicMessages => format!("{base_url}/messages"),
     };
     let test_model = model.trim();
     if test_model.is_empty() {
@@ -535,13 +536,16 @@ pub async fn test_relay_profile(
     }
 
     let payload = relay_profile_test_payload(profile.protocol, test_model);
-    let response = client
+    let mut request = client
         .post(&endpoint)
         .bearer_auth(api_key)
-        .header(reqwest::header::CONTENT_TYPE, "application/json")
-        .json(&payload)
-        .send()
-        .await?;
+        .header(reqwest::header::CONTENT_TYPE, "application/json");
+    if profile.protocol == RelayProtocol::AnthropicMessages {
+        request = request
+            .header("x-api-key", api_key)
+            .header("anthropic-version", "2023-06-01");
+    }
+    let response = request.json(&payload).send().await?;
     let http_status = response.status().as_u16();
 
     // 如果 404 且 base_url 末尾没有 /v1，尝试自动补 /v1 后再发一次。
@@ -552,14 +556,18 @@ pub async fn test_relay_profile(
         let v1_endpoint = match profile.protocol {
             RelayProtocol::Responses => format!("{v1_url}/responses"),
             RelayProtocol::ChatCompletions => format!("{v1_url}/chat/completions"),
+            RelayProtocol::AnthropicMessages => format!("{v1_url}/messages"),
         };
-        let v1_response = client
+        let mut v1_request = client
             .post(&v1_endpoint)
             .bearer_auth(api_key)
-            .header(reqwest::header::CONTENT_TYPE, "application/json")
-            .json(&payload)
-            .send()
-            .await?;
+            .header(reqwest::header::CONTENT_TYPE, "application/json");
+        if profile.protocol == RelayProtocol::AnthropicMessages {
+            v1_request = v1_request
+                .header("x-api-key", api_key)
+                .header("anthropic-version", "2023-06-01");
+        }
+        let v1_response = v1_request.json(&payload).send().await?;
         let v1_status = v1_response.status().as_u16();
         if v1_status < 400 {
             let response_text = v1_response.text().await.unwrap_or_default();
@@ -596,13 +604,20 @@ fn relay_profile_test_payload(protocol: RelayProtocol, model: &str) -> Value {
             ],
             "max_tokens": 16
         }),
+        RelayProtocol::AnthropicMessages => serde_json::json!({
+            "model": model,
+            "messages": [
+                { "role": "user", "content": "hi" }
+            ],
+            "max_tokens": 256
+        }),
     }
 }
 
 fn codex_base_url_for_protocol(base_url: &str, protocol: RelayProtocol, proxy_port: u16) -> String {
     match protocol {
         RelayProtocol::Responses => base_url.to_string(),
-        RelayProtocol::ChatCompletions => {
+        RelayProtocol::ChatCompletions | RelayProtocol::AnthropicMessages => {
             crate::protocol_proxy::local_responses_proxy_base_url(proxy_port)
         }
     }
@@ -2001,7 +2016,7 @@ pub fn relay_profile_base_url(profile: &RelayProfile) -> String {
             crate::protocol_proxy::DEFAULT_PROTOCOL_PROXY_PORT,
         );
     }
-    if profile.protocol == RelayProtocol::ChatCompletions {
+    if profile.protocol != RelayProtocol::Responses {
         if !profile.upstream_base_url.trim().is_empty() {
             return profile.upstream_base_url.trim().to_string();
         }
@@ -2017,7 +2032,7 @@ pub fn relay_profile_base_url(profile: &RelayProfile) -> String {
     let provider_base_url = provider_string_from_config(&profile.config_contents, "base_url")
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_default();
-    if profile.protocol == RelayProtocol::ChatCompletions
+    if profile.protocol != RelayProtocol::Responses
         && provider_base_url
             == crate::protocol_proxy::local_responses_proxy_base_url(
                 crate::protocol_proxy::DEFAULT_PROTOCOL_PROXY_PORT,

--- a/crates/codex-plus-core/src/settings.rs
+++ b/crates/codex-plus-core/src/settings.rs
@@ -183,6 +183,7 @@ pub enum RelayProtocol {
     #[default]
     Responses,
     ChatCompletions,
+    AnthropicMessages,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
@@ -659,7 +660,7 @@ impl BackendSettings {
 
     pub fn active_relay_uses_protocol_proxy(&self) -> bool {
         self.active_aggregate_relay_profile().is_some()
-            || self.active_relay_profile().protocol == RelayProtocol::ChatCompletions
+            || self.active_relay_profile().protocol != RelayProtocol::Responses
     }
 }
 

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -1329,7 +1329,16 @@ async fn launch_lifecycle_cleans_helper_when_launch_fails_after_helper_started()
 }
 
 #[tokio::test]
-async fn launch_starts_helper_when_chat_protocol_proxy_is_enabled() {
+async fn launch_starts_helper_when_non_responses_protocol_proxy_is_enabled() {
+    for protocol in [
+        RelayProtocol::ChatCompletions,
+        RelayProtocol::AnthropicMessages,
+    ] {
+        assert_launch_starts_protocol_proxy(protocol).await;
+    }
+}
+
+async fn assert_launch_starts_protocol_proxy(protocol: RelayProtocol) {
     let temp = tempfile::tempdir().unwrap();
     let app_dir = temp.path().join("Codex.app");
     std::fs::create_dir_all(&app_dir).unwrap();
@@ -1344,7 +1353,7 @@ async fn launch_starts_helper_when_chat_protocol_proxy_is_enabled() {
             base_url: "https://chat-only.example.test/v1".to_string(),
             upstream_base_url: "https://chat-only.example.test/v1".to_string(),
             api_key: "sk-test".to_string(),
-            protocol: RelayProtocol::ChatCompletions,
+            protocol,
             relay_mode: codex_plus_core::settings::RelayMode::MixedApi,
             official_mix_api_key: false,
             test_model: String::new(),

--- a/crates/codex-plus-core/tests/protocol_proxy.rs
+++ b/crates/codex-plus-core/tests/protocol_proxy.rs
@@ -1,13 +1,16 @@
 use codex_plus_core::protocol_proxy::{
-    ChatSseToResponsesConverter, audio_transcriptions_url, chat_completion_to_response,
+    AnthropicSseToResponsesConverter, ChatSseToResponsesConverter, anthropic_message_to_response,
+    anthropic_message_to_response_with_request, anthropic_messages_url,
+    anthropic_sse_to_responses_sse, audio_transcriptions_url, chat_completion_to_response,
     chat_completion_to_response_with_request, chat_completions_url, chat_sse_to_responses_sse,
     chat_sse_to_responses_sse_with_request, is_audio_transcriptions_proxy_path,
     is_chat_completions_proxy_path, is_models_proxy_path, is_responses_proxy_path, models_url,
     open_audio_transcriptions_proxy_request, open_chat_completions_proxy_request,
     open_models_proxy_request, open_responses_proxy_request,
     open_responses_proxy_request_with_settings, responses_error_from_upstream,
-    responses_to_chat_completions, send_upstream_request_with_header_timeout,
-    upstream_header_timeout, upstream_http_client, upstream_stream_header_timeout,
+    responses_to_anthropic_messages, responses_to_chat_completions,
+    send_upstream_request_with_header_timeout, upstream_header_timeout, upstream_http_client,
+    upstream_stream_header_timeout,
 };
 use codex_plus_core::settings::{
     AggregateRelayMember, AggregateRelayProfile, AggregateRelayStrategy, BackendSettings,
@@ -74,6 +77,73 @@ fn responses_request_converts_to_chat_completions() {
             ]
         })
     );
+}
+
+#[test]
+fn responses_request_converts_to_anthropic_messages_with_tools() {
+    let converted = responses_to_anthropic_messages(json!({
+        "model": "claude-fable-5",
+        "instructions": "You are a coding agent.",
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{ "type": "input_text", "text": "Check Paris." }]
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_weather",
+                "name": "get_weather",
+                "arguments": "{\"location\":\"Paris\"}"
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_weather",
+                "output": "18 C and sunny"
+            }
+        ],
+        "max_output_tokens": 2048,
+        "reasoning": { "effort": "low" },
+        "stream": true,
+        "parallel_tool_calls": false,
+        "tool_choice": "required",
+        "tools": [{
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": {
+                "type": "object",
+                "properties": { "location": { "type": "string" } },
+                "required": ["location"]
+            }
+        }]
+    }))
+    .unwrap();
+
+    assert_eq!(converted["model"], "claude-fable-5");
+    assert_eq!(converted["system"], "You are a coding agent.");
+    assert_eq!(converted["max_tokens"], 2048);
+    assert_eq!(converted["thinking"]["type"], "adaptive");
+    assert_eq!(converted["output_config"]["effort"], "low");
+    assert_eq!(converted["messages"][0]["role"], "user");
+    assert_eq!(converted["messages"][1]["role"], "assistant");
+    assert_eq!(converted["messages"][1]["content"][0]["type"], "tool_use");
+    assert_eq!(converted["messages"][1]["content"][0]["id"], "call_weather");
+    assert_eq!(
+        converted["messages"][1]["content"][0]["input"]["location"],
+        "Paris"
+    );
+    assert_eq!(converted["messages"][2]["role"], "user");
+    assert_eq!(
+        converted["messages"][2]["content"][0]["type"],
+        "tool_result"
+    );
+    assert_eq!(converted["tools"][0]["name"], "get_weather");
+    assert_eq!(converted["tools"][0]["input_schema"]["type"], "object");
+    assert_eq!(converted["tool_choice"]["type"], "auto");
+    assert_eq!(converted["tool_choice"]["disable_parallel_tool_use"], true);
+    assert_eq!(converted["stream"], true);
+    assert!(converted.get("stream_options").is_none());
 }
 
 #[test]
@@ -316,6 +386,129 @@ fn responses_request_preserves_reasoning_content_for_thinking_followup() {
     );
     assert_eq!(converted["messages"][1]["tool_calls"][0]["id"], "call_1");
     assert_eq!(converted["messages"][2]["role"], "tool");
+}
+
+#[test]
+fn responses_request_restores_anthropic_thinking_signature() {
+    let converted = responses_to_anthropic_messages(json!({
+        "model": "claude-fable-5",
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{ "type": "input_text", "text": "inspect files" }]
+            },
+            {
+                "id": "rs_1",
+                "type": "reasoning",
+                "encrypted_content": "sig_abc",
+                "summary": [{ "type": "summary_text", "text": "Need to inspect files." }]
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "shell_command",
+                "arguments": "{\"command\":\"rg foo\"}"
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": "result"
+            }
+        ]
+    }))
+    .unwrap();
+
+    assert_eq!(converted["messages"][1]["content"][0]["type"], "thinking");
+    assert_eq!(
+        converted["messages"][1]["content"][0]["thinking"],
+        "Need to inspect files."
+    );
+    assert_eq!(
+        converted["messages"][1]["content"][0]["signature"],
+        "sig_abc"
+    );
+    assert_eq!(converted["messages"][1]["content"][1]["type"], "tool_use");
+}
+
+#[test]
+fn anthropic_tool_round_trip_preserves_signature_and_tool_result() {
+    let first_request = json!({
+        "model": "claude-fable-5",
+        "input": [{
+            "type": "message",
+            "role": "user",
+            "content": [{ "type": "input_text", "text": "Inspect the repository." }]
+        }],
+        "tools": [{
+            "type": "function",
+            "name": "shell_command",
+            "description": "Run a shell command",
+            "parameters": {
+                "type": "object",
+                "properties": { "command": { "type": "string" } },
+                "required": ["command"]
+            }
+        }],
+        "stream": false
+    });
+    let first_response = anthropic_message_to_response_with_request(
+        json!({
+            "id": "msg_roundtrip",
+            "model": "claude-fable-5",
+            "content": [
+                { "type": "thinking", "thinking": "I should inspect it.", "signature": "sig_roundtrip" },
+                {
+                    "type": "tool_use",
+                    "id": "toolu_roundtrip",
+                    "name": "shell_command",
+                    "input": { "command": "git status --short" }
+                }
+            ],
+            "stop_reason": "tool_use",
+            "usage": { "input_tokens": 10, "output_tokens": 5 }
+        }),
+        &first_request,
+    )
+    .unwrap();
+    let mut second_input = first_request["input"].as_array().unwrap().clone();
+    second_input.extend(first_response["output"].as_array().unwrap().clone());
+    second_input.push(json!({
+        "type": "function_call_output",
+        "call_id": "toolu_roundtrip",
+        "output": "clean"
+    }));
+
+    let second_request = responses_to_anthropic_messages(json!({
+        "model": "claude-fable-5",
+        "input": second_input,
+        "tools": first_request["tools"],
+        "stream": true
+    }))
+    .unwrap();
+
+    assert_eq!(second_request["messages"][1]["role"], "assistant");
+    assert_eq!(
+        second_request["messages"][1]["content"][0]["type"],
+        "thinking"
+    );
+    assert_eq!(
+        second_request["messages"][1]["content"][0]["signature"],
+        "sig_roundtrip"
+    );
+    assert_eq!(
+        second_request["messages"][1]["content"][1]["type"],
+        "tool_use"
+    );
+    assert_eq!(second_request["messages"][2]["role"], "user");
+    assert_eq!(
+        second_request["messages"][2]["content"][0]["tool_use_id"],
+        "toolu_roundtrip"
+    );
+    assert_eq!(
+        second_request["messages"][2]["content"][0]["content"],
+        "clean"
+    );
 }
 
 #[test]
@@ -802,6 +995,68 @@ fn chat_completion_response_converts_to_responses_response() {
 }
 
 #[test]
+fn anthropic_message_response_converts_reasoning_tools_and_usage() {
+    let converted = anthropic_message_to_response(json!({
+        "id": "msg_123",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-fable-5",
+        "content": [
+            { "type": "thinking", "thinking": "I should check.", "signature": "sig_abc" },
+            { "type": "text", "text": "Let me check." },
+            {
+                "type": "tool_use",
+                "id": "toolu_123",
+                "name": "get_weather",
+                "input": { "location": "Paris" }
+            }
+        ],
+        "stop_reason": "tool_use",
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 3,
+            "cache_read_input_tokens": 2,
+            "cache_creation": {
+                "ephemeral_5m_input_tokens": 4,
+                "ephemeral_1h_input_tokens": 6
+            }
+        }
+    }))
+    .unwrap();
+
+    assert_eq!(converted["id"], "resp_msg_123");
+    assert_eq!(converted["output"][0]["type"], "reasoning");
+    assert_eq!(
+        converted["output"][0]["summary"][0]["text"],
+        "I should check."
+    );
+    assert_eq!(converted["output"][0]["encrypted_content"], "sig_abc");
+    assert_eq!(
+        converted["output"][1]["content"][0]["text"],
+        "Let me check."
+    );
+    assert_eq!(converted["output"][2]["type"], "function_call");
+    assert_eq!(converted["output"][2]["call_id"], "toolu_123");
+    assert_eq!(
+        converted["output"][2]["arguments"],
+        "{\"location\":\"Paris\"}"
+    );
+    assert_eq!(converted["usage"]["input_tokens"], 22);
+    assert_eq!(converted["usage"]["output_tokens"], 3);
+    assert_eq!(converted["usage"]["total_tokens"], 25);
+    assert_eq!(
+        converted["usage"]["input_tokens_details"]["cached_tokens"],
+        2
+    );
+    assert_eq!(
+        converted["usage"]["input_tokens_details"]["cache_write_tokens"],
+        10
+    );
+    assert_eq!(converted["usage"]["cache_creation_5m_input_tokens"], 4);
+    assert_eq!(converted["usage"]["cache_creation_1h_input_tokens"], 6);
+}
+
+#[test]
 fn chat_completion_response_maps_reasoning_tool_calls_and_usage_details() {
     let converted = chat_completion_to_response(json!({
         "id": "chatcmpl_1",
@@ -849,6 +1104,7 @@ fn chat_completion_response_maps_reasoning_tool_calls_and_usage_details() {
         converted["usage"]["input_tokens_details"]["cached_tokens"],
         3
     );
+    assert_eq!(converted["usage"]["input_tokens"], 10);
     assert_eq!(
         converted["usage"]["output_tokens_details"]["reasoning_tokens"],
         2
@@ -906,10 +1162,17 @@ fn chat_completion_response_accepts_responses_style_usage_fields() {
     }))
     .unwrap();
 
-    assert_eq!(converted["usage"]["input_tokens"], 7);
+    assert_eq!(converted["usage"]["input_tokens"], 12);
     assert_eq!(converted["usage"]["output_tokens"], 3);
     assert_eq!(converted["usage"]["total_tokens"], 15);
-    assert!(converted["usage"].get("input_tokens_details").is_none());
+    assert_eq!(
+        converted["usage"]["input_tokens_details"]["cached_tokens"],
+        1
+    );
+    assert_eq!(
+        converted["usage"]["input_tokens_details"]["cache_write_tokens"],
+        4
+    );
     assert_eq!(converted["usage"]["cache_read_input_tokens"], 1);
     assert_eq!(converted["usage"]["cache_creation_input_tokens"], 4);
 }
@@ -1060,7 +1323,7 @@ fn chat_completion_response_maps_gemini_and_claude_cache_usage_like_ccx() {
         }
     }))
     .unwrap();
-    assert_eq!(gemini["usage"]["input_tokens"], 15);
+    assert_eq!(gemini["usage"]["input_tokens"], 20);
     assert_eq!(gemini["usage"]["output_tokens"], 7);
     assert_eq!(gemini["usage"]["total_tokens"], 27);
     assert_eq!(gemini["usage"]["input_tokens_details"]["cached_tokens"], 5);
@@ -1079,13 +1342,17 @@ fn chat_completion_response_maps_gemini_and_claude_cache_usage_like_ccx() {
         }
     }))
     .unwrap();
-    assert_eq!(claude["usage"]["input_tokens"], 10);
+    assert_eq!(claude["usage"]["input_tokens"], 22);
     assert_eq!(claude["usage"]["total_tokens"], 25);
     assert_eq!(claude["usage"]["cache_read_input_tokens"], 2);
     assert_eq!(claude["usage"]["cache_creation_5m_input_tokens"], 4);
     assert_eq!(claude["usage"]["cache_creation_1h_input_tokens"], 6);
     assert_eq!(claude["usage"]["cache_ttl"], "mixed");
-    assert!(claude["usage"].get("input_tokens_details").is_none());
+    assert_eq!(claude["usage"]["input_tokens_details"]["cached_tokens"], 2);
+    assert_eq!(
+        claude["usage"]["input_tokens_details"]["cache_write_tokens"],
+        10
+    );
 }
 
 #[test]
@@ -1111,6 +1378,76 @@ fn chat_completion_response_splits_inline_think_block() {
     );
     assert_eq!(converted["output"][1]["type"], "message");
     assert_eq!(converted["output"][1]["content"][0]["text"], "pong");
+}
+
+#[test]
+fn anthropic_sse_converts_thinking_and_tool_use() {
+    let converted = anthropic_sse_to_responses_sse(
+        r#"event: message_start
+data: {"type":"message_start","message":{"id":"msg_stream","type":"message","role":"assistant","model":"claude-fable-5","content":[],"usage":{"input_tokens":20,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Check first."}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig_stream"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_stream","name":"get_weather","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"location\":\"Paris\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":5}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+"#,
+    );
+
+    assert!(converted.contains("event: response.created"));
+    assert!(converted.contains("\"id\":\"resp_msg_stream\""));
+    assert!(converted.contains("event: response.reasoning_summary_text.delta"));
+    assert!(converted.contains("\"delta\":\"Check first.\""));
+    assert!(converted.contains("\"encrypted_content\":\"sig_stream\""));
+    assert!(converted.contains("event: response.function_call_arguments.delta"));
+    assert!(converted.contains("\"call_id\":\"toolu_stream\""));
+    assert!(converted.contains("\"arguments\":\"{\\\"location\\\":\\\"Paris\\\"}\""));
+    assert!(converted.contains("\"input_tokens\":20"));
+    assert!(converted.contains("\"output_tokens\":5"));
+    assert!(converted.contains("event: response.completed"));
+    assert!(converted.contains("data: [DONE]"));
+}
+
+#[test]
+fn anthropic_sse_converter_handles_partial_utf8_chunks() {
+    let sse = "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_utf8\",\"model\":\"claude-fable-5\",\"content\":[],\"usage\":{}}}\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"你好\"}}\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
+    let bytes = sse.as_bytes();
+    let split = bytes
+        .windows("好".len())
+        .position(|window| window == "好".as_bytes())
+        .unwrap()
+        + 1;
+
+    let mut converter = AnthropicSseToResponsesConverter::default();
+    let mut output = converter.push_bytes(&bytes[..split]);
+    output.extend(converter.push_bytes(&bytes[split..]));
+    output.extend(converter.finish());
+    let output = String::from_utf8(output).unwrap();
+
+    assert!(output.contains("\"delta\":\"你好\""));
+    assert!(output.contains("event: response.completed"));
 }
 
 #[test]
@@ -1274,6 +1611,26 @@ fn chat_completions_url_normalizes_common_base_urls() {
     assert_eq!(
         chat_completions_url("https://api.example.test/openai#"),
         "https://api.example.test/openai/chat/completions"
+    );
+}
+
+#[test]
+fn anthropic_messages_url_normalizes_common_base_urls() {
+    assert_eq!(
+        anthropic_messages_url("https://api.example.test"),
+        "https://api.example.test/v1/messages"
+    );
+    assert_eq!(
+        anthropic_messages_url("https://api.example.test/v1"),
+        "https://api.example.test/v1/messages"
+    );
+    assert_eq!(
+        anthropic_messages_url("https://api.example.test/anthropic"),
+        "https://api.example.test/anthropic/messages"
+    );
+    assert_eq!(
+        anthropic_messages_url("https://api.example.test/v1/messages"),
+        "https://api.example.test/v1/messages"
     );
 }
 

--- a/crates/codex-plus-core/tests/protocol_proxy.rs
+++ b/crates/codex-plus-core/tests/protocol_proxy.rs
@@ -156,7 +156,7 @@ fn responses_request_converts_input_images_to_anthropic_sources() {
                 { "type": "input_text", "text": "What is this?" },
                 {
                     "type": "input_image",
-                    "image_url": "data:image/png;base64,abc123"
+                    "image_url": "data:image/png;charset=utf-8;base64,abc123"
                 }
             ]
         }]

--- a/crates/codex-plus-core/tests/protocol_proxy.rs
+++ b/crates/codex-plus-core/tests/protocol_proxy.rs
@@ -147,6 +147,32 @@ fn responses_request_converts_to_anthropic_messages_with_tools() {
 }
 
 #[test]
+fn responses_request_converts_input_images_to_anthropic_sources() {
+    let converted = responses_to_anthropic_messages(json!({
+        "model": "claude-fable-5",
+        "input": [{
+            "role": "user",
+            "content": [
+                { "type": "input_text", "text": "What is this?" },
+                {
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64,abc123"
+                }
+            ]
+        }]
+    }))
+    .unwrap();
+
+    let content = converted["messages"][0]["content"].as_array().unwrap();
+    assert_eq!(content[0]["type"], "text");
+    assert_eq!(content[0]["text"], "What is this?");
+    assert_eq!(content[1]["type"], "image");
+    assert_eq!(content[1]["source"]["type"], "base64");
+    assert_eq!(content[1]["source"]["media_type"], "image/png");
+    assert_eq!(content[1]["source"]["data"], "abc123");
+}
+
+#[test]
 fn responses_request_matches_ccs_reasoning_and_tool_choice_edges() {
     let non_reasoning = responses_to_chat_completions(json!({
         "model": "gpt-4o",

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -325,14 +325,22 @@ model = "gpt-5-mini"
 }
 
 #[test]
-fn apply_chat_protocol_relay_points_codex_to_local_responses_proxy() {
-    let temp = tempfile::tempdir().unwrap();
+fn apply_non_responses_protocol_relay_points_codex_to_local_responses_proxy() {
+    for protocol in [
+        RelayProtocol::ChatCompletions,
+        RelayProtocol::AnthropicMessages,
+    ] {
+        assert_relay_points_codex_to_local_responses_proxy(protocol);
+    }
+}
 
+fn assert_relay_points_codex_to_local_responses_proxy(protocol: RelayProtocol) {
+    let temp = tempfile::tempdir().unwrap();
     let result = codex_plus_core::relay_config::apply_relay_config_to_home_with_protocol(
         temp.path(),
         "https://chat-only.example.test/v1",
         "sk-test-redacted",
-        RelayProtocol::ChatCompletions,
+        protocol,
         57321,
     )
     .unwrap();
@@ -417,14 +425,23 @@ fn apply_aggregate_relay_points_codex_to_local_responses_proxy_without_snapshot(
 }
 
 #[test]
-fn chat_protocol_profile_keeps_upstream_base_url_separate_from_codex_proxy() {
+fn non_responses_profile_keeps_upstream_base_url_separate_from_codex_proxy() {
+    for protocol in [
+        RelayProtocol::ChatCompletions,
+        RelayProtocol::AnthropicMessages,
+    ] {
+        assert_profile_keeps_upstream_base_url_separate_from_codex_proxy(protocol);
+    }
+}
+
+fn assert_profile_keeps_upstream_base_url_separate_from_codex_proxy(protocol: RelayProtocol) {
     let temp = tempfile::tempdir().unwrap();
     let mut profile = RelayProfile {
         id: "relay-chat".to_string(),
         model: "deepseek-chat".to_string(),
         upstream_base_url: "https://api.deepseek.com".to_string(),
         api_key: "sk-test-redacted".to_string(),
-        protocol: RelayProtocol::ChatCompletions,
+        protocol,
         relay_mode: RelayMode::PureApi,
         config_contents: r#"model = "deepseek-chat"
 model_provider = "custom"


### PR DESCRIPTION
## Summary
- add a local Responses proxy path for Anthropic Messages upstreams
- convert Responses requests to Chat and then Anthropic Messages while preserving Codex tool shapes
- convert Anthropic JSON/SSE responses back to Responses, including adaptive thinking signatures and usage
- expose Anthropic Messages protocol settings and import support in the manager

## Motivation
Some legacy relays expose Fable only through `/v1/messages` and reject Codex Responses requests. The proxy keeps the Codex client on Responses while adapting the upstream wire protocol locally.

## Protocol compatibility
- text, image, custom, namespace, apply_patch, function-call, and tool-result history
- non-streaming JSON and streaming SSE lifecycle events
- adaptive thinking and `signature_delta` to `encrypted_content` round trips
- Anthropic cache read/write usage mapped to Responses usage details

## Test plan
- `cargo fmt --all -- --check`
- `cargo test -p codex-plus-core`
- `cargo check --workspace`
- `npm run check` in `apps/codex-plus-manager`
- `npm test` in `apps/codex-plus-manager`
- `npm run vite:build` in `apps/codex-plus-manager`
- local Claude Code Fable tool-call and Codex CLI end-to-end verification