### PR TITLE
Add reconciled token usage bridge

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -317,6 +317,16 @@ impl LaunchHooks for LauncherHooks {
         self.core.apply_active_relay_profile(settings).await
     }
 
+    async fn ensure_protocol_proxy_config(
+        &self,
+        settings: &codex_plus_core::settings::BackendSettings,
+        helper_port: u16,
+    ) -> anyhow::Result<()> {
+        self.core
+            .ensure_protocol_proxy_config(settings, helper_port)
+            .await
+    }
+
     async fn ensure_computer_use_config(
         &self,
         settings: &codex_plus_core::settings::BackendSettings,

--- a/crates/codex-plus-core/src/diagnostic_log.rs
+++ b/crates/codex-plus-core/src/diagnostic_log.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -7,9 +7,10 @@ use serde::Serialize;
 use serde_json::{Value, json};
 
 static TEST_LOG_PATH: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+static DIAGNOSTIC_LOG_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
-const MAX_DIAGNOSTIC_LOG_BYTES: u64 = 50 * 1024 * 1024;
-const COMPACTED_DIAGNOSTIC_LOG_BYTES: u64 = 5 * 1024 * 1024;
+const MAX_DIAGNOSTIC_LOG_BYTES: u64 = 20 * 1024 * 1024;
+const MAX_DIAGNOSTIC_LOG_ARCHIVES: usize = 3;
 
 #[derive(Debug, Clone, Serialize)]
 struct DiagnosticRecord {
@@ -20,6 +21,13 @@ struct DiagnosticRecord {
 }
 
 pub fn append_diagnostic_log(event: &str, detail: impl Serialize) -> std::io::Result<()> {
+    if !should_persist_event(event) {
+        return Ok(());
+    }
+    let _guard = DIAGNOSTIC_LOG_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .map_err(|_| std::io::Error::other("diagnostic log lock poisoned"))?;
     let path = diagnostic_log_path();
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -48,7 +56,7 @@ pub fn append_diagnostic_log(event: &str, detail: impl Serialize) -> std::io::Re
         .to_string()
     });
 
-    compact_diagnostic_log_if_needed(&path)?;
+    rotate_diagnostic_log(&path, MAX_DIAGNOSTIC_LOG_BYTES, MAX_DIAGNOSTIC_LOG_ARCHIVES)?;
     let mut file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
@@ -58,8 +66,16 @@ pub fn append_diagnostic_log(event: &str, detail: impl Serialize) -> std::io::Re
 }
 
 pub fn clear_diagnostic_log() -> std::io::Result<()> {
+    let _guard = DIAGNOSTIC_LOG_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .map_err(|_| std::io::Error::other("diagnostic log lock poisoned"))?;
     let path = diagnostic_log_path();
-    clear_diagnostic_log_path(&path)
+    clear_diagnostic_log_path(&path)?;
+    for index in 1..=MAX_DIAGNOSTIC_LOG_ARCHIVES {
+        clear_diagnostic_log_path(&diagnostic_log_archive_path(&path, index))?;
+    }
+    Ok(())
 }
 
 fn clear_diagnostic_log_path(path: &Path) -> std::io::Result<()> {
@@ -94,41 +110,44 @@ fn now_ms() -> u64 {
         .as_millis() as u64
 }
 
-fn compact_diagnostic_log_if_needed(path: &PathBuf) -> std::io::Result<()> {
-    compact_diagnostic_log(
-        path,
-        MAX_DIAGNOSTIC_LOG_BYTES,
-        COMPACTED_DIAGNOSTIC_LOG_BYTES,
+fn should_persist_event(event: &str) -> bool {
+    !matches!(
+        event,
+        "bridge.request" | "bridge.response" | "bridge.resolve_start" | "bridge.resolve_ok"
     )
 }
 
-fn compact_diagnostic_log(
-    path: &PathBuf,
-    max_bytes: u64,
-    compacted_bytes: u64,
-) -> std::io::Result<()> {
+fn rotate_diagnostic_log(path: &Path, max_bytes: u64, archives: usize) -> std::io::Result<()> {
     let len = match std::fs::metadata(path) {
         Ok(metadata) => metadata.len(),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
         Err(error) => return Err(error),
     };
-    if len <= max_bytes {
+    if len < max_bytes {
         return Ok(());
     }
 
-    let keep = compacted_bytes.min(len);
-    let mut file = std::fs::File::open(path)?;
-    file.seek(SeekFrom::Start(len - keep))?;
-    let mut tail = Vec::with_capacity(keep as usize);
-    file.read_to_end(&mut tail)?;
-    drop(file);
-    if len > keep {
-        if let Some(pos) = tail.iter().position(|byte| *byte == b'\n') {
-            tail.drain(..=pos);
+    for index in (1..=archives).rev() {
+        let destination = diagnostic_log_archive_path(path, index);
+        if destination.exists() {
+            std::fs::remove_file(&destination)?;
+        }
+        let source = if index == 1 {
+            path.to_path_buf()
+        } else {
+            diagnostic_log_archive_path(path, index - 1)
+        };
+        if source.exists() {
+            std::fs::rename(source, destination)?;
         }
     }
+    Ok(())
+}
 
-    crate::settings::atomic_write(path, &tail).map_err(std::io::Error::other)
+fn diagnostic_log_archive_path(path: &Path, index: usize) -> PathBuf {
+    let mut name = path.as_os_str().to_os_string();
+    name.push(format!(".{index}"));
+    PathBuf::from(name)
 }
 
 #[cfg(test)]
@@ -136,15 +155,43 @@ mod tests {
     use super::*;
 
     #[test]
-    fn compact_diagnostic_log_keeps_tail_and_drops_partial_first_line() {
+    fn rotate_diagnostic_log_renames_files_and_keeps_three_archives() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("codex-plus.log");
-        std::fs::write(&path, "line-1\nline-2\nline-3\nline-4\n").unwrap();
+        for index in 1..=4 {
+            std::fs::write(&path, format!("line-{index}\n")).unwrap();
+            rotate_diagnostic_log(&path, 1, 3).unwrap();
+        }
 
-        compact_diagnostic_log(&path, 12, 16).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(format!("{}.1", path.display())).unwrap(),
+            "line-4\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(format!("{}.2", path.display())).unwrap(),
+            "line-3\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(format!("{}.3", path.display())).unwrap(),
+            "line-2\n"
+        );
+        assert!(!std::path::Path::new(&format!("{}.4", path.display())).exists());
+    }
 
-        let contents = std::fs::read_to_string(path).unwrap();
-        assert_eq!(contents, "line-3\nline-4\n");
+    #[test]
+    fn high_frequency_success_events_are_not_persisted() {
+        for event in [
+            "bridge.request",
+            "bridge.response",
+            "bridge.resolve_start",
+            "bridge.resolve_ok",
+        ] {
+            assert!(!should_persist_event(event));
+        }
+        assert!(should_persist_event("bridge.resolve_failed"));
+        assert!(should_persist_event(
+            "protocol_proxy.usage_ledger_write_failed"
+        ));
     }
 
     #[test]

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -5,7 +5,7 @@ use std::pin::Pin;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
 use async_trait::async_trait;
@@ -24,6 +24,8 @@ const POST_LAUNCH_COMPUTER_USE_GUARD_SECONDS: &[u64] = &[0, 5, 15, 30, 60, 120, 
 const POST_LAUNCH_COMPUTER_USE_GUARD_STABLE_ATTEMPTS: usize = 3;
 static PET_OVERLAY_SYNC_FAILED: AtomicBool = AtomicBool::new(false);
 static PET_CURSOR_DRIVER_FAILED: AtomicBool = AtomicBool::new(false);
+const PROTOCOL_PROXY_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+const PROTOCOL_PROXY_STREAM_MAX_DURATION: Duration = Duration::from_secs(6 * 60 * 60);
 
 /// Asynchronous callback used by the bridge watchdog to restore a launcher-specific bridge.
 ///
@@ -147,6 +149,13 @@ pub trait LaunchHooks: Send + Sync {
     async fn apply_active_relay_profile(&self, _settings: &BackendSettings) -> anyhow::Result<()> {
         Ok(())
     }
+    async fn ensure_protocol_proxy_config(
+        &self,
+        _settings: &BackendSettings,
+        _helper_port: u16,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
     async fn ensure_computer_use_config(&self, _settings: &BackendSettings) -> anyhow::Result<()> {
         Ok(())
     }
@@ -266,7 +275,7 @@ where
 {
     let hooks = hooks.into_launch_hooks();
     let debug_port = hooks.select_debug_port(options.debug_port);
-    let mut helper_port = hooks.select_helper_port(options.helper_port);
+    let helper_port = hooks.select_helper_port(options.helper_port);
     let settings = hooks.load_settings().await?;
     let app_dir = hooks.resolve_app_dir(options.app_dir.as_deref(), &settings)?;
     let status_store = options.status_store.clone();
@@ -323,7 +332,9 @@ where
         }
         let protocol_proxy_enabled = relay_protocol_proxy_enabled(&settings);
         if protocol_proxy_enabled {
-            helper_port = crate::protocol_proxy::DEFAULT_PROTOCOL_PROXY_PORT;
+            hooks
+                .ensure_protocol_proxy_config(&settings, helper_port)
+                .await?;
         }
         if settings.enhancements_enabled || protocol_proxy_enabled {
             hooks.start_helper(helper_port).await?;
@@ -576,6 +587,20 @@ impl LaunchHooks for DefaultLaunchHooks {
             &common_config,
             settings.computer_use_guard_enabled,
         )?;
+        Ok(())
+    }
+
+    async fn ensure_protocol_proxy_config(
+        &self,
+        settings: &BackendSettings,
+        helper_port: u16,
+    ) -> anyhow::Result<()> {
+        if !settings.relay_profiles_enabled {
+            return Ok(());
+        }
+        let profile = settings.active_relay_profile();
+        let home = crate::relay_config::default_codex_home_dir();
+        crate::relay_config::ensure_protocol_proxy_config_in_home(&home, &profile, helper_port)?;
         Ok(())
     }
 
@@ -1390,6 +1415,11 @@ async fn handle_protocol_proxy_connection(
     remote_addr_text: Option<String>,
 ) -> anyhow::Result<()> {
     let request_json = serde_json::from_str::<serde_json::Value>(request_body).ok();
+    let fallback_model = request_json
+        .as_ref()
+        .and_then(|value| value.get("model"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("Unknown");
     let upstream = match crate::protocol_proxy::open_responses_proxy_request(
         request_body,
         request_user_agent,
@@ -1398,6 +1428,12 @@ async fn handle_protocol_proxy_connection(
     {
         Ok(upstream) => upstream,
         Err(error) => {
+            persist_protocol_proxy_usage(crate::token_usage::CapturedResponseUsage {
+                model: fallback_model.to_string(),
+                status: "failed".to_string(),
+                usage_missing: true,
+                ..crate::token_usage::CapturedResponseUsage::default()
+            });
             let body = serde_json::to_vec(
                 &serde_json::json!({                     "status": "failed",                     "message": error.to_string()                 }),
             )?;
@@ -1428,6 +1464,11 @@ async fn handle_protocol_proxy_connection(
             &upstream_content_type,
             &upstream_body,
         );
+        persist_protocol_proxy_usage(crate::token_usage::captured_response_usage_from_value(
+            &error,
+            fallback_model,
+            "failed",
+        ));
         let body = serde_json::to_vec(&error)?;
         write_http_response(stream, &status, "application/json; charset=utf-8", &body).await?;
         log_helper_response(
@@ -1440,17 +1481,45 @@ async fn handle_protocol_proxy_connection(
         stream.shutdown().await?;
         return Ok(());
     }
+
     if upstream.is_stream {
-        write_http_stream_headers(stream, "200 OK", "text/event-stream; charset=utf-8").await?;
+        let mut downstream_open =
+            write_http_stream_headers(stream, "200 OK", "text/event-stream; charset=utf-8")
+                .await
+                .is_ok();
+        let tracker_request = request_json.clone().unwrap_or_default();
+        let mut usage_tracker =
+            crate::token_usage::ResponsesSseUsageTracker::with_request(&tracker_request);
+        let stream_started = Instant::now();
         if upstream.wire_api == crate::protocol_proxy::UpstreamWireApi::Responses {
             let mut bytes_stream = upstream.response.bytes_stream();
-            while let Some(chunk) = bytes_stream.next().await {
-                if let Ok(bytes) = chunk {
-                    stream.write_all(&bytes).await?;
-                } else {
+            loop {
+                let remaining =
+                    PROTOCOL_PROXY_STREAM_MAX_DURATION.saturating_sub(stream_started.elapsed());
+                if remaining.is_zero() {
                     break;
                 }
+                let wait = PROTOCOL_PROXY_STREAM_IDLE_TIMEOUT.min(remaining);
+                let Ok(next) = tokio::time::timeout(wait, bytes_stream.next()).await else {
+                    break;
+                };
+                let Some(chunk) = next else {
+                    break;
+                };
+                match chunk {
+                    Ok(bytes) => {
+                        usage_tracker.push_bytes(&bytes);
+                        if downstream_open && stream.write_all(&bytes).await.is_err() {
+                            downstream_open = false;
+                        }
+                        if usage_tracker.is_terminal() {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
             }
+            persist_protocol_proxy_usage(usage_tracker.finish());
             log_helper_response(
                 "helper.protocol_proxy_stream_ok",
                 method,
@@ -1458,7 +1527,9 @@ async fn handle_protocol_proxy_connection(
                 "200 OK",
                 remote_addr_text,
             );
-            stream.shutdown().await?;
+            if downstream_open {
+                let _ = stream.shutdown().await;
+            }
             return Ok(());
         }
         let mut converter = request_json
@@ -1466,13 +1537,30 @@ async fn handle_protocol_proxy_connection(
             .map(crate::protocol_proxy::ChatSseToResponsesConverter::with_request)
             .unwrap_or_default();
         let mut bytes_stream = upstream.response.bytes_stream();
-        let mut stream_failed = false;
-        while let Some(chunk) = bytes_stream.next().await {
+        loop {
+            let remaining =
+                PROTOCOL_PROXY_STREAM_MAX_DURATION.saturating_sub(stream_started.elapsed());
+            if remaining.is_zero() {
+                break;
+            }
+            let wait = PROTOCOL_PROXY_STREAM_IDLE_TIMEOUT.min(remaining);
+            let Ok(next) = tokio::time::timeout(wait, bytes_stream.next()).await else {
+                break;
+            };
+            let Some(chunk) = next else {
+                break;
+            };
             match chunk {
                 Ok(bytes) => {
                     let converted = converter.push_bytes(&bytes);
                     if !converted.is_empty() {
-                        stream.write_all(&converted).await?;
+                        usage_tracker.push_bytes(&converted);
+                        if downstream_open && stream.write_all(&converted).await.is_err() {
+                            downstream_open = false;
+                        }
+                        if usage_tracker.is_terminal() {
+                            break;
+                        }
                     }
                 }
                 Err(error) => {
@@ -1481,19 +1569,23 @@ async fn handle_protocol_proxy_connection(
                         Some("stream_error".to_string()),
                     );
                     if !failed.is_empty() {
-                        stream.write_all(&failed).await?;
+                        usage_tracker.push_bytes(&failed);
+                        if downstream_open {
+                            let _ = stream.write_all(&failed).await;
+                        }
                     }
-                    stream_failed = true;
                     break;
                 }
             }
         }
-        if !stream_failed {
-            let tail = converter.finish();
-            if !tail.is_empty() {
-                stream.write_all(&tail).await?;
+        let tail = converter.finish();
+        if !tail.is_empty() {
+            usage_tracker.push_bytes(&tail);
+            if downstream_open && stream.write_all(&tail).await.is_err() {
+                downstream_open = false;
             }
         }
+        persist_protocol_proxy_usage(usage_tracker.finish());
         log_helper_response(
             "helper.protocol_proxy_stream_ok",
             method,
@@ -1501,11 +1593,20 @@ async fn handle_protocol_proxy_connection(
             "200 OK",
             remote_addr_text,
         );
-        stream.shutdown().await?;
+        if downstream_open {
+            let _ = stream.shutdown().await;
+        }
         return Ok(());
     }
     let upstream_body = upstream.response.bytes().await?;
     if upstream.wire_api == crate::protocol_proxy::UpstreamWireApi::Responses {
+        if let Ok(response_json) = serde_json::from_slice::<serde_json::Value>(&upstream_body) {
+            persist_protocol_proxy_usage(crate::token_usage::captured_response_usage_from_value(
+                &response_json,
+                fallback_model,
+                "completed",
+            ));
+        }
         write_http_response(
             stream,
             "200 OK",
@@ -1533,6 +1634,11 @@ async fn handle_protocol_proxy_connection(
     } else {
         crate::protocol_proxy::chat_completion_to_response(chat_json)?
     };
+    persist_protocol_proxy_usage(crate::token_usage::captured_response_usage_from_value(
+        &response_json,
+        fallback_model,
+        "completed",
+    ));
     let body = serde_json::to_vec(&response_json)?;
     write_http_response(stream, "200 OK", "application/json; charset=utf-8", &body).await?;
     log_helper_response(
@@ -1544,6 +1650,20 @@ async fn handle_protocol_proxy_connection(
     );
     stream.shutdown().await?;
     Ok(())
+}
+
+fn persist_protocol_proxy_usage(captured: crate::token_usage::CapturedResponseUsage) {
+    if let Err(error) = crate::token_usage::append_proxy_usage_record(&captured) {
+        let _ = crate::diagnostic_log::append_diagnostic_log(
+            "protocol_proxy.usage_ledger_write_failed",
+            serde_json::json!({
+                "model": captured.model,
+                "status": captured.status,
+                "usageMissing": captured.usage_missing,
+                "error": error.to_string()
+            }),
+        );
+    }
 }
 async fn handle_audio_transcriptions_proxy_connection(
     stream: &mut tokio::net::TcpStream,

--- a/crates/codex-plus-core/src/lib.rs
+++ b/crates/codex-plus-core/src/lib.rs
@@ -37,6 +37,7 @@ pub mod script_market;
 pub mod settings;
 pub mod status;
 pub mod stepwise;
+pub mod token_usage;
 pub mod update;
 pub mod upstream_worktree;
 pub mod user_scripts;

--- a/crates/codex-plus-core/src/paths.rs
+++ b/crates/codex-plus-core/src/paths.rs
@@ -6,6 +6,7 @@ const SETTINGS_FILE: &str = "settings.json";
 const LATEST_STATUS_FILE: &str = "latest-status.json";
 const DIAGNOSTIC_LOG_FILE: &str = "codex-plus.log";
 const PENDING_PROVIDER_IMPORT_FILE: &str = "pending-provider-import.json";
+const TOKEN_USAGE_PROXY_LEDGER_FILE: &str = "token-usage-responses.jsonl";
 
 pub fn default_app_state_dir() -> PathBuf {
     if let Some(home_dir) = directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf()) {
@@ -32,6 +33,10 @@ pub fn default_diagnostic_log_path() -> PathBuf {
 
 pub fn default_pending_provider_import_path() -> PathBuf {
     default_app_state_dir().join(PENDING_PROVIDER_IMPORT_FILE)
+}
+
+pub fn default_token_usage_proxy_ledger_path() -> PathBuf {
+    default_app_state_dir().join(TOKEN_USAGE_PROXY_LEDGER_FILE)
 }
 
 fn settings_path_for_tests() -> Option<PathBuf> {

--- a/crates/codex-plus-core/src/protocol_proxy.rs
+++ b/crates/codex-plus-core/src/protocol_proxy.rs
@@ -130,6 +130,16 @@ pub fn local_responses_proxy_base_url(port: u16) -> String {
     format!("http://127.0.0.1:{port}/v1")
 }
 
+pub fn is_local_responses_proxy_base_url(value: &str) -> bool {
+    let Ok(url) = reqwest::Url::parse(value.trim()) else {
+        return false;
+    };
+    url.scheme() == "http"
+        && matches!(url.host_str(), Some("127.0.0.1" | "localhost" | "::1"))
+        && url.port().is_some()
+        && url.path().trim_end_matches('/') == "/v1"
+}
+
 pub fn responses_to_chat_completions(body: Value) -> anyhow::Result<Value> {
     let mut result = json!({});
 
@@ -576,6 +586,8 @@ async fn open_responses_proxy_request_with_settings_and_user_agent(
                 );
                 crate::relay_rotation::record_relay_request_failure(&settings);
                 if has_more_candidates {
+                    let _ =
+                        crate::token_usage::append_proxy_retry_attempt(&request_json, attempt + 1);
                     continue;
                 }
                 return Err(error).with_context(|| {
@@ -625,6 +637,7 @@ async fn open_responses_proxy_request_with_settings_and_user_agent(
                 response: upstream,
             });
         }
+        let _ = crate::token_usage::append_proxy_retry_attempt(&request_json, attempt + 1);
         let _ = crate::diagnostic_log::append_diagnostic_log(
             "protocol_proxy.upstream_failover",
             json!({

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -608,6 +608,89 @@ fn codex_base_url_for_protocol(base_url: &str, protocol: RelayProtocol, proxy_po
     }
 }
 
+pub fn ensure_protocol_proxy_config_in_home(
+    home: &Path,
+    profile: &RelayProfile,
+    helper_port: u16,
+) -> anyhow::Result<bool> {
+    let config_path = home.join("config.toml");
+    let existing = std::fs::read_to_string(&config_path).unwrap_or_default();
+    if existing.trim().is_empty() {
+        anyhow::bail!("Codex config.toml 不存在，无法启用协议代理");
+    }
+    let provider_id = parse_toml_document(&profile.config_contents)
+        .ok()
+        .and_then(|document| active_provider_id(&document))
+        .or_else(|| {
+            parse_toml_document(&existing)
+                .ok()
+                .and_then(|document| active_provider_id(&document))
+        })
+        .unwrap_or_else(|| RELAY_PROVIDER.to_string());
+    let local_base_url = crate::protocol_proxy::local_responses_proxy_base_url(helper_port);
+    let (updated, found_provider, changed) =
+        replace_provider_base_url_text(&existing, &provider_id, &local_base_url);
+    if !found_provider {
+        anyhow::bail!("config.toml 中未找到当前模型供应商 {provider_id}");
+    }
+    if changed {
+        crate::settings::atomic_write(&config_path, updated.as_bytes())?;
+    }
+    Ok(changed)
+}
+
+fn replace_provider_base_url_text(
+    config: &str,
+    provider_id: &str,
+    base_url: &str,
+) -> (String, bool, bool) {
+    let target_plain = format!("[model_providers.{provider_id}]");
+    let target_quoted = format!("[model_providers.\"{provider_id}\"]");
+    let mut output = Vec::new();
+    let mut in_target = false;
+    let mut found_provider = false;
+    let mut replaced = false;
+    let mut modified = false;
+
+    for line in config.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            if in_target && !replaced {
+                output.push(format!("base_url = \"{base_url}\""));
+                replaced = true;
+                modified = true;
+            }
+            in_target = trimmed == target_plain || trimmed == target_quoted;
+            found_provider |= in_target;
+        }
+        if in_target
+            && trimmed
+                .split_once('=')
+                .is_some_and(|(key, _)| key.trim() == "base_url")
+        {
+            let indent = line.len().saturating_sub(line.trim_start().len());
+            let replacement = format!("{}base_url = \"{base_url}\"", " ".repeat(indent));
+            modified |= line != replacement;
+            output.push(replacement);
+            replaced = true;
+        } else {
+            output.push(line.to_string());
+        }
+    }
+    if in_target && !replaced {
+        output.push(format!("base_url = \"{base_url}\""));
+        modified = true;
+    }
+    let newline = if config.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
+    let mut updated = output.join(newline);
+    updated.push_str(newline);
+    (updated, found_provider, found_provider && modified)
+}
+
 pub fn clear_relay_config_to_home(home: &Path) -> anyhow::Result<RelayApplyResult> {
     clear_relay_config_to_home_with_auth(home, None)
 }
@@ -2001,10 +2084,10 @@ pub fn relay_profile_base_url(profile: &RelayProfile) -> String {
             crate::protocol_proxy::DEFAULT_PROTOCOL_PROXY_PORT,
         );
     }
+    if !profile.upstream_base_url.trim().is_empty() {
+        return profile.upstream_base_url.trim().to_string();
+    }
     if profile.protocol == RelayProtocol::ChatCompletions {
-        if !profile.upstream_base_url.trim().is_empty() {
-            return profile.upstream_base_url.trim().to_string();
-        }
         if let Some(value) = root_key_string(&profile.config_contents, CHAT_UPSTREAM_BASE_URL_KEY)
             .filter(|value| !value.trim().is_empty())
         {
@@ -2017,13 +2100,15 @@ pub fn relay_profile_base_url(profile: &RelayProfile) -> String {
     let provider_base_url = provider_string_from_config(&profile.config_contents, "base_url")
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_default();
-    if profile.protocol == RelayProtocol::ChatCompletions
-        && provider_base_url
-            == crate::protocol_proxy::local_responses_proxy_base_url(
-                crate::protocol_proxy::DEFAULT_PROTOCOL_PROXY_PORT,
-            )
-    {
-        String::new()
+    if crate::protocol_proxy::is_local_responses_proxy_base_url(&provider_base_url) {
+        let saved_base_url = profile.base_url.trim();
+        if saved_base_url.is_empty()
+            || crate::protocol_proxy::is_local_responses_proxy_base_url(saved_base_url)
+        {
+            String::new()
+        } else {
+            saved_base_url.to_string()
+        }
     } else if !provider_base_url.is_empty() {
         provider_base_url
     } else {

--- a/crates/codex-plus-core/src/routes.rs
+++ b/crates/codex-plus-core/src/routes.rs
@@ -175,6 +175,7 @@ pub async fn handle_bridge_request(
         "/manager/open" => ctx.runtime.open_manager().await,
         "/backend/status" => ctx.runtime.backend_status().await,
         "/codex-model-catalog" | "/codex-config-model" => ctx.runtime.codex_model_catalog().await,
+        "/token-usage/events" => crate::token_usage::events_value(payload.clone()),
         "/diagnostics/log" => diagnostic_log_value(payload.clone()),
         "/ads" => ctx.runtime.ads().await,
         "/zed-remote/status" => ctx.runtime.zed_remote_status().await,

--- a/crates/codex-plus-core/src/settings.rs
+++ b/crates/codex-plus-core/src/settings.rs
@@ -658,8 +658,16 @@ impl BackendSettings {
     }
 
     pub fn active_relay_uses_protocol_proxy(&self) -> bool {
-        self.active_aggregate_relay_profile().is_some()
-            || self.active_relay_profile().protocol == RelayProtocol::ChatCompletions
+        if self.active_aggregate_relay_profile().is_some() {
+            return true;
+        }
+        let relay = self.active_relay_profile();
+        let relay_mode_uses_api =
+            relay.relay_mode != RelayMode::Official || relay.official_mix_api_key;
+        relay_mode_uses_api
+            && !crate::relay_config::relay_profile_base_url(&relay)
+                .trim()
+                .is_empty()
     }
 }
 

--- a/crates/codex-plus-core/src/token_usage.rs
+++ b/crates/codex-plus-core/src/token_usage.rs
@@ -1,0 +1,1475 @@
+use std::collections::{HashMap, HashSet};
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UsageCounts {
+    pub input: u64,
+    pub cached_input: u64,
+    pub cache_write: u64,
+    pub output: u64,
+    pub reasoning: u64,
+    pub total: u64,
+}
+
+impl UsageCounts {
+    pub fn has_tokens(&self) -> bool {
+        self.input > 0
+            || self.cached_input > 0
+            || self.cache_write > 0
+            || self.output > 0
+            || self.reasoning > 0
+            || self.total > 0
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CapturedResponseUsage {
+    pub response_id: String,
+    pub model: String,
+    pub status: String,
+    pub usage: UsageCounts,
+    pub usage_missing: bool,
+}
+
+pub struct ResponsesSseUsageTracker {
+    buffer: String,
+    utf8_remainder: Vec<u8>,
+    fallback: CapturedResponseUsage,
+    terminal: Option<CapturedResponseUsage>,
+}
+
+impl ResponsesSseUsageTracker {
+    pub fn with_request(request: &Value) -> Self {
+        Self {
+            buffer: String::new(),
+            utf8_remainder: Vec::new(),
+            fallback: CapturedResponseUsage {
+                model: request
+                    .get("model")
+                    .and_then(Value::as_str)
+                    .unwrap_or("Unknown")
+                    .to_string(),
+                status: "incomplete".to_string(),
+                usage_missing: true,
+                ..CapturedResponseUsage::default()
+            },
+            terminal: None,
+        }
+    }
+
+    pub fn push_bytes(&mut self, bytes: &[u8]) {
+        append_utf8_safe(&mut self.buffer, &mut self.utf8_remainder, bytes);
+        while let Some(block) = take_sse_block(&mut self.buffer) {
+            self.handle_block(&block);
+        }
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        self.terminal.is_some()
+    }
+
+    pub fn finish(&mut self) -> CapturedResponseUsage {
+        if !self.utf8_remainder.is_empty() {
+            self.buffer
+                .push_str(&String::from_utf8_lossy(&self.utf8_remainder));
+            self.utf8_remainder.clear();
+        }
+        if !self.buffer.trim().is_empty() {
+            let block = std::mem::take(&mut self.buffer);
+            self.handle_block(&block);
+        }
+        self.terminal
+            .take()
+            .unwrap_or_else(|| self.fallback.clone())
+    }
+
+    fn handle_block(&mut self, block: &str) {
+        let mut event_name = String::new();
+        let mut data_parts = Vec::new();
+        for line in block.lines() {
+            if let Some(event) = strip_sse_field(line, "event") {
+                event_name = event.trim().to_string();
+            }
+            if let Some(data) = strip_sse_field(line, "data") {
+                data_parts.push(data.to_string());
+            }
+        }
+        if data_parts.is_empty() {
+            return;
+        }
+        let data = data_parts.join("\n");
+        if data.trim() == "[DONE]" {
+            return;
+        }
+        let Ok(value) = serde_json::from_str::<Value>(&data) else {
+            return;
+        };
+        self.remember_response_metadata(&value);
+        let event_type = value
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or(event_name.as_str());
+        let status = if event_type.ends_with(".completed") {
+            "completed"
+        } else if event_type.ends_with(".failed") || event_type == "error" {
+            "failed"
+        } else if event_type.ends_with(".incomplete") {
+            "incomplete"
+        } else {
+            return;
+        };
+        self.terminal = Some(captured_response_usage_from_value(
+            &value,
+            &self.fallback.model,
+            status,
+        ));
+    }
+
+    fn remember_response_metadata(&mut self, value: &Value) {
+        let response = value.get("response").unwrap_or(value);
+        if let Some(id) = response
+            .get("id")
+            .or_else(|| value.get("response_id"))
+            .and_then(Value::as_str)
+            .filter(|id| !id.trim().is_empty())
+        {
+            self.fallback.response_id = id.to_string();
+        }
+        if let Some(model) = response
+            .get("model")
+            .or_else(|| value.get("model"))
+            .and_then(Value::as_str)
+            .filter(|model| !model.trim().is_empty())
+        {
+            self.fallback.model = model.to_string();
+        }
+        if let Some(status) = response
+            .get("status")
+            .or_else(|| value.get("status"))
+            .and_then(Value::as_str)
+            .filter(|status| !status.trim().is_empty())
+        {
+            self.fallback.status = status.to_string();
+        }
+    }
+}
+
+fn take_sse_block(buffer: &mut String) -> Option<String> {
+    let lf = buffer.find("\n\n").map(|index| (index, 2));
+    let crlf = buffer.find("\r\n\r\n").map(|index| (index, 4));
+    let (index, delimiter_len) = match (lf, crlf) {
+        (Some(left), Some(right)) => left.min(right),
+        (Some(value), None) | (None, Some(value)) => value,
+        (None, None) => return None,
+    };
+    let block = buffer[..index].to_string();
+    buffer.drain(..index + delimiter_len);
+    Some(block)
+}
+
+fn append_utf8_safe(buffer: &mut String, remainder: &mut Vec<u8>, bytes: &[u8]) {
+    if bytes.is_empty() {
+        return;
+    }
+    let mut combined = std::mem::take(remainder);
+    combined.extend_from_slice(bytes);
+    match std::str::from_utf8(&combined) {
+        Ok(text) => buffer.push_str(text),
+        Err(error) => {
+            let valid = error.valid_up_to();
+            buffer.push_str(std::str::from_utf8(&combined[..valid]).unwrap_or_default());
+            if error.error_len().is_none() {
+                remainder.extend_from_slice(&combined[valid..]);
+            } else {
+                buffer.push_str(&String::from_utf8_lossy(&combined[valid..]));
+            }
+        }
+    }
+}
+
+fn strip_sse_field<'a>(line: &'a str, field: &str) -> Option<&'a str> {
+    let rest = line.strip_prefix(field)?.strip_prefix(':')?;
+    Some(rest.strip_prefix(' ').unwrap_or(rest))
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RolloutEvent {
+    pub id: String,
+    pub session_id: String,
+    pub timestamp: String,
+    pub model: String,
+    pub usage: UsageCounts,
+    pub totals: UsageCounts,
+    #[serde(default)]
+    pub source: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub usage_missing: bool,
+    #[serde(default)]
+    pub timestamp_ms: u64,
+    #[serde(default)]
+    pub response_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct TokenUsageQuery {
+    pub since: String,
+    pub days: u64,
+    pub limit: usize,
+    pub proxy_since_ms: u64,
+    pub proxy_offset: u64,
+    pub proxy_generation: String,
+    pub include_rollout: bool,
+    pub rollout_incremental: bool,
+}
+
+impl Default for TokenUsageQuery {
+    fn default() -> Self {
+        Self {
+            since: String::new(),
+            days: 7,
+            limit: 100_000,
+            proxy_since_ms: 0,
+            proxy_offset: 0,
+            proxy_generation: String::new(),
+            include_rollout: true,
+            rollout_incremental: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenUsageResult {
+    pub events: Vec<RolloutEvent>,
+    pub warnings: Vec<String>,
+    pub next_since: String,
+    pub proxy_next_since_ms: u64,
+    pub proxy_enabled_at_ms: u64,
+    pub missing_usage: usize,
+    pub proxy_next_offset: u64,
+    pub proxy_generation: String,
+    pub proxy_reset: bool,
+}
+
+#[derive(Default)]
+pub struct RolloutTailer {
+    files: HashMap<PathBuf, RolloutFileCursor>,
+}
+
+#[derive(Default)]
+struct RolloutFileCursor {
+    offset: u64,
+    observed_len: u64,
+    modified_ms: u64,
+    first_line_hash: String,
+    session_id: String,
+    model: String,
+}
+
+impl RolloutTailer {
+    pub fn reset(&mut self) {
+        self.files.clear();
+    }
+
+    pub fn read_from_roots(
+        &mut self,
+        roots: &[PathBuf],
+        query: &TokenUsageQuery,
+    ) -> TokenUsageResult {
+        let days = query.days.clamp(1, 31);
+        let cutoff = SystemTime::now()
+            .checked_sub(Duration::from_secs(days * 24 * 60 * 60))
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        let mut paths = Vec::new();
+        for root in roots {
+            collect_rollout_paths(root, cutoff, &mut paths);
+        }
+        paths.sort();
+        let active_paths = paths.iter().cloned().collect::<HashSet<_>>();
+        self.files.retain(|path, _| active_paths.contains(path));
+
+        let mut events = Vec::new();
+        let mut warnings = Vec::new();
+        for path in paths {
+            if let Err(error) = self.read_path(&path, &mut events) {
+                let name = path
+                    .file_name()
+                    .and_then(|value| value.to_str())
+                    .unwrap_or("rollout file");
+                warnings.push(format!("{name}: {error}"));
+            }
+        }
+        events.sort_by(|left, right| {
+            left.timestamp_ms
+                .cmp(&right.timestamp_ms)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        let limit = query.limit.clamp(1, 100_000);
+        let events = deduplicate_rollout_events(events)
+            .into_iter()
+            .filter(|event| query.since.is_empty() || event.timestamp > query.since)
+            .take(limit)
+            .collect::<Vec<_>>();
+        let next_since = events
+            .last()
+            .map(|event| event.timestamp.clone())
+            .unwrap_or_else(|| query.since.clone());
+        TokenUsageResult {
+            events,
+            warnings,
+            next_since,
+            proxy_next_since_ms: query.proxy_since_ms,
+            proxy_enabled_at_ms: 0,
+            missing_usage: 0,
+            proxy_next_offset: query.proxy_offset,
+            proxy_generation: query.proxy_generation.clone(),
+            proxy_reset: false,
+        }
+    }
+
+    fn read_path(&mut self, path: &Path, events: &mut Vec<RolloutEvent>) -> std::io::Result<()> {
+        let metadata = fs::metadata(path)?;
+        let len = metadata.len();
+        let modified_ms = metadata
+            .modified()
+            .ok()
+            .and_then(|value| value.duration_since(UNIX_EPOCH).ok())
+            .map(|value| value.as_millis() as u64)
+            .unwrap_or_default();
+        let cursor = self.files.entry(path.to_path_buf()).or_default();
+        if cursor.observed_len == len && cursor.modified_ms == modified_ms {
+            return Ok(());
+        }
+
+        let first_line_hash = rollout_first_line_hash(path)?;
+        if cursor.offset > len
+            || (!cursor.first_line_hash.is_empty() && cursor.first_line_hash != first_line_hash)
+        {
+            *cursor = RolloutFileCursor::default();
+        }
+        cursor.first_line_hash = first_line_hash;
+
+        let mut file = File::open(path)?;
+        file.seek(SeekFrom::Start(cursor.offset))?;
+        let mut reader = BufReader::new(file);
+        let mut next_offset = cursor.offset;
+        loop {
+            let mut line = String::new();
+            let bytes = reader.read_line(&mut line)?;
+            if bytes == 0 || !line.ends_with('\n') {
+                break;
+            }
+            next_offset = next_offset.saturating_add(bytes as u64);
+            parse_rollout_line(&line, &mut cursor.session_id, &mut cursor.model, events);
+        }
+        cursor.offset = next_offset;
+        cursor.observed_len = len;
+        cursor.modified_ms = modified_ms;
+        Ok(())
+    }
+}
+
+fn rollout_first_line_hash(path: &Path) -> std::io::Result<String> {
+    let file = File::open(path)?;
+    let mut first_line = String::new();
+    BufReader::new(file).read_line(&mut first_line)?;
+    let mut digest = Sha256::new();
+    digest.update(first_line.as_bytes());
+    Ok(format!("{:x}", digest.finalize()))
+}
+
+const PROXY_ROLLOUT_MATCH_WINDOW_MS: u64 = 5 * 60 * 1_000;
+
+#[derive(Hash, Eq, PartialEq)]
+struct RequestUsageKey {
+    model: String,
+    input: u64,
+    cached_input: u64,
+    output: u64,
+}
+
+fn request_usage_key(event: &RolloutEvent) -> RequestUsageKey {
+    RequestUsageKey {
+        model: event.model.trim().to_ascii_lowercase(),
+        input: event.usage.input,
+        cached_input: event.usage.cached_input,
+        output: event.usage.output,
+    }
+}
+
+fn remove_rollouts_captured_by_proxy(
+    rollout_events: &mut Vec<RolloutEvent>,
+    proxy_events: &[RolloutEvent],
+) {
+    let mut rollout_by_usage = HashMap::<RequestUsageKey, Vec<usize>>::new();
+    for (index, event) in rollout_events.iter().enumerate() {
+        if event.timestamp_ms == 0 || !event.usage.has_tokens() {
+            continue;
+        }
+        rollout_by_usage
+            .entry(request_usage_key(event))
+            .or_default()
+            .push(index);
+    }
+
+    let mut matched_rollouts = HashSet::new();
+    for proxy in proxy_events {
+        if proxy.timestamp_ms == 0 || proxy.usage_missing || !proxy.usage.has_tokens() {
+            continue;
+        }
+        let key = request_usage_key(proxy);
+        let exact_candidates = rollout_by_usage
+            .get(&key)
+            .into_iter()
+            .flatten()
+            .copied()
+            .filter(|index| !matched_rollouts.contains(index))
+            .filter_map(|index| {
+                let delta = rollout_events[index]
+                    .timestamp_ms
+                    .abs_diff(proxy.timestamp_ms);
+                (delta <= PROXY_ROLLOUT_MATCH_WINDOW_MS).then_some((index, delta))
+            })
+            .collect::<Vec<_>>();
+        let nearest = if exact_candidates.is_empty() {
+            let renamed_candidates = rollout_events
+                .iter()
+                .enumerate()
+                .filter(|(index, event)| {
+                    !matched_rollouts.contains(index)
+                        && event.usage.input == proxy.usage.input
+                        && event.usage.cached_input == proxy.usage.cached_input
+                        && event.usage.output == proxy.usage.output
+                })
+                .filter_map(|(index, event)| {
+                    let delta = event.timestamp_ms.abs_diff(proxy.timestamp_ms);
+                    (delta <= PROXY_ROLLOUT_MATCH_WINDOW_MS).then_some((index, delta))
+                })
+                .collect::<Vec<_>>();
+            (renamed_candidates.len() == 1).then(|| renamed_candidates[0].0)
+        } else {
+            exact_candidates
+                .into_iter()
+                .min_by_key(|(_, delta)| *delta)
+                .map(|(index, _)| index)
+        };
+        if let Some(index) = nearest {
+            matched_rollouts.insert(index);
+        }
+    }
+
+    let mut index = 0;
+    rollout_events.retain(|_| {
+        let keep = !matched_rollouts.contains(&index);
+        index += 1;
+        keep
+    });
+}
+
+#[derive(Hash, Eq, PartialEq)]
+enum EventKey {
+    Watermark {
+        session_id: String,
+        input: u64,
+        cached_input: u64,
+        cache_write: u64,
+        output: u64,
+        reasoning: u64,
+        total: u64,
+    },
+    EventId(String),
+}
+
+fn event_key(event: &RolloutEvent) -> EventKey {
+    if !event.session_id.is_empty() && event.totals.has_tokens() {
+        return EventKey::Watermark {
+            session_id: event.session_id.clone(),
+            input: event.totals.input,
+            cached_input: event.totals.cached_input,
+            cache_write: event.totals.cache_write,
+            output: event.totals.output,
+            reasoning: event.totals.reasoning,
+            total: event.totals.total,
+        };
+    }
+    EventKey::EventId(event.id.clone())
+}
+
+fn model_is_unknown(model: &str) -> bool {
+    model.trim().is_empty() || model.eq_ignore_ascii_case("unknown")
+}
+
+pub fn deduplicate_rollout_events(events: Vec<RolloutEvent>) -> Vec<RolloutEvent> {
+    let mut indexes = HashMap::new();
+    let mut deduplicated = Vec::with_capacity(events.len());
+
+    for event in events {
+        let key = event_key(&event);
+        if let Some(index) = indexes.get(&key).copied() {
+            let existing: &mut RolloutEvent = &mut deduplicated[index];
+            if model_is_unknown(&existing.model) && !model_is_unknown(&event.model) {
+                *existing = event;
+            }
+            continue;
+        }
+        indexes.insert(key, deduplicated.len());
+        deduplicated.push(event);
+    }
+
+    deduplicated
+}
+
+pub fn read_rollout_events(query: &TokenUsageQuery) -> TokenUsageResult {
+    let codex_home = crate::codex_home::default_codex_home_dir();
+    read_rollout_events_from_roots(
+        &[
+            codex_home.join("sessions"),
+            codex_home.join("archived_sessions"),
+        ],
+        query,
+    )
+}
+
+pub fn read_rollout_events_from_roots(
+    roots: &[PathBuf],
+    query: &TokenUsageQuery,
+) -> TokenUsageResult {
+    let days = query.days.clamp(1, 31);
+    let cutoff = SystemTime::now()
+        .checked_sub(Duration::from_secs(days * 24 * 60 * 60))
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+    let mut paths = Vec::new();
+    for root in roots {
+        collect_rollout_paths(root, cutoff, &mut paths);
+    }
+    paths.sort();
+
+    let mut events = Vec::new();
+    let mut warnings = Vec::new();
+    for path in paths {
+        if let Err(error) = parse_rollout(&path, &mut events) {
+            let name = path
+                .file_name()
+                .and_then(|value| value.to_str())
+                .unwrap_or("rollout file");
+            warnings.push(format!("{name}: {error}"));
+        }
+    }
+    events.sort_by(|left, right| {
+        left.timestamp
+            .cmp(&right.timestamp)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    let deduplicated = deduplicate_rollout_events(events);
+    let limit = query.limit.clamp(1, 100_000);
+    let events = deduplicated
+        .into_iter()
+        .filter(|event| query.since.is_empty() || event.timestamp > query.since)
+        .take(limit)
+        .collect::<Vec<_>>();
+    let next_since = events
+        .last()
+        .map(|event| event.timestamp.clone())
+        .unwrap_or_else(|| query.since.clone());
+
+    TokenUsageResult {
+        events,
+        warnings,
+        next_since,
+        proxy_next_since_ms: query.proxy_since_ms,
+        proxy_enabled_at_ms: 0,
+        missing_usage: 0,
+        proxy_next_offset: 0,
+        proxy_generation: String::new(),
+        proxy_reset: false,
+    }
+}
+
+fn collect_rollout_paths(root: &Path, cutoff: SystemTime, paths: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rollout_paths(&path, cutoff, paths);
+            continue;
+        }
+        let is_rollout = path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .is_some_and(|name| name.starts_with("rollout-") && name.ends_with(".jsonl"));
+        if !is_rollout {
+            continue;
+        }
+        let recent = entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .map(|modified| modified >= cutoff)
+            .unwrap_or(true);
+        if recent {
+            paths.push(path);
+        }
+    }
+}
+
+fn parse_rollout(path: &Path, events: &mut Vec<RolloutEvent>) -> anyhow::Result<()> {
+    let file = File::open(path)?;
+    let mut session_id = String::new();
+    let mut model = String::new();
+
+    for line in BufReader::new(file).lines() {
+        let line = line?;
+        parse_rollout_line(&line, &mut session_id, &mut model, events);
+    }
+    Ok(())
+}
+
+fn parse_rollout_line(
+    line: &str,
+    session_id: &mut String,
+    model: &mut String,
+    events: &mut Vec<RolloutEvent>,
+) {
+    if !line.contains("token_count")
+        && !line.contains("session_meta")
+        && !line.contains("turn_context")
+    {
+        return;
+    }
+    let Ok(record) = serde_json::from_str::<Value>(line) else {
+        return;
+    };
+    let payload = record.get("payload").unwrap_or(&Value::Null);
+    let record_type = payload
+        .get("type")
+        .and_then(Value::as_str)
+        .or_else(|| record.get("type").and_then(Value::as_str))
+        .unwrap_or_default();
+    match record_type {
+        "session_meta" => *session_id = string_field(payload, &["session_id", "id"]),
+        "turn_context" => {
+            let next_model = string_field(payload, &["model"]);
+            if !next_model.is_empty() {
+                *model = next_model;
+            }
+        }
+        "token_count" => {
+            let info = payload.get("info").unwrap_or(&Value::Null);
+            let usage = usage_counts(
+                info.get("last_token_usage")
+                    .or_else(|| info.get("lastTokenUsage"))
+                    .unwrap_or(&Value::Null),
+            );
+            if !usage.has_tokens() {
+                return;
+            }
+            let totals = usage_counts(
+                info.get("total_token_usage")
+                    .or_else(|| info.get("totalTokenUsage"))
+                    .unwrap_or(&Value::Null),
+            );
+            let timestamp = record
+                .get("timestamp")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let event_model = if model.is_empty() {
+                "Unknown".to_string()
+            } else {
+                model.clone()
+            };
+            let id = stable_event_id(session_id, &timestamp, &usage, &totals);
+            let timestamp_ms = timestamp_to_epoch_ms(&timestamp).unwrap_or_default();
+            events.push(RolloutEvent {
+                id,
+                session_id: session_id.clone(),
+                timestamp,
+                model: event_model,
+                usage,
+                totals,
+                source: "rollout".to_string(),
+                status: "completed".to_string(),
+                usage_missing: false,
+                timestamp_ms,
+                response_id: String::new(),
+            });
+        }
+        _ => {}
+    }
+}
+
+fn usage_counts(value: &Value) -> UsageCounts {
+    let input = number_field(value, &["input_tokens", "inputTokens"]);
+    let output = number_field(value, &["output_tokens", "outputTokens"]);
+    UsageCounts {
+        input,
+        cached_input: number_field(value, &["cached_input_tokens", "cachedInputTokens"]),
+        cache_write: number_field(
+            value,
+            &[
+                "cache_write_input_tokens",
+                "cacheWriteInputTokens",
+                "cache_creation_input_tokens",
+                "cacheCreationInputTokens",
+            ],
+        ),
+        output,
+        reasoning: number_field(value, &["reasoning_output_tokens", "reasoningOutputTokens"]),
+        total: number_field(value, &["total_tokens", "totalTokens"])
+            .max(input.saturating_add(output)),
+    }
+}
+
+fn number_field(value: &Value, names: &[&str]) -> u64 {
+    names
+        .iter()
+        .find_map(|name| value.get(name).and_then(Value::as_u64))
+        .unwrap_or(0)
+}
+
+fn string_field(value: &Value, names: &[&str]) -> String {
+    names
+        .iter()
+        .find_map(|name| value.get(name).and_then(Value::as_str))
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn stable_event_id(
+    session_id: &str,
+    timestamp: &str,
+    usage: &UsageCounts,
+    totals: &UsageCounts,
+) -> String {
+    let mut digest = Sha256::new();
+    if !session_id.is_empty() && totals.has_tokens() {
+        digest.update(b"watermark-v2\0");
+        digest.update(session_id.as_bytes());
+        for value in [
+            totals.input,
+            totals.cached_input,
+            totals.cache_write,
+            totals.output,
+            totals.reasoning,
+            totals.total,
+        ] {
+            digest.update(value.to_le_bytes());
+        }
+    } else {
+        digest.update(b"event-v1\0");
+        digest.update(session_id.as_bytes());
+        digest.update(timestamp.as_bytes());
+        for value in [
+            usage.input,
+            usage.cached_input,
+            usage.cache_write,
+            usage.output,
+            usage.reasoning,
+            usage.total,
+        ] {
+            digest.update(value.to_le_bytes());
+        }
+    }
+    format!("{:x}", digest.finalize())
+}
+
+static PROXY_LEDGER_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+static ROLLOUT_TAILER: OnceLock<Mutex<RolloutTailer>> = OnceLock::new();
+static LEDGER_GENERATION_COUNTER: AtomicU64 = AtomicU64::new(0);
+const LEDGER_HEADER_TYPE: &str = "codex_plus_token_usage_ledger";
+const MAX_PROXY_LEDGER_BYTES: u64 = 20 * 1024 * 1024;
+const MAX_PROXY_LEDGER_ARCHIVES: usize = 3;
+
+pub fn captured_response_usage_from_value(
+    value: &Value,
+    fallback_model: &str,
+    fallback_status: &str,
+) -> CapturedResponseUsage {
+    let response = value.get("response").unwrap_or(value);
+    let usage_value = response.get("usage").or_else(|| value.get("usage"));
+    let usage = usage_value.map(usage_counts_from_api).unwrap_or_default();
+    let response_id = string_field(response, &["id", "response_id", "responseId"]);
+    let response_id = if response_id.is_empty() {
+        string_field(value, &["response_id", "responseId", "id"])
+    } else {
+        response_id
+    };
+    let model = {
+        let response_model = string_field(response, &["model"]);
+        if response_model.is_empty() {
+            let event_model = string_field(value, &["model"]);
+            if event_model.is_empty() {
+                fallback_model.to_string()
+            } else {
+                event_model
+            }
+        } else {
+            response_model
+        }
+    };
+    let status = {
+        let response_status = string_field(response, &["status"]);
+        if response_status.is_empty() {
+            let event_status = string_field(value, &["status"]);
+            if event_status.is_empty() {
+                fallback_status.to_string()
+            } else {
+                event_status
+            }
+        } else {
+            response_status
+        }
+    };
+    let usage_missing = usage_value.is_none_or(|value| !has_usage_fields(value));
+
+    CapturedResponseUsage {
+        response_id,
+        model,
+        status,
+        usage,
+        usage_missing,
+    }
+}
+
+fn usage_counts_from_api(value: &Value) -> UsageCounts {
+    let input = number_field(
+        value,
+        &[
+            "input_tokens",
+            "inputTokens",
+            "prompt_tokens",
+            "promptTokens",
+        ],
+    );
+    let output = number_field(
+        value,
+        &[
+            "output_tokens",
+            "outputTokens",
+            "completion_tokens",
+            "completionTokens",
+        ],
+    );
+    let input_details = value
+        .get("input_tokens_details")
+        .or_else(|| value.get("inputTokensDetails"))
+        .or_else(|| value.get("prompt_tokens_details"))
+        .or_else(|| value.get("promptTokensDetails"))
+        .unwrap_or(&Value::Null);
+    let output_details = value
+        .get("output_tokens_details")
+        .or_else(|| value.get("outputTokensDetails"))
+        .or_else(|| value.get("completion_tokens_details"))
+        .or_else(|| value.get("completionTokensDetails"))
+        .unwrap_or(&Value::Null);
+    UsageCounts {
+        input,
+        cached_input: number_field(
+            value,
+            &[
+                "cached_input_tokens",
+                "cachedInputTokens",
+                "cache_read_input_tokens",
+                "cacheReadInputTokens",
+            ],
+        )
+        .max(number_field(
+            input_details,
+            &[
+                "cached_tokens",
+                "cachedTokens",
+                "cache_read_tokens",
+                "cacheReadTokens",
+            ],
+        )),
+        cache_write: number_field(
+            value,
+            &[
+                "cache_write_input_tokens",
+                "cacheWriteInputTokens",
+                "cache_creation_input_tokens",
+                "cacheCreationInputTokens",
+            ],
+        )
+        .max(number_field(
+            input_details,
+            &[
+                "cache_write_tokens",
+                "cacheWriteTokens",
+                "cache_creation_tokens",
+                "cacheCreationTokens",
+            ],
+        )),
+        output,
+        reasoning: number_field(value, &["reasoning_output_tokens", "reasoningOutputTokens"]).max(
+            number_field(output_details, &["reasoning_tokens", "reasoningTokens"]),
+        ),
+        total: number_field(value, &["total_tokens", "totalTokens"])
+            .max(input.saturating_add(output)),
+    }
+}
+
+fn has_usage_fields(value: &Value) -> bool {
+    [
+        "input_tokens",
+        "inputTokens",
+        "prompt_tokens",
+        "promptTokens",
+        "output_tokens",
+        "outputTokens",
+        "completion_tokens",
+        "completionTokens",
+        "total_tokens",
+        "totalTokens",
+    ]
+    .iter()
+    .any(|name| value.get(name).is_some())
+}
+
+pub fn append_proxy_usage_record(captured: &CapturedResponseUsage) -> std::io::Result<()> {
+    append_proxy_usage_record_at(
+        &crate::paths::default_token_usage_proxy_ledger_path(),
+        captured,
+        now_ms(),
+    )
+}
+
+pub fn append_proxy_retry_attempt(request: &Value, attempt: usize) -> std::io::Result<()> {
+    append_proxy_retry_attempt_at(
+        &crate::paths::default_token_usage_proxy_ledger_path(),
+        request,
+        attempt,
+        now_ms(),
+    )
+}
+
+pub fn append_proxy_retry_attempt_at(
+    path: &Path,
+    request: &Value,
+    attempt: usize,
+    timestamp_ms: u64,
+) -> std::io::Result<()> {
+    let model = request
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("Unknown");
+    let mut digest = Sha256::new();
+    digest.update(b"proxy-retry-v1\0");
+    digest.update(timestamp_ms.to_le_bytes());
+    digest.update((attempt as u64).to_le_bytes());
+    digest.update(model.as_bytes());
+    digest.update(
+        LEDGER_GENERATION_COUNTER
+            .fetch_add(1, Ordering::Relaxed)
+            .to_le_bytes(),
+    );
+    append_proxy_usage_record_at(
+        path,
+        &CapturedResponseUsage {
+            response_id: format!("retry:{:x}", digest.finalize()),
+            model: model.to_string(),
+            status: "retry".to_string(),
+            usage_missing: true,
+            ..CapturedResponseUsage::default()
+        },
+        timestamp_ms,
+    )
+}
+
+pub fn append_proxy_usage_record_at(
+    path: &Path,
+    captured: &CapturedResponseUsage,
+    timestamp_ms: u64,
+) -> std::io::Result<()> {
+    let _guard = PROXY_LEDGER_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .map_err(|_| std::io::Error::other("token usage ledger lock poisoned"))?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    rotate_proxy_ledger_if_needed(path)?;
+    let response_id = captured.response_id.trim().to_string();
+    let id = stable_proxy_event_id(&response_id, captured, timestamp_ms);
+    let event = RolloutEvent {
+        id,
+        session_id: String::new(),
+        timestamp: timestamp_ms.to_string(),
+        model: if captured.model.trim().is_empty() {
+            "Unknown".to_string()
+        } else {
+            captured.model.clone()
+        },
+        usage: captured.usage.clone(),
+        totals: UsageCounts::default(),
+        source: "proxy".to_string(),
+        status: captured.status.clone(),
+        usage_missing: captured.usage_missing,
+        timestamp_ms,
+        response_id,
+    };
+    let needs_header = fs::metadata(path)
+        .map(|metadata| metadata.len() == 0)
+        .unwrap_or(true);
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    if needs_header {
+        let header = serde_json::json!({
+            "type": LEDGER_HEADER_TYPE,
+            "generation": new_ledger_generation(timestamp_ms),
+        });
+        let mut line = serde_json::to_vec(&header)?;
+        line.push(b'\n');
+        file.write_all(&line)?;
+    }
+    let mut line = serde_json::to_vec(&event)?;
+    line.push(b'\n');
+    file.write_all(&line)?;
+    Ok(())
+}
+
+fn rotate_proxy_ledger_if_needed(path: &Path) -> std::io::Result<()> {
+    let should_rotate = fs::metadata(path)
+        .map(|metadata| metadata.len() >= MAX_PROXY_LEDGER_BYTES)
+        .unwrap_or(false);
+    if !should_rotate {
+        return Ok(());
+    }
+    for index in (1..=MAX_PROXY_LEDGER_ARCHIVES).rev() {
+        let destination = proxy_ledger_archive_path(path, index);
+        if destination.exists() {
+            fs::remove_file(&destination)?;
+        }
+        let source = if index == 1 {
+            path.to_path_buf()
+        } else {
+            proxy_ledger_archive_path(path, index - 1)
+        };
+        if source.exists() {
+            fs::rename(source, destination)?;
+        }
+    }
+    Ok(())
+}
+
+fn proxy_ledger_archive_path(path: &Path, index: usize) -> PathBuf {
+    let mut name = path.as_os_str().to_os_string();
+    name.push(format!(".{index}"));
+    PathBuf::from(name)
+}
+
+pub fn read_proxy_usage_records_from_path(
+    path: &Path,
+    since_ms: u64,
+    limit: usize,
+) -> std::io::Result<Vec<RolloutEvent>> {
+    let (events, _, _, _) = read_all_proxy_usage_records(path)?;
+    let mut events = events
+        .into_iter()
+        .filter(|event| event.timestamp_ms > since_ms)
+        .collect::<Vec<_>>();
+    events.truncate(limit.max(1));
+    Ok(events)
+}
+
+fn read_all_proxy_usage_records(
+    path: &Path,
+) -> std::io::Result<(Vec<RolloutEvent>, u64, bool, String)> {
+    let mut events = Vec::new();
+    for index in (1..=MAX_PROXY_LEDGER_ARCHIVES).rev() {
+        let archive = proxy_ledger_archive_path(path, index);
+        let (mut archived, _, _, _) =
+            read_proxy_usage_records_from_offset(&archive, 0, "", usize::MAX)?;
+        events.append(&mut archived);
+    }
+    let (mut current, next_offset, reset, generation) =
+        read_proxy_usage_records_from_offset(path, 0, "", usize::MAX)?;
+    events.append(&mut current);
+    let mut seen = HashSet::new();
+    events.retain(|event| {
+        let key = if event.response_id.is_empty() {
+            event.id.clone()
+        } else {
+            format!("response:{}", event.response_id)
+        };
+        seen.insert(key)
+    });
+    events.sort_by_key(|event| event.timestamp_ms);
+    Ok((events, next_offset, reset, generation))
+}
+
+fn read_proxy_usage_records_from_offset(
+    path: &Path,
+    offset: u64,
+    expected_generation: &str,
+    limit: usize,
+) -> std::io::Result<(Vec<RolloutEvent>, u64, bool, String)> {
+    let mut file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok((Vec::new(), 0, offset > 0, String::new()));
+        }
+        Err(error) => return Err(error),
+    };
+    let len = file.metadata()?.len();
+    let (generation, data_start) = read_ledger_header(&mut file)?;
+    let generation_changed = !expected_generation.is_empty() && expected_generation != generation;
+    let reset = generation_changed || offset > len;
+    let start = if reset || offset == 0 {
+        data_start
+    } else {
+        offset
+    };
+    file.seek(SeekFrom::Start(start))?;
+
+    let mut seen = HashSet::new();
+    let mut events = Vec::new();
+    let mut reader = BufReader::new(file);
+    let mut next_offset = start;
+    while events.len() < limit.max(1) {
+        let mut line = String::new();
+        let bytes = reader.read_line(&mut line)?;
+        if bytes == 0 {
+            break;
+        }
+        if !line.ends_with('\n') {
+            break;
+        }
+        let complete_offset = next_offset.saturating_add(bytes as u64);
+        let Ok(event) = serde_json::from_str::<RolloutEvent>(&line) else {
+            next_offset = complete_offset;
+            continue;
+        };
+        next_offset = complete_offset;
+        let key = if event.response_id.is_empty() {
+            event.id.clone()
+        } else {
+            format!("response:{}", event.response_id)
+        };
+        if !seen.insert(key) {
+            continue;
+        }
+        events.push(event);
+    }
+    events.sort_by_key(|event| event.timestamp_ms);
+    Ok((events, next_offset, reset, generation))
+}
+
+fn read_ledger_header(file: &mut File) -> std::io::Result<(String, u64)> {
+    file.seek(SeekFrom::Start(0))?;
+    let mut reader = BufReader::new(&mut *file);
+    let mut first_line = String::new();
+    let bytes = reader.read_line(&mut first_line)?;
+    let header = serde_json::from_str::<Value>(&first_line).ok();
+    let is_header = header
+        .as_ref()
+        .and_then(|value| value.get("type"))
+        .and_then(Value::as_str)
+        == Some(LEDGER_HEADER_TYPE);
+    let generation = if is_header {
+        header
+            .as_ref()
+            .and_then(|value| value.get("generation"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    } else {
+        "legacy-v1".to_string()
+    };
+    Ok((generation, if is_header { bytes as u64 } else { 0 }))
+}
+
+fn new_ledger_generation(timestamp_ms: u64) -> String {
+    let sequence = LEDGER_GENERATION_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut digest = Sha256::new();
+    digest.update(b"ledger-v1\0");
+    digest.update(timestamp_ms.to_le_bytes());
+    digest.update(std::process::id().to_le_bytes());
+    digest.update(sequence.to_le_bytes());
+    format!("{:x}", digest.finalize())
+}
+
+pub fn read_token_usage_events_from_sources(
+    roots: &[PathBuf],
+    ledger_path: &Path,
+    query: &TokenUsageQuery,
+) -> TokenUsageResult {
+    let cutoff_ms = now_ms().saturating_sub(query.days.clamp(1, 31) * 24 * 60 * 60 * 1_000);
+    if !query.include_rollout {
+        return match read_proxy_usage_records_from_offset(
+            ledger_path,
+            query.proxy_offset,
+            &query.proxy_generation,
+            query.limit.clamp(1, 1_000_000),
+        ) {
+            Ok((events, proxy_next_offset, proxy_reset, proxy_generation)) => {
+                let events = events
+                    .into_iter()
+                    .filter(|event| event.timestamp_ms >= cutoff_ms)
+                    .collect::<Vec<_>>();
+                let missing_usage = events.iter().filter(|event| event.usage_missing).count();
+                let proxy_next_since_ms = events
+                    .last()
+                    .map(|event| event.timestamp_ms)
+                    .unwrap_or(query.proxy_since_ms);
+                TokenUsageResult {
+                    events,
+                    warnings: Vec::new(),
+                    next_since: query.since.clone(),
+                    proxy_next_since_ms,
+                    proxy_enabled_at_ms: 0,
+                    missing_usage,
+                    proxy_next_offset,
+                    proxy_generation,
+                    proxy_reset,
+                }
+            }
+            Err(error) => TokenUsageResult {
+                events: Vec::new(),
+                warnings: vec![format!("proxy token usage ledger: {error}")],
+                next_since: query.since.clone(),
+                proxy_next_since_ms: query.proxy_since_ms,
+                proxy_enabled_at_ms: 0,
+                missing_usage: 0,
+                proxy_next_offset: query.proxy_offset,
+                proxy_generation: query.proxy_generation.clone(),
+                proxy_reset: false,
+            },
+        };
+    }
+
+    let rollout = read_rollout_events_from_roots(roots, query);
+    merge_full_rollout_with_proxy(rollout, ledger_path, query, cutoff_ms)
+}
+
+fn merge_full_rollout_with_proxy(
+    mut rollout: TokenUsageResult,
+    ledger_path: &Path,
+    query: &TokenUsageQuery,
+    cutoff_ms: u64,
+) -> TokenUsageResult {
+    let proxy_match_since_ms = cutoff_ms.saturating_sub(PROXY_ROLLOUT_MATCH_WINDOW_MS);
+    let (all_proxy, proxy_next_offset, proxy_reset, proxy_generation) =
+        match read_all_proxy_usage_records(ledger_path) {
+            Ok((events, next_offset, reset, generation)) => (
+                events
+                    .into_iter()
+                    .filter(|event| event.timestamp_ms >= proxy_match_since_ms)
+                    .collect(),
+                next_offset,
+                reset,
+                generation,
+            ),
+            Err(error) => {
+                rollout
+                    .warnings
+                    .push(format!("proxy token usage ledger: {error}"));
+                (Vec::new(), 0, false, String::new())
+            }
+        };
+    let proxy_enabled_at_ms = all_proxy
+        .iter()
+        .map(|event| event.timestamp_ms)
+        .min()
+        .unwrap_or_default();
+    remove_rollouts_captured_by_proxy(&mut rollout.events, &all_proxy);
+
+    let mut proxy = all_proxy
+        .into_iter()
+        .filter(|event| event.timestamp_ms >= cutoff_ms)
+        .filter(|event| event.timestamp_ms > query.proxy_since_ms)
+        .collect::<Vec<_>>();
+    let missing_usage = proxy.iter().filter(|event| event.usage_missing).count();
+    let proxy_next_since_ms = proxy
+        .last()
+        .map(|event| event.timestamp_ms)
+        .unwrap_or(query.proxy_since_ms);
+    rollout.events.append(&mut proxy);
+    rollout.events.sort_by(|left, right| {
+        left.timestamp_ms
+            .cmp(&right.timestamp_ms)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    rollout.events.truncate(query.limit.clamp(1, 1_000_000));
+    rollout.proxy_next_since_ms = proxy_next_since_ms;
+    rollout.proxy_enabled_at_ms = proxy_enabled_at_ms;
+    rollout.missing_usage = missing_usage;
+    rollout.proxy_next_offset = proxy_next_offset;
+    rollout.proxy_generation = proxy_generation;
+    rollout.proxy_reset = proxy_reset;
+    rollout
+}
+
+pub fn read_token_usage_events(query: &TokenUsageQuery) -> TokenUsageResult {
+    let codex_home = crate::codex_home::default_codex_home_dir();
+    let roots = [
+        codex_home.join("sessions"),
+        codex_home.join("archived_sessions"),
+    ];
+    let ledger_path = crate::paths::default_token_usage_proxy_ledger_path();
+    if !query.include_rollout {
+        return read_token_usage_events_from_sources(&roots, &ledger_path, query);
+    }
+
+    let mut tailer = match ROLLOUT_TAILER
+        .get_or_init(|| Mutex::new(RolloutTailer::default()))
+        .lock()
+    {
+        Ok(tailer) => tailer,
+        Err(_) => {
+            let mut result = read_token_usage_events_from_sources(&roots, &ledger_path, query);
+            result
+                .warnings
+                .push("rollout tailer lock poisoned; used full scan".to_string());
+            return result;
+        }
+    };
+    if !query.rollout_incremental {
+        tailer.reset();
+    }
+    let rollout = tailer.read_from_roots(&roots, query);
+    let cutoff_ms = now_ms().saturating_sub(query.days.clamp(1, 31) * 24 * 60 * 60 * 1_000);
+    if !query.rollout_incremental {
+        merge_full_rollout_with_proxy(rollout, &ledger_path, query, cutoff_ms)
+    } else {
+        merge_incremental_rollout_with_proxy(rollout, &ledger_path, query, cutoff_ms)
+    }
+}
+
+fn merge_incremental_rollout_with_proxy(
+    mut rollout: TokenUsageResult,
+    ledger_path: &Path,
+    query: &TokenUsageQuery,
+    cutoff_ms: u64,
+) -> TokenUsageResult {
+    let (mut proxy, proxy_next_offset, proxy_reset, proxy_generation) =
+        match read_proxy_usage_records_from_offset(
+            ledger_path,
+            query.proxy_offset,
+            &query.proxy_generation,
+            query.limit.clamp(1, 1_000_000),
+        ) {
+            Ok(result) => result,
+            Err(error) => {
+                rollout
+                    .warnings
+                    .push(format!("proxy token usage ledger: {error}"));
+                return rollout;
+            }
+        };
+    proxy.retain(|event| event.timestamp_ms >= cutoff_ms);
+    remove_rollouts_captured_by_proxy(&mut rollout.events, &proxy);
+    let missing_usage = proxy.iter().filter(|event| event.usage_missing).count();
+    let proxy_next_since_ms = proxy
+        .last()
+        .map(|event| event.timestamp_ms)
+        .unwrap_or(query.proxy_since_ms);
+    rollout.events.append(&mut proxy);
+    rollout.events.sort_by(|left, right| {
+        left.timestamp_ms
+            .cmp(&right.timestamp_ms)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    rollout.events.truncate(query.limit.clamp(1, 1_000_000));
+    rollout.proxy_next_since_ms = proxy_next_since_ms;
+    rollout.missing_usage = missing_usage;
+    rollout.proxy_next_offset = proxy_next_offset;
+    rollout.proxy_generation = proxy_generation;
+    rollout.proxy_reset = proxy_reset;
+    rollout
+}
+
+fn stable_proxy_event_id(
+    response_id: &str,
+    captured: &CapturedResponseUsage,
+    timestamp_ms: u64,
+) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"proxy-v1\0");
+    if response_id.is_empty() {
+        digest.update(timestamp_ms.to_le_bytes());
+        digest.update(captured.model.as_bytes());
+        digest.update(captured.status.as_bytes());
+        digest.update(
+            LEDGER_GENERATION_COUNTER
+                .fetch_add(1, Ordering::Relaxed)
+                .to_le_bytes(),
+        );
+    } else {
+        digest.update(response_id.as_bytes());
+    }
+    format!("{:x}", digest.finalize())
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn timestamp_to_epoch_ms(timestamp: &str) -> Option<u64> {
+    let bytes = timestamp.as_bytes();
+    if bytes.len() < 20 || bytes.get(4) != Some(&b'-') || bytes.get(7) != Some(&b'-') {
+        return None;
+    }
+    let year = timestamp.get(0..4)?.parse::<i64>().ok()?;
+    let month = timestamp.get(5..7)?.parse::<i64>().ok()?;
+    let day = timestamp.get(8..10)?.parse::<i64>().ok()?;
+    let hour = timestamp.get(11..13)?.parse::<i64>().ok()?;
+    let minute = timestamp.get(14..16)?.parse::<i64>().ok()?;
+    let second = timestamp.get(17..19)?.parse::<i64>().ok()?;
+    let millis = timestamp
+        .get(19..)
+        .and_then(|rest| rest.strip_prefix('.'))
+        .map(|fraction| {
+            fraction
+                .chars()
+                .take_while(|ch| ch.is_ascii_digit())
+                .take(3)
+                .collect::<String>()
+        })
+        .filter(|fraction| !fraction.is_empty())
+        .and_then(|mut fraction| {
+            while fraction.len() < 3 {
+                fraction.push('0');
+            }
+            fraction.parse::<i64>().ok()
+        })
+        .unwrap_or(0);
+    let adjusted_year = year - i64::from(month <= 2);
+    let era = if adjusted_year >= 0 {
+        adjusted_year
+    } else {
+        adjusted_year - 399
+    } / 400;
+    let year_of_era = adjusted_year - era * 400;
+    let shifted_month = month + if month > 2 { -3 } else { 9 };
+    let day_of_year = (153 * shifted_month + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    let days = era * 146_097 + day_of_era - 719_468;
+    let seconds = days
+        .checked_mul(86_400)?
+        .checked_add(hour * 3_600 + minute * 60 + second)?;
+    u64::try_from(seconds.checked_mul(1_000)?.checked_add(millis)?).ok()
+}
+
+pub fn events_value(payload: Value) -> anyhow::Result<Value> {
+    let query = serde_json::from_value::<TokenUsageQuery>(payload).unwrap_or_default();
+    Ok(serde_json::to_value(read_token_usage_events(&query))?)
+}

--- a/crates/codex-plus-core/tests/bridge_routes.rs
+++ b/crates/codex-plus-core/tests/bridge_routes.rs
@@ -34,6 +34,10 @@ async fn bridge_routes_cover_all_current_paths() {
         ("/backend/status", json!({})),
         ("/codex-model-catalog", json!({})),
         ("/codex-config-model", json!({})),
+        (
+            "/token-usage/events",
+            json!({"includeRollout": false, "days": 1, "limit": 1}),
+        ),
         ("/ads", json!({})),
         ("/zed-remote/status", json!({})),
         (
@@ -105,6 +109,13 @@ async fn bridge_routes_cover_all_current_paths() {
             "{path} should be routed"
         );
     }
+}
+
+#[tokio::test]
+async fn token_usage_prices_route_is_not_exposed() {
+    let result = handle_bridge_request(test_context(), "/token-usage/prices", json!({})).await;
+
+    assert_eq!(result["message"], "Unknown bridge path");
 }
 
 #[tokio::test]
@@ -793,7 +804,7 @@ async fn core_runtime_manager_route_attempts_to_open_manager_binary() {
 }
 
 #[tokio::test]
-async fn bridge_backend_status_writes_diagnostic_log() {
+async fn bridge_backend_status_keeps_specific_diagnostic_without_high_frequency_envelopes() {
     let temp = tempfile::tempdir().unwrap();
     let log_path = temp.path().join("codex-plus.log");
     codex_plus_core::diagnostic_log::set_diagnostic_log_path_for_tests(Some(log_path.clone()));
@@ -806,9 +817,9 @@ async fn bridge_backend_status_writes_diagnostic_log() {
 
     assert_eq!(result["status"], "ok");
     let contents = std::fs::read_to_string(&log_path).unwrap();
-    assert!(contents.contains("bridge.request"));
+    assert!(!contents.contains("bridge.request"));
+    assert!(!contents.contains("bridge.response"));
     assert!(contents.contains("bridge.backend_status_ok"));
-    assert!(contents.contains("/backend/status"));
     codex_plus_core::diagnostic_log::set_diagnostic_log_path_for_tests(None);
 }
 

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -475,6 +475,42 @@ fn launcher_does_not_override_codex_app_environment() {
 }
 
 #[test]
+fn active_responses_api_relay_uses_protocol_proxy() {
+    let settings = BackendSettings {
+        relay_profiles: vec![RelayProfile {
+            id: "responses-relay".to_string(),
+            relay_mode: codex_plus_core::settings::RelayMode::PureApi,
+            protocol: RelayProtocol::Responses,
+            base_url: "https://relay.example/v1".to_string(),
+            api_key: "test-key".to_string(),
+            ..RelayProfile::default()
+        }],
+        active_relay_id: "responses-relay".to_string(),
+        ..BackendSettings::default()
+    };
+
+    assert!(settings.active_relay_uses_protocol_proxy());
+}
+
+#[test]
+fn protocol_proxy_usage_capture_has_bounded_idle_and_absolute_stream_lifetimes() {
+    let source = include_str!("../src/launcher.rs");
+    let proxy_handler = source
+        .split("async fn handle_protocol_proxy_connection")
+        .nth(1)
+        .and_then(|tail| {
+            tail.split("async fn handle_audio_transcriptions_proxy_connection")
+                .next()
+        })
+        .expect("protocol proxy handler should exist");
+
+    assert!(!proxy_handler.contains("Duration::from_secs(20)"));
+    assert!(proxy_handler.contains("PROTOCOL_PROXY_STREAM_IDLE_TIMEOUT"));
+    assert!(proxy_handler.contains("PROTOCOL_PROXY_STREAM_MAX_DURATION"));
+    assert!(proxy_handler.contains("tokio::time::timeout"));
+}
+
+#[test]
 fn launcher_prepares_projectless_main_window_when_enhancements_are_enabled() {
     let source = include_str!("../src/launcher.rs");
 
@@ -1391,14 +1427,15 @@ async fn launch_starts_helper_when_chat_protocol_proxy_is_enabled() {
 
     let before_stop = events.lock().unwrap().clone();
     assert!(before_stop.contains(&"select-helper:58000".to_string()));
-    assert!(before_stop.contains(&"start-helper:57321".to_string()));
-    assert!(!before_stop.contains(&"inject:9229:57321".to_string()));
+    assert!(before_stop.contains(&"ensure-protocol-proxy:58000".to_string()));
+    assert!(before_stop.contains(&"start-helper:58000".to_string()));
+    assert!(!before_stop.contains(&"inject:9229:58000".to_string()));
 
     handle.wait_for_codex_exit().await.unwrap();
 
     let after_stop = events.lock().unwrap().clone();
     assert!(after_stop.contains(&"wait-codex".to_string()));
-    assert!(after_stop.contains(&"shutdown-helper:57321".to_string()));
+    assert!(after_stop.contains(&"shutdown-helper:58000".to_string()));
 }
 
 #[tokio::test]
@@ -1683,6 +1720,15 @@ impl LaunchHooks for FakeHooks {
             return Ok(());
         }
         self.event("apply-relay");
+        Ok(())
+    }
+
+    async fn ensure_protocol_proxy_config(
+        &self,
+        _settings: &BackendSettings,
+        helper_port: u16,
+    ) -> anyhow::Result<()> {
+        self.event(format!("ensure-protocol-proxy:{helper_port}"));
         Ok(())
     }
 

--- a/crates/codex-plus-core/tests/protocol_proxy.rs
+++ b/crates/codex-plus-core/tests/protocol_proxy.rs
@@ -13,6 +13,7 @@ use codex_plus_core::settings::{
     AggregateRelayMember, AggregateRelayProfile, AggregateRelayStrategy, BackendSettings,
     RelayMode, RelayProfile,
 };
+use codex_plus_core::token_usage::ResponsesSseUsageTracker;
 use serde_json::json;
 use std::io::{Read, Write};
 use std::net::TcpListener;
@@ -21,6 +22,53 @@ use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+#[test]
+fn responses_usage_tracker_extracts_chunked_completed_usage() {
+    let request = json!({"model": "gpt-5.6-terra", "stream": true});
+    let mut tracker = ResponsesSseUsageTracker::with_request(&request);
+    let event = concat!(
+        "event: response.completed\n",
+        "data: {\"type\":\"response.completed\",\"response\":{",
+        "\"id\":\"resp_123\",\"model\":\"gpt-5.6-terra\",\"status\":\"completed\",",
+        "\"usage\":{\"input_tokens\":300000,\"input_tokens_details\":{\"cached_tokens\":280000},",
+        "\"cache_creation_input_tokens\":1200,\"output_tokens\":900,",
+        "\"output_tokens_details\":{\"reasoning_tokens\":250},\"total_tokens\":300900}}}\n\n"
+    );
+
+    for chunk in event.as_bytes().chunks(17) {
+        tracker.push_bytes(chunk);
+    }
+    let captured = tracker.finish();
+
+    assert_eq!(captured.response_id, "resp_123");
+    assert_eq!(captured.model, "gpt-5.6-terra");
+    assert_eq!(captured.status, "completed");
+    assert!(!captured.usage_missing);
+    assert_eq!(captured.usage.input, 300_000);
+    assert_eq!(captured.usage.cached_input, 280_000);
+    assert_eq!(captured.usage.cache_write, 1_200);
+    assert_eq!(captured.usage.output, 900);
+    assert_eq!(captured.usage.reasoning, 250);
+}
+
+#[test]
+fn responses_usage_tracker_marks_terminal_event_without_usage() {
+    let request = json!({"model": "test-model", "stream": true});
+    let mut tracker = ResponsesSseUsageTracker::with_request(&request);
+    tracker.push_bytes(
+        br#"event: response.failed
+data: {"type":"response.failed","response":{"id":"resp_missing","status":"failed"}}
+
+"#,
+    );
+
+    let captured = tracker.finish();
+
+    assert_eq!(captured.response_id, "resp_missing");
+    assert_eq!(captured.status, "failed");
+    assert!(captured.usage_missing);
+}
 
 #[test]
 fn responses_request_converts_to_chat_completions() {

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -7,13 +7,69 @@ use codex_plus_core::relay_config::{
     backfill_relay_profile_from_home, backfill_relay_profile_from_home_with_common,
     chatgpt_auth_status_from_home, clear_relay_config_to_home,
     clear_relay_config_to_home_with_auth, delete_context_entry_from_common_config,
-    extract_common_config_from_config, filter_common_config_for_selection,
-    list_context_entries_from_common_config, normalize_relay_profile_for_storage,
-    relay_config_status_from_home, sanitize_common_config_contents,
-    set_codex_goals_feature_in_home, strip_common_config_from_config,
-    sync_live_config_context_entries, upsert_context_entry_in_common_config,
+    ensure_protocol_proxy_config_in_home, extract_common_config_from_config,
+    filter_common_config_for_selection, list_context_entries_from_common_config,
+    normalize_relay_profile_for_storage, relay_config_status_from_home,
+    sanitize_common_config_contents, set_codex_goals_feature_in_home,
+    strip_common_config_from_config, sync_live_config_context_entries,
+    upsert_context_entry_in_common_config,
 };
 use codex_plus_core::settings::{RelayContextSelection, RelayMode, RelayProfile, RelayProtocol};
+
+#[test]
+fn protocol_proxy_startup_rewrites_only_the_active_provider_to_the_selected_helper_port() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = RelayProfile {
+        id: "relay-responses".to_string(),
+        protocol: RelayProtocol::Responses,
+        relay_mode: RelayMode::PureApi,
+        config_contents: "model_provider = \"custom\"\n".to_string(),
+        ..RelayProfile::default()
+    };
+    std::fs::write(
+        temp.path().join("config.toml"),
+        r#"model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+base_url = "https://relay.example/v1"
+
+[model_providers.unrelated]
+base_url = "https://keep.example/v1"
+"#,
+    )
+    .unwrap();
+
+    let changed = ensure_protocol_proxy_config_in_home(temp.path(), &profile, 58_000).unwrap();
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+
+    assert!(changed);
+    assert!(config.contains(r#"base_url = "http://127.0.0.1:58000/v1""#));
+    assert!(config.contains(r#"base_url = "https://keep.example/v1""#));
+    assert!(!config.contains("57321"));
+}
+
+#[test]
+fn responses_profile_never_treats_the_local_protocol_proxy_as_its_upstream() {
+    let profile = RelayProfile {
+        protocol: RelayProtocol::Responses,
+        base_url: "https://relay.example/v1".to_string(),
+        upstream_base_url: "https://relay.example/v1".to_string(),
+        config_contents: r#"model_provider = "custom"
+
+[model_providers.custom]
+base_url = "http://127.0.0.1:58000/v1"
+"#
+        .to_string(),
+        ..RelayProfile::default()
+    };
+
+    assert_eq!(
+        codex_plus_core::relay_config::relay_profile_base_url(&profile),
+        "https://relay.example/v1"
+    );
+}
 
 fn write_remote_plugin_marketplace_snapshot(home: &std::path::Path) {
     let root = home.join(".tmp").join("plugins-remote");

--- a/crates/codex-plus-core/tests/token_usage.rs
+++ b/crates/codex-plus-core/tests/token_usage.rs
@@ -1,0 +1,683 @@
+use std::fs;
+use std::io::Write;
+
+use codex_plus_core::token_usage::{
+    CapturedResponseUsage, RolloutEvent, RolloutTailer, TokenUsageQuery, UsageCounts,
+    append_proxy_retry_attempt_at, append_proxy_usage_record_at, deduplicate_rollout_events,
+    read_proxy_usage_records_from_path, read_rollout_events_from_roots,
+    read_token_usage_events_from_sources,
+};
+use serde_json::json;
+
+fn event(id: &str, timestamp: &str, model: &str) -> RolloutEvent {
+    RolloutEvent {
+        id: id.to_string(),
+        session_id: "session-1".to_string(),
+        timestamp: timestamp.to_string(),
+        model: model.to_string(),
+        usage: UsageCounts {
+            input: 179_540,
+            cached_input: 179_200,
+            cache_write: 0,
+            output: 506,
+            reasoning: 130,
+            total: 180_046,
+        },
+        totals: UsageCounts {
+            input: 72_898_219,
+            cached_input: 67_888_640,
+            cache_write: 0,
+            output: 210_561,
+            reasoning: 56_791,
+            total: 73_108_780,
+        },
+        source: "rollout".to_string(),
+        status: "completed".to_string(),
+        usage_missing: false,
+        timestamp_ms: 0,
+        response_id: String::new(),
+    }
+}
+
+#[test]
+fn proxy_ledger_round_trips_and_deduplicates_response_id() {
+    let temp = tempfile::tempdir().unwrap();
+    let ledger = temp.path().join("responses-usage.jsonl");
+    let captured = CapturedResponseUsage {
+        response_id: "resp-1".to_string(),
+        model: "gpt-5.6-terra".to_string(),
+        status: "completed".to_string(),
+        usage: UsageCounts {
+            input: 300_000,
+            cached_input: 280_000,
+            cache_write: 0,
+            output: 900,
+            reasoning: 250,
+            total: 300_900,
+        },
+        usage_missing: false,
+    };
+
+    append_proxy_usage_record_at(&ledger, &captured, 1_721_600_000_000).unwrap();
+    append_proxy_usage_record_at(&ledger, &captured, 1_721_600_000_100).unwrap();
+
+    let records = read_proxy_usage_records_from_path(&ledger, 0, 100).unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].response_id, "resp-1");
+    assert_eq!(records[0].timestamp_ms, 1_721_600_000_000);
+    assert_eq!(records[0].usage.input, 300_000);
+}
+
+#[test]
+fn proxy_retry_attempt_records_status_without_persisting_request_contents() {
+    let temp = tempfile::tempdir().unwrap();
+    let ledger = temp.path().join("responses-usage.jsonl");
+    let request = json!({
+        "model": "test-model",
+        "input": "private prompt",
+        "api_key": "must-not-be-written"
+    });
+
+    append_proxy_retry_attempt_at(&ledger, &request, 2, 1_721_600_000_000).unwrap();
+
+    let records = read_proxy_usage_records_from_path(&ledger, 0, 100).unwrap();
+    let raw = fs::read_to_string(&ledger).unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].model, "test-model");
+    assert_eq!(records[0].status, "retry");
+    assert!(records[0].usage_missing);
+    assert!(!raw.contains("private prompt"));
+    assert!(!raw.contains("must-not-be-written"));
+}
+
+#[test]
+fn proxy_ledger_rotates_at_twenty_megabytes_and_keeps_three_archives() {
+    let temp = tempfile::tempdir().unwrap();
+    let ledger = temp.path().join("responses-usage.jsonl");
+    let captured = |index: u64| CapturedResponseUsage {
+        response_id: format!("resp-{index}"),
+        model: "test-model".to_string(),
+        status: "completed".to_string(),
+        usage: UsageCounts {
+            input: index,
+            total: index,
+            ..UsageCounts::default()
+        },
+        usage_missing: false,
+    };
+
+    for index in 1..=4 {
+        append_proxy_usage_record_at(&ledger, &captured(index), index).unwrap();
+        fs::OpenOptions::new()
+            .write(true)
+            .open(&ledger)
+            .unwrap()
+            .set_len(20 * 1024 * 1024)
+            .unwrap();
+    }
+    append_proxy_usage_record_at(&ledger, &captured(5), 5).unwrap();
+
+    assert!(fs::metadata(&ledger).unwrap().len() < 1024 * 1024);
+    for index in 1..=3 {
+        assert!(fs::metadata(format!("{}.{}", ledger.display(), index)).is_ok());
+    }
+    assert!(fs::metadata(format!("{}.4", ledger.display())).is_err());
+}
+
+#[test]
+fn combined_reader_pages_past_the_proxy_ledger_limit() {
+    let temp = tempfile::tempdir().unwrap();
+    let ledger = temp.path().join("responses-usage.jsonl");
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+
+    let mut file = std::io::BufWriter::new(std::fs::File::create(&ledger).unwrap());
+    for index in 1..=100_001_u64 {
+        let record = RolloutEvent {
+            id: format!("event-{index}"),
+            session_id: String::new(),
+            timestamp: (now_ms + index).to_string(),
+            model: "test-model".to_string(),
+            usage: UsageCounts {
+                input: 1,
+                total: 1,
+                ..UsageCounts::default()
+            },
+            totals: UsageCounts::default(),
+            source: "proxy".to_string(),
+            status: "completed".to_string(),
+            usage_missing: false,
+            timestamp_ms: now_ms + index,
+            response_id: format!("resp-{index}"),
+        };
+        serde_json::to_writer(&mut file, &record).unwrap();
+        writeln!(file).unwrap();
+    }
+    file.flush().unwrap();
+
+    let result = read_token_usage_events_from_sources(
+        &[],
+        &ledger,
+        &TokenUsageQuery {
+            days: 1,
+            limit: 2,
+            proxy_since_ms: now_ms + 100_000,
+            ..TokenUsageQuery::default()
+        },
+    );
+
+    assert_eq!(result.events.len(), 1);
+    assert_eq!(result.events[0].response_id, "resp-100001");
+    assert_eq!(result.proxy_next_since_ms, now_ms + 100_001);
+}
+
+#[test]
+fn incremental_reader_skips_rollouts_and_resumes_from_proxy_offset() {
+    let temp = tempfile::tempdir().unwrap();
+    let rollout = temp.path().join("rollout-session.jsonl");
+    let ledger = temp.path().join("responses-usage.jsonl");
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    fs::write(
+        &rollout,
+        [
+            json!({"timestamp":"2026-07-28T00:00:00.000Z","payload":{"type":"session_meta","session_id":"session-1"}}),
+            json!({"timestamp":"2026-07-28T00:00:00.000Z","payload":{"type":"turn_context","model":"rollout-model"}}),
+            json!({"timestamp":"2026-07-28T00:00:01.000Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"output_tokens":10},"total_token_usage":{"input_tokens":100,"output_tokens":10}}}}),
+        ]
+        .iter()
+        .map(serde_json::Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n"),
+    )
+    .unwrap();
+    append_proxy_usage_record_at(
+        &ledger,
+        &CapturedResponseUsage {
+            response_id: "resp-first".to_string(),
+            model: "proxy-model".to_string(),
+            status: "completed".to_string(),
+            usage: UsageCounts {
+                input: 1,
+                total: 1,
+                ..UsageCounts::default()
+            },
+            usage_missing: false,
+        },
+        now_ms + 1,
+    )
+    .unwrap();
+    let first_offset = fs::metadata(&ledger).unwrap().len();
+    append_proxy_usage_record_at(
+        &ledger,
+        &CapturedResponseUsage {
+            response_id: "resp-second".to_string(),
+            model: "proxy-model".to_string(),
+            status: "completed".to_string(),
+            usage: UsageCounts {
+                input: 2,
+                total: 2,
+                ..UsageCounts::default()
+            },
+            usage_missing: false,
+        },
+        now_ms + 2,
+    )
+    .unwrap();
+    let query: TokenUsageQuery = serde_json::from_value(json!({
+        "days": 1,
+        "limit": 100,
+        "includeRollout": false,
+        "proxyOffset": first_offset
+    }))
+    .unwrap();
+
+    let result =
+        read_token_usage_events_from_sources(&[temp.path().to_path_buf()], &ledger, &query);
+    let value = serde_json::to_value(&result).unwrap();
+
+    assert_eq!(result.events.len(), 1);
+    assert_eq!(result.events[0].response_id, "resp-second");
+    assert_eq!(
+        value["proxyNextOffset"],
+        fs::metadata(&ledger).unwrap().len()
+    );
+    assert_eq!(value["proxyReset"], false);
+}
+
+#[test]
+fn incremental_reader_does_not_advance_past_an_incomplete_jsonl_record() {
+    let temp = tempfile::tempdir().unwrap();
+    let ledger = temp.path().join("responses-usage.jsonl");
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    append_proxy_usage_record_at(
+        &ledger,
+        &CapturedResponseUsage {
+            response_id: "resp-complete".to_string(),
+            model: "test-model".to_string(),
+            status: "completed".to_string(),
+            usage: UsageCounts {
+                input: 1,
+                total: 1,
+                ..UsageCounts::default()
+            },
+            usage_missing: false,
+        },
+        now_ms,
+    )
+    .unwrap();
+    let complete_offset = fs::metadata(&ledger).unwrap().len();
+    let pending = serde_json::to_string(&RolloutEvent {
+        id: "pending-event".to_string(),
+        session_id: String::new(),
+        timestamp: (now_ms + 1).to_string(),
+        model: "test-model".to_string(),
+        usage: UsageCounts {
+            input: 2,
+            total: 2,
+            ..UsageCounts::default()
+        },
+        totals: UsageCounts::default(),
+        source: "proxy".to_string(),
+        status: "completed".to_string(),
+        usage_missing: false,
+        timestamp_ms: now_ms + 1,
+        response_id: "resp-pending".to_string(),
+    })
+    .unwrap();
+    let split = pending.len() / 2;
+    let mut file = fs::OpenOptions::new().append(true).open(&ledger).unwrap();
+    file.write_all(&pending.as_bytes()[..split]).unwrap();
+    file.flush().unwrap();
+
+    let first = read_token_usage_events_from_sources(
+        &[],
+        &ledger,
+        &serde_json::from_value(json!({
+            "includeRollout": false,
+            "proxyOffset": complete_offset,
+            "limit": 100
+        }))
+        .unwrap(),
+    );
+    assert!(first.events.is_empty());
+    assert_eq!(first.proxy_next_offset, complete_offset);
+
+    file.write_all(&pending.as_bytes()[split..]).unwrap();
+    file.write_all(b"\n").unwrap();
+    file.flush().unwrap();
+    let second = read_token_usage_events_from_sources(
+        &[],
+        &ledger,
+        &serde_json::from_value(json!({
+            "includeRollout": false,
+            "proxyOffset": complete_offset,
+            "limit": 100
+        }))
+        .unwrap(),
+    );
+    assert_eq!(second.events.len(), 1);
+    assert_eq!(second.events[0].response_id, "resp-pending");
+}
+
+#[test]
+fn incremental_reader_resets_when_ledger_generation_changes() {
+    let temp = tempfile::tempdir().unwrap();
+    let ledger = temp.path().join("responses-usage.jsonl");
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    let captured = |response_id: &str, input: u64| CapturedResponseUsage {
+        response_id: response_id.to_string(),
+        model: "test-model".to_string(),
+        status: "completed".to_string(),
+        usage: UsageCounts {
+            input,
+            total: input,
+            ..UsageCounts::default()
+        },
+        usage_missing: false,
+    };
+    append_proxy_usage_record_at(&ledger, &captured("old", 1), now_ms).unwrap();
+    let original = read_token_usage_events_from_sources(
+        &[],
+        &ledger,
+        &serde_json::from_value(json!({ "includeRollout": false, "limit": 100 })).unwrap(),
+    );
+    let original_generation = original.proxy_generation.clone();
+    let original_offset = original.proxy_next_offset;
+
+    fs::remove_file(&ledger).unwrap();
+    append_proxy_usage_record_at(&ledger, &captured("new-1", 20), now_ms + 1).unwrap();
+    append_proxy_usage_record_at(&ledger, &captured("new-2", 30), now_ms + 2).unwrap();
+    assert!(fs::metadata(&ledger).unwrap().len() > original_offset);
+
+    let replaced = read_token_usage_events_from_sources(
+        &[],
+        &ledger,
+        &serde_json::from_value(json!({
+            "includeRollout": false,
+            "proxyOffset": original_offset,
+            "proxyGeneration": original_generation,
+            "limit": 100
+        }))
+        .unwrap(),
+    );
+    assert!(replaced.proxy_reset);
+    assert_ne!(replaced.proxy_generation, original_generation);
+    assert_eq!(
+        replaced
+            .events
+            .iter()
+            .map(|event| event.response_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["new-1", "new-2"]
+    );
+}
+
+#[test]
+fn combined_reader_uses_rollout_before_first_proxy_record_and_proxy_after_it() {
+    let temp = tempfile::tempdir().unwrap();
+    let rollout = temp.path().join("rollout-session.jsonl");
+    let ledger = temp.path().join("responses-usage.jsonl");
+    fs::write(
+        &rollout,
+        [
+            json!({"timestamp":"2026-07-23T00:00:00.000Z","payload":{"type":"session_meta","session_id":"session-1"}}),
+            json!({"timestamp":"2026-07-23T00:00:00.000Z","payload":{"type":"turn_context","model":"gpt-5.6-terra"}}),
+            json!({"timestamp":"2026-07-23T00:00:01.000Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"output_tokens":10},"total_token_usage":{"input_tokens":100,"output_tokens":10}}}}),
+            json!({"timestamp":"2026-07-23T00:00:03.000Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":200,"output_tokens":20},"total_token_usage":{"input_tokens":300,"output_tokens":30}}}}),
+        ]
+        .iter()
+        .map(serde_json::Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n"),
+    )
+    .unwrap();
+    append_proxy_usage_record_at(
+        &ledger,
+        &CapturedResponseUsage {
+            response_id: "resp-after-cutover".to_string(),
+            model: "gpt-5.6-terra".to_string(),
+            status: "completed".to_string(),
+            usage: UsageCounts {
+                input: 200,
+                output: 20,
+                total: 220,
+                ..UsageCounts::default()
+            },
+            usage_missing: false,
+        },
+        1_784_764_802_000,
+    )
+    .unwrap();
+
+    let result = read_token_usage_events_from_sources(
+        &[temp.path().to_path_buf()],
+        &ledger,
+        &TokenUsageQuery {
+            days: 31,
+            limit: 100,
+            ..TokenUsageQuery::default()
+        },
+    );
+
+    assert_eq!(result.events.len(), 2);
+    assert_eq!(result.events[0].source, "rollout");
+    assert_eq!(result.events[0].usage.input, 100);
+    assert_eq!(result.events[1].source, "proxy");
+    assert_eq!(result.events[1].response_id, "resp-after-cutover");
+    assert_eq!(result.proxy_enabled_at_ms, 1_784_764_802_000);
+}
+
+#[test]
+fn combined_reader_keeps_unmatched_rollout_events_during_proxy_gaps() {
+    let temp = tempfile::tempdir().unwrap();
+    let rollout = temp.path().join("rollout-session.jsonl");
+    let ledger = temp.path().join("responses-usage.jsonl");
+    fs::write(
+        &rollout,
+        [
+            json!({"timestamp":"2026-07-23T00:00:00.000Z","payload":{"type":"session_meta","session_id":"session-1"}}),
+            json!({"timestamp":"2026-07-23T00:00:00.000Z","payload":{"type":"turn_context","model":"gpt-5.6-terra"}}),
+            json!({"timestamp":"2026-07-23T00:00:01.000Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"output_tokens":10},"total_token_usage":{"input_tokens":100,"output_tokens":10}}}}),
+            json!({"timestamp":"2026-07-23T00:00:03.000Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":200,"output_tokens":20},"total_token_usage":{"input_tokens":300,"output_tokens":30}}}}),
+            json!({"timestamp":"2026-07-23T00:00:05.000Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":300,"output_tokens":30},"total_token_usage":{"input_tokens":600,"output_tokens":60}}}}),
+        ]
+        .iter()
+        .map(serde_json::Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n"),
+    )
+    .unwrap();
+    append_proxy_usage_record_at(
+        &ledger,
+        &CapturedResponseUsage {
+            response_id: "resp-middle".to_string(),
+            model: "gpt-5.6-terra".to_string(),
+            status: "completed".to_string(),
+            usage: UsageCounts {
+                input: 200,
+                output: 20,
+                total: 220,
+                ..UsageCounts::default()
+            },
+            usage_missing: false,
+        },
+        1_784_764_803_000,
+    )
+    .unwrap();
+
+    let result = read_token_usage_events_from_sources(
+        &[temp.path().to_path_buf()],
+        &ledger,
+        &TokenUsageQuery {
+            days: 31,
+            limit: 100,
+            ..TokenUsageQuery::default()
+        },
+    );
+
+    assert_eq!(result.events.len(), 3);
+    assert_eq!(result.events[0].usage.input, 100);
+    assert_eq!(result.events[1].source, "proxy");
+    assert_eq!(result.events[1].usage.input, 200);
+    assert_eq!(result.events[2].source, "rollout");
+    assert_eq!(result.events[2].usage.input, 300);
+}
+
+#[test]
+fn combined_reader_matches_a_uniquely_renamed_model_without_model_aliases() {
+    let temp = tempfile::tempdir().unwrap();
+    let rollout = temp.path().join("rollout-session.jsonl");
+    let ledger = temp.path().join("responses-usage.jsonl");
+    fs::write(
+        &rollout,
+        [
+            json!({"timestamp":"2026-07-23T00:00:00.000Z","payload":{"type":"session_meta","session_id":"session-1"}}),
+            json!({"timestamp":"2026-07-23T00:00:00.000Z","payload":{"type":"turn_context","model":"local-model-name"}}),
+            json!({"timestamp":"2026-07-23T00:00:01.000Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":200,"cached_input_tokens":100,"output_tokens":20},"total_token_usage":{"input_tokens":200,"cached_input_tokens":100,"output_tokens":20}}}}),
+        ]
+        .iter()
+        .map(serde_json::Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n"),
+    )
+    .unwrap();
+    append_proxy_usage_record_at(
+        &ledger,
+        &CapturedResponseUsage {
+            response_id: "resp-renamed".to_string(),
+            model: "provider-model-name".to_string(),
+            status: "completed".to_string(),
+            usage: UsageCounts {
+                input: 200,
+                cached_input: 100,
+                output: 20,
+                total: 220,
+                ..UsageCounts::default()
+            },
+            usage_missing: false,
+        },
+        1_784_764_801_500,
+    )
+    .unwrap();
+
+    let result = read_token_usage_events_from_sources(
+        &[temp.path().to_path_buf()],
+        &ledger,
+        &TokenUsageQuery {
+            days: 31,
+            limit: 100,
+            ..TokenUsageQuery::default()
+        },
+    );
+
+    assert_eq!(result.events.len(), 1);
+    assert_eq!(result.events[0].source, "proxy");
+    assert_eq!(result.events[0].response_id, "resp-renamed");
+    assert!(!include_str!("../src/token_usage.rs").contains("gpt-5.6"));
+}
+
+#[test]
+fn same_session_watermark_ignores_model_and_prefers_known_model() {
+    let original = event("original", "2026-07-22T00:23:39.106Z", "gpt-5.6-terra");
+    let replay = event("replay", "2026-07-22T05:13:32.738Z", "Unknown");
+
+    let deduplicated = deduplicate_rollout_events(vec![original.clone(), replay]);
+
+    assert_eq!(deduplicated, vec![original]);
+}
+
+#[test]
+fn rollout_reader_deduplicates_child_history_across_models() {
+    let temp = tempfile::tempdir().unwrap();
+    let original = temp.path().join("rollout-original.jsonl");
+    let replay = temp.path().join("rollout-child.jsonl");
+    let usage = json!({
+        "input_tokens": 179540,
+        "cached_input_tokens": 179200,
+        "cache_creation_input_tokens": 128,
+        "output_tokens": 506,
+        "reasoning_output_tokens": 130,
+        "total_tokens": 180046
+    });
+    let totals = json!({
+        "input_tokens": 72898219,
+        "cached_input_tokens": 67888640,
+        "cache_creation_input_tokens": 128,
+        "output_tokens": 210561,
+        "reasoning_output_tokens": 56791,
+        "total_tokens": 73108780
+    });
+    let token_count = |timestamp: &str| {
+        json!({
+            "timestamp": timestamp,
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": usage,
+                    "total_token_usage": totals
+                }
+            }
+        })
+    };
+    fs::write(
+        &original,
+        [
+            json!({"timestamp":"2026-07-22T00:23:24.431Z","payload":{"type":"session_meta","session_id":"session-1","id":"session-1"}}),
+            json!({"timestamp":"2026-07-22T00:23:24.431Z","payload":{"type":"turn_context","turn_id":"turn-1","model":"gpt-5.6-terra"}}),
+            token_count("2026-07-22T00:23:39.106Z"),
+        ]
+        .iter()
+        .map(serde_json::Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n"),
+    )
+    .unwrap();
+    fs::write(
+        &replay,
+        [
+            json!({"timestamp":"2026-07-22T05:13:32.738Z","payload":{"type":"session_meta","session_id":"session-1","id":"child-1","source":{"subagent":{}}}}),
+            token_count("2026-07-22T05:13:32.738Z"),
+        ]
+        .iter()
+        .map(serde_json::Value::to_string)
+        .collect::<Vec<_>>()
+        .join("\n"),
+    )
+    .unwrap();
+
+    let result = read_rollout_events_from_roots(
+        &[temp.path().to_path_buf()],
+        &TokenUsageQuery {
+            days: 7,
+            limit: 100,
+            ..TokenUsageQuery::default()
+        },
+    );
+
+    assert!(result.warnings.is_empty());
+    assert_eq!(result.events.len(), 1);
+    assert_eq!(result.events[0].model, "gpt-5.6-terra");
+    assert_eq!(result.events[0].usage.cache_write, 128);
+    assert!(
+        serde_json::to_value(&result.events[0])
+            .unwrap()
+            .get("sourcePath")
+            .is_none()
+    );
+}
+
+#[test]
+fn rollout_tailer_reads_only_events_appended_since_the_previous_scan() {
+    let temp = tempfile::tempdir().unwrap();
+    let rollout = temp.path().join("rollout-session.jsonl");
+    let initial = [
+        json!({"timestamp":"2026-07-28T00:00:00.000Z","payload":{"type":"session_meta","session_id":"session-1"}}),
+        json!({"timestamp":"2026-07-28T00:00:00.000Z","payload":{"type":"turn_context","model":"test-model"}}),
+        json!({"timestamp":"2026-07-28T00:00:01.000Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"output_tokens":10},"total_token_usage":{"input_tokens":100,"output_tokens":10}}}}),
+    ]
+    .iter()
+    .map(serde_json::Value::to_string)
+    .collect::<Vec<_>>()
+    .join("\n");
+    fs::write(&rollout, format!("{initial}\n")).unwrap();
+    let query = TokenUsageQuery {
+        days: 31,
+        limit: 100,
+        ..TokenUsageQuery::default()
+    };
+    let mut tailer = RolloutTailer::default();
+
+    let first = tailer.read_from_roots(&[temp.path().to_path_buf()], &query);
+    assert_eq!(first.events.len(), 1);
+    assert_eq!(first.events[0].usage.input, 100);
+
+    let mut file = fs::OpenOptions::new().append(true).open(&rollout).unwrap();
+    writeln!(
+        file,
+        "{}",
+        json!({"timestamp":"2026-07-28T00:00:02.000Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":200,"output_tokens":20},"total_token_usage":{"input_tokens":300,"output_tokens":30}}}})
+    )
+    .unwrap();
+    file.flush().unwrap();
+
+    let second = tailer.read_from_roots(&[temp.path().to_path_buf()], &query);
+    assert_eq!(second.events.len(), 1);
+    assert_eq!(second.events[0].usage.input, 200);
+    assert!(
+        tailer
+            .read_from_roots(&[temp.path().to_path_buf()], &query)
+            .events
+            .is_empty()
+    );
+}

--- a/docs/token-usage-reconciliation.md
+++ b/docs/token-usage-reconciliation.md
@@ -1,0 +1,112 @@
+# Token Usage Reconciliation
+
+Codex++ exposes one local bridge route for the companion user script:
+
+```text
+/token-usage/events
+```
+
+The bridge does not provide prices and does not contact a billing provider. Model prices,
+long-context thresholds, and multipliers remain optional local settings in the user script. An
+empty price table and multiplier `1` are the defaults.
+
+## Data flow
+
+1. `MessagePort` events update the current page immediately.
+2. At script startup, the bridge scans recent rollout JSONL files once and builds per-file tail
+   cursors.
+3. Every 60 seconds, the script asks for incremental reconciliation. Codex++ checks rollout file
+   metadata and reads only new bytes from changed or newly created files.
+4. Responses routed through the local protocol proxy append terminal usage and retry attempts to a
+   bounded JSONL ledger.
+5. The script matches MessagePort, rollout, and proxy events one-to-one using Input, Cached Input,
+   Output, and a bounded time window. A model-name mismatch is accepted only when those fields
+   identify one unique candidate; proxy-only Cache Write and Reasoning values replace the live
+   request instead of creating a second request.
+
+This captures subagent rollout files without repeatedly reading all session history.
+
+## Script installation
+
+Install `Codex Reconciled Token Usage` from the Codex++ Script Market after using a Codex++ build
+that contains this bridge. The market script is:
+
+```text
+scripts/codex-reconciled-token-usage.js
+```
+
+Release metadata:
+
+```text
+Version: 1.0.0
+Author: QingJunXue
+```
+
+After installation, reload user scripts or restart Codex++ once. Existing data from
+`__myCodexTokenStatsV1` and existing local price settings are migrated once to the new storage
+namespace. No relay CSV or provider-specific API is required.
+
+## Bridge request
+
+```json
+{
+  "since": "2026-07-28T00:00:00.000Z",
+  "days": 7,
+  "limit": 10000,
+  "includeRollout": true,
+  "rolloutIncremental": true,
+  "proxySinceMs": 1785196800000,
+  "proxyOffset": 12345,
+  "proxyGeneration": "ledger-generation"
+}
+```
+
+- Initial reconciliation uses `rolloutIncremental: false` and empty cursors.
+- Periodic reconciliation uses `rolloutIncremental: true` and the returned cursors.
+- A changed proxy ledger generation sets `proxyReset: true`; the script then performs one full
+  rebuild.
+
+## Bridge response
+
+```json
+{
+  "events": [],
+  "warnings": [],
+  "nextSince": "2026-07-28T00:00:00.000Z",
+  "proxyNextSinceMs": 1785196800000,
+  "proxyNextOffset": 12345,
+  "proxyGeneration": "ledger-generation",
+  "proxyReset": false,
+  "missingUsage": 0
+}
+```
+
+Each event contains model, timestamp, status, source, response ID when available, and Token counts
+for input, cached input, cache write, output, reasoning, and total.
+
+Request status meanings:
+
+- `completed`: terminal model response.
+- `failed` or `incomplete`: final request without a successful terminal response.
+- `retry`: an upstream attempt failed and Codex++ continued with another relay candidate.
+
+## Disk behavior
+
+- The proxy usage ledger is append-only during normal requests, rotates at 20 MB, and retains three
+  archives.
+- Incomplete JSONL tail records do not advance the read cursor.
+- Rollout files are read fully once at startup, then tailed incrementally.
+- Diagnostic logs rotate at 20 MB and retain three archives.
+- High-frequency successful `bridge.request`, `bridge.response`, `bridge.resolve_start`, and
+  `bridge.resolve_ok` events are not persisted.
+- No explicit `fsync` is performed per Token event.
+
+## Privacy and limits
+
+- The usage ledger does not store prompts, response text, API keys, or upstream URLs.
+- Rollout files currently do not expose cache-write Token fields in every Codex build. Missing values
+  remain zero rather than being inferred from input Tokens.
+- Official-login traffic that does not pass through the protocol proxy is reconciled from rollout
+  tails. API relay traffic additionally receives request-attempt and terminal usage events from the
+  proxy.
+- Cost estimates remain local and depend on user-entered request-level prices and thresholds.


### PR DESCRIPTION
## Summary

- add a single local `/token-usage/events` bridge without a price endpoint or billing-provider dependency
- reconcile MessagePort, rollout JSONL, subagent rollout files, and protocol-proxy Usage events
- capture Input, Cached Input, Cache Write, Output, Reasoning, request status, retries, and Usage-missing responses
- follow the dynamically selected Helper port and prevent local proxy URLs from becoming upstream URLs
- add bounded stream lifetimes, downstream-disconnect resilience, ledger rotation, and diagnostic-log rotation

## Disk and privacy behavior

- rollout files are read fully once, then tailed incrementally
- proxy ledger rotates at 20 MB and retains three archives
- diagnostic logs rotate at 20 MB and retain three archives
- high-frequency successful bridge events are not persisted
- the Usage ledger stores no prompts, response text, API keys, or upstream URLs

## Verification

- `cargo fmt --all -- --check`
- Token Usage tests: 13/13
- Bridge route tests: 27/27
- Protocol proxy tests: 48/48
- Relay configuration tests: 103/103
- Launcher tests: 74/74, with one unrelated Windows symlink-privilege test skipped
- Diagnostic log tests: 3/3
- scoped Clippy: 0 warnings in the new Token Usage implementation
- `cargo build --release -p codex-plus-launcher`

The skipped launcher test requires Windows symbolic-link privilege and fails with OS error 1314 independently of this change.