### PR TITLE
feat(manager): add realtime voice relay toggle

### DIFF
--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -81,6 +81,7 @@ import {
   type ModelWindowRow,
 } from "./model-windows";
 import { resolveProviderSyncCompletion } from "./provider-sync-flow";
+import { configHasFeature, setFeatureInConfig } from "./relay-features";
 import {
   defaultDreamSkinTheme,
   defaultDreamSkinColors,
@@ -5723,15 +5724,33 @@ function RelayProfileEditor({
         <Field className="relay-field-goals" label={t("Codex 目标")}>
           <label className="inline-check">
             <input
-              checked={configHasCodexGoalsFeature(profile.configContents)}
+              checked={configHasFeature(profile.configContents, "goals")}
               onChange={(event) =>
                 updateDraft({
-                  configContents: setCodexGoalsFeatureInConfig(profile.configContents, event.currentTarget.checked),
+                  configContents: setFeatureInConfig(profile.configContents, "goals", event.currentTarget.checked),
                 })
               }
               type="checkbox"
             />
             <span>{t("启用目标功能")}</span>
+          </label>
+        </Field>
+        <Field className="relay-field-voice" label={t("实时语音聊天")}>
+          <label className="inline-check">
+            <input
+              checked={configHasFeature(profile.configContents, "realtime_conversation")}
+              onChange={(event) =>
+                updateDraft({
+                  configContents: setFeatureInConfig(
+                    profile.configContents,
+                    "realtime_conversation",
+                    event.currentTarget.checked,
+                  ),
+                })
+              }
+              type="checkbox"
+            />
+            <span>{t("启用语音聊天")}</span>
           </label>
         </Field>
         <div className="relay-advanced-toggle">
@@ -7283,70 +7302,6 @@ function filterContextEntriesBySelection(entries: CodexContextEntries, selection
   };
 }
 
-function configHasCodexGoalsFeature(configContents: string): boolean {
-  let inFeatures = false;
-  for (const line of configContents.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (/^\[features\]$/.test(trimmed)) {
-      inFeatures = true;
-      continue;
-    }
-    if (inFeatures && /^\[[^\]]+\]$/.test(trimmed)) {
-      inFeatures = false;
-    }
-    if (inFeatures && /^goals\s*=\s*true\b/.test(trimmed)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function setCodexGoalsFeatureInConfig(configContents: string, enabled: boolean): string {
-  const lines = configContents.split(/\r?\n/);
-  const next: string[] = [];
-  let inFeatures = false;
-  let sawFeatures = false;
-  let featuresHasGoals = false;
-
-  const maybeInsertGoals = () => {
-    if (enabled && sawFeatures && !featuresHasGoals) {
-      next.push("goals = true");
-      featuresHasGoals = true;
-    }
-  };
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (/^\[features\]$/.test(trimmed)) {
-      if (inFeatures) maybeInsertGoals();
-      inFeatures = true;
-      sawFeatures = true;
-      featuresHasGoals = false;
-      next.push(line);
-      continue;
-    }
-    if (inFeatures && /^\[[^\]]+\]$/.test(trimmed)) {
-      maybeInsertGoals();
-      inFeatures = false;
-    }
-    if (inFeatures && /^goals\s*=/.test(trimmed)) {
-      if (enabled && !featuresHasGoals) {
-        next.push("goals = true");
-        featuresHasGoals = true;
-      }
-      continue;
-    }
-    next.push(line);
-  }
-
-  if (inFeatures) maybeInsertGoals();
-  if (enabled && !sawFeatures) {
-    const trimmed = ensureTrailingNewline(next.join("\n").trimEnd());
-    return joinTomlSections([trimmed, "[features]\ngoals = true"]);
-  }
-
-  return ensureTrailingNewline(next.join("\n").trimEnd());
-}
 
 function effectiveRelayConfigPreview(profile: RelayProfile, settings: BackendSettings, contextProfile = profile): string {
   const entries = contextEntriesForProfile(settings, contextProfile);

--- a/apps/codex-plus-manager/src/relay-features.test.ts
+++ b/apps/codex-plus-manager/src/relay-features.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { configHasFeature, setFeatureInConfig } from "./relay-features.ts";
+
+describe("relay feature helpers", () => {
+  it("writes realtime_conversation without overwriting other features", () => {
+    const config = setFeatureInConfig(
+      `model = "gpt-5.6-sol"\n\n[features]\nfast_mode = true\nimage_generation = true\n`,
+      "realtime_conversation",
+      true,
+    );
+
+    assert.match(config, /fast_mode = true/);
+    assert.match(config, /image_generation = true/);
+    assert.match(config, /realtime_conversation = true/);
+    assert.ok(configHasFeature(config, "realtime_conversation"));
+  });
+
+  it("removes only realtime_conversation when disabled", () => {
+    const config = setFeatureInConfig(
+      `[features]\nfast_mode = true\nrealtime_conversation = true\n`,
+      "realtime_conversation",
+      false,
+    );
+
+    assert.match(config, /fast_mode = true/);
+    assert.doesNotMatch(config, /realtime_conversation/);
+    assert.ok(!configHasFeature(config, "realtime_conversation"));
+  });
+
+  it("creates a features table when the profile has none", () => {
+    const config = setFeatureInConfig('model = "gpt-5.6-sol"\n', "realtime_conversation", true);
+
+    assert.match(config, /\[features\]/);
+    assert.match(config, /realtime_conversation = true/);
+  });
+});

--- a/apps/codex-plus-manager/src/relay-features.ts
+++ b/apps/codex-plus-manager/src/relay-features.ts
@@ -1,0 +1,75 @@
+export function configHasFeature(configContents: string, feature: string): boolean {
+  let inFeatures = false;
+  const featurePattern = new RegExp(`^${escapeRegExp(feature)}\\s*=\\s*true\\b`);
+
+  for (const line of configContents.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (/^\[features\]$/.test(trimmed)) {
+      inFeatures = true;
+      continue;
+    }
+    if (inFeatures && /^\[[^\]]+\]$/.test(trimmed)) {
+      inFeatures = false;
+    }
+    if (inFeatures && featurePattern.test(trimmed)) return true;
+  }
+  return false;
+}
+
+export function setFeatureInConfig(configContents: string, feature: string, enabled: boolean): string {
+  const lines = configContents.split(/\r?\n/);
+  const next: string[] = [];
+  const featurePattern = new RegExp(`^${escapeRegExp(feature)}\\s*=`);
+  let inFeatures = false;
+  let sawFeatures = false;
+  let featuresHasFeature = false;
+
+  const maybeInsertFeature = () => {
+    if (enabled && sawFeatures && !featuresHasFeature) {
+      next.push(`${feature} = true`);
+      featuresHasFeature = true;
+    }
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (/^\[features\]$/.test(trimmed)) {
+      if (inFeatures) maybeInsertFeature();
+      inFeatures = true;
+      sawFeatures = true;
+      featuresHasFeature = false;
+      next.push(line);
+      continue;
+    }
+    if (inFeatures && /^\[[^\]]+\]$/.test(trimmed)) {
+      maybeInsertFeature();
+      inFeatures = false;
+    }
+    if (inFeatures && featurePattern.test(trimmed)) {
+      if (enabled && !featuresHasFeature) {
+        next.push(`${feature} = true`);
+        featuresHasFeature = true;
+      }
+      continue;
+    }
+    next.push(line);
+  }
+
+  if (inFeatures) maybeInsertFeature();
+  if (enabled && !sawFeatures) {
+    return joinTomlSections([ensureTrailingNewline(next.join("\n").trimEnd()), `[features]\n${feature} = true`]);
+  }
+  return ensureTrailingNewline(next.join("\n").trimEnd());
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function ensureTrailingNewline(value: string): string {
+  return value.trim() ? `${value}\n` : "";
+}
+
+function joinTomlSections(sections: string[]): string {
+  return ensureTrailingNewline(sections.map((section) => section.trim()).filter(Boolean).join("\n\n"));
+}

--- a/apps/codex-plus-manager/src/styles.css
+++ b/apps/codex-plus-manager/src/styles.css
@@ -1387,6 +1387,10 @@ body {
   grid-column: 1;
 }
 
+.relay-field-voice {
+  grid-column: 1;
+}
+
 .relay-advanced-toggle {
   grid-column: 1;
 }


### PR DESCRIPTION
## Summary
- add a per-relay-profile realtime voice toggle
- persist `realtime_conversation = true` alongside existing feature flags
- share TOML feature handling with the existing Goals toggle

## Testing
- `/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node --experimental-strip-types --test src/relay-features.test.ts`
- `git diff --check`

`npm run check` was not run because this checkout has no installed frontend dependencies (`tsc` is unavailable).