### PR TITLE
fix(ci): keep upstream theme assets LF-normalized

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,10 +7,7 @@
 *.sh text eol=lf
 .github/workflows/*.yml text eol=lf
 
-# Preserve the original Snow Skin asset line endings for byte-exact bundling.
-assets/inject/upstream/snow-skin/*.js text eol=lf
-assets/inject/upstream/snow-skin/*.css text eol=lf
-
-# Keep byte-exact macOS theme assets identical on every checkout platform.
-assets/inject/upstream/*/macos/*.js text eol=lf
-assets/inject/upstream/*/macos/*.css text eol=lf
+# Keep every byte-exact upstream theme asset stable on all checkout platforms.
+assets/inject/upstream/**/*.js text eol=lf
+assets/inject/upstream/**/*.css text eol=lf
+assets/inject/upstream/skin-packs/packs/*/theme.json text eol=lf


### PR DESCRIPTION
## Summary

- normalize all byte-exact upstream JavaScript and CSS assets to LF
- normalize skin-pack `theme.json` files to LF
- keep the existing platform-independent SHA-256 baselines unchanged

## Root cause

The `upstream_theme_assets.rs` tests hash raw file bytes. The previous `.gitattributes` rules covered only part of the tested assets, so Windows checkouts converted uncovered LF files to CRLF and caused byte-exact hash failures.

The upstream `main` commit `01c69a8` reproduced the issue before these feature changes were involved:

https://github.com/BigPizzaV3/CodexPlusPlus/actions/runs/30603754154

The failing hashes match the CRLF-transformed bytes, while the expected hashes match the repository LF bytes.

## Validation

- `cargo test -p codex-plus-core --test upstream_theme_assets --locked`
- `git diff --check`
- verified every asset covered by `upstream_theme_assets.rs` resolves to `text eol=lf`

This is a repository-level maintenance fix for #1732.

Closes #1732.
