### PR TITLE
feat(image-output): render generated images from rollout

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use codex_plus_core::launcher::{
     BridgeReinjector, DefaultLaunchHooks, LaunchHooks, LaunchOptions, launch_and_inject_with_hooks,
 };
-use codex_plus_core::models::{DeleteResult, ExportResult, SessionRef};
+use codex_plus_core::models::{DeleteResult, ExportResult, ImageOutputResult, SessionRef};
 use codex_plus_core::routes::{BridgeContext, BridgeDataService, BridgeRuntimeService};
 use codex_plus_core::user_scripts::UserScriptManager;
 use serde_json::{Value, json};
@@ -463,6 +463,15 @@ impl BridgeDataService for LauncherDataService {
         })
         .await
         .map_err(|error| anyhow::anyhow!("export markdown task failed: {error}"))
+    }
+
+    async fn image_outputs(&self, session: SessionRef) -> anyhow::Result<ImageOutputResult> {
+        let db_paths = self.candidate_db_paths();
+        tokio::task::spawn_blocking(move || {
+            codex_plus_data::image_outputs_from_paths(db_paths, &session)
+        })
+        .await
+        .map_err(|error| anyhow::anyhow!("image outputs task failed: {error}"))
     }
 
     async fn thread_usage_history(&self, session: SessionRef) -> anyhow::Result<Value> {

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -3299,10 +3299,10 @@
     refreshCodexServiceTierControls();
   }
 
-  function withBackendTimeout(request) {
+  function withBackendTimeout(request, timeoutMs = 2000, message = "后端检查超时") {
     return Promise.race([
       request,
-      new Promise((resolve) => setTimeout(() => resolve({ status: "failed", message: "后端检查超时", timeout: true }), 2000)),
+      new Promise((resolve) => setTimeout(() => resolve({ status: "failed", message, timeout: true }), timeoutMs)),
     ]);
   }
 
@@ -8805,6 +8805,7 @@
         refreshAfterPending: false,
         timer: 0,
         lastFetchAt: 0,
+        pendingSince: 0,
         signatureBySession: Object.create(null),
         imagesBySession: Object.create(null),
       };
@@ -8812,6 +8813,7 @@
     if (!window.__codexPlusImageOutputRuntime.imagesBySession || typeof window.__codexPlusImageOutputRuntime.imagesBySession !== "object") {
       window.__codexPlusImageOutputRuntime.imagesBySession = Object.create(null);
     }
+    window.__codexPlusImageOutputRuntime.pendingSince = finiteNonNegativeNumber(window.__codexPlusImageOutputRuntime.pendingSince);
     return window.__codexPlusImageOutputRuntime;
   }
 
@@ -9008,25 +9010,48 @@
     return resolvedGroups.length === groups.length;
   }
 
+  function clearStaleImageOutputRequest(runtime, now = Date.now()) {
+    if (!runtime.pending) return false;
+    if (runtime.pendingSince && now - runtime.pendingSince < 12000) return false;
+    runtime.pending = false;
+    runtime.pendingSince = 0;
+    runtime.refreshAfterPending = false;
+    sendCodexPlusDiagnostic("image_outputs_stale_request_cleared", {
+      activeSessionId: runtime.activeSessionId || "",
+    });
+    return true;
+  }
+
   async function refreshImageOutputs() {
     const runtime = imageOutputRuntime();
     const ref = currentSessionRef();
     const sessionId = validThreadScrollSessionKey(ref.session_id);
     removeStaleImageOutputLists(sessionId);
     if (!sessionId) return;
+    const now = Date.now();
+    clearStaleImageOutputRequest(runtime, now);
     if (runtime.pending) {
       runtime.refreshAfterPending = true;
       return;
     }
-    const now = Date.now();
     const cachedSignature = runtime.signatureBySession[sessionId] || "";
     const cachedImages = runtime.imagesBySession?.[sessionId] || [];
-    if (runtime.activeSessionId === sessionId && now - finiteNonNegativeNumber(runtime.lastFetchAt) < 2500 && (!cachedSignature || (imageOutputListSignature(sessionId) === cachedSignature && !imageOutputListsNeedReposition(sessionId, cachedImages)))) return;
+    if (runtime.activeSessionId === sessionId && now - finiteNonNegativeNumber(runtime.lastFetchAt) < 2500) {
+      if (cachedSignature && (imageOutputListSignature(sessionId) !== cachedSignature || imageOutputListsNeedReposition(sessionId, cachedImages))) {
+        renderImageOutputs(sessionId, cachedImages);
+      }
+      return;
+    }
     runtime.pending = true;
+    runtime.pendingSince = now;
     runtime.activeSessionId = sessionId;
     runtime.lastFetchAt = now;
     try {
-      const result = await postJson("/image-outputs", { session_id: sessionId, title: ref.title || "" });
+      const result = await withBackendTimeout(
+        postJson("/image-outputs", { session_id: sessionId, title: ref.title || "" }),
+        10000,
+        "图片输出请求超时",
+      );
       if (sessionId !== validThreadScrollSessionKey(currentSessionRef().session_id)) {
         runtime.refreshAfterPending = true;
         return;
@@ -9036,8 +9061,7 @@
       if (result?.status === "found" && (runtime.signatureBySession[sessionId] !== signature || imageOutputListSignature(sessionId) !== signature || imageOutputListsNeedReposition(sessionId, images))) {
         runtime.signatureBySession[sessionId] = signature;
         runtime.imagesBySession[sessionId] = images;
-        const complete = renderImageOutputs(sessionId, images);
-        if (!complete && images.length) scheduleImageOutputsRefresh(400);
+        renderImageOutputs(sessionId, images);
         if (images.length) sendCodexPlusDiagnostic("image_outputs_rendered", { sessionId, count: images.length });
       }
     } catch (error) {
@@ -9048,6 +9072,7 @@
       });
     } finally {
       runtime.pending = false;
+      runtime.pendingSince = 0;
       if (runtime.refreshAfterPending) {
         runtime.refreshAfterPending = false;
         scheduleImageOutputsRefresh(0);
@@ -9062,6 +9087,29 @@
       runtime.timer = 0;
       refreshImageOutputs();
     }, delayMs);
+  }
+
+  function recoverImageOutputs() {
+    if (document.visibilityState === "hidden") return;
+    const runtime = imageOutputRuntime();
+    const sessionId = validThreadScrollSessionKey(currentSessionRef().session_id);
+    if (!sessionId) return;
+    clearStaleImageOutputRequest(runtime);
+    const cachedImages = runtime.imagesBySession?.[sessionId] || [];
+    if (cachedImages.length) renderImageOutputs(sessionId, cachedImages);
+    scheduleImageOutputsRefresh(0);
+  }
+
+  function installImageOutputRecovery() {
+    window.removeEventListener("focus", window.__codexPlusImageOutputFocusHandler, true);
+    document.removeEventListener("visibilitychange", window.__codexPlusImageOutputVisibilityHandler, true);
+    window.__codexPlusImageOutputFocusHandler = recoverImageOutputs;
+    window.__codexPlusImageOutputVisibilityHandler = () => {
+      if (document.visibilityState === "visible") recoverImageOutputs();
+    };
+    window.addEventListener("focus", window.__codexPlusImageOutputFocusHandler, true);
+    document.addEventListener("visibilitychange", window.__codexPlusImageOutputVisibilityHandler, true);
+    clearStaleImageOutputRequest(imageOutputRuntime());
   }
 
   function sortStateFromMoveResult(result, ref, row) {
@@ -10779,6 +10827,15 @@
     });
   }
 
+  function mutationsRemovedImageOutputList(mutations) {
+    return (mutations || []).some((mutation) => Array.from(mutation.removedNodes).some((node) => (
+      node.nodeType === 1 && (
+        node.matches?.("[data-codex-plus-image-output-list]") ||
+        node.querySelector?.("[data-codex-plus-image-output-list]")
+      )
+    )));
+  }
+
   function runScheduledScan() {
     window.__codexSessionDeleteScanPending = false;
     clearTimeout(window.__codexSessionDeleteScanTimer);
@@ -10790,6 +10847,9 @@
     window.__codexSessionDeleteLastMutations = mutations;
     scheduleZedRemoteMenuRefresh(mutations);
     schedulePluginAutoExpand();
+    if (document.visibilityState !== "hidden" && mutationsRemovedImageOutputList(mutations)) {
+      scheduleImageOutputsRefresh(100);
+    }
     if (!shouldScheduleScan(mutations)) return;
     if (window.__codexSessionDeleteScanPending) return;
     window.__codexSessionDeleteScanPending = true;
@@ -10801,6 +10861,7 @@
   if (!window.__CODEX_PLUS_TEST_PROJECTLESS__) void loadCodexProjectlessMainWindowSetting();
   installUpstreamBranchDropdownAdapter();
   installUpstreamWorktreeNativeAdapter();
+  installImageOutputRecovery();
   scan();
   window.__codexProjectMoveApplyProjection = applyProjectMoveProjection;
   window.__codexProjectMoveReadProjection = readProjectMoveProjection;

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -1263,6 +1263,27 @@
       .codex-plus-form-message[data-status="ok"] { color: #34d399; }
       .codex-plus-form-message[data-status="failed"] { color: #f87171; }
       .codex-plus-form-message[data-status="loading"] { color: #fbbf24; }
+      .codex-plus-image-output-list {
+        box-sizing: border-box;
+        width: min(100%, 720px);
+        margin: 12px 0 0;
+        display: grid;
+        gap: 12px;
+      }
+      .codex-plus-image-output {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      .codex-plus-image-output img {
+        display: block;
+        width: 100%;
+        max-height: min(70vh, 720px);
+        object-fit: contain;
+        border: 1px solid rgba(148, 163, 184, .28);
+        border-radius: 8px;
+        background: rgba(15, 23, 42, .08);
+      }
       .codex-plus-backend-status { display: grid; gap: 4px; min-width: 132px; justify-items: end; }
       .codex-plus-backend-label { color: #a1a1aa; font-size: 12px; }
       .codex-plus-backend-label[data-status="ok"] { color: #34d399; }
@@ -8776,6 +8797,273 @@
     showToast(result.message || "导出失败", null);
   }
 
+  function imageOutputRuntime() {
+    if (!window.__codexPlusImageOutputRuntime || typeof window.__codexPlusImageOutputRuntime !== "object") {
+      window.__codexPlusImageOutputRuntime = {
+        activeSessionId: "",
+        pending: false,
+        refreshAfterPending: false,
+        timer: 0,
+        lastFetchAt: 0,
+        signatureBySession: Object.create(null),
+        imagesBySession: Object.create(null),
+      };
+    }
+    if (!window.__codexPlusImageOutputRuntime.imagesBySession || typeof window.__codexPlusImageOutputRuntime.imagesBySession !== "object") {
+      window.__codexPlusImageOutputRuntime.imagesBySession = Object.create(null);
+    }
+    return window.__codexPlusImageOutputRuntime;
+  }
+
+  function removeStaleImageOutputLists(activeSessionId, activeGroupKeys = null) {
+    document.querySelectorAll("[data-codex-plus-image-output-list]").forEach((list) => {
+      if (!activeSessionId || list.dataset.codexPlusImageOutputSession !== activeSessionId) {
+        list.remove();
+        return;
+      }
+      if (activeGroupKeys && !activeGroupKeys.has(list.dataset.codexPlusImageOutputGroup || "")) {
+        list.remove();
+      }
+    });
+  }
+
+  function isImageOutputContentCandidate(node) {
+    if (!node?.isConnected) return false;
+    if (node.tagName === "SPAN") return false;
+    if (node.closest?.("[data-codex-plus-image-output-list]")) return false;
+    if (node.closest?.(".composer-surface-chrome, .ProseMirror, [role='textbox']")) return false;
+    if (node.closest?.("[data-testid='source-panel'], [class*='thread-floating-content']")) return false;
+    const text = String(node.innerText || node.textContent || "").trim();
+    return text.length > 0;
+  }
+
+  function imageOutputMarkdownSelector() {
+    return [
+      ".prose",
+      "[data-message-content]",
+      '[data-testid*="message-content"]',
+      '[class*="_markdownContent_"]',
+    ].join(", ");
+  }
+
+  function imageOutputContentAnchorForAssistant(assistant, markdownSelector) {
+    const contentCandidates = Array.from(assistant.querySelectorAll?.(markdownSelector) || [])
+      .filter(isImageOutputContentCandidate);
+    return contentCandidates[contentCandidates.length - 1] || assistant;
+  }
+
+  function imageOutputAssistantAnchors(root) {
+    const markdownSelector = imageOutputMarkdownSelector();
+    const assistantMessages = Array.from(root?.querySelectorAll?.('[data-message-author-role="assistant"]') || [])
+      .filter((node) => node.isConnected && !node.closest?.("[data-codex-plus-image-output-list]"));
+    if (assistantMessages.length) {
+      return assistantMessages.map((assistant) => imageOutputContentAnchorForAssistant(assistant, markdownSelector));
+    }
+    const contentCandidates = Array.from(root?.querySelectorAll?.(markdownSelector) || [])
+      .filter(isImageOutputContentCandidate);
+    if (contentCandidates.length) return contentCandidates;
+    const turnCandidates = Array.from(root?.querySelectorAll?.('[data-testid="conversation-turn"]') || [])
+      .filter(isImageOutputContentCandidate);
+    return turnCandidates;
+  }
+
+  function normalizeImageOutputText(value) {
+    return String(value || "").replace(/\s+/g, " ").trim();
+  }
+
+  function imageOutputAssistantText(images) {
+    return normalizeImageOutputText(images.find((image) => normalizeImageOutputText(image?.assistant_text))?.assistant_text);
+  }
+
+  function imageOutputAnchor(root, images, groupIndex, groupCount) {
+    const anchors = imageOutputAssistantAnchors(root);
+    const assistantText = imageOutputAssistantText(images);
+    if (assistantText) {
+      const matched = anchors.find((anchor) => normalizeImageOutputText(anchor.innerText || anchor.textContent).includes(assistantText));
+      if (matched) return matched;
+      const prefix = assistantText.slice(0, 120);
+      if (prefix.length >= 12) {
+        const prefixMatched = anchors.find((anchor) => normalizeImageOutputText(anchor.innerText || anchor.textContent).includes(prefix));
+        if (prefixMatched) return prefixMatched;
+      }
+      return null;
+    }
+    const fallbackIndex = Math.max(0, anchors.length - Math.max(1, groupCount) + groupIndex);
+    return anchors[fallbackIndex] || anchors[anchors.length - 1] || null;
+  }
+
+  function cssEscapeValue(value) {
+    if (window.CSS && typeof window.CSS.escape === "function") return window.CSS.escape(value);
+    return String(value).replace(/["\\]/g, "\\$&");
+  }
+
+  function imageOutputGroupKey(image, index) {
+    return String(image?.turn_id || image?.id || `image-${index + 1}`);
+  }
+
+  function imageOutputGroups(images) {
+    const groups = [];
+    const groupByKey = new Map();
+    images.forEach((image, index) => {
+      const key = imageOutputGroupKey(image, index);
+      let group = groupByKey.get(key);
+      if (!group) {
+        group = { key, images: [] };
+        groupByKey.set(key, group);
+        groups.push(group);
+      }
+      group.images.push(image);
+    });
+    return groups;
+  }
+
+  function ensureImageOutputList(root, sessionId, groupKey, anchor) {
+    let list = root.querySelector?.(`[data-codex-plus-image-output-list][data-codex-plus-image-output-session="${cssEscapeValue(sessionId)}"][data-codex-plus-image-output-group="${cssEscapeValue(groupKey)}"]`);
+    if (!list?.isConnected) {
+      list = document.createElement("div");
+      list.className = "codex-plus-image-output-list";
+      list.dataset.codexPlusImageOutputList = "true";
+      list.dataset.codexPlusImageOutputSession = sessionId;
+      list.dataset.codexPlusImageOutputGroup = groupKey;
+    }
+    const parent = anchor || root;
+    if (list.parentElement !== parent) parent.appendChild(list);
+    return list;
+  }
+
+  function imageOutputListSignature(sessionId) {
+    const root = conversationRoot();
+    const lists = Array.from(root?.querySelectorAll?.(`[data-codex-plus-image-output-list][data-codex-plus-image-output-session="${cssEscapeValue(sessionId)}"]`) || [])
+      .filter((list) => list.isConnected);
+    if (!lists.length) return "";
+    return lists.map((list) => {
+      const images = Array.from(list.querySelectorAll("[data-codex-plus-image-output-id]")).map((figure) => {
+        const id = figure.dataset.codexPlusImageOutputId || "";
+        const dataUrlLength = String(figure.querySelector("img")?.src || "").length;
+        return `${id}:${dataUrlLength}`;
+      }).join("|");
+      return `${list.dataset.codexPlusImageOutputGroup || ""}[${images}]`;
+    }).join("||");
+  }
+
+  function imageOutputRenderSignature(images) {
+    return imageOutputGroups(Array.isArray(images) ? images : []).map((group) => {
+      const groupImages = group.images.map((image, index) => {
+        const id = String(image?.id || `image-${index + 1}`);
+        return `${id}:${String(image?.data_url || "").length}`;
+      }).join("|");
+      return `${group.key}[${groupImages}]`;
+    }).join("||");
+  }
+
+  function imageOutputListsNeedReposition(sessionId, images) {
+    const root = conversationRoot();
+    if (!root?.isConnected) return true;
+    const groups = imageOutputGroups(Array.isArray(images) ? images : []);
+    return groups.some((group, groupIndex) => {
+      const anchor = imageOutputAnchor(root, group.images, groupIndex, groups.length);
+      if (!anchor?.isConnected) return true;
+      const list = root.querySelector?.(`[data-codex-plus-image-output-list][data-codex-plus-image-output-session="${cssEscapeValue(sessionId)}"][data-codex-plus-image-output-group="${cssEscapeValue(group.key)}"]`);
+      return !list?.isConnected || list.parentElement !== anchor;
+    });
+  }
+
+  function renderImageOutputs(sessionId, images) {
+    const root = conversationRoot();
+    if (!root?.isConnected) return false;
+    const groups = imageOutputGroups(Array.isArray(images) ? images : []);
+    const resolvedGroups = groups.map((group, groupIndex) => ({
+      group,
+      anchor: imageOutputAnchor(root, group.images, groupIndex, groups.length),
+    })).filter((entry) => entry.anchor?.isConnected);
+    const activeGroupKeys = new Set(resolvedGroups.map((entry) => entry.group.key));
+    removeStaleImageOutputLists(sessionId, activeGroupKeys);
+    resolvedGroups.forEach(({ group, anchor }) => {
+      const list = ensureImageOutputList(root, sessionId, group.key, anchor);
+      const seen = new Set();
+      group.images.forEach((image, index) => {
+        const id = String(image?.id || `image-${index + 1}`);
+        const dataUrl = String(image?.data_url || "");
+        if (!id || !dataUrl.startsWith("data:image/")) return;
+        seen.add(id);
+        let figure = list.querySelector(`[data-codex-plus-image-output-id="${cssEscapeValue(id)}"]`);
+        if (!figure) {
+          figure = document.createElement("figure");
+          figure.className = "codex-plus-image-output";
+          figure.dataset.codexPlusImageOutputId = id;
+          const img = document.createElement("img");
+          img.loading = "lazy";
+          img.decoding = "async";
+          img.alt = String(image?.revised_prompt || "Generated image");
+          figure.appendChild(img);
+          list.appendChild(figure);
+        }
+        const img = figure.querySelector("img");
+        if (img && img.src !== dataUrl) img.src = dataUrl;
+      });
+      list.querySelectorAll("[data-codex-plus-image-output-id]").forEach((figure) => {
+        if (!seen.has(figure.dataset.codexPlusImageOutputId || "")) figure.remove();
+      });
+    });
+    return resolvedGroups.length === groups.length;
+  }
+
+  async function refreshImageOutputs() {
+    const runtime = imageOutputRuntime();
+    const ref = currentSessionRef();
+    const sessionId = validThreadScrollSessionKey(ref.session_id);
+    removeStaleImageOutputLists(sessionId);
+    if (!sessionId) return;
+    if (runtime.pending) {
+      runtime.refreshAfterPending = true;
+      return;
+    }
+    const now = Date.now();
+    const cachedSignature = runtime.signatureBySession[sessionId] || "";
+    const cachedImages = runtime.imagesBySession?.[sessionId] || [];
+    if (runtime.activeSessionId === sessionId && now - finiteNonNegativeNumber(runtime.lastFetchAt) < 2500 && (!cachedSignature || (imageOutputListSignature(sessionId) === cachedSignature && !imageOutputListsNeedReposition(sessionId, cachedImages)))) return;
+    runtime.pending = true;
+    runtime.activeSessionId = sessionId;
+    runtime.lastFetchAt = now;
+    try {
+      const result = await postJson("/image-outputs", { session_id: sessionId, title: ref.title || "" });
+      if (sessionId !== validThreadScrollSessionKey(currentSessionRef().session_id)) {
+        runtime.refreshAfterPending = true;
+        return;
+      }
+      const images = Array.isArray(result?.images) ? result.images : [];
+      const signature = imageOutputRenderSignature(images);
+      if (result?.status === "found" && (runtime.signatureBySession[sessionId] !== signature || imageOutputListSignature(sessionId) !== signature || imageOutputListsNeedReposition(sessionId, images))) {
+        runtime.signatureBySession[sessionId] = signature;
+        runtime.imagesBySession[sessionId] = images;
+        const complete = renderImageOutputs(sessionId, images);
+        if (!complete && images.length) scheduleImageOutputsRefresh(400);
+        if (images.length) sendCodexPlusDiagnostic("image_outputs_rendered", { sessionId, count: images.length });
+      }
+    } catch (error) {
+      sendCodexPlusDiagnostic("image_outputs_refresh_failed", {
+        sessionId,
+        errorName: error?.name || "",
+        errorMessage: error?.message || String(error),
+      });
+    } finally {
+      runtime.pending = false;
+      if (runtime.refreshAfterPending) {
+        runtime.refreshAfterPending = false;
+        scheduleImageOutputsRefresh(0);
+      }
+    }
+  }
+
+  function scheduleImageOutputsRefresh(delayMs = 150) {
+    const runtime = imageOutputRuntime();
+    clearTimeout(runtime.timer);
+    runtime.timer = setTimeout(() => {
+      runtime.timer = 0;
+      refreshImageOutputs();
+    }, delayMs);
+  }
+
   function sortStateFromMoveResult(result, ref, row) {
     const trustedSortMs = timestampMsFromPayload(result);
     return { sortMs: trustedSortMs || rowSortMs(row, ref), sortMsTrusted: !!trustedSortMs };
@@ -10416,6 +10704,7 @@
     scheduleThreadScrollSync();
     refreshCodexModelWhitelistFromScan(window.__codexSessionDeleteLastMutations);
     schedulePluginAutoExpand();
+    scheduleImageOutputsRefresh();
   }
 
   function runScanStep(step) {
@@ -10433,7 +10722,7 @@
   }
 
   function isExtensionUiNode(node) {
-    return !!node?.closest?.(`.codex-delete-toast, .codex-delete-confirm-overlay, .codex-plus-modal-overlay, .${projectMoveOverlayClass}, .${codexServiceTierBadgeClass}, .codex-zed-remote-button, .codex-zed-remote-toast, #codex-plus-menu`);
+    return !!node?.closest?.(`.codex-delete-toast, .codex-delete-confirm-overlay, .codex-plus-modal-overlay, .codex-plus-image-output-list, .${projectMoveOverlayClass}, .${codexServiceTierBadgeClass}, .codex-zed-remote-button, .codex-zed-remote-toast, #codex-plus-menu`);
   }
 
   function scanRelevantSelector() {

--- a/crates/codex-plus-core/src/models.rs
+++ b/crates/codex-plus-core/src/models.rs
@@ -56,6 +56,32 @@ pub struct ExportResult {
     pub markdown: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImageOutputStatus {
+    Found,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ImageOutput {
+    pub id: String,
+    pub turn_id: Option<String>,
+    pub assistant_text: Option<String>,
+    pub data_url: String,
+    pub output_format: String,
+    pub revised_prompt: Option<String>,
+    pub timestamp: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ImageOutputResult {
+    pub status: ImageOutputStatus,
+    pub session_id: String,
+    pub message: String,
+    pub images: Vec<ImageOutput>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -174,5 +200,47 @@ mod tests {
         let result = serde_json::from_value::<ExportResult>(value.clone()).unwrap();
 
         assert_eq!(serde_json::to_value(result).unwrap(), value);
+    }
+
+    #[test]
+    fn image_output_result_json_shape_matches_rust_model() {
+        let result = ImageOutputResult {
+            status: ImageOutputStatus::Found,
+            session_id: "s1".to_string(),
+            message: "found 1 image".to_string(),
+            images: vec![ImageOutput {
+                id: "img-1".to_string(),
+                turn_id: Some("turn-1".to_string()),
+                assistant_text: Some("done".to_string()),
+                data_url: "data:image/png;base64,aGVsbG8=".to_string(),
+                output_format: "png".to_string(),
+                revised_prompt: Some("prompt".to_string()),
+                timestamp: Some("2026-07-25T12:00:00Z".to_string()),
+            }],
+        };
+
+        let value = serde_json::to_value(&result).unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "status": "found",
+                "session_id": "s1",
+                "message": "found 1 image",
+                "images": [{
+                    "id": "img-1",
+                    "turn_id": "turn-1",
+                    "assistant_text": "done",
+                    "data_url": "data:image/png;base64,aGVsbG8=",
+                    "output_format": "png",
+                    "revised_prompt": "prompt",
+                    "timestamp": "2026-07-25T12:00:00Z"
+                }]
+            })
+        );
+        assert_eq!(
+            serde_json::from_value::<ImageOutputResult>(value).unwrap(),
+            result
+        );
     }
 }

--- a/crates/codex-plus-core/src/routes.rs
+++ b/crates/codex-plus-core/src/routes.rs
@@ -5,7 +5,10 @@ use std::time::Instant;
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
-use crate::models::{DeleteResult, DeleteStatus, ExportResult, ExportStatus, SessionRef};
+use crate::models::{
+    DeleteResult, DeleteStatus, ExportResult, ExportStatus, ImageOutputResult, ImageOutputStatus,
+    SessionRef,
+};
 use crate::settings::{BackendSettings, SettingsStore};
 use crate::status::StatusStore;
 use crate::user_scripts::UserScriptManager;
@@ -106,6 +109,7 @@ pub trait BridgeDataService: Send + Sync {
     async fn delete(&self, session: SessionRef) -> anyhow::Result<DeleteResult>;
     async fn undo(&self, undo_token: String) -> anyhow::Result<DeleteResult>;
     async fn export_markdown(&self, session: SessionRef) -> anyhow::Result<ExportResult>;
+    async fn image_outputs(&self, session: SessionRef) -> anyhow::Result<ImageOutputResult>;
     async fn thread_usage_history(&self, session: SessionRef) -> anyhow::Result<Value>;
     async fn find_archived_thread_by_title(
         &self,
@@ -229,6 +233,9 @@ pub async fn handle_bridge_request(
                 .export_markdown(session_from_payload(&payload))
                 .await,
         ),
+        "/image-outputs" => {
+            result_value(ctx.data.image_outputs(session_from_payload(&payload)).await)
+        }
         "/thread-usage-history" => {
             ctx.data
                 .thread_usage_history(session_from_payload(&payload))
@@ -575,6 +582,15 @@ impl BridgeDataService for UnavailableDataService {
             message: "Markdown export service is not wired in core launcher hooks".to_string(),
             filename: None,
             markdown: None,
+        })
+    }
+
+    async fn image_outputs(&self, session: SessionRef) -> anyhow::Result<ImageOutputResult> {
+        Ok(ImageOutputResult {
+            status: ImageOutputStatus::Failed,
+            session_id: session.session_id,
+            message: "Image output service is not wired in core launcher hooks".to_string(),
+            images: Vec::new(),
         })
     }
 

--- a/crates/codex-plus-core/tests/bridge_routes.rs
+++ b/crates/codex-plus-core/tests/bridge_routes.rs
@@ -4,7 +4,10 @@ use async_trait::async_trait;
 use codex_plus_core::launcher::{
     CodexLaunch, LaunchHooks, LaunchOptions, ProcessWaitStrategy, launch_and_inject_with_hooks,
 };
-use codex_plus_core::models::{DeleteResult, DeleteStatus, ExportResult, ExportStatus, SessionRef};
+use codex_plus_core::models::{
+    DeleteResult, DeleteStatus, ExportResult, ExportStatus, ImageOutput, ImageOutputResult,
+    ImageOutputStatus, SessionRef,
+};
 use codex_plus_core::routes::{
     BridgeContext, BridgeDataService, BridgeRuntimeService, BridgeSettingsService,
     CoreRuntimeService, handle_bridge_request,
@@ -78,6 +81,10 @@ async fn bridge_routes_cover_all_current_paths() {
         ("/undo", json!({"undo_token": "undo-1"})),
         (
             "/export-markdown",
+            json!({"session_id": "s1", "title": "First"}),
+        ),
+        (
+            "/image-outputs",
             json!({"session_id": "s1", "title": "First"}),
         ),
         (
@@ -1329,6 +1336,23 @@ impl BridgeDataService for FakeData {
             message: "exported".to_string(),
             filename: Some("First.md".to_string()),
             markdown: Some("# First\n".to_string()),
+        })
+    }
+
+    async fn image_outputs(&self, session: SessionRef) -> anyhow::Result<ImageOutputResult> {
+        Ok(ImageOutputResult {
+            status: ImageOutputStatus::Found,
+            session_id: session.session_id,
+            message: "found".to_string(),
+            images: vec![ImageOutput {
+                id: "img-1".to_string(),
+                turn_id: Some("turn-1".to_string()),
+                assistant_text: Some("done".to_string()),
+                data_url: "data:image/png;base64,aGVsbG8=".to_string(),
+                output_format: "png".to_string(),
+                revised_prompt: None,
+                timestamp: None,
+            }],
         })
     }
 

--- a/crates/codex-plus-data/src/image_outputs.rs
+++ b/crates/codex-plus-data/src/image_outputs.rs
@@ -1,0 +1,411 @@
+use codex_plus_core::models::{ImageOutput, ImageOutputResult, ImageOutputStatus, SessionRef};
+use rusqlite::Connection;
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const MAX_IMAGES: usize = 8;
+const MAX_BASE64_CHARS: usize = 24 * 1024 * 1024;
+
+pub fn image_outputs_from_paths(
+    db_paths: impl IntoIterator<Item = PathBuf>,
+    session: &SessionRef,
+) -> ImageOutputResult {
+    let thread_id = normalize_session_id(&session.session_id);
+    let mut result = failed(&thread_id, "未找到对应会话");
+    let mut saw_candidate = false;
+    for db_path in db_paths {
+        if !db_path.exists() {
+            continue;
+        }
+        saw_candidate = true;
+        let candidate = ImageOutputService::new(Some(db_path)).load(session);
+        if matches!(candidate.status, ImageOutputStatus::Found) {
+            if !candidate.images.is_empty() {
+                return candidate;
+            }
+            result = candidate;
+            continue;
+        }
+        if result.message == "未找到对应会话" || candidate.message != "未找到对应会话"
+        {
+            result = candidate;
+        }
+    }
+    if saw_candidate {
+        result
+    } else {
+        failed(&thread_id, "未配置本地 Codex 数据库")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ImageOutputService {
+    db_path: Option<PathBuf>,
+}
+
+impl ImageOutputService {
+    pub fn new(db_path: Option<impl Into<PathBuf>>) -> Self {
+        Self {
+            db_path: db_path.map(Into::into),
+        }
+    }
+
+    pub fn load(&self, session: &SessionRef) -> ImageOutputResult {
+        let Some(db_path) = &self.db_path else {
+            return failed(&session.session_id, "未配置本地 Codex 数据库");
+        };
+        if !db_path.exists() {
+            return failed(
+                &session.session_id,
+                format!("数据库不存在：{}", db_path.to_string_lossy()),
+            );
+        }
+        let thread_id = normalize_session_id(&session.session_id);
+        let result = (|| -> anyhow::Result<ImageOutputResult> {
+            let db = Connection::open(db_path)?;
+            let record = match lookup_thread_record(&db, db_path, &thread_id)? {
+                ThreadLookup::Found(record) => record,
+                ThreadLookup::Missing => return Ok(failed(&thread_id, "未找到对应会话")),
+                ThreadLookup::Unsupported => {
+                    return Ok(failed(&thread_id, "不支持当前本地存储结构"));
+                }
+            };
+            let Some(rollout_path) = record
+                .rollout_path
+                .filter(|path| !path.as_os_str().is_empty())
+            else {
+                return Ok(failed(&thread_id, "会话缺少 rollout 文件路径"));
+            };
+            if !rollout_path.is_file() {
+                return Ok(failed(
+                    &thread_id,
+                    format!("rollout 文件不存在：{}", rollout_path.to_string_lossy()),
+                ));
+            }
+            let images = load_image_outputs(&rollout_path)?;
+            let message = if images.is_empty() {
+                "未找到图片生成结果".to_string()
+            } else {
+                format!("已找到 {} 张图片生成结果", images.len())
+            };
+            Ok(ImageOutputResult {
+                status: ImageOutputStatus::Found,
+                session_id: thread_id.clone(),
+                message,
+                images,
+            })
+        })();
+        result.unwrap_or_else(|err| failed(&thread_id, format!("读取 rollout 失败：{err}")))
+    }
+}
+
+#[derive(Debug)]
+struct ThreadRecord {
+    rollout_path: Option<PathBuf>,
+}
+
+#[derive(Debug)]
+enum ThreadLookup {
+    Found(ThreadRecord),
+    Missing,
+    Unsupported,
+}
+
+fn failed(session_id: &str, message: impl Into<String>) -> ImageOutputResult {
+    ImageOutputResult {
+        status: ImageOutputStatus::Failed,
+        session_id: session_id.to_string(),
+        message: message.into(),
+        images: Vec::new(),
+    }
+}
+
+fn lookup_thread_record(
+    db: &Connection,
+    db_path: &Path,
+    thread_id: &str,
+) -> anyhow::Result<ThreadLookup> {
+    if has_columns(db, "threads", &["id", "rollout_path"])? {
+        let row = db.query_row(
+            "SELECT rollout_path FROM threads WHERE id = ?1",
+            [thread_id],
+            |row| {
+                Ok(ThreadRecord {
+                    rollout_path: row
+                        .get::<_, Option<String>>(0)?
+                        .filter(|path| !path.trim().is_empty())
+                        .map(PathBuf::from),
+                })
+            },
+        );
+        return match row {
+            Ok(row) => Ok(ThreadLookup::Found(row)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(ThreadLookup::Missing),
+            Err(err) => Err(err.into()),
+        };
+    }
+
+    if has_columns(db, "automation_runs", &["thread_id"])? {
+        let row = db.query_row(
+            "SELECT 1 FROM automation_runs WHERE thread_id = ?1",
+            [thread_id],
+            |_| Ok(()),
+        );
+        return match row {
+            Ok(()) => Ok(ThreadLookup::Found(ThreadRecord {
+                rollout_path: discover_rollout_path(db_path, thread_id)?,
+            })),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(ThreadLookup::Missing),
+            Err(err) => Err(err.into()),
+        };
+    }
+
+    Ok(ThreadLookup::Unsupported)
+}
+
+fn discover_rollout_path(db_path: &Path, thread_id: &str) -> anyhow::Result<Option<PathBuf>> {
+    for home in codex_home_candidates(db_path) {
+        let mut candidates = Vec::new();
+        collect_jsonl_files(&home.join("sessions"), &mut candidates)?;
+        collect_jsonl_files(&home.join("archived_sessions"), &mut candidates)?;
+        candidates.sort_by_key(|path| {
+            std::cmp::Reverse(
+                fs::metadata(path)
+                    .and_then(|metadata| metadata.modified())
+                    .ok(),
+            )
+        });
+        for path in candidates {
+            if rollout_matches_thread(&path, thread_id)? {
+                return Ok(Some(path));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn codex_home_candidates(db_path: &Path) -> Vec<PathBuf> {
+    let mut homes = Vec::new();
+    for ancestor in db_path.ancestors().skip(1) {
+        if ancestor.join("sessions").is_dir() || ancestor.join("archived_sessions").is_dir() {
+            homes.push(ancestor.to_path_buf());
+        }
+    }
+    if homes.is_empty() {
+        if let Some(parent) = db_path.parent().and_then(Path::parent) {
+            homes.push(parent.to_path_buf());
+        }
+    }
+    homes
+}
+
+fn collect_jsonl_files(dir: &Path, output: &mut Vec<PathBuf>) -> anyhow::Result<()> {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Ok(());
+    };
+    for entry in entries {
+        let path = entry?.path();
+        if path.is_dir() {
+            collect_jsonl_files(&path, output)?;
+        } else if path.extension().and_then(|value| value.to_str()) == Some("jsonl") {
+            output.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn rollout_matches_thread(path: &Path, thread_id: &str) -> anyhow::Result<bool> {
+    for raw in fs::read_to_string(path)?.lines() {
+        if raw.trim().is_empty() {
+            continue;
+        }
+        let Ok(event) = serde_json::from_str::<Value>(raw) else {
+            continue;
+        };
+        if event.get("type") != Some(&Value::String("session_meta".to_string())) {
+            continue;
+        }
+        let id = event
+            .get("payload")
+            .and_then(|payload| payload.get("id"))
+            .or_else(|| event.get("id"))
+            .and_then(Value::as_str)
+            .map(normalize_session_id)
+            .unwrap_or_default();
+        if id == thread_id {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn has_columns(db: &Connection, table: &str, columns: &[&str]) -> anyhow::Result<bool> {
+    let existing = table_columns(db, table)?;
+    if existing.is_empty() {
+        return Ok(false);
+    }
+    Ok(columns
+        .iter()
+        .all(|column| existing.iter().any(|existing| existing == column)))
+}
+
+fn table_columns(db: &Connection, table: &str) -> anyhow::Result<Vec<String>> {
+    if !db
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            [table],
+            |_| Ok(()),
+        )
+        .is_ok()
+    {
+        return Ok(Vec::new());
+    }
+    let mut stmt = db.prepare(&format!(
+        "PRAGMA table_info(\"{}\")",
+        table.replace('"', "\"\"")
+    ))?;
+    let columns = stmt.query_map([], |row| row.get::<_, String>(1))?;
+    Ok(columns.collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+fn load_image_outputs(path: &Path) -> anyhow::Result<Vec<ImageOutput>> {
+    let mut assistant_text_by_turn: HashMap<String, String> = HashMap::new();
+    let mut seen = HashSet::new();
+    let mut images = Vec::new();
+    for raw in fs::read_to_string(path)?.lines() {
+        if raw.trim().is_empty() {
+            continue;
+        }
+        let event: Value = serde_json::from_str(raw)?;
+        if event.get("type") != Some(&Value::String("response_item".to_string())) {
+            continue;
+        }
+        let payload = &event["payload"];
+        if payload.get("type") == Some(&Value::String("message".to_string()))
+            && payload.get("role") == Some(&Value::String("assistant".to_string()))
+        {
+            if let (Some(turn_id), Some(text)) = (
+                turn_id_from_payload(payload),
+                assistant_text_from_payload(payload),
+            ) {
+                assistant_text_by_turn.insert(turn_id.to_string(), text);
+            }
+            continue;
+        }
+        if payload.get("type") != Some(&Value::String("image_generation_call".to_string())) {
+            continue;
+        }
+        let Some(result) = payload.get("result").and_then(Value::as_str) else {
+            continue;
+        };
+        let result = result.trim();
+        if result.is_empty() || result.len() > MAX_BASE64_CHARS {
+            continue;
+        }
+        let id = payload
+            .get("id")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .map(ToString::to_string)
+            .unwrap_or_else(|| format!("image-output-{}", images.len() + 1));
+        if !seen.insert(id.clone()) {
+            continue;
+        }
+        let output_format = payload
+            .get("output_format")
+            .and_then(Value::as_str)
+            .map(normalize_image_format)
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| infer_image_format(result).to_string());
+        let data_url = image_data_url(result, &output_format);
+        images.push(ImageOutput {
+            id,
+            turn_id: turn_id_from_payload(payload).map(ToString::to_string),
+            assistant_text: None,
+            data_url,
+            output_format,
+            revised_prompt: payload
+                .get("revised_prompt")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .map(ToString::to_string),
+            timestamp: event
+                .get("timestamp")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .map(ToString::to_string),
+        });
+    }
+    if images.len() > MAX_IMAGES {
+        images = images.split_off(images.len() - MAX_IMAGES);
+    }
+    for image in images.iter_mut() {
+        image.assistant_text = image
+            .turn_id
+            .as_ref()
+            .and_then(|turn_id| assistant_text_by_turn.get(turn_id))
+            .cloned();
+    }
+    Ok(images)
+}
+
+fn turn_id_from_payload(payload: &Value) -> Option<&str> {
+    payload
+        .get("internal_chat_message_metadata_passthrough")
+        .and_then(|metadata| metadata.get("turn_id"))
+        .and_then(Value::as_str)
+}
+
+fn assistant_text_from_payload(payload: &Value) -> Option<String> {
+    let text = payload
+        .get("content")?
+        .as_array()?
+        .iter()
+        .filter_map(|content| content.get("text").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let text = text.trim();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text.to_string())
+    }
+}
+
+fn image_data_url(result: &str, output_format: &str) -> String {
+    if result.starts_with("data:image/") {
+        return result.to_string();
+    }
+    format!("data:image/{output_format};base64,{result}")
+}
+
+fn infer_image_format(result: &str) -> &'static str {
+    if result.starts_with("iVBORw0KGgo") {
+        "png"
+    } else if result.starts_with("/9j/") {
+        "jpeg"
+    } else if result.starts_with("UklGR") {
+        "webp"
+    } else if result.starts_with("R0lGOD") {
+        "gif"
+    } else {
+        "png"
+    }
+}
+
+fn normalize_image_format(value: &str) -> String {
+    value
+        .trim()
+        .trim_start_matches("image/")
+        .to_ascii_lowercase()
+        .replace("jpg", "jpeg")
+}
+
+fn normalize_session_id(session_id: &str) -> String {
+    session_id
+        .strip_prefix("local:")
+        .unwrap_or(session_id)
+        .to_string()
+}

--- a/crates/codex-plus-data/src/lib.rs
+++ b/crates/codex-plus-data/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod backup;
+pub mod image_outputs;
 pub mod markdown;
 pub mod provider_sync;
 pub mod storage;
 
 pub use backup::BackupStore;
+pub use image_outputs::{ImageOutputService, image_outputs_from_paths};
 pub use markdown::{MarkdownExportService, export_markdown_from_paths};
 pub use provider_sync::{
     ProviderSyncResult, ProviderSyncStatus, ProviderSyncTargetList, ProviderSyncTargetOption,

--- a/crates/codex-plus-data/tests/image_outputs.rs
+++ b/crates/codex-plus-data/tests/image_outputs.rs
@@ -1,0 +1,136 @@
+use codex_plus_core::models::{ImageOutputStatus, SessionRef};
+use codex_plus_data::{ImageOutputService, image_outputs_from_paths};
+use rusqlite::Connection;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+fn session(id: &str, title: &str) -> SessionRef {
+    SessionRef::new(id, title).unwrap()
+}
+
+fn create_codex_thread_db(path: &Path, rollout_path: &Path, thread_id: &str) {
+    let db = Connection::open(path).unwrap();
+    db.execute(
+        "CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT, title TEXT)",
+        [],
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO threads (id, rollout_path, title) VALUES (?1, ?2, 'Image Thread')",
+        (thread_id, rollout_path.to_string_lossy().to_string()),
+    )
+    .unwrap();
+}
+
+#[test]
+fn image_outputs_loads_image_generation_call_result() {
+    let tmp = tempdir().unwrap();
+    let db_path = tmp.path().join("state_5.sqlite");
+    let rollout_path = tmp.path().join("rollout.jsonl");
+    fs::write(
+        &rollout_path,
+        concat!(
+            "{\"type\":\"session_meta\",\"timestamp\":\"2026-07-25T12:00:00Z\",\"payload\":{\"id\":\"thread-1\"}}\n",
+            "{\"type\":\"response_item\",\"timestamp\":\"2026-07-25T12:02:00Z\",\"payload\":{\"type\":\"image_generation_call\",\"id\":\"ig_1\",\"status\":\"completed\",\"revised_prompt\":\"draw a fox\",\"result\":\"iVBORw0KGgoAAAANSUhEUgAAAAE=\",\"internal_chat_message_metadata_passthrough\":{\"turn_id\":\"turn-1\"}}}\n",
+            "{\"type\":\"response_item\",\"timestamp\":\"2026-07-25T12:03:00Z\",\"payload\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"done\"}],\"internal_chat_message_metadata_passthrough\":{\"turn_id\":\"turn-1\"}}}\n"
+        ),
+    )
+    .unwrap();
+    create_codex_thread_db(&db_path, &rollout_path, "thread-1");
+
+    let result = ImageOutputService::new(Some(&db_path)).load(&session("local:thread-1", ""));
+
+    assert_eq!(result.status, ImageOutputStatus::Found);
+    assert_eq!(result.session_id, "thread-1");
+    assert_eq!(result.images.len(), 1);
+    let image = &result.images[0];
+    assert_eq!(image.id, "ig_1");
+    assert_eq!(image.turn_id.as_deref(), Some("turn-1"));
+    assert_eq!(image.assistant_text.as_deref(), Some("done"));
+    assert_eq!(image.output_format, "png");
+    assert_eq!(image.revised_prompt.as_deref(), Some("draw a fox"));
+    assert_eq!(image.timestamp.as_deref(), Some("2026-07-25T12:02:00Z"));
+    assert_eq!(
+        image.data_url,
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE="
+    );
+}
+
+#[test]
+fn image_outputs_searches_candidate_databases_and_discovers_automation_rollout() {
+    let tmp = tempdir().unwrap();
+    let codex_home = tmp.path().join(".codex");
+    let first_db_path = codex_home.join("sqlite").join("first.sqlite");
+    let second_db_path = codex_home.join("sqlite").join("second.sqlite");
+    let sessions_dir = codex_home.join("archived_sessions").join("2026");
+    fs::create_dir_all(&sessions_dir).unwrap();
+    fs::create_dir_all(first_db_path.parent().unwrap()).unwrap();
+
+    let first_db = Connection::open(&first_db_path).unwrap();
+    first_db
+        .execute(
+            "CREATE TABLE automation_runs (thread_id TEXT PRIMARY KEY)",
+            [],
+        )
+        .unwrap();
+    first_db
+        .execute(
+            "INSERT INTO automation_runs (thread_id) VALUES ('other-thread')",
+            [],
+        )
+        .unwrap();
+
+    let second_db = Connection::open(&second_db_path).unwrap();
+    second_db
+        .execute(
+            "CREATE TABLE automation_runs (thread_id TEXT PRIMARY KEY)",
+            [],
+        )
+        .unwrap();
+    second_db
+        .execute(
+            "INSERT INTO automation_runs (thread_id) VALUES ('thread-2')",
+            [],
+        )
+        .unwrap();
+
+    fs::write(
+        sessions_dir.join("rollout-thread-2.jsonl"),
+        concat!(
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"thread-2\"}}\n",
+            "{\"type\":\"response_item\",\"payload\":{\"type\":\"image_generation_call\",\"id\":\"ig_2\",\"output_format\":\"webp\",\"result\":\"UklGRaaaa\"}}\n"
+        ),
+    )
+    .unwrap();
+
+    let result = image_outputs_from_paths(
+        [first_db_path, second_db_path],
+        &session("thread-2", "Ignored"),
+    );
+
+    assert_eq!(result.status, ImageOutputStatus::Found);
+    assert_eq!(result.images.len(), 1);
+    assert_eq!(
+        result.images[0].data_url,
+        "data:image/webp;base64,UklGRaaaa"
+    );
+}
+
+#[test]
+fn image_outputs_returns_found_with_empty_images_when_rollout_has_no_generation_results() {
+    let tmp = tempdir().unwrap();
+    let db_path = tmp.path().join("state_5.sqlite");
+    let rollout_path = tmp.path().join("rollout.jsonl");
+    fs::write(
+        &rollout_path,
+        "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"no image\"}]}}\n",
+    )
+    .unwrap();
+    create_codex_thread_db(&db_path, &rollout_path, "thread-3");
+
+    let result = ImageOutputService::new(Some(&db_path)).load(&session("thread-3", ""));
+
+    assert_eq!(result.status, ImageOutputStatus::Found);
+    assert!(result.images.is_empty());
+}


### PR DESCRIPTION
## 变更概述

Render image generation results stored in Codex rollout files so generated images can appear in the Codex++ chat UI.

## 主要改动

- Add an image output data service that locates rollout JSONL files and extracts image_generation_call results as data URLs.
- Add the /image-outputs bridge route and wire it through the launcher data service.
- Render found images in the injected chat UI and keep the data bridge watchdog from falling back to core-only routes.
- Add data-layer and bridge route tests.

## 验证

- cargo test -p codex-plus-data image_outputs
- cargo test -p codex-plus-core bridge_routes_cover_all_current_paths

[#AI]