### PR TITLE
feat: 完善用户脚本热重载与启动自查

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,10 @@ assets/inject/upstream/snow-skin/*.css text eol=lf
 # Keep byte-exact macOS theme assets identical on every checkout platform.
 assets/inject/upstream/*/macos/*.js text eol=lf
 assets/inject/upstream/*/macos/*.css text eol=lf
+
+# Keep the remaining byte-exact upstream theme assets stable on Windows.
+assets/inject/upstream/*/windows/*.js text eol=lf
+assets/inject/upstream/*/windows/*.css text eol=lf
+assets/inject/upstream/glass-vision/*.js text eol=lf
+assets/inject/upstream/glass-vision/*.css text eol=lf
+assets/inject/upstream/skin-packs/packs/*/theme.json text eol=lf

--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -6,10 +6,15 @@ use codex_plus_core::launcher::{
 };
 use codex_plus_core::models::{DeleteResult, ExportResult, SessionRef};
 use codex_plus_core::routes::{BridgeContext, BridgeDataService, BridgeRuntimeService};
-use codex_plus_core::user_scripts::UserScriptManager;
+use codex_plus_core::user_scripts::{
+    UserScriptManager, user_script_presence_expression, user_script_presence_from_evaluation,
+};
 use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+
+const USER_SCRIPT_STARTUP_CHECK_ATTEMPTS: usize = 3;
+const USER_SCRIPT_STARTUP_CHECK_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
 
 #[derive(Clone)]
 struct LauncherHooks {
@@ -562,6 +567,20 @@ impl LauncherRuntimeService {
         *self.websocket_url.lock().unwrap() = Some(websocket_url.to_string());
     }
 
+    fn is_current_user_script_target(&self, websocket_url: &str, expected_keys: &[String]) -> bool {
+        let target_matches = self
+            .websocket_url
+            .lock()
+            .unwrap()
+            .as_deref()
+            .is_some_and(|current| current == websocket_url);
+        target_matches
+            && self
+                .user_scripts
+                .enabled_script_keys()
+                .is_ok_and(|current| current == expected_keys)
+    }
+
     async fn reload_user_scripts_now(&self) -> anyhow::Result<Value> {
         let bundle = self.user_scripts.build_reload_bundle()?;
         let websocket_url = self.websocket_url.lock().unwrap().clone();
@@ -570,6 +589,87 @@ impl LauncherRuntimeService {
         }
         self.user_scripts.inventory()
     }
+
+    fn start_user_script_startup_check(
+        self: &Arc<Self>,
+        websocket_url: String,
+        expected_keys: Vec<String>,
+    ) {
+        if expected_keys.is_empty() {
+            return;
+        }
+        let runtime = self.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(USER_SCRIPT_STARTUP_CHECK_DELAY).await;
+            let expression = match user_script_presence_expression(&expected_keys) {
+                Ok(expression) => expression,
+                Err(error) => {
+                    let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+                        "user_scripts.startup_check_failed",
+                        json!({ "error": error.to_string() }),
+                    );
+                    return;
+                }
+            };
+
+            for attempt in 1..=USER_SCRIPT_STARTUP_CHECK_ATTEMPTS {
+                if !runtime.is_current_user_script_target(&websocket_url, &expected_keys) {
+                    let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+                        "user_scripts.startup_check",
+                        json!({ "status": "obsolete", "attempt": attempt }),
+                    );
+                    return;
+                }
+                match user_scripts_are_present(&websocket_url, &expression).await {
+                    Ok(true) => {
+                        let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+                            "user_scripts.startup_check",
+                            json!({ "status": "ok", "attempt": attempt }),
+                        );
+                        return;
+                    }
+                    Ok(false) if attempt < USER_SCRIPT_STARTUP_CHECK_ATTEMPTS => {
+                        let bundle = match runtime.user_scripts.build_reload_bundle() {
+                            Ok(bundle) => bundle,
+                            Err(error) => {
+                                let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+                                    "user_scripts.startup_reload_failed",
+                                    json!({ "attempt": attempt, "error": error.to_string() }),
+                                );
+                                return;
+                            }
+                        };
+                        if let Err(error) =
+                            codex_plus_core::bridge::evaluate_script(&websocket_url, &bundle).await
+                        {
+                            let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+                                "user_scripts.startup_reload_failed",
+                                json!({ "attempt": attempt, "error": error.to_string() }),
+                            );
+                        }
+                    }
+                    Ok(false) => break,
+                    Err(error) => {
+                        let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+                            "user_scripts.startup_check_failed",
+                            json!({ "attempt": attempt, "error": error.to_string() }),
+                        );
+                    }
+                }
+                tokio::time::sleep(USER_SCRIPT_STARTUP_CHECK_DELAY).await;
+            }
+
+            let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+                "user_scripts.startup_check",
+                json!({ "status": "missing", "expected_keys": expected_keys }),
+            );
+        });
+    }
+}
+
+async fn user_scripts_are_present(websocket_url: &str, expression: &str) -> anyhow::Result<bool> {
+    let response = codex_plus_core::bridge::evaluate_script(websocket_url, expression).await?;
+    user_script_presence_from_evaluation(&response)
 }
 
 #[async_trait::async_trait]
@@ -748,6 +848,7 @@ async fn try_inject_with_context(
         .unwrap_or_default();
     let script = codex_plus_core::assets::injection_script_with_settings(helper_port, &settings);
     let user_bundle = runtime.user_scripts.build_enabled_bundle()?;
+    let expected_user_script_keys = runtime.user_scripts.enabled_script_keys()?;
     let new_document_scripts = if user_bundle.is_empty() {
         vec![script]
     } else {
@@ -765,6 +866,7 @@ async fn try_inject_with_context(
         &new_document_scripts,
     )
     .await?;
+    runtime.start_user_script_startup_check(websocket_url.to_string(), expected_user_script_keys);
     Ok(())
 }
 
@@ -884,13 +986,24 @@ mod tests {
     }
 
     #[test]
-    fn launcher_uses_event_driven_user_script_reload_without_file_polling() {
+    fn launcher_uses_finite_user_script_startup_check_without_file_polling() {
         let source = include_str!("main.rs");
 
+        assert!(source.contains("start_user_script_startup_check"));
+        assert!(source.contains("USER_SCRIPT_STARTUP_CHECK_ATTEMPTS"));
+        assert!(source.contains("user_script_presence_expression"));
         assert!(source.contains("build_reload_bundle"));
-        assert!(!source.contains("start_user_script_hot_reload_watchdog"));
-        assert!(!source.contains("user_scripts.snapshot()"));
-        assert!(!source.contains("tokio::time::interval(std::time::Duration::from_secs(1))"));
+        for forbidden in [
+            ["start_user_script_hot_reload", "_watchdog"].concat(),
+            ["user_scripts.", "snapshot()"].concat(),
+            [
+                "tokio::time::interval(",
+                "std::time::Duration::from_secs(1))",
+            ]
+            .concat(),
+        ] {
+            assert!(!source.contains(&forbidden), "found {forbidden}");
+        }
     }
 
     #[tokio::test]

--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -561,6 +561,15 @@ impl LauncherRuntimeService {
     fn set_websocket_url(&self, websocket_url: &str) {
         *self.websocket_url.lock().unwrap() = Some(websocket_url.to_string());
     }
+
+    async fn reload_user_scripts_now(&self) -> anyhow::Result<Value> {
+        let bundle = self.user_scripts.build_reload_bundle()?;
+        let websocket_url = self.websocket_url.lock().unwrap().clone();
+        if let Some(websocket_url) = websocket_url {
+            codex_plus_core::bridge::evaluate_script(&websocket_url, &bundle).await?;
+        }
+        self.user_scripts.inventory()
+    }
 }
 
 #[async_trait::async_trait]
@@ -579,26 +588,21 @@ impl BridgeRuntimeService for LauncherRuntimeService {
 
     async fn set_user_scripts_enabled(&self, enabled: bool) -> anyhow::Result<Value> {
         self.user_scripts.set_global_enabled(enabled)?;
-        self.user_scripts.inventory()
+        self.reload_user_scripts_now().await
     }
 
     async fn set_user_script_enabled(&self, key: String, enabled: bool) -> anyhow::Result<Value> {
         self.user_scripts.set_script_enabled(&key, enabled)?;
-        self.user_scripts.inventory()
+        self.reload_user_scripts_now().await
     }
 
     async fn delete_user_script(&self, key: String) -> anyhow::Result<Value> {
         self.user_scripts.delete_user_script(&key)?;
-        self.user_scripts.inventory()
+        self.reload_user_scripts_now().await
     }
 
     async fn reload_user_scripts(&self) -> anyhow::Result<Value> {
-        let bundle = self.user_scripts.build_enabled_bundle()?;
-        let websocket_url = self.websocket_url.lock().unwrap().clone();
-        if let Some(websocket_url) = websocket_url.filter(|_| !bundle.trim().is_empty()) {
-            codex_plus_core::bridge::evaluate_script(&websocket_url, &bundle).await?;
-        }
-        self.user_scripts.inventory()
+        self.reload_user_scripts_now().await
     }
 
     async fn open_devtools(&self) -> anyhow::Result<Value> {
@@ -743,10 +747,7 @@ async fn try_inject_with_context(
         .load()
         .unwrap_or_default();
     let script = codex_plus_core::assets::injection_script_with_settings(helper_port, &settings);
-    let user_bundle = runtime
-        .user_scripts
-        .build_enabled_bundle()
-        .unwrap_or_default();
+    let user_bundle = runtime.user_scripts.build_enabled_bundle()?;
     let new_document_scripts = if user_bundle.is_empty() {
         vec![script]
     } else {
@@ -763,7 +764,8 @@ async fn try_inject_with_context(
         }),
         &new_document_scripts,
     )
-    .await
+    .await?;
+    Ok(())
 }
 
 fn default_codex_db_path() -> PathBuf {
@@ -879,6 +881,16 @@ mod tests {
         assert!(source.contains("async fn start_computer_use_guard_watchdog"));
         assert!(source.contains("self.core"));
         assert!(source.contains(".start_computer_use_guard_watchdog(settings)"));
+    }
+
+    #[test]
+    fn launcher_uses_event_driven_user_script_reload_without_file_polling() {
+        let source = include_str!("main.rs");
+
+        assert!(source.contains("build_reload_bundle"));
+        assert!(!source.contains("start_user_script_hot_reload_watchdog"));
+        assert!(!source.contains("user_scripts.snapshot()"));
+        assert!(!source.contains("tokio::time::interval(std::time::Duration::from_secs(1))"));
     }
 
     #[tokio::test]

--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -392,6 +392,12 @@ pub struct LaunchRequest {
 
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct UserScriptReloadRequest {
+    pub debug_port: u16,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LogRequest {
     #[serde(default = "default_log_lines")]
     pub lines: usize,
@@ -2068,7 +2074,10 @@ pub async fn refresh_script_market() -> CommandResult<ScriptMarketPayload> {
 }
 
 #[tauri::command]
-pub async fn install_market_script(id: String) -> CommandResult<ScriptMarketPayload> {
+pub async fn install_market_script(
+    id: String,
+    debug_port: u16,
+) -> CommandResult<ScriptMarketPayload> {
     let trimmed = id.trim();
     if trimmed.is_empty() {
         return failed(
@@ -2094,10 +2103,13 @@ pub async fn install_market_script(id: String) -> CommandResult<ScriptMarketPayl
     };
     let manager = default_user_script_manager();
     match script_market::install_market_script(&manager, script).await {
-        Ok(()) => ok(
-            "脚本已安装。",
-            script_market_payload_from_manifest(&manifest, "ok", "脚本已安装。"),
-        ),
+        Ok(()) => {
+            let message = script_change_reload_message("脚本已安装。", debug_port).await;
+            ok(
+                &message,
+                script_market_payload_from_manifest(&manifest, "ok", &message),
+            )
+        }
         Err(error) => failed(
             &format!("安装脚本失败：{error}"),
             script_market_payload_from_manifest(
@@ -2110,21 +2122,29 @@ pub async fn install_market_script(id: String) -> CommandResult<ScriptMarketPayl
 }
 
 #[tauri::command]
-pub fn set_user_script_enabled(key: String, enabled: bool) -> CommandResult<SettingsPayload> {
+pub async fn set_user_script_enabled(
+    key: String,
+    enabled: bool,
+    debug_port: u16,
+) -> CommandResult<SettingsPayload> {
     let trimmed = key.trim();
     if trimmed.is_empty() {
         return failed("脚本 key 不能为空。", fallback_settings_payload());
     }
     let manager = default_user_script_manager();
     match manager.set_script_enabled(trimmed, enabled) {
-        Ok(_) => settings_payload(
-            if enabled {
-                "脚本已启用。"
-            } else {
-                "脚本已禁用。"
-            },
-            "脚本启停失败",
-        ),
+        Ok(_) => {
+            let message = script_change_reload_message(
+                if enabled {
+                    "脚本已启用。"
+                } else {
+                    "脚本已禁用。"
+                },
+                debug_port,
+            )
+            .await;
+            settings_payload(&message, "脚本启停失败")
+        }
         Err(error) => failed(
             &format!("脚本启停失败：{error}"),
             fallback_settings_payload(),
@@ -2133,18 +2153,67 @@ pub fn set_user_script_enabled(key: String, enabled: bool) -> CommandResult<Sett
 }
 
 #[tauri::command]
-pub fn delete_user_script(key: String) -> CommandResult<SettingsPayload> {
+pub async fn delete_user_script(key: String, debug_port: u16) -> CommandResult<SettingsPayload> {
     let trimmed = key.trim();
     if trimmed.is_empty() {
         return failed("脚本 key 不能为空。", fallback_settings_payload());
     }
     let manager = default_user_script_manager();
     match manager.delete_user_script(trimmed) {
-        Ok(_) => settings_payload("脚本已删除。", "脚本删除失败"),
+        Ok(_) => {
+            let message = script_change_reload_message("脚本已删除。", debug_port).await;
+            settings_payload(&message, "脚本删除失败")
+        }
         Err(error) => failed(
             &format!("脚本删除失败：{error}"),
             fallback_settings_payload(),
         ),
+    }
+}
+
+#[tauri::command]
+pub async fn reload_user_scripts(
+    request: UserScriptReloadRequest,
+) -> CommandResult<SettingsPayload> {
+    let debug_port = request.debug_port;
+    if debug_port == 0 {
+        return failed("Codex 调试端口无效。", fallback_settings_payload());
+    }
+
+    let result = reload_user_scripts_on_page(debug_port).await;
+
+    match result {
+        Ok(()) => settings_payload("用户脚本已热重载。", "脚本热重载失败"),
+        Err(error) => failed(
+            &format!("脚本热重载失败：{error}"),
+            fallback_settings_payload(),
+        ),
+    }
+}
+
+async fn reload_user_scripts_on_page(debug_port: u16) -> anyhow::Result<()> {
+    let manager = default_user_script_manager();
+    let bundle = manager.build_reload_bundle()?;
+    let targets = codex_plus_core::cdp::list_targets(debug_port).await?;
+    let target = codex_plus_core::cdp::pick_injectable_codex_page_target(&targets)?;
+    let websocket_url = target
+        .web_socket_debugger_url
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("目标页面没有可用的 CDP WebSocket"))?;
+    codex_plus_core::bridge::evaluate_script(websocket_url, &bundle).await?;
+    Ok(())
+}
+
+async fn script_change_reload_message(message: &str, debug_port: u16) -> String {
+    match reload_user_scripts_on_page(debug_port).await {
+        Ok(()) => format!("{message} 已热重载当前页面。"),
+        Err(error) => {
+            let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+                "user_scripts.change_reload_failed",
+                json!({ "debug_port": debug_port, "error": error.to_string() }),
+            );
+            format!("{message} 当前页面未能热重载，可点击“热重载”重试。")
+        }
     }
 }
 

--- a/apps/codex-plus-manager/src-tauri/src/lib.rs
+++ b/apps/codex-plus-manager/src-tauri/src/lib.rs
@@ -104,6 +104,7 @@ pub fn run() {
             commands::install_market_script,
             commands::set_user_script_enabled,
             commands::delete_user_script,
+            commands::reload_user_scripts,
             commands::open_external_url,
             commands::install_entrypoints,
             commands::uninstall_entrypoints,

--- a/apps/codex-plus-manager/src-tauri/tests/windows_subsystem.rs
+++ b/apps/codex-plus-manager/src-tauri/tests/windows_subsystem.rs
@@ -356,6 +356,37 @@ fn manager_ui_no_longer_exposes_command_wrapper_or_startup_marketplace_prompt() 
 }
 
 #[test]
+fn manager_script_market_exposes_manual_hot_reload_command() {
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let app_tsx = manifest_dir.parent().unwrap().join("src/App.tsx");
+    let app_tsx = std::fs::read_to_string(&app_tsx).expect("read manager App.tsx");
+    let commands_rs = std::fs::read_to_string(manifest_dir.join("src/commands.rs"))
+        .expect("read manager commands.rs");
+    let lib_rs =
+        std::fs::read_to_string(manifest_dir.join("src/lib.rs")).expect("read manager lib.rs");
+
+    assert!(app_tsx.contains("const reloadUserScripts = async ()"));
+    assert!(
+        app_tsx
+            .contains("call<SettingsResult>(\"reload_user_scripts\", { request: { debugPort } })")
+    );
+    assert!(app_tsx.contains("actions.reloadUserScripts()"));
+    assert!(app_tsx.contains("{t(\"热重载\")}"));
+    assert!(commands_rs.contains("pub async fn reload_user_scripts("));
+    assert!(commands_rs.contains("pub struct UserScriptReloadRequest"));
+    assert!(commands_rs.contains("async fn reload_user_scripts_on_page("));
+    assert!(commands_rs.contains("async fn script_change_reload_message("));
+    assert!(
+        app_tsx.contains("call<ScriptMarketResult>(\"install_market_script\", { id, debugPort })")
+    );
+    assert!(app_tsx.contains(
+        "call<SettingsResult>(\"set_user_script_enabled\", { key, enabled, debugPort })"
+    ));
+    assert!(app_tsx.contains("call<SettingsResult>(\"delete_user_script\", { key, debugPort })"));
+    assert!(lib_rs.contains("commands::reload_user_scripts"));
+}
+
+#[test]
 fn manager_update_install_keeps_visible_progress_bar() {
     let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let app_tsx = manifest_dir.parent().unwrap().join("src/App.tsx");

--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -1021,7 +1021,8 @@ export function App() {
   };
 
   const installMarketScript = async (id: string) => {
-    const result = await run(() => call<ScriptMarketResult>("install_market_script", { id }));
+    const debugPort = overview?.latest_launch?.debug_port ?? parsePort(launchForm.debugPort, 9229);
+    const result = await run(() => call<ScriptMarketResult>("install_market_script", { id, debugPort }));
     if (result) {
       setScriptMarket(result);
       setSettings((current) => (current ? { ...current, user_scripts: result.user_scripts } : current));
@@ -1030,7 +1031,8 @@ export function App() {
   };
 
   const setUserScriptEnabled = async (key: string, enabled: boolean) => {
-    const result = await run(() => call<SettingsResult>("set_user_script_enabled", { key, enabled }));
+    const debugPort = overview?.latest_launch?.debug_port ?? parsePort(launchForm.debugPort, 9229);
+    const result = await run(() => call<SettingsResult>("set_user_script_enabled", { key, enabled, debugPort }));
     if (result) {
       setSettings(result);
       setScriptMarket((current) => syncMarketInstalledState(current, result.user_scripts));
@@ -1042,11 +1044,25 @@ export function App() {
     const script = settings?.user_scripts?.scripts?.find((item) => item.key === key);
     const name = script?.name || key;
     if (!window.confirm(tf("删除脚本“{0}”？此操作会移除本地脚本文件。", [name]))) return;
-    const result = await run(() => call<SettingsResult>("delete_user_script", { key }));
+    const debugPort = overview?.latest_launch?.debug_port ?? parsePort(launchForm.debugPort, 9229);
+    const result = await run(() => call<SettingsResult>("delete_user_script", { key, debugPort }));
     if (result) {
       setSettings(result);
       setScriptMarket((current) => syncMarketInstalledState(current, result.user_scripts));
       showResultNotice(t("本地脚本"), result);
+    }
+  };
+
+  const reloadUserScripts = async () => {
+    const debugPort = overview?.latest_launch?.debug_port ?? parsePort(launchForm.debugPort, 9229);
+    const result = await run(() => call<SettingsResult>("reload_user_scripts", { request: { debugPort } }));
+    if (result) {
+      setSettings(result);
+      setScriptMarket((current) => syncMarketInstalledState(current, result.user_scripts));
+      showResultNotice(t("脚本市场"), {
+        ...result,
+        message: isSuccessStatus(result.status) ? t("用户脚本已热重载。") : result.message,
+      });
     }
   };
 
@@ -2620,6 +2636,7 @@ export function App() {
       installMarketScript,
       setUserScriptEnabled,
       deleteUserScript,
+      reloadUserScripts,
       refreshLocalSessions,
       deleteLocalSession,
       deleteLocalSessions,
@@ -2966,6 +2983,7 @@ type Actions = {
   installMarketScript: (id: string) => Promise<void>;
   setUserScriptEnabled: (key: string, enabled: boolean) => Promise<void>;
   deleteUserScript: (key: string) => Promise<void>;
+  reloadUserScripts: () => Promise<void>;
   refreshLocalSessions: (silent?: boolean, offset?: number) => Promise<LocalSessionsResult | null>;
   deleteLocalSession: (session: LocalSession) => Promise<void>;
   deleteLocalSessions: (sessions: LocalSession[]) => Promise<void>;
@@ -4503,6 +4521,10 @@ function UserScriptsScreen({ settings, market, actions }: { settings: SettingsRe
             <Button onClick={() => void actions.refreshCurrent()} variant="secondary">
               <RefreshCw className="h-4 w-4" />
               {t("刷新本地")}
+            </Button>
+            <Button onClick={() => void actions.reloadUserScripts()} variant="secondary">
+              <RotateCcw className="h-4 w-4" />
+              {t("热重载")}
             </Button>
           </Toolbar>
         </CardContent>

--- a/apps/codex-plus-manager/src/i18n-en.ts
+++ b/apps/codex-plus-manager/src/i18n-en.ts
@@ -329,6 +329,8 @@ export const EN_PLAIN: Record<string, string> = {
   "刷新当前页面": "Refresh current page",
   "刷新推荐": "Refresh recommendations",
   "刷新本地": "Refresh local",
+  "热重载": "Hot reload",
+  "用户脚本已热重载。": "User scripts hot reloaded.",
   "刷新项目": "Refresh projects",
   "加入当前工作区": "Add to current workspace",
   "包含版本、路径、设置和平台信息": "Includes version, paths, settings and platform info",

--- a/crates/codex-plus-core/src/cdp.rs
+++ b/crates/codex-plus-core/src/cdp.rs
@@ -257,6 +257,15 @@ pub fn pick_injectable_codex_page_target(targets: &[CdpTarget]) -> anyhow::Resul
         .iter()
         .filter(|target| is_injectable_page_target(target))
     {
+        if is_preferred_codex_page_target(target) {
+            return Ok(target.clone());
+        }
+    }
+
+    for target in targets
+        .iter()
+        .filter(|target| is_injectable_page_target(target))
+    {
         if is_primary_codex_page_target(target) {
             return Ok(target.clone());
         }
@@ -274,17 +283,36 @@ pub fn is_injectable_page_target(target: &CdpTarget) -> bool {
 }
 
 pub fn is_codex_page_target(target: &CdpTarget) -> bool {
-    if target.target_type != "page" {
+    if target.target_type != "page" || is_codex_plus_manager_page(target) {
         return false;
     }
     let haystack = format!("{} {}", target.title, target.url).to_lowercase();
     haystack.contains("codex") || is_chatgpt_desktop_page(&target.title, &target.url)
 }
 
+fn is_codex_plus_manager_page(target: &CdpTarget) -> bool {
+    let title = target.title.trim().to_lowercase();
+    title.contains("codex++") && (title.contains("manager") || title.contains("管理工具"))
+}
+
 pub fn is_primary_codex_page_target(target: &CdpTarget) -> bool {
     is_codex_page_target(target)
         && !is_avatar_overlay_page_target(target)
         && !is_quick_chat_page_target(target)
+}
+
+fn is_preferred_codex_page_target(target: &CdpTarget) -> bool {
+    is_primary_codex_page_target(target)
+        && (is_codex_app_page(target) || is_chatgpt_desktop_page(&target.title, &target.url))
+}
+
+fn is_codex_app_page(target: &CdpTarget) -> bool {
+    let Ok(url) = reqwest::Url::parse(target.url.trim()) else {
+        return false;
+    };
+    url.scheme().eq_ignore_ascii_case("app")
+        && url.host_str() == Some("-")
+        && url.path().eq_ignore_ascii_case("/index.html")
 }
 
 pub fn is_avatar_overlay_page_target(target: &CdpTarget) -> bool {

--- a/crates/codex-plus-core/src/routes.rs
+++ b/crates/codex-plus-core/src/routes.rs
@@ -393,7 +393,7 @@ impl BridgeRuntimeService for CoreRuntimeService {
         match &self.user_scripts {
             Some(user_scripts) => {
                 user_scripts.set_global_enabled(enabled)?;
-                user_scripts.inventory()
+                self.reload_user_scripts().await
             }
             None => {
                 let mut inventory = empty_user_script_inventory();
@@ -407,7 +407,7 @@ impl BridgeRuntimeService for CoreRuntimeService {
         match &self.user_scripts {
             Some(user_scripts) => {
                 user_scripts.set_script_enabled(&key, enabled)?;
-                user_scripts.inventory()
+                self.reload_user_scripts().await
             }
             None => Ok(empty_user_script_inventory()),
         }
@@ -417,7 +417,7 @@ impl BridgeRuntimeService for CoreRuntimeService {
         match &self.user_scripts {
             Some(user_scripts) => {
                 user_scripts.delete_user_script(&key)?;
-                user_scripts.inventory()
+                self.reload_user_scripts().await
             }
             None => Ok(empty_user_script_inventory()),
         }
@@ -429,10 +429,8 @@ impl BridgeRuntimeService for CoreRuntimeService {
             self.websocket_url.as_deref(),
             &self.user_script_evaluator,
         ) {
-            let bundle = user_scripts.build_enabled_bundle()?;
-            if !bundle.trim().is_empty() {
-                evaluator(websocket_url, &bundle)?;
-            }
+            let bundle = user_scripts.build_reload_bundle()?;
+            evaluator(websocket_url, &bundle)?;
         }
         self.user_script_inventory().await
     }

--- a/crates/codex-plus-core/src/user_scripts.rs
+++ b/crates/codex-plus-core/src/user_scripts.rs
@@ -9,6 +9,16 @@ use serde_json::{Map, Value, json};
 
 use crate::script_market::MarketScript;
 
+const USER_SCRIPT_RELOAD_PRELUDE: &str = r#"
+(() => {
+  const registry = window.__codexPlusUserScripts;
+  if (registry) {
+    window.dispatchEvent(new CustomEvent("codex-plus-user-scripts-before-reload", { detail: registry }));
+  }
+  window.__codexPlusUserScripts = { scripts: {} };
+})();
+"#;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct UserScriptConfig {
     pub enabled: bool,
@@ -212,6 +222,13 @@ impl UserScriptManager {
             blocks.push(wrap_script(&script, &source));
         }
         Ok(blocks.join("\n"))
+    }
+
+    pub fn build_reload_bundle(&self) -> anyhow::Result<String> {
+        Ok(format!(
+            "{USER_SCRIPT_RELOAD_PRELUDE}\n{}",
+            self.build_enabled_bundle()?
+        ))
     }
 
     fn scan_scripts(

--- a/crates/codex-plus-core/src/user_scripts.rs
+++ b/crates/codex-plus-core/src/user_scripts.rs
@@ -231,6 +231,19 @@ impl UserScriptManager {
         ))
     }
 
+    pub fn enabled_script_keys(&self) -> anyhow::Result<Vec<String>> {
+        let config = self.load_config();
+        if !config.enabled {
+            return Ok(Vec::new());
+        }
+        Ok(self
+            .scan_script_files(&config)?
+            .into_iter()
+            .filter(|script| script.enabled)
+            .map(|script| script.key)
+            .collect())
+    }
+
     fn scan_scripts(
         &self,
         config: &UserScriptConfig,
@@ -338,6 +351,24 @@ struct UserScriptFile {
     source: String,
     path: PathBuf,
     enabled: bool,
+}
+
+pub fn user_script_presence_expression(expected_keys: &[String]) -> anyhow::Result<String> {
+    let expected_keys = serde_json::to_string(expected_keys)?;
+    Ok(format!(
+        r#"(() => {{
+  const scripts = window.__codexPlusUserScripts && window.__codexPlusUserScripts.scripts;
+  const expected = {expected_keys};
+  return !!scripts && expected.every((key) => Object.prototype.hasOwnProperty.call(scripts, key));
+}})()"#
+    ))
+}
+
+pub fn user_script_presence_from_evaluation(response: &Value) -> anyhow::Result<bool> {
+    response
+        .pointer("/result/result/value")
+        .and_then(Value::as_bool)
+        .ok_or_else(|| anyhow::anyhow!("user script startup check returned no boolean result"))
 }
 
 fn wrap_script(script: &UserScriptFile, source: &str) -> String {

--- a/crates/codex-plus-core/tests/bridge_routes.rs
+++ b/crates/codex-plus-core/tests/bridge_routes.rs
@@ -762,6 +762,91 @@ async fn core_runtime_reload_evaluates_enabled_user_bundle_and_status_is_ok() {
 }
 
 #[tokio::test]
+async fn core_runtime_toggling_user_script_reloads_current_page_bundle() {
+    let temp = tempfile::tempdir().unwrap();
+    let user_dir = temp.path().join("user");
+    std::fs::create_dir_all(&user_dir).unwrap();
+    std::fs::write(user_dir.join("demo.js"), "window.demoReloaded = true;").unwrap();
+    let manager = UserScriptManager::new(
+        temp.path().join("builtin"),
+        user_dir,
+        temp.path().join("user_scripts.json"),
+    );
+    let evaluated = Arc::new(Mutex::new(Vec::<String>::new()));
+    let runtime = CoreRuntimeService::new(9229, StatusStore::default())
+        .with_user_scripts(manager)
+        .with_user_script_evaluator({
+            let evaluated = evaluated.clone();
+            Arc::new(move |websocket_url, script| {
+                evaluated
+                    .lock()
+                    .unwrap()
+                    .push(format!("{websocket_url}:{script}"));
+                Ok(json!({"status": "ok"}))
+            })
+        })
+        .with_websocket_url("ws://page");
+    let ctx = BridgeContext::core_with_data(Arc::new(runtime), Arc::new(FakeData::default()));
+
+    let toggled = handle_bridge_request(
+        ctx,
+        "/user-scripts/set-script-enabled",
+        json!({"key": "user:demo.js", "enabled": true}),
+    )
+    .await;
+
+    assert_eq!(toggled["scripts"][0]["enabled"], true);
+    let evaluated = evaluated.lock().unwrap();
+    assert_eq!(evaluated.len(), 1);
+    assert!(evaluated[0].contains("window.demoReloaded = true;"));
+}
+
+#[test]
+fn user_script_reload_bundle_resets_runtime_registry_before_enabled_scripts() {
+    let temp = tempfile::tempdir().unwrap();
+    let user_dir = temp.path().join("user");
+    std::fs::create_dir_all(&user_dir).unwrap();
+    std::fs::write(user_dir.join("demo.js"), "window.reloadVersion = 2;").unwrap();
+    let manager = UserScriptManager::new(
+        temp.path().join("builtin"),
+        user_dir,
+        temp.path().join("user_scripts.json"),
+    );
+
+    let bundle = manager.build_reload_bundle().unwrap();
+
+    assert!(bundle.contains("codex-plus-user-scripts-before-reload"));
+    assert!(bundle.contains("window.__codexPlusUserScripts = { scripts: {} }"));
+    assert!(bundle.contains("window.reloadVersion = 2;"));
+    assert!(
+        bundle
+            .find("window.__codexPlusUserScripts = { scripts: {} }")
+            .unwrap()
+            < bundle.find("window.reloadVersion = 2;").unwrap()
+    );
+}
+
+#[test]
+fn user_script_reload_bundle_clears_runtime_when_all_scripts_are_disabled() {
+    let temp = tempfile::tempdir().unwrap();
+    let user_dir = temp.path().join("user");
+    std::fs::create_dir_all(&user_dir).unwrap();
+    std::fs::write(user_dir.join("demo.js"), "window.shouldNotReload = true;").unwrap();
+    let manager = UserScriptManager::new(
+        temp.path().join("builtin"),
+        user_dir,
+        temp.path().join("user_scripts.json"),
+    );
+    manager.set_global_enabled(false).unwrap();
+
+    let bundle = manager.build_reload_bundle().unwrap();
+
+    assert!(bundle.contains("codex-plus-user-scripts-before-reload"));
+    assert!(bundle.contains("window.__codexPlusUserScripts = { scripts: {} }"));
+    assert!(!bundle.contains("window.shouldNotReload = true;"));
+}
+
+#[tokio::test]
 async fn core_runtime_open_devtools_uses_inspector_url_opener() {
     let opened = Arc::new(Mutex::new(Vec::<String>::new()));
     let runtime = CoreRuntimeService::new(9229, StatusStore::default())

--- a/crates/codex-plus-core/tests/bridge_routes.rs
+++ b/crates/codex-plus-core/tests/bridge_routes.rs
@@ -11,7 +11,9 @@ use codex_plus_core::routes::{
 };
 use codex_plus_core::settings::BackendSettings;
 use codex_plus_core::status::StatusStore;
-use codex_plus_core::user_scripts::UserScriptManager;
+use codex_plus_core::user_scripts::{
+    UserScriptManager, user_script_presence_expression, user_script_presence_from_evaluation,
+};
 use serde_json::{Value, json};
 
 #[tokio::test]
@@ -799,6 +801,44 @@ async fn core_runtime_toggling_user_script_reloads_current_page_bundle() {
     let evaluated = evaluated.lock().unwrap();
     assert_eq!(evaluated.len(), 1);
     assert!(evaluated[0].contains("window.demoReloaded = true;"));
+}
+
+#[test]
+fn user_script_startup_presence_check_only_includes_enabled_scripts() {
+    let temp = tempfile::tempdir().unwrap();
+    let user_dir = temp.path().join("user");
+    std::fs::create_dir_all(&user_dir).unwrap();
+    std::fs::write(user_dir.join("enabled.js"), "window.enabled = true;").unwrap();
+    std::fs::write(user_dir.join("disabled.js"), "window.disabled = true;").unwrap();
+    let manager = UserScriptManager::new(
+        temp.path().join("builtin"),
+        user_dir,
+        temp.path().join("user_scripts.json"),
+    );
+    manager
+        .set_script_enabled("user:disabled.js", false)
+        .unwrap();
+
+    let keys = manager.enabled_script_keys().unwrap();
+    let expression = user_script_presence_expression(&keys).unwrap();
+
+    assert_eq!(keys, vec!["user:enabled.js"]);
+    assert!(expression.contains(r#"["user:enabled.js"]"#));
+    assert!(!expression.contains("user:disabled.js"));
+
+    manager.set_global_enabled(false).unwrap();
+    assert!(manager.enabled_script_keys().unwrap().is_empty());
+}
+
+#[test]
+fn user_script_startup_presence_check_reads_boolean_cdp_result() {
+    let present = json!({"result": {"result": {"value": true}}});
+    let missing = json!({"result": {"result": {"value": false}}});
+    let malformed = json!({"result": {"result": {"type": "undefined"}}});
+
+    assert!(user_script_presence_from_evaluation(&present).unwrap());
+    assert!(!user_script_presence_from_evaluation(&missing).unwrap());
+    assert!(user_script_presence_from_evaluation(&malformed).is_err());
 }
 
 #[test]

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -2318,6 +2318,32 @@ fn pick_injectable_codex_page_target_accepts_chatgpt_desktop_error_page() {
 }
 
 #[test]
+fn pick_injectable_codex_page_target_prefers_native_app_over_manager_page() {
+    let targets = vec![
+        target(
+            "manager",
+            "page",
+            "Codex++ 管理工具",
+            "http://127.0.0.1:1420/",
+            Some("ws://manager"),
+        ),
+        target(
+            "main",
+            "page",
+            "Codex",
+            "app://-/index.html",
+            Some("ws://main"),
+        ),
+    ];
+
+    let picked = pick_injectable_codex_page_target(&targets)
+        .expect("native Codex app page should outrank the manager page");
+
+    assert_eq!(picked.id, "main");
+    assert!(!is_primary_codex_page_target(&targets[0]));
+}
+
+#[test]
 fn avatar_overlay_target_detection_is_narrow() {
     let overlay = target(
         "avatar",


### PR DESCRIPTION
## 更新内容

- 将用户脚本自动热重载改为事件驱动，安装、启用、禁用或删除脚本后立即刷新当前 Codex 页面。
- 在管理工具的脚本市场中增加手动“热重载”按钮，方便脚本开发调试。
- reload 前发送 cleanup 事件并重建脚本运行时注册表，禁用或删除脚本后可以清理旧状态。
- bridge 注入完成后执行一次有限启动自查；发现启用脚本未注册时自动补载，避免偶发启动漏加载。
- 修复调试端口同时包含 Codex 主页面和管理工具时，CDP 目标可能选错的问题。

## 启动自查策略

- 启动后最多检查 3 次。
- 只有脚本注册表不存在或缺少应启用脚本时才 reload。
- 脚本已经执行但自身报错时不会重复运行。
- renderer target 或脚本配置变化后，旧自查任务会自动退出。

## 验证

- `cargo fmt --check`
- `cargo test -p codex-plus-core --test bridge_routes`
- `cargo test -p codex-plus-core --test cdp_bridge`
- `cargo test -p codex-plus-manager --test windows_subsystem`
- `cargo test -p codex-plus-launcher --no-run`
- `npm run check`
- `npm test`
- `npm run vite:build`

本地实际启动验证中，启动自查在第 1 次检查通过，bridge 与 helper 状态正常。