### PR TITLE
fix: recover plugin search for API key mode

### DIFF
--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -469,7 +469,7 @@
   const codexThreadServiceTierDraftBindWindowMs = 60 * 1000;
   const codexServiceTierRequestOverrideVersion = "3";
   const codexAppServerModelRequestPatchVersion = "2";
-  const codexPluginMarketplaceUnlockVersion = "12";
+  const codexPluginMarketplaceUnlockVersion = "13";
   const codexPluginAutoExpandVersion = "1";
   const codexPluginAutoExpandMaxClicks = 80;
   const codexPluginAutoExpandClickDelayMs = 90;
@@ -3780,16 +3780,31 @@
       return params;
     }
     const next = { ...params };
+    const requestCwds = Array.isArray(next.cwds)
+      ? next.cwds.filter((cwd) => typeof cwd === "string" && cwd.trim())
+      : [];
+    if (requestCwds.length > 0) {
+      window.__codexPluginMarketplaceLastCwds = Array.from(new Set(requestCwds));
+    } else if (Array.isArray(window.__codexPluginMarketplaceLastCwds) && window.__codexPluginMarketplaceLastCwds.length > 0) {
+      next.cwds = [...window.__codexPluginMarketplaceLastCwds];
+    }
     const hadMarketplaceKinds = Object.prototype.hasOwnProperty.call(next, "marketplaceKinds");
-    const nextKinds = Array.isArray(next.marketplaceKinds)
+    let nextKinds = Array.isArray(next.marketplaceKinds)
       ? next.marketplaceKinds.map((kind) => restorePluginMarketplaceName(kind))
       : ["local"];
+    const remoteCatalogUnavailable = window.__codexPluginMarketplaceRemoteCatalogUnavailable === true;
+    if (remoteCatalogUnavailable) {
+      nextKinds = nextKinds.filter((kind) => kind !== "created-by-me-remote" && kind !== "shared-with-me");
+    }
+    if (!nextKinds.includes("local")) nextKinds.push("local");
     if (!nextKinds.includes("vertical")) nextKinds.push("vertical");
     next.marketplaceKinds = Array.from(new Set(nextKinds));
     sendCodexPlusDiagnostic("plugin_marketplace_request_expanded", {
       hadMarketplaceKinds,
       marketplaceKinds: next.marketplaceKinds,
       cwdCount: Array.isArray(next.cwds) ? next.cwds.length : 0,
+      cwdRestored: requestCwds.length === 0 && Array.isArray(next.cwds) && next.cwds.length > 0,
+      remoteCatalogUnavailable,
     });
     return next;
   }
@@ -4047,6 +4062,37 @@
     return result;
   }
 
+  function pluginMarketplaceErrorText(value, visited = new WeakSet(), depth = 0) {
+    if (typeof value === "string") return value;
+    if (!value || typeof value !== "object" || depth > 4 || visited.has(value)) return "";
+    visited.add(value);
+    const parts = [];
+    for (const key of ["message", "error", "detail", "cause", "data", "response"]) {
+      const text = pluginMarketplaceErrorText(value[key], visited, depth + 1);
+      if (text) parts.push(text);
+    }
+    return parts.join(" ");
+  }
+
+  function pluginMarketplaceRemoteAuthError(value) {
+    const text = pluginMarketplaceErrorText(value).toLowerCase();
+    return text.includes("chatgpt authentication required for remote plugin catalog") && text.includes("api key auth is not supported");
+  }
+
+  function markPluginMarketplaceRemoteCatalogUnavailable(error) {
+    window.__codexPluginMarketplaceRemoteCatalogUnavailable = true;
+    sendCodexPlusDiagnostic("plugin_marketplace_remote_auth_fallback", {
+      errorMessage: pluginMarketplaceErrorText(error),
+      rememberedCwdCount: Array.isArray(window.__codexPluginMarketplaceLastCwds)
+        ? window.__codexPluginMarketplaceLastCwds.length
+        : 0,
+    });
+  }
+
+  function localPluginMarketplaceFallbackResult() {
+    return patchPluginMarketplaceResult("list-plugins", { marketplaces: [] });
+  }
+
   function pluginAutoExpandVisibleElement(el) {
     if (!(el instanceof HTMLElement) || !el.isConnected) return false;
     const style = getComputedStyle(el);
@@ -4166,6 +4212,10 @@
         const result = await originalSendRequest(method, requestParams, options);
         return patchPluginMarketplaceResult(requestMethod, result);
       } catch (error) {
+        if (requestMethod === "list-plugins" && pluginMarketplaceRemoteAuthError(error)) {
+          markPluginMarketplaceRemoteCatalogUnavailable(error);
+          return localPluginMarketplaceFallbackResult();
+        }
         if (requestMethod === "install-plugin") {
           sendCodexPlusDiagnostic("plugin_install_request_failed", {
             method: String(method || ""),
@@ -4265,8 +4315,17 @@
       }
       if (typeof data.bodyJsonString !== "string" || !data.bodyJsonString.trim()) return false;
       try {
-        const result = JSON.parse(data.bodyJsonString);
-        if (result && typeof result === "object") {
+        let result = JSON.parse(data.bodyJsonString);
+        if (pluginMarketplaceRemoteAuthError(result?.error || result)) {
+          markPluginMarketplaceRemoteCatalogUnavailable(result?.error || result);
+          const fallback = localPluginMarketplaceFallbackResult();
+          if (result && typeof result === "object" && Object.prototype.hasOwnProperty.call(result, "id")) {
+            delete result.error;
+            result.result = fallback;
+          } else {
+            result = fallback;
+          }
+        } else if (result && typeof result === "object") {
           patchPluginMarketplaceResult("list-plugins", result);
           patchPluginMarketplaceResult("list-plugins", result.data);
         }
@@ -4292,11 +4351,35 @@
       if (!requestIds.has(requestId)) return false;
       requestIds.delete(requestId);
     }
+    if (pluginMarketplaceRemoteAuthError(message?.error)) {
+      markPluginMarketplaceRemoteCatalogUnavailable(message.error);
+      delete message.error;
+      message.result = localPluginMarketplaceFallbackResult();
+      return true;
+    }
     const result = message?.result;
     if (!result || typeof result !== "object") return false;
     patchPluginMarketplaceResult("list-plugins", result);
     patchPluginMarketplaceResult("list-plugins", result.data);
     return true;
+  }
+
+  if (window.__CODEX_PLUS_TEST_PLUGIN_MARKETPLACE__) {
+    window.__codexPlusPluginMarketplaceTest = {
+      patchRequestParams: patchPluginMarketplaceRequestParams,
+      patchRequestMessage: patchPluginMarketplaceRequestMessage,
+      patchResponseData: patchPluginMarketplaceResponseData,
+      remoteAuthError: pluginMarketplaceRemoteAuthError,
+      localFallback: localPluginMarketplaceFallbackResult,
+      remoteCatalogUnavailable: () => window.__codexPluginMarketplaceRemoteCatalogUnavailable === true,
+      reset: () => {
+        delete window.__codexPluginMarketplaceLastCwds;
+        delete window.__codexPluginMarketplaceRemoteCatalogUnavailable;
+        window.__codexPluginMarketplaceRequestIds = new Set();
+        window.__codexPluginMarketplaceFetchRequestIds = new Set();
+      },
+    };
+    return;
   }
 
   function clearPluginMarketplaceQueryCache() {

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -469,7 +469,7 @@
   const codexThreadServiceTierDraftBindWindowMs = 60 * 1000;
   const codexServiceTierRequestOverrideVersion = "3";
   const codexAppServerModelRequestPatchVersion = "2";
-  const codexPluginMarketplaceUnlockVersion = "13";
+  const codexPluginMarketplaceUnlockVersion = "14";
   const codexPluginAutoExpandVersion = "1";
   const codexPluginAutoExpandMaxClicks = 80;
   const codexPluginAutoExpandClickDelayMs = 90;
@@ -3773,6 +3773,23 @@
     removeDuplicateCodexPlusMenus(menu);
   }
 
+  const codexPluginRemoteOnlyMarketplaceKinds = new Set(["created-by-me-remote", "shared-with-me"]);
+
+  function pluginMarketplaceRequestProfile(params) {
+    const marketplaceKinds = Array.isArray(params?.marketplaceKinds)
+      ? Array.from(new Set(params.marketplaceKinds.map((kind) => restorePluginMarketplaceName(kind))))
+      : [];
+    const hasRemoteOnlyKind = marketplaceKinds.some((kind) => codexPluginRemoteOnlyMarketplaceKinds.has(kind));
+    const hasLocalKind = marketplaceKinds.includes("local");
+    const hasOtherKind = marketplaceKinds.some(
+      (kind) => !codexPluginRemoteOnlyMarketplaceKinds.has(kind) && kind !== "vertical"
+    );
+    return {
+      marketplaceKinds,
+      remoteOnly: hasRemoteOnlyKind && !hasLocalKind && !hasOtherKind,
+    };
+  }
+
   function patchPluginMarketplaceRequestParams(method, params) {
     if (method === "list-plugins") {
       if (!params || typeof params !== "object") return params;
@@ -3780,12 +3797,13 @@
       return params;
     }
     const next = { ...params };
+    const requestProfile = pluginMarketplaceRequestProfile(next);
     const requestCwds = Array.isArray(next.cwds)
       ? next.cwds.filter((cwd) => typeof cwd === "string" && cwd.trim())
       : [];
     if (requestCwds.length > 0) {
       window.__codexPluginMarketplaceLastCwds = Array.from(new Set(requestCwds));
-    } else if (Array.isArray(window.__codexPluginMarketplaceLastCwds) && window.__codexPluginMarketplaceLastCwds.length > 0) {
+    } else if (!requestProfile.remoteOnly && Array.isArray(window.__codexPluginMarketplaceLastCwds) && window.__codexPluginMarketplaceLastCwds.length > 0) {
       next.cwds = [...window.__codexPluginMarketplaceLastCwds];
     }
     const hadMarketplaceKinds = Object.prototype.hasOwnProperty.call(next, "marketplaceKinds");
@@ -3793,11 +3811,13 @@
       ? next.marketplaceKinds.map((kind) => restorePluginMarketplaceName(kind))
       : ["local"];
     const remoteCatalogUnavailable = window.__codexPluginMarketplaceRemoteCatalogUnavailable === true;
-    if (remoteCatalogUnavailable) {
+    if (!requestProfile.remoteOnly && remoteCatalogUnavailable) {
       nextKinds = nextKinds.filter((kind) => kind !== "created-by-me-remote" && kind !== "shared-with-me");
     }
-    if (!nextKinds.includes("local")) nextKinds.push("local");
-    if (!nextKinds.includes("vertical")) nextKinds.push("vertical");
+    if (!requestProfile.remoteOnly) {
+      if (!nextKinds.includes("local")) nextKinds.push("local");
+      if (!nextKinds.includes("vertical")) nextKinds.push("vertical");
+    }
     next.marketplaceKinds = Array.from(new Set(nextKinds));
     sendCodexPlusDiagnostic("plugin_marketplace_request_expanded", {
       hadMarketplaceKinds,
@@ -3805,6 +3825,7 @@
       cwdCount: Array.isArray(next.cwds) ? next.cwds.length : 0,
       cwdRestored: requestCwds.length === 0 && Array.isArray(next.cwds) && next.cwds.length > 0,
       remoteCatalogUnavailable,
+      remoteOnly: requestProfile.remoteOnly,
     });
     return next;
   }
@@ -4023,13 +4044,14 @@
     return next;
   }
 
-  function patchPluginMarketplaceResult(method, result) {
+  function patchPluginMarketplaceResult(method, result, options = {}) {
     if (method !== "list-plugins") return result;
+    const mergeLocal = options.mergeLocal !== false;
     let patchedCount = 0;
     try {
       const pluginMarketplaceCounts = {};
       if (Array.isArray(result?.marketplaces)) {
-        mergeLocalPluginMarketplaces(result);
+        if (mergeLocal) mergeLocalPluginMarketplaces(result);
         result.marketplaces.forEach((marketplace) => {
           if (Array.isArray(marketplace?.plugins)) {
             marketplace.plugins.forEach((plugin) => {
@@ -4048,6 +4070,7 @@
             remoteMarketplaceName: marketplace?.remoteMarketplaceName || null,
           })),
           pluginMarketplaceCounts,
+          mergeLocal,
         });
       }
       if (patchedCount > 0) {
@@ -4089,8 +4112,20 @@
     });
   }
 
+  function pluginMarketplaceFallbackResult(mergeLocal = true) {
+    return patchPluginMarketplaceResult("list-plugins", {
+      marketplaces: [],
+      marketplaceLoadErrors: [],
+      featuredPluginIds: [],
+    }, { mergeLocal });
+  }
+
   function localPluginMarketplaceFallbackResult() {
-    return patchPluginMarketplaceResult("list-plugins", { marketplaces: [] });
+    return pluginMarketplaceFallbackResult(true);
+  }
+
+  function remoteOnlyPluginMarketplaceFallbackResult() {
+    return pluginMarketplaceFallbackResult(false);
   }
 
   function pluginAutoExpandVisibleElement(el) {
@@ -4195,7 +4230,9 @@
     client.__codexPluginMarketplaceOriginalSendRequest = originalSendRequest;
     client.sendRequest = async function codexPluginMarketplacePatchedSendRequest(method, params, options) {
       const requestMethod = appServerModelRequestMethod(String(method || ""), params);
-      const requestParams = patchPluginMarketplaceRequestParams(requestMethod, restorePluginMarketplaceRequestParams(params, requestMethod));
+      const restoredRequestParams = restorePluginMarketplaceRequestParams(params, requestMethod);
+      const requestProfile = pluginMarketplaceRequestProfile(restoredRequestParams);
+      const requestParams = patchPluginMarketplaceRequestParams(requestMethod, restoredRequestParams);
       if (requestMethod === "install-plugin") {
         sendCodexPlusDiagnostic("plugin_install_request_debug", {
           method: String(method || ""),
@@ -4210,11 +4247,13 @@
       }
       try {
         const result = await originalSendRequest(method, requestParams, options);
-        return patchPluginMarketplaceResult(requestMethod, result);
+        return patchPluginMarketplaceResult(requestMethod, result, { mergeLocal: !requestProfile.remoteOnly });
       } catch (error) {
         if (requestMethod === "list-plugins" && pluginMarketplaceRemoteAuthError(error)) {
           markPluginMarketplaceRemoteCatalogUnavailable(error);
-          return localPluginMarketplaceFallbackResult();
+          return requestProfile.remoteOnly
+            ? remoteOnlyPluginMarketplaceFallbackResult()
+            : localPluginMarketplaceFallbackResult();
         }
         if (requestMethod === "install-plugin") {
           sendCodexPlusDiagnostic("plugin_install_request_failed", {
@@ -4250,13 +4289,15 @@
       } else if (requestBody && typeof requestBody === "object") {
         params = requestBody;
       }
-      const requestParams = patchPluginMarketplaceRequestParams(
-        requestMethod,
-        restorePluginMarketplaceRequestParams(params, requestMethod)
-      );
+      const restoredRequestParams = restorePluginMarketplaceRequestParams(params, requestMethod);
+      const requestProfile = pluginMarketplaceRequestProfile(restoredRequestParams);
+      const requestParams = patchPluginMarketplaceRequestParams(requestMethod, restoredRequestParams);
       if (requestMethod === "list-plugins" && message.requestId != null) {
         window.__codexPluginMarketplaceFetchRequestIds = window.__codexPluginMarketplaceFetchRequestIds || new Set();
-        window.__codexPluginMarketplaceFetchRequestIds.add(String(message.requestId));
+        const requestId = String(message.requestId);
+        window.__codexPluginMarketplaceFetchRequestIds.add(requestId);
+        window.__codexPluginMarketplaceFetchRequestProfiles = window.__codexPluginMarketplaceFetchRequestProfiles || new Map();
+        window.__codexPluginMarketplaceFetchRequestProfiles.set(requestId, requestProfile);
       }
       if (requestParams === params) return message;
       if (requestMethod === "install-plugin") {
@@ -4279,13 +4320,15 @@
     if (message.type === "mcp-request" && message.request && typeof message.request === "object") {
       const requestMethod = appServerModelRequestMethod(String(message.request.method || ""), message.request.params);
       if (requestMethod !== "list-plugins" && requestMethod !== "install-plugin") return message;
-      const requestParams = patchPluginMarketplaceRequestParams(
-        requestMethod,
-        restorePluginMarketplaceRequestParams(message.request.params, requestMethod)
-      );
+      const restoredRequestParams = restorePluginMarketplaceRequestParams(message.request.params, requestMethod);
+      const requestProfile = pluginMarketplaceRequestProfile(restoredRequestParams);
+      const requestParams = patchPluginMarketplaceRequestParams(requestMethod, restoredRequestParams);
       if (requestMethod === "list-plugins" && message.request.id != null) {
         window.__codexPluginMarketplaceRequestIds = window.__codexPluginMarketplaceRequestIds || new Set();
-        window.__codexPluginMarketplaceRequestIds.add(String(message.request.id));
+        const requestId = String(message.request.id);
+        window.__codexPluginMarketplaceRequestIds.add(requestId);
+        window.__codexPluginMarketplaceRequestProfiles = window.__codexPluginMarketplaceRequestProfiles || new Map();
+        window.__codexPluginMarketplaceRequestProfiles.set(requestId, requestProfile);
       }
       if (requestParams === message.request.params) return message;
       if (requestMethod === "install-plugin") {
@@ -4309,16 +4352,21 @@
     if (data?.type === "fetch-response") {
       const requestId = data.requestId != null ? String(data.requestId) : "";
       const requestIds = window.__codexPluginMarketplaceFetchRequestIds;
+      const requestProfiles = window.__codexPluginMarketplaceFetchRequestProfiles;
+      const requestProfile = requestProfiles instanceof Map ? requestProfiles.get(requestId) : null;
       if (requestIds instanceof Set && requestIds.size > 0) {
         if (!requestIds.has(requestId)) return false;
         requestIds.delete(requestId);
       }
+      if (requestProfiles instanceof Map) requestProfiles.delete(requestId);
       if (typeof data.bodyJsonString !== "string" || !data.bodyJsonString.trim()) return false;
       try {
         let result = JSON.parse(data.bodyJsonString);
         if (pluginMarketplaceRemoteAuthError(result?.error || result)) {
           markPluginMarketplaceRemoteCatalogUnavailable(result?.error || result);
-          const fallback = localPluginMarketplaceFallbackResult();
+          const fallback = requestProfile?.remoteOnly
+            ? remoteOnlyPluginMarketplaceFallbackResult()
+            : localPluginMarketplaceFallbackResult();
           if (result && typeof result === "object" && Object.prototype.hasOwnProperty.call(result, "id")) {
             delete result.error;
             result.result = fallback;
@@ -4326,8 +4374,9 @@
             result = fallback;
           }
         } else if (result && typeof result === "object") {
-          patchPluginMarketplaceResult("list-plugins", result);
-          patchPluginMarketplaceResult("list-plugins", result.data);
+          const patchOptions = { mergeLocal: requestProfile?.remoteOnly !== true };
+          patchPluginMarketplaceResult("list-plugins", result, patchOptions);
+          patchPluginMarketplaceResult("list-plugins", result.data, patchOptions);
         }
         data.bodyJsonString = JSON.stringify(result);
         return true;
@@ -4347,20 +4396,26 @@
     }
     const requestId = message?.id != null ? String(message.id) : "";
     const requestIds = window.__codexPluginMarketplaceRequestIds;
+    const requestProfiles = window.__codexPluginMarketplaceRequestProfiles;
+    const requestProfile = requestProfiles instanceof Map ? requestProfiles.get(requestId) : null;
     if (requestIds instanceof Set && requestIds.size > 0) {
       if (!requestIds.has(requestId)) return false;
       requestIds.delete(requestId);
     }
+    if (requestProfiles instanceof Map) requestProfiles.delete(requestId);
     if (pluginMarketplaceRemoteAuthError(message?.error)) {
       markPluginMarketplaceRemoteCatalogUnavailable(message.error);
       delete message.error;
-      message.result = localPluginMarketplaceFallbackResult();
+      message.result = requestProfile?.remoteOnly
+        ? remoteOnlyPluginMarketplaceFallbackResult()
+        : localPluginMarketplaceFallbackResult();
       return true;
     }
     const result = message?.result;
     if (!result || typeof result !== "object") return false;
-    patchPluginMarketplaceResult("list-plugins", result);
-    patchPluginMarketplaceResult("list-plugins", result.data);
+    const patchOptions = { mergeLocal: requestProfile?.remoteOnly !== true };
+    patchPluginMarketplaceResult("list-plugins", result, patchOptions);
+    patchPluginMarketplaceResult("list-plugins", result.data, patchOptions);
     return true;
   }
 
@@ -4371,12 +4426,16 @@
       patchResponseData: patchPluginMarketplaceResponseData,
       remoteAuthError: pluginMarketplaceRemoteAuthError,
       localFallback: localPluginMarketplaceFallbackResult,
+      remoteOnlyFallback: remoteOnlyPluginMarketplaceFallbackResult,
+      requestProfile: pluginMarketplaceRequestProfile,
       remoteCatalogUnavailable: () => window.__codexPluginMarketplaceRemoteCatalogUnavailable === true,
       reset: () => {
         delete window.__codexPluginMarketplaceLastCwds;
         delete window.__codexPluginMarketplaceRemoteCatalogUnavailable;
         window.__codexPluginMarketplaceRequestIds = new Set();
         window.__codexPluginMarketplaceFetchRequestIds = new Set();
+        window.__codexPluginMarketplaceRequestProfiles = new Map();
+        window.__codexPluginMarketplaceFetchRequestProfiles = new Map();
       },
     };
     return;

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -899,7 +899,7 @@ fn injection_script_does_not_unlock_disabled_plugin_install_buttons() {
 fn injection_script_keeps_bundled_marketplace_name_for_default_filter() {
     let script = assets::injection_script(57321);
 
-    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"12\""));
+    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"13\""));
     assert!(!script.contains("function pluginMarketplaceAliasForName"));
     assert!(
         !script.contains("if (name === \"openai-bundled\") return \"codex-plus-openai-bundled\"")
@@ -911,7 +911,7 @@ fn injection_script_keeps_bundled_marketplace_name_for_default_filter() {
 fn injection_script_does_not_bypass_plugin_marketplace_search_filters() {
     let script = assets::injection_script(57321);
 
-    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"12\""));
+    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"13\""));
     assert!(script.contains("isCodexPluginBuildFlavorFilter"));
     assert!(script.contains("source.includes(\"!u(e.marketplaceName)||e.marketplaceName===r\")"));
     assert!(script.contains("source.includes(\"!t.includes(e.name)\")"));
@@ -923,7 +923,7 @@ fn injection_script_does_not_bypass_plugin_marketplace_search_filters() {
 fn injection_script_expands_api_key_plugin_marketplace_requests() {
     let script = assets::injection_script(57321);
 
-    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"12\""));
+    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"13\""));
     assert!(script.contains("installPluginMarketplaceRequestPatch"));
     assert!(script.contains("installPluginMarketplaceBridgePatch"));
     assert!(script.contains("installPluginBuildFlavorFilterPatch"));
@@ -943,13 +943,15 @@ fn injection_script_expands_api_key_plugin_marketplace_requests() {
     assert!(script.contains("message.type === \"fetch\""));
     assert!(script.contains("data?.type === \"fetch-response\""));
     assert!(script.contains("__codexPluginMarketplaceFetchRequestIds"));
-    assert!(script.contains("const nextKinds = Array.isArray(next.marketplaceKinds)"));
+    assert!(script.contains("let nextKinds = Array.isArray(next.marketplaceKinds)"));
+    assert!(script.contains("if (!nextKinds.includes(\"local\")) nextKinds.push(\"local\")"));
     assert!(script.contains("if (!nextKinds.includes(\"vertical\")) nextKinds.push(\"vertical\")"));
     assert!(script.contains("next.marketplaceKinds = Array.from(new Set(nextKinds))"));
     assert!(script.contains("patchPluginMarketplaceResult"));
     assert!(script.contains("__CODEX_PLUS_PLUGIN_MARKETPLACES__"));
     assert!(script.contains("mergeLocalPluginMarketplaces(result)"));
     assert!(script.contains("plugin_marketplace_local_merged"));
+    assert!(script.contains("plugin_marketplace_remote_auth_fallback"));
     assert!(script.contains("cloned.marketplaceName = marketplaceName"));
     assert!(script.contains("cloned.marketplacePath = marketplaceName"));
     assert!(script.contains("restorePluginMarketplaceName"));
@@ -1001,6 +1003,133 @@ fn injection_script_logs_marketplace_grouping_diagnostics() {
     assert!(script.contains("marketplaces: result.marketplaces.map"));
     assert!(script.contains("pluginMarketplaceCounts"));
     assert!(script.contains("remoteMarketplaceName"));
+}
+
+#[test]
+fn injection_script_recovers_plugin_search_from_remote_auth_errors() {
+    let cases = run_plugin_marketplace_search_contract_harness();
+
+    assert_eq!(cases["initialKinds"], json!(["local", "vertical"]));
+    assert_eq!(
+        cases["searchKinds"],
+        json!(["created-by-me-remote", "vertical", "local"])
+    );
+    assert_eq!(cases["searchCwds"], json!(["C:/workspace"]));
+    assert_eq!(cases["responsePatched"], true);
+    assert_eq!(cases["responseHasError"], false);
+    assert_eq!(cases["fallbackMarketplaceNames"], json!(["fixture-local"]));
+    assert_eq!(cases["fallbackPluginNames"], json!(["alpha"]));
+    assert_eq!(cases["remoteUnavailable"], true);
+    assert_eq!(cases["subsequentKinds"], json!(["vertical", "local"]));
+    assert_eq!(cases["subsequentCwds"], json!(["C:/workspace"]));
+    assert_eq!(
+        cases["chatGptKinds"],
+        json!(["created-by-me-remote", "vertical", "local"])
+    );
+    assert_eq!(cases["unrelatedErrorMatched"], false);
+}
+
+fn run_plugin_marketplace_search_contract_harness() -> serde_json::Value {
+    let temp = tempfile::tempdir().expect("temp dir should be created");
+    let script_path = temp.path().join("renderer-inject.js");
+    let harness_path = temp.path().join("plugin-marketplace-harness.cjs");
+    std::fs::write(&script_path, assets::injection_script(57321))
+        .expect("injection script should be written");
+    let mut harness = std::fs::File::create(&harness_path).expect("harness should be created");
+    write!(
+        harness,
+        r#"
+const scriptPath = {script_path};
+const store = new Map();
+function node() {{
+  return {{
+    appendChild() {{}}, prepend() {{}}, remove() {{}}, setAttribute() {{}}, removeAttribute() {{}},
+    addEventListener() {{}}, querySelector() {{ return null; }}, querySelectorAll() {{ return []; }},
+    closest() {{ return null; }},
+    classList: {{ add() {{}}, remove() {{}}, toggle() {{}}, contains() {{ return false; }} }},
+    dataset: {{}}, style: {{}}, children: [], isConnected: true, textContent: "", innerHTML: "",
+  }};
+}}
+globalThis.window = globalThis;
+window.__CODEX_PLUS_TEST_PLUGIN_MARKETPLACE__ = true;
+window.addEventListener = () => {{}};
+window.removeEventListener = () => {{}};
+window.dispatchEvent = () => true;
+globalThis.document = {{
+  scripts: [], documentElement: node(), body: node(), createElement: () => node(),
+  getElementById: () => null, querySelector: () => null, querySelectorAll: () => [],
+  addEventListener() {{}}, removeEventListener() {{}},
+}};
+globalThis.localStorage = {{
+  getItem: (key) => store.has(key) ? store.get(key) : null,
+  setItem: (key, value) => store.set(key, String(value)), removeItem: (key) => store.delete(key),
+}};
+globalThis.sessionStorage = globalThis.localStorage;
+globalThis.location = {{ href: "https://codex.test/index.html", pathname: "/index.html", search: "", hash: "" }};
+window.location = globalThis.location;
+globalThis.navigator = {{ userAgent: "node-test", sendBeacon: () => false }};
+globalThis.performance = {{ getEntriesByType: () => [] }};
+globalThis.fetch = async () => ({{ ok: true, json: async () => ({{}}) }});
+require(scriptPath);
+window.__CODEX_PLUS_PLUGIN_MARKETPLACES__ = [{{
+  name: "fixture-local",
+  displayName: "Fixture Local",
+  path: "C:/fixture/marketplace.json",
+  plugins: [{{ id: "alpha@fixture-local", name: "alpha", marketplaceName: "fixture-local" }}],
+}}];
+const api = window.__codexPlusPluginMarketplaceTest;
+api.reset();
+const initial = api.patchRequestParams("list-plugins", {{ cwds: ["C:/workspace"] }});
+const searchMessage = api.patchRequestMessage({{
+  type: "mcp-request",
+  request: {{
+    id: "search-1",
+    method: "vscode://codex/list-plugins",
+    params: {{ marketplaceKinds: ["created-by-me-remote", "vertical"] }},
+  }},
+}});
+const remoteAuthMessage = "list remote plugin catalog: chatgpt authentication required for remote plugin catalog; api key auth is not supported";
+const response = {{
+  type: "mcp-response",
+  message: {{ id: "search-1", error: {{ code: -32600, message: remoteAuthMessage }} }},
+}};
+const responsePatched = api.patchResponseData(response);
+const subsequent = api.patchRequestParams("list-plugins", {{ marketplaceKinds: ["created-by-me-remote", "vertical"] }});
+const fallbackMarketplaces = response.message.result?.marketplaces || [];
+api.reset();
+const chatGpt = api.patchRequestParams("list-plugins", {{ marketplaceKinds: ["created-by-me-remote", "vertical"] }});
+const cases = {{
+  initialKinds: initial.marketplaceKinds,
+  searchKinds: searchMessage.request.params.marketplaceKinds,
+  searchCwds: searchMessage.request.params.cwds,
+  responsePatched,
+  responseHasError: Object.prototype.hasOwnProperty.call(response.message, "error"),
+  fallbackMarketplaceNames: fallbackMarketplaces.map((marketplace) => marketplace.name),
+  fallbackPluginNames: fallbackMarketplaces.flatMap((marketplace) => marketplace.plugins || []).map((plugin) => plugin.name),
+  remoteUnavailable: subsequent.marketplaceKinds.includes("created-by-me-remote") === false,
+  subsequentKinds: subsequent.marketplaceKinds,
+  subsequentCwds: subsequent.cwds,
+  chatGptKinds: chatGpt.marketplaceKinds,
+  unrelatedErrorMatched: api.remoteAuthError({{ message: "network unavailable" }}),
+}};
+process.stdout.write(JSON.stringify(cases));
+"#,
+        script_path = serde_json::to_string(&script_path.to_string_lossy().to_string())
+            .expect("script path should serialize")
+    )
+    .expect("harness should be written");
+
+    let output = std::process::Command::new("node")
+        .arg(&harness_path)
+        .output()
+        .expect("node should execute plugin marketplace harness");
+    assert!(
+        output.status.success(),
+        "plugin marketplace harness failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout)
+        .expect("plugin marketplace harness output should be JSON")
 }
 
 #[test]

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -899,7 +899,7 @@ fn injection_script_does_not_unlock_disabled_plugin_install_buttons() {
 fn injection_script_keeps_bundled_marketplace_name_for_default_filter() {
     let script = assets::injection_script(57321);
 
-    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"13\""));
+    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"14\""));
     assert!(!script.contains("function pluginMarketplaceAliasForName"));
     assert!(
         !script.contains("if (name === \"openai-bundled\") return \"codex-plus-openai-bundled\"")
@@ -911,7 +911,7 @@ fn injection_script_keeps_bundled_marketplace_name_for_default_filter() {
 fn injection_script_does_not_bypass_plugin_marketplace_search_filters() {
     let script = assets::injection_script(57321);
 
-    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"13\""));
+    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"14\""));
     assert!(script.contains("isCodexPluginBuildFlavorFilter"));
     assert!(script.contains("source.includes(\"!u(e.marketplaceName)||e.marketplaceName===r\")"));
     assert!(script.contains("source.includes(\"!t.includes(e.name)\")"));
@@ -923,7 +923,7 @@ fn injection_script_does_not_bypass_plugin_marketplace_search_filters() {
 fn injection_script_expands_api_key_plugin_marketplace_requests() {
     let script = assets::injection_script(57321);
 
-    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"13\""));
+    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"14\""));
     assert!(script.contains("installPluginMarketplaceRequestPatch"));
     assert!(script.contains("installPluginMarketplaceBridgePatch"));
     assert!(script.contains("installPluginBuildFlavorFilterPatch"));
@@ -943,6 +943,10 @@ fn injection_script_expands_api_key_plugin_marketplace_requests() {
     assert!(script.contains("message.type === \"fetch\""));
     assert!(script.contains("data?.type === \"fetch-response\""));
     assert!(script.contains("__codexPluginMarketplaceFetchRequestIds"));
+    assert!(script.contains("__codexPluginMarketplaceFetchRequestProfiles"));
+    assert!(script.contains("__codexPluginMarketplaceRequestProfiles"));
+    assert!(script.contains("pluginMarketplaceRequestProfile"));
+    assert!(script.contains("remoteOnlyPluginMarketplaceFallbackResult"));
     assert!(script.contains("let nextKinds = Array.isArray(next.marketplaceKinds)"));
     assert!(script.contains("if (!nextKinds.includes(\"local\")) nextKinds.push(\"local\")"));
     assert!(script.contains("if (!nextKinds.includes(\"vertical\")) nextKinds.push(\"vertical\")"));
@@ -1010,22 +1014,29 @@ fn injection_script_recovers_plugin_search_from_remote_auth_errors() {
     let cases = run_plugin_marketplace_search_contract_harness();
 
     assert_eq!(cases["initialKinds"], json!(["local", "vertical"]));
-    assert_eq!(
-        cases["searchKinds"],
-        json!(["created-by-me-remote", "vertical", "local"])
-    );
-    assert_eq!(cases["searchCwds"], json!(["C:/workspace"]));
+    assert_eq!(cases["searchKinds"], json!(["created-by-me-remote"]));
+    assert_eq!(cases["searchCwds"], serde_json::Value::Null);
+    assert_eq!(cases["searchRemoteOnly"], true);
     assert_eq!(cases["responsePatched"], true);
     assert_eq!(cases["responseHasError"], false);
-    assert_eq!(cases["fallbackMarketplaceNames"], json!(["fixture-local"]));
-    assert_eq!(cases["fallbackPluginNames"], json!(["alpha"]));
+    assert_eq!(cases["fallbackMarketplaceNames"], json!([]));
+    assert_eq!(cases["fallbackPluginNames"], json!([]));
+    assert_eq!(cases["fallbackFeaturedPluginIds"], json!([]));
+    assert_eq!(cases["fallbackMarketplaceLoadErrors"], json!([]));
     assert_eq!(cases["remoteUnavailable"], true);
-    assert_eq!(cases["subsequentKinds"], json!(["vertical", "local"]));
-    assert_eq!(cases["subsequentCwds"], json!(["C:/workspace"]));
+    assert_eq!(cases["subsequentKinds"], json!(["created-by-me-remote"]));
+    assert_eq!(cases["subsequentCwds"], serde_json::Value::Null);
     assert_eq!(
-        cases["chatGptKinds"],
-        json!(["created-by-me-remote", "vertical", "local"])
+        cases["generalAfterFallbackKinds"],
+        json!(["local", "vertical"])
     );
+    assert_eq!(cases["generalAfterFallbackCwds"], json!(["C:/workspace"]));
+    assert_eq!(
+        cases["localFallbackMarketplaceNames"],
+        json!(["fixture-local"])
+    );
+    assert_eq!(cases["localFallbackPluginNames"], json!(["alpha"]));
+    assert_eq!(cases["chatGptKinds"], json!(["created-by-me-remote"]));
     assert_eq!(cases["unrelatedErrorMatched"], false);
 }
 
@@ -1085,7 +1096,7 @@ const searchMessage = api.patchRequestMessage({{
   request: {{
     id: "search-1",
     method: "vscode://codex/list-plugins",
-    params: {{ marketplaceKinds: ["created-by-me-remote", "vertical"] }},
+    params: {{ marketplaceKinds: ["created-by-me-remote"] }},
   }},
 }});
 const remoteAuthMessage = "list remote plugin catalog: chatgpt authentication required for remote plugin catalog; api key auth is not supported";
@@ -1094,21 +1105,31 @@ const response = {{
   message: {{ id: "search-1", error: {{ code: -32600, message: remoteAuthMessage }} }},
 }};
 const responsePatched = api.patchResponseData(response);
-const subsequent = api.patchRequestParams("list-plugins", {{ marketplaceKinds: ["created-by-me-remote", "vertical"] }});
+const subsequent = api.patchRequestParams("list-plugins", {{ marketplaceKinds: ["created-by-me-remote"] }});
+const generalAfterFallback = api.patchRequestParams("list-plugins", {{ marketplaceKinds: ["created-by-me-remote", "local", "vertical"] }});
 const fallbackMarketplaces = response.message.result?.marketplaces || [];
+const localFallbackMarketplaces = api.localFallback().marketplaces || [];
+const remoteUnavailable = api.remoteCatalogUnavailable();
 api.reset();
-const chatGpt = api.patchRequestParams("list-plugins", {{ marketplaceKinds: ["created-by-me-remote", "vertical"] }});
+const chatGpt = api.patchRequestParams("list-plugins", {{ marketplaceKinds: ["created-by-me-remote"] }});
 const cases = {{
   initialKinds: initial.marketplaceKinds,
   searchKinds: searchMessage.request.params.marketplaceKinds,
-  searchCwds: searchMessage.request.params.cwds,
+  searchCwds: searchMessage.request.params.cwds ?? null,
+  searchRemoteOnly: api.requestProfile({{ marketplaceKinds: ["created-by-me-remote"] }}).remoteOnly,
   responsePatched,
   responseHasError: Object.prototype.hasOwnProperty.call(response.message, "error"),
   fallbackMarketplaceNames: fallbackMarketplaces.map((marketplace) => marketplace.name),
   fallbackPluginNames: fallbackMarketplaces.flatMap((marketplace) => marketplace.plugins || []).map((plugin) => plugin.name),
-  remoteUnavailable: subsequent.marketplaceKinds.includes("created-by-me-remote") === false,
+  fallbackFeaturedPluginIds: response.message.result?.featuredPluginIds || [],
+  fallbackMarketplaceLoadErrors: response.message.result?.marketplaceLoadErrors || [],
+  remoteUnavailable,
   subsequentKinds: subsequent.marketplaceKinds,
-  subsequentCwds: subsequent.cwds,
+  subsequentCwds: subsequent.cwds ?? null,
+  generalAfterFallbackKinds: generalAfterFallback.marketplaceKinds,
+  generalAfterFallbackCwds: generalAfterFallback.cwds,
+  localFallbackMarketplaceNames: localFallbackMarketplaces.map((marketplace) => marketplace.name),
+  localFallbackPluginNames: localFallbackMarketplaces.flatMap((marketplace) => marketplace.plugins || []).map((plugin) => plugin.name),
   chatGptKinds: chatGpt.marketplaceKinds,
   unrelatedErrorMatched: api.remoteAuthError({{ message: "network unavailable" }}),
 }};

--- a/crates/codex-plus-core/tests/upstream_theme_assets.rs
+++ b/crates/codex-plus-core/tests/upstream_theme_assets.rs
@@ -27,7 +27,7 @@ fn bundled_target_renderers_and_styles_remain_byte_exact() {
         ),
         (
             "assets/inject/upstream/dream-skin/macos/renderer-inject.js",
-            "806D23E953CE356DA621E164467141E7CA8B28235562F4252386FDABF952A5B5",
+            "6DA5B029E4AC061759B3F8407EB7CB426411F04E617872D91CF384562512952E",
         ),
         (
             "assets/inject/upstream/dream-skin/macos/dream-skin.css",
@@ -43,7 +43,7 @@ fn bundled_target_renderers_and_styles_remain_byte_exact() {
         ),
         (
             "assets/inject/upstream/cidala-tiger/macos/renderer-inject.js",
-            "09F5BF89BFD8DA90E0E3FD74CA840AD417B63BDF6E5DFDBCB720FD1A6B1FF54E",
+            "FEE13448B276B8100865D3782342AC674759B755CDD27B002482C977B7311186",
         ),
         (
             "assets/inject/upstream/cidala-tiger/macos/dream-skin.css",


### PR DESCRIPTION
## Summary

- preserve `local` / `vertical` plugin catalogs and the last valid `cwds` for normal marketplace requests
- detect `created-by-me-remote` and `shared-with-me` as dedicated remote-only queries instead of mixing local plugins into them
- recover API-key sessions from the remote catalog authentication error by returning an empty remote-only result while keeping the normal local catalog available
- remember remote catalog unavailability and remove remote-only kinds from later mixed/general requests
- carry the request profile through the client, fetch, and MCP bridge response paths
- add a Node-backed regression harness covering request expansion, CWD restoration, remote auth fallback, local fallback, and ChatGPT-compatible request semantics

## Why

Current Codex Desktop plugin search issues a dedicated `created-by-me-remote` `plugin/list` request. API-key authentication cannot access that catalog, so app-server returns:

```text
chatgpt authentication required for remote plugin catalog; api key auth is not supported
```

The previous Codex++ request adapter only added `local` when `marketplaceKinds` was absent, so this error surfaced as a marketplace search failure.

A local fallback must also remain isolated from the dedicated remote query. If local plugins are returned as `created-by-me-remote` results, the current Codex frontend treats them as remote plugins and throws because they do not have `remotePluginId`.

This change keeps remote-only results empty on API-key auth failure while the normal local/vertical query continues to supply searchable local plugins.

## Verification

- `node --check assets/inject/renderer-inject.js`
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `cargo test -p codex-plus-core --test cdp_bridge -- --test-threads=1` — 89 passed

Runtime verification on Windows with Codex Desktop `26.721.4979.0` confirmed:

- the normal request returns five local marketplaces through `marketplaceKinds: ["local", "vertical"]`
- the dedicated request remains `marketplaceKinds: ["created-by-me-remote"]` with `remoteOnly: true`
- the API-key authentication error is converted to an empty remote-only result with `mergeLocal: false`
- searches with matching and non-matching text both render normally
- no `missing remotePluginId` or React error-boundary failure is produced

## Scope

This PR is intentionally separate from #1660 and contains no Fast/service-tier changes. It only updates:

- `assets/inject/renderer-inject.js`
- `crates/codex-plus-core/tests/cdp_bridge.rs`
