### PR TITLE
fix: align portrait composer companions by rendered height

### DIFF
--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -3995,11 +3995,11 @@ function DreamSkinScreen({
                     <Input
                       disabled={!companionDataUrl}
                       inputMode="numeric"
-                      max={48}
-                      min={-48}
+                      max={160}
+                      min={-160}
                       type="number"
                       value={companion?.offsetY ?? 4}
-                      onChange={(event) => updateCompanion({ offsetY: Math.max(-48, Math.min(48, Number(event.currentTarget.value) || 0)) })}
+                      onChange={(event) => updateCompanion({ offsetY: Math.max(-160, Math.min(160, Number(event.currentTarget.value) || 0)) })}
                     />
                   </Field>
                 </div>

--- a/apps/codex-plus-manager/src/dream-skin.test.ts
+++ b/apps/codex-plus-manager/src/dream-skin.test.ts
@@ -102,6 +102,20 @@ describe("dream skin theme helpers", () => {
     assert.match(renderer, /ensureDreamSkinCompanion\(\s*window\.__CODEX_PLUS_DREAM_SKIN_THEME__/);
   });
 
+  it("aligns tall companion images by rendered height with a wider vertical offset range", async () => {
+    const renderer = await readFile(new URL("../../../assets/inject/renderer-inject.js", import.meta.url), "utf8");
+    const app = await readFile(new URL("./App.tsx", import.meta.url), "utf8");
+
+    assert.match(renderer, /companion\.naturalWidth/);
+    assert.match(renderer, /companion\.naturalHeight/);
+    assert.match(renderer, /composer\.rect\.bottom - renderedHeight \+ config\.offsetY/);
+    assert.match(renderer, /window\.innerHeight - renderedHeight - edge/);
+    assert.match(renderer, /const offsetY = Math\.max\(-160, Math\.min\(Number\(companion\.offsetY\) \|\| 0, 160\)\)/);
+    assert.match(app, /min=\{-160\}/);
+    assert.match(app, /max=\{160\}/);
+    assert.match(app, /Math\.max\(-160, Math\.min\(160, Number\(event\.currentTarget\.value\) \|\| 0\)\)/);
+  });
+
   it("keeps the Windows skin active when the sidebar is hidden", async () => {
     const renderer = await readFile(
       new URL("../../../assets/inject/upstream/dream-skin/windows/renderer-inject.js", import.meta.url),

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -1651,7 +1651,7 @@
     const width = Math.max(48, Math.min(Number(companion.width) || 96, 160));
     const side = ["left", "right"].includes(companion.side) ? companion.side : "auto";
     const offsetX = Math.max(-48, Math.min(Number(companion.offsetX) || 0, 48));
-    const offsetY = Math.max(-48, Math.min(Number(companion.offsetY) || 0, 48));
+    const offsetY = Math.max(-160, Math.min(Number(companion.offsetY) || 0, 160));
     return { dataUrl, width, side, offsetX, offsetY };
   }
 
@@ -1689,7 +1689,14 @@
       });
       document.body.appendChild(companion);
     }
-    if (companion.src !== config.dataUrl) companion.src = config.dataUrl;
+    if (companion.src !== config.dataUrl) {
+      companion.onload = () => ensureDreamSkinCompanion(theme);
+      companion.src = config.dataUrl;
+    }
+
+    const renderedHeight = companion.naturalWidth > 0 && companion.naturalHeight > 0
+      ? Math.min(160, config.width * companion.naturalHeight / companion.naturalWidth)
+      : config.width;
 
     const gap = 12;
     const edge = 8;
@@ -1711,8 +1718,8 @@
     const top = Math.max(
       edge,
       Math.min(
-        composer.rect.bottom - config.width + config.offsetY,
-        window.innerHeight - config.width - edge,
+        composer.rect.bottom - renderedHeight + config.offsetY,
+        window.innerHeight - renderedHeight - edge,
       ),
     );
     companion.style.width = `${config.width}px`;


### PR DESCRIPTION
## Problem

Tall companion images were positioned with the configured width as if it were their rendered height. A 96 px wide portrait image rendered at about 140 px tall, so it appeared roughly 44 px too low. The manager and renderer also clamped vertical offset to -48..48, which was insufficient to compensate.

## Changes

- position companion images using the natural aspect ratio and rendered height
- reposition after the image load event so natural dimensions are available
- clamp against the viewport using rendered height
- expand vertical offset from -48..48 to -160..160 in both manager and runtime
- add a regression test for portrait companion alignment and range consistency

## Verification

- manager tests: 36 passed, 0 failed
- TypeScript check: passed
- renderer syntax check: passed
- live CDP verification with the current 1520x2212 companion:
  - old top: 912 px
  - corrected top: 868 px
  - rendered height: 139.7 px
  - configured offsetY: -10
- screenshot confirmed the companion no longer sits below the composer