### PR TITLE
feat: add Atlas Cloud provider preset

### DIFF
--- a/apps/codex-plus-manager/src/presets.test.ts
+++ b/apps/codex-plus-manager/src/presets.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { PRESETS } from "./presets.ts";
+
+test("Atlas Cloud preset uses the OpenAI-compatible chat endpoint", () => {
+  const presets = PRESETS.filter((preset) => preset.id === "atlascloud");
+
+  assert.equal(presets.length, 1);
+  assert.deepEqual(presets[0], {
+    id: "atlascloud",
+    name: "Atlas Cloud",
+    websiteUrl: "https://www.atlascloud.ai",
+    apiKeyUrl: "https://www.atlascloud.ai/console/api-keys",
+    category: "aggregator",
+    baseUrl: "https://api.atlascloud.ai/v1",
+    protocol: "chatCompletions",
+    model: "deepseek-ai/deepseek-v4-pro",
+    modelList: ["deepseek-ai/deepseek-v4-pro"],
+  });
+});

--- a/apps/codex-plus-manager/src/presets.ts
+++ b/apps/codex-plus-manager/src/presets.ts
@@ -163,6 +163,17 @@ export const PRESETS: ProviderPreset[] = [
 
   // ── 聚合/中转 ──
   {
+    id: "atlascloud",
+    name: "Atlas Cloud",
+    websiteUrl: "https://www.atlascloud.ai",
+    apiKeyUrl: "https://www.atlascloud.ai/console/api-keys",
+    category: "aggregator",
+    baseUrl: "https://api.atlascloud.ai/v1",
+    protocol: "chatCompletions",
+    model: "deepseek-ai/deepseek-v4-pro",
+    modelList: ["deepseek-ai/deepseek-v4-pro"],
+  },
+  {
     id: "jojocode",
     name: "JOJO Code",
     websiteUrl: "https://jojocode.com/",


### PR DESCRIPTION
## Summary
- add an Atlas Cloud provider preset to Codex++ provider switching
- configure the OpenAI-compatible chat completions endpoint and default model
- include API key and website links without promotional metadata

## Testing
- `npm test`
- `npm run check`
- `npm run vite:build`
- live Atlas Cloud forced tool-call request (HTTP 200)