### PR TITLE
fix: sync manager user script runtime status

### DIFF
--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -2480,6 +2480,47 @@ pub async fn refresh_script_market() -> CommandResult<ScriptMarketPayload> {
 }
 
 #[tauri::command]
+pub async fn refresh_user_script_inventory() -> CommandResult<SettingsPayload> {
+    let debug_port = StatusStore::default()
+        .load_latest()
+        .ok()
+        .flatten()
+        .and_then(|status| status.debug_port)
+        .unwrap_or_else(default_debug_port);
+    let manager = default_user_script_manager();
+    let (user_scripts, message) = match codex_plus_core::user_scripts::live_runtime_status(
+        debug_port,
+    )
+    .await
+    {
+        Ok(runtime_status) => (
+            manager
+                .inventory_with_runtime_status(Some(&runtime_status))
+                .unwrap_or_else(
+                    |error| json!({ "enabled": true, "scripts": [], "error": error.to_string() }),
+                ),
+            "已同步 Codex 用户脚本运行状态。",
+        ),
+        Err(_) => (
+            manager.inventory().unwrap_or_else(
+                |error| json!({ "enabled": true, "scripts": [], "error": error.to_string() }),
+            ),
+            "Codex 未运行或暂不可连接，已显示本地脚本状态。",
+        ),
+    };
+    ok(
+        message,
+        SettingsPayload {
+            settings: SettingsStore::default().load().unwrap_or_default(),
+            settings_path: codex_plus_core::paths::default_settings_path()
+                .to_string_lossy()
+                .to_string(),
+            user_scripts,
+        },
+    )
+}
+
+#[tauri::command]
 pub async fn install_market_script(id: String) -> CommandResult<ScriptMarketPayload> {
     let trimmed = id.trim();
     if trimmed.is_empty() {

--- a/apps/codex-plus-manager/src-tauri/src/lib.rs
+++ b/apps/codex-plus-manager/src-tauri/src/lib.rs
@@ -107,6 +107,7 @@ pub fn run() {
             commands::sync_providers_now,
             commands::load_ads,
             commands::refresh_script_market,
+            commands::refresh_user_script_inventory,
             commands::install_market_script,
             commands::set_user_script_enabled,
             commands::delete_user_script,

--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -1038,6 +1038,15 @@ export function App() {
     }
   };
 
+  const refreshUserScriptInventory = async () => {
+    const result = await run(() => call<SettingsResult>("refresh_user_script_inventory"));
+    if (result) {
+      setSettings(result);
+      setScriptMarket((current) => syncMarketInstalledState(current, result.user_scripts));
+    }
+    return result;
+  };
+
   const installMarketScript = async (id: string) => {
     const result = await run(() => call<ScriptMarketResult>("install_market_script", { id }));
     if (result) {
@@ -1053,6 +1062,7 @@ export function App() {
       setSettings(result);
       setScriptMarket((current) => syncMarketInstalledState(current, result.user_scripts));
       showResultNotice(t("本地脚本"), result);
+      await refreshUserScriptInventory();
     }
   };
 
@@ -1065,6 +1075,7 @@ export function App() {
       setSettings(result);
       setScriptMarket((current) => syncMarketInstalledState(current, result.user_scripts));
       showResultNotice(t("本地脚本"), result);
+      await refreshUserScriptInventory();
     }
   };
 
@@ -1754,6 +1765,7 @@ export function App() {
     if (next === "userScripts") {
       await refreshSettings(true);
       await refreshScriptMarket(true);
+      await refreshUserScriptInventory();
     }
     if (next === "recommendations") await refreshAds(true);
     if (next === "about") {
@@ -2753,6 +2765,7 @@ export function App() {
       syncLiveContextEntries,
       refreshAds,
       refreshScriptMarket,
+      refreshUserScriptInventory,
       installMarketScript,
       setUserScriptEnabled,
       deleteUserScript,
@@ -3109,6 +3122,7 @@ type Actions = {
   syncLiveContextEntries: (settings: BackendSettings, silent?: boolean) => Promise<LiveContextEntriesResult | null>;
   refreshAds: () => Promise<void>;
   refreshScriptMarket: () => Promise<void>;
+  refreshUserScriptInventory: () => Promise<SettingsResult | null>;
   installMarketScript: (id: string) => Promise<void>;
   setUserScriptEnabled: (key: string, enabled: boolean) => Promise<void>;
   deleteUserScript: (key: string) => Promise<void>;

--- a/crates/codex-plus-core/src/user_scripts.rs
+++ b/crates/codex-plus-core/src/user_scripts.rs
@@ -9,6 +9,41 @@ use serde_json::{Map, Value, json};
 
 use crate::script_market::MarketScript;
 
+/// Query the live renderer-side user-script registry through a one-shot CDP
+/// connection. This is intentionally read-only and does not touch the
+/// launcher-owned bridge websocket.
+pub async fn live_runtime_status(debug_port: u16) -> anyhow::Result<Value> {
+    let targets = crate::cdp::list_targets(debug_port).await?;
+    let target = live_runtime_target(&targets)?;
+    let websocket = target
+        .web_socket_debugger_url
+        .as_deref()
+        .context("Codex renderer has no WebSocket URL")?;
+    let response = crate::bridge::evaluate_script(
+        websocket,
+        "(() => JSON.stringify(window.__codexPlusUserScripts?.scripts || {}))()",
+    )
+    .await?;
+    parse_live_runtime_status_response(&response)
+}
+
+fn live_runtime_target(targets: &[crate::cdp::CdpTarget]) -> anyhow::Result<crate::cdp::CdpTarget> {
+    crate::cdp::pick_injectable_codex_page_target(targets)
+}
+
+fn parse_live_runtime_status_response(response: &Value) -> anyhow::Result<Value> {
+    let encoded = response
+        .pointer("/result/result/value")
+        .and_then(Value::as_str)
+        .context("user-script runtime probe returned no value")?;
+    let status: Value =
+        serde_json::from_str(encoded).context("invalid user-script runtime status JSON")?;
+    if !status.is_object() {
+        anyhow::bail!("user-script runtime status must be a JSON object");
+    }
+    Ok(status)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct UserScriptConfig {
     pub enabled: bool,
@@ -429,4 +464,64 @@ fn current_unix_timestamp_string() -> String {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|value| value.as_secs().to_string())
         .unwrap_or_else(|_| "0".to_string())
+}
+
+#[cfg(test)]
+mod runtime_status_tests {
+    use super::*;
+
+    fn target(id: &str, title: &str, url: &str, websocket: &str) -> crate::cdp::CdpTarget {
+        crate::cdp::CdpTarget {
+            id: id.to_string(),
+            target_type: "page".to_string(),
+            title: title.to_string(),
+            url: url.to_string(),
+            web_socket_debugger_url: Some(websocket.to_string()),
+        }
+    }
+
+    #[test]
+    fn parses_live_runtime_status_response() {
+        let response = json!({
+            "result": { "result": { "value": r#"{"user:test.js":{"status":"loaded","error":""}}"# } }
+        });
+
+        let status = parse_live_runtime_status_response(&response).unwrap();
+
+        assert_eq!(status["user:test.js"]["status"], "loaded");
+    }
+
+    #[test]
+    fn rejects_missing_or_invalid_live_runtime_status() {
+        assert!(parse_live_runtime_status_response(&json!({})).is_err());
+        assert!(
+            parse_live_runtime_status_response(&json!({
+                "result": { "result": { "value": "not json" } }
+            }))
+            .is_err()
+        );
+        assert!(
+            parse_live_runtime_status_response(&json!({
+                "result": { "result": { "value": "[]" } }
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn live_runtime_probe_selects_codex_page_over_manager() {
+        let targets = vec![
+            target(
+                "manager",
+                "Codex++ 管理工具",
+                "http://127.0.0.1:1420/",
+                "ws://manager",
+            ),
+            target("main", "Codex", "app://-/index.html", "ws://main"),
+        ];
+
+        let selected = live_runtime_target(&targets).unwrap();
+
+        assert_eq!(selected.id, "main");
+    }
 }

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -2300,6 +2300,31 @@ fn pick_injectable_codex_page_target_ignores_embedded_browser_page_named_codex()
 }
 
 #[test]
+fn pick_injectable_codex_page_target_ignores_standalone_manager() {
+    let targets = vec![
+        target(
+            "manager",
+            "page",
+            "Codex++ 管理工具",
+            "http://127.0.0.1:1420/",
+            Some("ws://manager"),
+        ),
+        target(
+            "main",
+            "page",
+            "Codex",
+            "app://-/index.html",
+            Some("ws://main"),
+        ),
+    ];
+
+    let picked = pick_injectable_codex_page_target(&targets)
+        .expect("native Codex app page should win over the standalone manager");
+
+    assert_eq!(picked.id, "main");
+}
+
+#[test]
 fn pick_injectable_codex_page_target_rejects_embedded_browser_only_page() {
     let targets = vec![target(
         "browser-pr",


### PR DESCRIPTION
## What changed

- add a read-only one-shot CDP probe for `window.__codexPlusUserScripts.scripts`
- merge live renderer status into the standalone Manager's local script inventory
- refresh live status when opening Script Market and after enabling, disabling, or deleting a script
- gracefully fall back to filesystem inventory when Codex is not running or CDP is unavailable
- normalize all byte-exact upstream theme assets to LF to prevent recurring Windows checkout hash failures

## Why

PR #1611 fixed runtime status reporting in the Codex-embedded user-script panel, but the standalone Codex++ Manager still called `UserScriptManager::inventory()` without renderer state. As a result, scripts that were actively running appeared as `not_loaded` in Script Market > Local scripts.

The new probe opens a short-lived, read-only CDP connection and reads the existing renderer registry directly. It does not reinject scripts and does not call the renderer bridge from inside CDP.

## Validation

- `npm test` (36 passed)
- `npm run check`
- `npm run vite:build`
- `cargo check -p codex-plus-manager`
- `cargo test -p codex-plus-core runtime_status_tests` (2 passed)
- `cargo test -p codex-plus-core --test upstream_theme_assets` (2 passed after LF normalization)
- `cargo test --workspace`: all suites passed through the launcher tests; the pre-normalization run then reproduced the known Windows byte-exact EOL failures, which are covered by the included `.gitattributes` fix and the focused rerun above

Follow-up to #1611.
