### PR TITLE
fix: 保留 Chat Completions 转换中的 encrypted_content

### DIFF
--- a/crates/codex-plus-core/src/protocol_proxy.rs
+++ b/crates/codex-plus-core/src/protocol_proxy.rs
@@ -2361,6 +2361,15 @@ fn responses_content_to_chat_content(_role: &str, content: &Value) -> Value {
                     }
                 }
             }
+            "encrypted_content" => {
+                if let Some(value) = part
+                    .get("encrypted_content")
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.is_empty())
+                {
+                    chat_parts.push(json!({ "type": "text", "text": value }));
+                }
+            }
             "refusal" => {
                 if let Some(value) = part.get("refusal").and_then(Value::as_str) {
                     if !value.is_empty() {

--- a/crates/codex-plus-core/tests/encrypted_content_subagent.rs
+++ b/crates/codex-plus-core/tests/encrypted_content_subagent.rs
@@ -1,0 +1,30 @@
+use codex_plus_core::protocol_proxy::responses_to_chat_completions;
+use serde_json::json;
+
+#[test]
+fn responses_request_preserves_encrypted_content_for_subagent_tasks() {
+    let converted = responses_to_chat_completions(json!({
+        "model": "deepseek-v4-flash",
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": "Message Type: NEW_TASK\nTask name: /root/probe_none\nSender: /root\nPayload:\n"
+                    },
+                    {
+                        "type": "encrypted_content",
+                        "encrypted_content": "请回显标记：PROBE-NONE-7F3A"
+                    }
+                ]
+            }
+        ]
+    }))
+    .unwrap();
+
+    let content = converted["messages"][0]["content"].as_str().unwrap();
+    assert!(content.contains("Payload:"));
+    assert!(content.contains("PROBE-NONE-7F3A"));
+}


### PR DESCRIPTION
## 摘要

- Responses 转 Chat Completions 时保留 Codex 的 `encrypted_content` 内容
- 将非空加密任务文本作为普通用户文本输出，子代理不再只收到空 `Payload:`
- 新增回归测试，覆盖真实 Codex `agent_message` 中空 `input_text` + `encrypted_content` 的结构

## 根因

`responses_content_to_chat_content` 只处理：

- `input_text`
- `output_text`
- `text`
- `refusal`
- `input_image`

Codex 多代理消息把真实任务放在 `encrypted_content`。当 relay 使用 Chat Completions 协议时该字段被丢弃，子代理只收到：

```text
Message Type: NEW_TASK
Task name: /root/probe_none
Sender: /root
Payload:
```

## 改动

- `crates/codex-plus-core/src/protocol_proxy.rs`：转换非空 `encrypted_content` 为文本
- `crates/codex-plus-core/tests/encrypted_content_subagent.rs`：新增回归测试

## 验证

- `cargo test -p codex-plus-core --test encrypted_content_subagent`：1 通过
- `cargo test -p codex-plus-core --test protocol_proxy`：48 通过
- `cargo fmt --all`：通过
- 变更行无新增 Clippy 警告

Windows 本地 1.2.44 构建实测：

- 子代理探针返回 `PROBE-FIX-5C41`
- 第二个探针返回 `PROBE-FIX-9F77` 并正确报告任务名
- 子代理成功抓取 GitHub Trending Top 10

## 范围

本 PR 只修复 Chat Completions 转换路径。第三方 Responses 直连透传时忽略 `encrypted_content` 的情况不在本次范围。

关联：#1706
