### PR TITLE
fix: recover launcher against an existing Codex CDP

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -408,8 +408,9 @@ impl LaunchHooks for LauncherHooks {
     async fn wait_for_codex_exit(
         &self,
         launch: &codex_plus_core::launcher::CodexLaunch,
+        debug_port: u16,
     ) -> anyhow::Result<()> {
-        self.core.wait_for_codex_exit(launch).await
+        self.core.wait_for_codex_exit(launch, debug_port).await
     }
 
     async fn shutdown_helper(&self, helper_port: u16) {

--- a/crates/codex-plus-core/src/cdp.rs
+++ b/crates/codex-plus-core/src/cdp.rs
@@ -1,9 +1,12 @@
 use anyhow::{Context, bail};
 use serde::Deserialize;
-use std::net::IpAddr;
+use std::io::{Read, Write};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream};
 use std::time::Duration;
 
 const CDP_HTTP_TIMEOUT: Duration = Duration::from_secs(3);
+const CDP_PROBE_TIMEOUT: Duration = Duration::from_millis(300);
+const CDP_PROBE_MAX_BYTES: usize = 256 * 1024;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct CdpTarget {
@@ -38,6 +41,80 @@ impl CdpBrowserIdentity {
             _ => bail!("browser WebSocket URL has no Browser ID"),
         }
     }
+}
+
+/// Returns whether the requested loopback port exposes a CDP target list.
+pub(crate) fn endpoint_available(debug_port: u16) -> bool {
+    [
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), debug_port),
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), debug_port),
+    ]
+    .into_iter()
+    .any(|address| probe_endpoint(address, debug_port))
+}
+
+fn probe_endpoint(address: SocketAddr, debug_port: u16) -> bool {
+    let Ok(mut stream) = TcpStream::connect_timeout(&address, CDP_PROBE_TIMEOUT) else {
+        return false;
+    };
+    let _ = stream.set_read_timeout(Some(CDP_PROBE_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(CDP_PROBE_TIMEOUT));
+    let request =
+        format!("GET /json HTTP/1.1\r\nHost: 127.0.0.1:{debug_port}\r\nConnection: close\r\n\r\n");
+    if stream.write_all(request.as_bytes()).is_err() {
+        return false;
+    }
+
+    let mut response = Vec::new();
+    let mut chunk = [0_u8; 8192];
+    while response.len() < CDP_PROBE_MAX_BYTES {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read) => {
+                response.extend_from_slice(&chunk[..read]);
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                break;
+            }
+            Err(_) => return false,
+        }
+    }
+
+    response_contains_codex_target(&response, debug_port)
+}
+
+fn response_contains_codex_target(response: &[u8], debug_port: u16) -> bool {
+    let Some(header_end) = response.windows(4).position(|window| window == b"\r\n\r\n") else {
+        return false;
+    };
+    let headers = String::from_utf8_lossy(&response[..header_end]);
+    let status_ok = headers
+        .lines()
+        .next()
+        .is_some_and(|line| line.starts_with("HTTP/") && line.contains(" 200 "));
+    if !status_ok {
+        return false;
+    }
+    let Ok(targets) = serde_json::from_slice::<Vec<CdpTarget>>(&response[header_end + 4..]) else {
+        return false;
+    };
+    targets.iter().any(|target| {
+        is_primary_codex_page_target(target)
+            && target
+                .url
+                .trim()
+                .to_ascii_lowercase()
+                .starts_with("app://-/")
+            && target
+                .web_socket_debugger_url
+                .as_deref()
+                .is_some_and(|url| validate_cdp_websocket_url(url, debug_port).is_ok())
+    })
 }
 
 pub async fn list_targets(debug_port: u16) -> anyhow::Result<Vec<CdpTarget>> {
@@ -227,4 +304,72 @@ fn is_chatgpt_desktop_page(title: &str, url: &str) -> bool {
             || url == "https://chat.openai.com"
             || url.starts_with("https://chat.openai.com/")
             || url.starts_with("data:text/html"))
+}
+
+#[cfg(test)]
+mod endpoint_tests {
+    use super::*;
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn serve_once(build_body: impl FnOnce(u16) -> String) -> (u16, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let body = build_body(port);
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request);
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        (port, handle)
+    }
+
+    #[test]
+    fn endpoint_available_accepts_devtools_target_response() {
+        let (port, server) = serve_once(|port| {
+            format!(
+                r#"[{{"id":"codex","type":"page","title":"Codex","url":"app://-/index.html","webSocketDebuggerUrl":"ws://127.0.0.1:{port}/devtools/page/1"}}]"#
+            )
+        });
+
+        assert!(endpoint_available(port));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn endpoint_available_rejects_ordinary_http_response() {
+        let (port, server) = serve_once(|_| r#"{"status":"ok"}"#.to_string());
+
+        assert!(!endpoint_available(port));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn endpoint_available_rejects_non_codex_devtools_target() {
+        let (port, server) = serve_once(|port| {
+            format!(
+                r#"[{{"id":"chrome","type":"page","title":"New Tab","url":"chrome://newtab","webSocketDebuggerUrl":"ws://127.0.0.1:{port}/devtools/page/1"}}]"#
+            )
+        });
+
+        assert!(!endpoint_available(port));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn endpoint_available_rejects_chatgpt_web_target() {
+        let (port, server) = serve_once(|port| {
+            format!(
+                r#"[{{"id":"chatgpt","type":"page","title":"ChatGPT","url":"https://chatgpt.com/","webSocketDebuggerUrl":"ws://127.0.0.1:{port}/devtools/page/1"}}]"#
+            )
+        });
+
+        assert!(!endpoint_available(port));
+        server.join().unwrap();
+    }
 }

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -122,7 +122,10 @@ impl std::fmt::Debug for LaunchHandle {
 
 impl LaunchHandle {
     pub async fn wait_for_codex_exit(&self) -> anyhow::Result<()> {
-        let result = self.hooks.wait_for_codex_exit(&self.launch).await;
+        let result = self
+            .hooks
+            .wait_for_codex_exit(&self.launch, self.debug_port)
+            .await;
         if self.helper_started {
             self.hooks.shutdown_helper(self.helper_port).await;
         }
@@ -216,7 +219,11 @@ pub trait LaunchHooks: Send + Sync {
         Ok(())
     }
     async fn write_status(&self, status: &str);
-    async fn wait_for_codex_exit(&self, launch: &CodexLaunch) -> anyhow::Result<()>;
+    async fn wait_for_codex_exit(
+        &self,
+        launch: &CodexLaunch,
+        debug_port: u16,
+    ) -> anyhow::Result<()>;
     async fn shutdown_helper(&self, helper_port: u16);
     async fn terminate_codex(&self, launch: &CodexLaunch);
 }
@@ -913,7 +920,11 @@ impl LaunchHooks for DefaultLaunchHooks {
 
     async fn write_status(&self, _status: &str) {}
 
-    async fn wait_for_codex_exit(&self, launch: &CodexLaunch) -> anyhow::Result<()> {
+    async fn wait_for_codex_exit(
+        &self,
+        launch: &CodexLaunch,
+        debug_port: u16,
+    ) -> anyhow::Result<()> {
         match launch {
             CodexLaunch::Process { .. } => {
                 if let Some(mut child) = self.child.lock().await.take() {
@@ -936,7 +947,10 @@ impl LaunchHooks for DefaultLaunchHooks {
         }
         let mut empty_streak = 0u32;
         loop {
-            if crate::watcher::find_codex_processes().is_empty() {
+            let has_codex_process = !crate::watcher::find_codex_processes().is_empty();
+            let cdp_available = should_probe_launcher_cdp(cfg!(windows), has_codex_process)
+                && crate::cdp::endpoint_available(debug_port);
+            if !launcher_target_alive(has_codex_process, cdp_available) {
                 empty_streak = empty_streak.saturating_add(1);
                 if empty_streak >= 3 {
                     break;
@@ -2268,6 +2282,14 @@ pub fn browser_identity_changed(previous: Option<&str>, current: &str) -> bool {
     previous.is_some_and(|previous| previous != current)
 }
 
+fn launcher_target_alive(has_codex_process: bool, cdp_available: bool) -> bool {
+    has_codex_process || cdp_available
+}
+
+fn should_probe_launcher_cdp(is_windows: bool, has_codex_process: bool) -> bool {
+    is_windows && !has_codex_process
+}
+
 async fn check_and_reinject_bridge_inner(
     debug_port: u16,
     helper_port: u16,
@@ -3019,6 +3041,18 @@ mod tests {
                 Ok(())
             })
         })
+    }
+
+    #[test]
+    fn launcher_stays_alive_while_injected_cdp_endpoint_is_available() {
+        assert!(launcher_target_alive(false, true));
+    }
+
+    #[test]
+    fn launcher_only_probes_cdp_for_unrecognized_windows_processes() {
+        assert!(should_probe_launcher_cdp(true, false));
+        assert!(!should_probe_launcher_cdp(true, true));
+        assert!(!should_probe_launcher_cdp(false, false));
     }
 
     #[tokio::test]

--- a/crates/codex-plus-core/src/ports.rs
+++ b/crates/codex-plus-core/src/ports.rs
@@ -77,6 +77,7 @@ pub fn select_packaged_codex_debug_port(requested: u16) -> u16 {
         requested,
         cfg!(windows),
         can_bind_loopback_port,
+        crate::cdp::endpoint_available,
         find_available_loopback_port,
     )
 }
@@ -85,9 +86,14 @@ pub fn select_packaged_codex_debug_port_with(
     requested: u16,
     is_windows: bool,
     can_bind: impl Fn(u16) -> bool,
+    is_existing_cdp: impl Fn(u16) -> bool,
     find_available: impl Fn() -> u16,
 ) -> u16 {
-    select_platform_loopback_port_with(requested, is_windows, can_bind, find_available)
+    if !is_windows || can_bind(requested) || is_existing_cdp(requested) {
+        requested
+    } else {
+        find_available()
+    }
 }
 
 pub fn select_platform_loopback_port_with(

--- a/crates/codex-plus-core/tests/bridge_routes.rs
+++ b/crates/codex-plus-core/tests/bridge_routes.rs
@@ -1471,7 +1471,11 @@ impl LaunchHooks for ContextHooks {
         self.event(format!("status:{status}"));
     }
 
-    async fn wait_for_codex_exit(&self, _launch: &CodexLaunch) -> anyhow::Result<()> {
+    async fn wait_for_codex_exit(
+        &self,
+        _launch: &CodexLaunch,
+        _debug_port: u16,
+    ) -> anyhow::Result<()> {
         Ok(())
     }
 

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -772,9 +772,17 @@ fn ports_windows_falls_back_to_ephemeral_when_requested_is_busy() {
 
 #[test]
 fn ports_windows_packaged_debug_falls_back_to_ephemeral_when_requested_is_busy() {
-    let selected = select_packaged_codex_debug_port_with(9229, true, |_| false, || 43001);
+    let selected =
+        select_packaged_codex_debug_port_with(9229, true, |_| false, |_| false, || 43001);
 
     assert_eq!(selected, 43001);
+}
+
+#[test]
+fn ports_windows_packaged_debug_keeps_requested_when_existing_cdp_is_available() {
+    let selected = select_packaged_codex_debug_port_with(9229, true, |_| false, |_| true, || 43001);
+
+    assert_eq!(selected, 9229);
 }
 
 #[test]
@@ -1756,7 +1764,11 @@ impl LaunchHooks for FakeHooks {
         self.event(format!("status:{status}"));
     }
 
-    async fn wait_for_codex_exit(&self, _launch: &CodexLaunch) -> anyhow::Result<()> {
+    async fn wait_for_codex_exit(
+        &self,
+        _launch: &CodexLaunch,
+        _debug_port: u16,
+    ) -> anyhow::Result<()> {
         self.event("wait-codex");
         Ok(())
     }


### PR DESCRIPTION
## Summary

- reuse the requested Windows debug port when it already exposes a validated primary Codex `app://` CDP target
- keep the launcher helper and bridge alive while the injected CDP endpoint remains available
- limit the lifetime CDP fallback to Windows when normal Codex process discovery finds no process
- reject unrelated HTTP services, Chrome DevTools targets, and ChatGPT web targets
- add focused regression coverage for port selection, endpoint validation, launcher lifetime, and fallback scope

Closes #1658.

## Root cause

The packaged Windows port selector treated every non-bindable requested port as a conflict. When portable Codex was already running on `9229`, the launcher selected an ephemeral port while the existing single-instance app stayed on `9229`, so injection failed.

After injection, launcher lifetime tracking fell back to process discovery. Portable Codex uses `ChatGPT.exe` outside `WindowsApps`, which is intentionally excluded to avoid matching ordinary ChatGPT sessions. Once the activation PID ended, the launcher incorrectly shut down its helper even though the injected CDP endpoint was still alive.

## Validation

- `cargo test -p codex-plus-core --lib endpoint_available_` — 4 passed
- `cargo test -p codex-plus-core --lib launcher_stays_alive_while_injected_cdp_endpoint_is_available` — passed
- `cargo test -p codex-plus-core --lib launcher_only_probes_cdp_for_unrecognized_windows_processes` — passed
- `cargo test -p codex-plus-core --test launcher ports_` — 4 passed
- `cargo check -p codex-plus-launcher` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- manual Windows verification: launcher remained alive, `57321/backend/status` returned `ok`, and the injected UI indicator reported `status=ok`

## Notes

A full launcher integration run passed 72/73 tests; the remaining existing symlink test requires the Windows `SeCreateSymbolicLinkPrivilege` and failed with OS error 1314 in this environment. Repository-wide Clippy with `-D warnings` is not currently clean because upstream `main` has unrelated existing warnings.
