### PR TITLE
fix(macos): preserve app icons during entrypoint repair

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -144,6 +144,8 @@ jobs:
             test -f "$app/Contents/Info.plist"
             test -f "$app/Contents/PkgInfo"
             test -x "$app/Contents/MacOS/$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$app/Contents/Info.plist")"
+            icon="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIconFile' "$app/Contents/Info.plist")"
+            test -f "$app/Contents/Resources/$icon"
             plutil -lint "$app/Contents/Info.plist" >/dev/null
             codesign -dv "$app" >/dev/null 2>&1
             echo "verified: $app"

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -137,6 +137,8 @@ jobs:
             test -f "$app/Contents/Info.plist"
             test -f "$app/Contents/PkgInfo"
             test -x "$app/Contents/MacOS/$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$app/Contents/Info.plist")"
+            icon="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIconFile' "$app/Contents/Info.plist")"
+            test -f "$app/Contents/Resources/$icon"
             plutil -lint "$app/Contents/Info.plist" >/dev/null
             codesign -dv "$app" >/dev/null 2>&1
             echo "verified: $app"

--- a/crates/codex-plus-core/src/install/macos.rs
+++ b/crates/codex-plus-core/src/install/macos.rs
@@ -135,12 +135,20 @@ fn write_bundle(bundle: &MacosAppBundle) -> anyhow::Result<()> {
 
 #[cfg(target_os = "macos")]
 fn copy_icon(resources: &Path) -> anyhow::Result<()> {
-    let source = std::env::current_exe()
-        .ok()
-        .and_then(|path| path.parent().map(Path::to_path_buf))
-        .map(|path| path.join("codex-plus-plus.png"));
-    if let Some(source) = source.filter(|path| path.exists()) {
-        fs::copy(source, resources.join("codex-plus-plus.png"))?;
+    let source = std::env::current_exe().ok().and_then(|executable| {
+        let macos = executable.parent()?;
+        let contents = macos.parent()?;
+        let bundled_icon = contents.join("Resources/codex-plus-plus.icns");
+        bundled_icon.exists().then_some(bundled_icon).or_else(|| {
+            let sidecar_icon = macos.join("codex-plus-plus.icns");
+            sidecar_icon.exists().then_some(sidecar_icon)
+        })
+    });
+    if let Some(source) = source {
+        let target = resources.join("codex-plus-plus.icns");
+        if source != target {
+            fs::copy(source, target)?;
+        }
     }
     Ok(())
 }
@@ -178,7 +186,7 @@ fn info_plist(display_name: &str, executable_name: &str, identifier_suffix: &str
   <key>CFBundleExecutable</key>
   <string>{executable_name}</string>
   <key>CFBundleIconFile</key>
-  <string>codex-plus-plus.png</string>
+  <string>codex-plus-plus.icns</string>
   <key>LSUIElement</key>
   <true/>
   <key>LSMinimumSystemVersion</key>

--- a/crates/codex-plus-core/tests/installers.rs
+++ b/crates/codex-plus-core/tests/installers.rs
@@ -80,6 +80,18 @@ fn macos_bundle_metadata_contains_silent_and_manager_apps() {
             .info_plist
             .contains("<string>Codex++ 管理工具</string>")
     );
+    assert!(
+        silent
+            .info_plist
+            .contains("<string>codex-plus-plus.icns</string>")
+    );
+    assert!(
+        manager
+            .info_plist
+            .contains("<string>codex-plus-plus.icns</string>")
+    );
+    assert!(!silent.info_plist.contains("codex-plus-plus.png"));
+    assert!(!manager.info_plist.contains("codex-plus-plus.png"));
     assert_eq!(
         silent.binary_target_name.as_deref(),
         Some("codex-plus-plus")


### PR DESCRIPTION
## Summary
- make repaired macOS app bundles reference the packaged `.icns` icon
- copy the `.icns` from the current app bundle instead of looking for a missing PNG sidecar
- verify in CI that every `CFBundleIconFile` actually exists
- add regression assertions for repaired bundle metadata

## Root cause
The release DMG is packaged correctly with `codex-plus-plus.icns`, but the in-app entrypoint repair path rewrites `Info.plist` to `codex-plus-plus.png` and looks for a PNG beside the executable. That file is absent in the DMG apps, so Finder/Spotlight display a generic icon after repair.

## Verification
- `cargo fmt --all -- --check`
- targeted regression test passes: `cargo test -p codex-plus-core --test installers macos_bundle_metadata_contains_silent_and_manager_apps -- --exact`
- workflow YAML parses successfully
- `git diff --check` passes

## Existing unrelated test failures
The full `installers` test binary currently has two pre-existing macOS companion-path assertion failures involving `CodexPlusPlusManager` vs `codex-plus-plus-manager`; this PR does not touch that path logic.