### PR TITLE
feat: add optional official usage alert hiding

### DIFF
--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -268,6 +268,7 @@ export type RelayProfile = {
   protocol: RelayProtocol;
   relayMode: RelayMode;
   officialMixApiKey: boolean;
+  hideOfficialUsageAlert: boolean;
   testModel: string;
   configContents: string;
   authContents: string;
@@ -854,6 +855,7 @@ const defaultSettings: BackendSettings = {
       protocol: "responses",
       relayMode: "official",
       officialMixApiKey: false,
+      hideOfficialUsageAlert: false,
       testModel: "",
       configContents: "",
       authContents: "",
@@ -6228,6 +6230,21 @@ function RelayProfileEditor({
             <p className="field-hint">{t("当前继承公共配置；修改后将为该供应商保存独立设置。")}</p>
           ) : null}
         </Field>
+        {profile.relayMode === "official" ? (
+          <Field className="relay-field-official-usage-alert" label={t("官方登录")}>
+            <label className="inline-check">
+              <input
+                checked={profile.hideOfficialUsageAlert}
+                onChange={(event) => updateDraft({ hideOfficialUsageAlert: event.currentTarget.checked })}
+                type="checkbox"
+              />
+              <span>{t("关闭官方低额度提示")}</span>
+            </label>
+            <p className="field-hint">
+              {t("关闭后仍可从 Codex 左下角账户菜单查看官方剩余额度。")}
+            </p>
+          </Field>
+        ) : null}
         <div className="relay-advanced-toggle">
           <Button
             aria-expanded={showAdvanced}
@@ -8409,6 +8426,7 @@ function normalizeSettings(settings: BackendSettings): BackendSettings {
             protocol: "responses" as RelayProtocol,
             relayMode: "official" as RelayMode,
             officialMixApiKey: false,
+            hideOfficialUsageAlert: false,
             testModel: "",
             configContents: "",
             authContents: "",
@@ -8489,6 +8507,7 @@ function normalizeRelayProfile(profile: RelayProfile, defaultContextSelection = 
         protocol: "responses",
         relayMode: "aggregate",
         officialMixApiKey: false,
+        hideOfficialUsageAlert: false,
         testModel: profile.testModel || "",
         configContents: "",
         authContents: "",
@@ -8519,6 +8538,7 @@ function normalizeRelayProfile(profile: RelayProfile, defaultContextSelection = 
     protocol: profile.protocol === "chatCompletions" ? "chatCompletions" : "responses",
     relayMode,
     officialMixApiKey,
+    hideOfficialUsageAlert: profile.hideOfficialUsageAlert === true,
     testModel: profile.testModel || "",
     configContents: relayMode === "official" && !officialMixApiKey ? "" : profile.configContents || "",
     authContents: relayMode === "official" && !officialMixApiKey ? buildOfficialRelayAuthJson(profile.authContents || "") : profile.authContents || "",
@@ -9253,6 +9273,7 @@ function createRelayProfile(settings: BackendSettings): RelayProfile {
     protocol: "responses" as RelayProtocol,
     relayMode: "official" as RelayMode,
     officialMixApiKey: false,
+    hideOfficialUsageAlert: false,
     testModel: "",
     configContents: "",
     authContents: "",
@@ -9290,6 +9311,7 @@ function createAggregateRelayProfile(settings: BackendSettings): RelayProfile {
       protocol: "responses",
       relayMode: "aggregate",
       officialMixApiKey: false,
+      hideOfficialUsageAlert: false,
       testModel: "",
       configContents: "",
       authContents: "",
@@ -9429,6 +9451,7 @@ function normalizeAggregateRelayProfile(profile: RelayProfile, settings: Backend
     protocol: "responses",
     relayMode: "aggregate",
     officialMixApiKey: false,
+    hideOfficialUsageAlert: false,
     configContents: "",
     authContents: "",
     sub2apiEnabled: false,

--- a/apps/codex-plus-manager/src/components/ProviderPresetSelector.tsx
+++ b/apps/codex-plus-manager/src/components/ProviderPresetSelector.tsx
@@ -13,6 +13,7 @@ export type RelayProfile = {
   protocol: RelayProtocol;
   relayMode: string;
   officialMixApiKey: boolean;
+  hideOfficialUsageAlert: boolean;
   testModel: string;
   configContents: string;
   authContents: string;
@@ -48,6 +49,7 @@ export function createPresetPatch(preset: ProviderPreset): PresetPatch {
     modelList: preset.modelList?.join("\n") ?? "",
     relayMode: preset.category === "official" ? "official" : "pureApi",
     officialMixApiKey: false,
+    hideOfficialUsageAlert: false,
   };
 }
 

--- a/apps/codex-plus-manager/src/i18n-en.ts
+++ b/apps/codex-plus-manager/src/i18n-en.ts
@@ -642,6 +642,9 @@ export const EN_PLAIN: Record<string, string> = {
   "深色": "Dark",
   "混入 API": "Mixed-in API",
   "混入 API KEY": "Mix in API KEY",
+  "关闭官方低额度提示": "Hide official low-usage alert",
+  "关闭后仍可从 Codex 左下角账户菜单查看官方剩余额度。":
+    "When hidden, you can still view the official quota from the account menu in the lower-left corner of Codex.",
   "混入 API Key": "Mix in API Key",
   "添加供应商": "Add provider",
   "添加模型": "Add model",

--- a/apps/codex-plus-manager/src/model-windows.test.ts
+++ b/apps/codex-plus-manager/src/model-windows.test.ts
@@ -21,6 +21,7 @@ const _profileTypeCheck: RelayProfile = {
   protocol: "responses",
   relayMode: "official",
   officialMixApiKey: false,
+  hideOfficialUsageAlert: false,
   testModel: "",
   configContents: "",
   authContents: "",

--- a/apps/codex-plus-manager/src/renderer-inject.test.ts
+++ b/apps/codex-plus-manager/src/renderer-inject.test.ts
@@ -2,6 +2,82 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { readFile } from "node:fs/promises";
 
+type FakeElementOptions = {
+  className?: string;
+  dismissLabel?: string;
+  hasProgress?: boolean;
+  styleDisplay?: string;
+};
+
+class FakeElement {
+  children: FakeElement[] = [];
+  dataset: Record<string, string> = {};
+  parentElement: FakeElement | null = null;
+  style: { display: string };
+  private readonly className: string;
+  private readonly dismissLabel: string;
+  private readonly hasProgress: boolean;
+
+  constructor(options: FakeElementOptions = {}) {
+    this.className = options.className ?? "";
+    this.dismissLabel = options.dismissLabel ?? "";
+    this.hasProgress = options.hasProgress ?? false;
+    this.style = { display: options.styleDisplay ?? "" };
+  }
+
+  appendChild(child: FakeElement) {
+    child.parentElement = this;
+    this.children.push(child);
+  }
+
+  getAttribute(name: string) {
+    return name === "aria-label" ? this.dismissLabel : null;
+  }
+
+  matches(selector: string) {
+    return selector === "div.w-full" && this.className.split(/\s+/).includes("w-full");
+  }
+
+  querySelector(selector: string) {
+    return selector === 'progress[max="100"]' && this.hasProgress ? new FakeElement() : null;
+  }
+
+  querySelectorAll(selector: string) {
+    return selector === "button" && this.dismissLabel ? [this] : [];
+  }
+}
+
+function usageAlertRuntime(renderer: string, cards: FakeElement[], managed: FakeElement[]) {
+  const start = renderer.indexOf("  function officialUsageAlertHidden(");
+  const end = renderer.indexOf("\n  let zedRemoteStatusPromise", start);
+  assert.ok(start >= 0 && end > start);
+  const source = renderer.slice(start, end);
+  const selectors: string[] = [];
+  const document = {
+    querySelectorAll(selector: string) {
+      selectors.push(selector);
+      return selector === '[data-codex-plus-usage-alert-hidden="true"]'
+        ? managed.filter((node) => node.dataset.codexPlusUsageAlertHidden === "true")
+        : cards;
+    },
+  };
+  const windowValue: Record<string, unknown> = {};
+  const create = new Function(
+    "window",
+    "document",
+    "HTMLElement",
+    `${source}\nreturn { officialUsageAlertHidden, refreshOfficialUsageAlertVisibility };`,
+  ) as (
+    windowValue: Record<string, unknown>,
+    documentValue: typeof document,
+    elementType: typeof FakeElement,
+  ) => {
+    officialUsageAlertHidden: () => boolean;
+    refreshOfficialUsageAlertVisibility: () => void;
+  };
+  return { runtime: create(windowValue, document, FakeElement), selectors, windowValue };
+}
+
 describe("renderer injection header compatibility", () => {
   it("anchors the Codex++ menu to current and legacy application top bars only", async () => {
     const renderer = await readFile(new URL("../../../assets/inject/renderer-inject.js", import.meta.url), "utf8");
@@ -19,5 +95,42 @@ describe("renderer injection header compatibility", () => {
     assert.match(renderer, /!window\.electronBridge/);
     assert.ok(renderer.includes("/^app:\\\/\\\/\\-\\//i.test(window.location.href)"));
     assert.match(renderer, /codexPlusIsNodeTestHarness/);
+  });
+
+  it("hides only the official usage alert and restores it without changing upstream styles", async () => {
+    const renderer = await readFile(new URL("../../../assets/inject/renderer-inject.js", import.meta.url), "utf8");
+    const wrapper = new FakeElement({ className: "w-full", styleDisplay: "grid" });
+    const usageAlert = new FakeElement({ dismissLabel: "Dismiss usage alert", hasProgress: true });
+    const otherStatus = new FakeElement({ dismissLabel: "Dismiss sync status", hasProgress: true });
+    wrapper.appendChild(usageAlert);
+    const { runtime, selectors, windowValue } = usageAlertRuntime(renderer, [usageAlert, otherStatus], [wrapper]);
+
+    windowValue.__CODEX_PLUS_HIDE_OFFICIAL_USAGE_ALERT__ = true;
+    runtime.refreshOfficialUsageAlertVisibility();
+
+    assert.equal(wrapper.dataset.codexPlusUsageAlertHidden, "true");
+    assert.equal(wrapper.style.display, "grid");
+    assert.equal(otherStatus.dataset.codexPlusUsageAlertHidden, undefined);
+    assert.deepEqual(selectors, [
+      '[data-codex-plus-usage-alert-hidden="true"]',
+      'aside.app-shell-left-panel [role="status"][aria-live="polite"]',
+    ]);
+
+    windowValue.__CODEX_PLUS_HIDE_OFFICIAL_USAGE_ALERT__ = false;
+    runtime.refreshOfficialUsageAlertVisibility();
+
+    assert.equal(wrapper.dataset.codexPlusUsageAlertHidden, undefined);
+    assert.equal(wrapper.style.display, "grid");
+    assert.equal(wrapper.children[0], usageAlert);
+    assert.equal(selectors.at(-1), '[data-codex-plus-usage-alert-hidden="true"]');
+  });
+
+  it("refreshes active-profile usage alert settings through the existing backend heartbeat", async () => {
+    const renderer = await readFile(new URL("../../../assets/inject/renderer-inject.js", import.meta.url), "utf8");
+
+    assert.match(renderer, /typeof nextStatus\.hideOfficialUsageAlert === "boolean"/);
+    assert.match(renderer, /window\.__CODEX_PLUS_HIDE_OFFICIAL_USAGE_ALERT__ = nextStatus\.hideOfficialUsageAlert/);
+    assert.match(renderer, /\[data-codex-plus-usage-alert-hidden="true"\] \{ display: none !important; \}/);
+    assert.doesNotMatch(renderer, /container\.style\.(?:setProperty|removeProperty)\("display"/);
   });
 });

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -829,6 +829,7 @@
       .codex-project-move-item-path { margin-top: 2px; color: #6b7280; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
       .codex-project-move-empty { padding: 18px 12px; color: #6b7280; text-align: center; }
       .codex-project-move-hidden { display: none !important; }
+      [data-codex-plus-usage-alert-hidden="true"] { display: none !important; }
       [data-codex-project-move-injected-list="true"] { display: flex; flex-direction: column; }
       .codex-archive-delete-all {
         border: 1px solid #ef4444;
@@ -3368,6 +3369,10 @@
     const nextStatus = await withBackendTimeout(postJson("/backend/status", {}));
     if (seq !== codexPlusBackendCheckSeq) return;
     codexPlusBackendStatus = nextStatus;
+    if (nextStatus?.status === "ok" && typeof nextStatus.hideOfficialUsageAlert === "boolean") {
+      window.__CODEX_PLUS_HIDE_OFFICIAL_USAGE_ALERT__ = nextStatus.hideOfficialUsageAlert;
+      refreshOfficialUsageAlertVisibility();
+    }
     if (nextStatus?.status !== "ok") {
       sendCodexPlusDiagnostic("backend_check_failed", {
         status: nextStatus?.status || "unknown",
@@ -9202,6 +9207,7 @@
 
   function scanLightweight() {
     installStyle();
+    refreshOfficialUsageAlertVisibility();
     installCodexServiceTierDispatcherPatch();
     installCodexPlusMenu();
     localizeCodexMenus();
@@ -9214,6 +9220,40 @@
     installThreadScrollRouteHooks();
     scheduleThreadScrollSync(true);
     refreshCodexServiceTierControls();
+  }
+
+  function officialUsageAlertHidden() {
+    return window.__CODEX_PLUS_HIDE_OFFICIAL_USAGE_ALERT__ === true;
+  }
+
+  function officialUsageAlertCards(scope = document) {
+    const root = scope?.querySelectorAll ? scope : document;
+    return Array.from(root.querySelectorAll('aside.app-shell-left-panel [role="status"][aria-live="polite"]')).filter((card) => {
+      if (!(card instanceof HTMLElement)) return false;
+      const progress = card.querySelector('progress[max="100"]');
+      if (!progress) return false;
+      const dismissButton = Array.from(card.querySelectorAll("button")).find((button) =>
+        /dismiss usage alert|关闭使用量提醒/i.test(button.getAttribute("aria-label") || ""),
+      );
+      return !!dismissButton;
+    });
+  }
+
+  function officialUsageAlertContainer(card) {
+    const parent = card.parentElement;
+    return parent?.children.length === 1 && parent.matches("div.w-full") ? parent : card;
+  }
+
+  function refreshOfficialUsageAlertVisibility() {
+    const hidden = officialUsageAlertHidden();
+    document.querySelectorAll('[data-codex-plus-usage-alert-hidden="true"]').forEach((container) => {
+      delete container.dataset.codexPlusUsageAlertHidden;
+    });
+    if (!hidden) return;
+    officialUsageAlertCards().forEach((card) => {
+      const container = officialUsageAlertContainer(card);
+      container.dataset.codexPlusUsageAlertHidden = "true";
+    });
   }
 
   let zedRemoteStatusPromise = null;
@@ -9830,6 +9870,7 @@
   function scanRelevantSelector() {
     return [
       selectors.sidebarThread,
+      'aside.app-shell-left-panel [role="status"][aria-live="polite"]',
       '[data-app-action-sidebar-section-heading="Chats"]',
       '[data-app-action-sidebar-section-heading="Projects"]',
       '[data-codex-project-move-row="true"]',

--- a/crates/codex-plus-core/src/assets.rs
+++ b/crates/codex-plus-core/src/assets.rs
@@ -387,6 +387,11 @@ pub fn injection_script(helper_port: u16) -> String {
     injection_script_with_settings(helper_port, &BackendSettings::default())
 }
 
+pub fn hide_official_usage_alert_config(settings: &BackendSettings) -> bool {
+    let profile = settings.active_relay_profile();
+    profile.relay_mode == crate::settings::RelayMode::Official && profile.hide_official_usage_alert
+}
+
 pub fn injection_script_with_settings(helper_port: u16, settings: &BackendSettings) -> String {
     let helper_url = format!("http://127.0.0.1:{helper_port}");
     let image_overlay = image_overlay_config(helper_port, settings);
@@ -398,8 +403,9 @@ pub fn injection_script_with_settings(helper_port: u16, settings: &BackendSettin
     let paste_fix = paste_fix_enabled_config(settings);
     let force_chinese_locale = force_chinese_locale_config(settings);
     let fast_startup = fast_startup_config(settings);
+    let hide_official_usage_alert = hide_official_usage_alert_config(settings);
     format!(
-        "window.__CODEX_SESSION_DELETE_HELPER__ = {};\nwindow.__CODEX_PLUS_VERSION__ = {};\nwindow.__CODEX_PLUS_BUILD__ = {};\nwindow.__CODEX_PLUS_IMAGE_OVERLAY__ = {};\nwindow.__CODEX_PLUS_PLUGIN_MARKETPLACES__ = {};\nwindow.__CODEX_PLUS_EXTERNAL_DREAM_SKIN_RUNTIME__ = true;\nwindow.__CODEX_PLUS_DREAM_SKIN_PLATFORM__ = {};\nwindow.__CODEX_PLUS_DREAM_SKIN_REVISION__ = {};\nwindow.__CODEX_PLUS_DREAM_SKIN_ART__ = {};\nwindow.__CODEX_PLUS_DREAM_SKIN_ART_SIGNATURE__ = {};\nwindow.__CODEX_PLUS_DREAM_SKIN_THEME__ = {};\nwindow.__CODEX_PLUS_PASTE_FIX__ = {};\nwindow.__CODEX_PLUS_FORCE_CHINESE_LOCALE__ = {};\nwindow.__CODEX_PLUS_FAST_STARTUP__ = {};\n{}\n{}\n{}",
+        "window.__CODEX_SESSION_DELETE_HELPER__ = {};\nwindow.__CODEX_PLUS_VERSION__ = {};\nwindow.__CODEX_PLUS_BUILD__ = {};\nwindow.__CODEX_PLUS_IMAGE_OVERLAY__ = {};\nwindow.__CODEX_PLUS_PLUGIN_MARKETPLACES__ = {};\nwindow.__CODEX_PLUS_EXTERNAL_DREAM_SKIN_RUNTIME__ = true;\nwindow.__CODEX_PLUS_DREAM_SKIN_PLATFORM__ = {};\nwindow.__CODEX_PLUS_DREAM_SKIN_REVISION__ = {};\nwindow.__CODEX_PLUS_DREAM_SKIN_ART__ = {};\nwindow.__CODEX_PLUS_DREAM_SKIN_ART_SIGNATURE__ = {};\nwindow.__CODEX_PLUS_DREAM_SKIN_THEME__ = {};\nwindow.__CODEX_PLUS_PASTE_FIX__ = {};\nwindow.__CODEX_PLUS_FORCE_CHINESE_LOCALE__ = {};\nwindow.__CODEX_PLUS_FAST_STARTUP__ = {};\nwindow.__CODEX_PLUS_HIDE_OFFICIAL_USAGE_ALERT__ = {};\n{}\n{}\n{}",
         serde_json::to_string(&helper_url).expect("helper URL should serialize"),
         serde_json::to_string(crate::version::VERSION).expect("version should serialize"),
         serde_json::to_string(DIAGNOSTIC_BUILD_ID).expect("build id should serialize"),
@@ -416,6 +422,8 @@ pub fn injection_script_with_settings(helper_port: u16, settings: &BackendSettin
         serde_json::to_string(&force_chinese_locale)
             .expect("force Chinese locale config should serialize"),
         serde_json::to_string(&fast_startup).expect("fast startup config should serialize"),
+        serde_json::to_string(&hide_official_usage_alert)
+            .expect("usage alert config should serialize"),
         renderer_script(),
         stepwise_script(),
         dream_skin_target_runtime,

--- a/crates/codex-plus-core/src/ccs_import.rs
+++ b/crates/codex-plus-core/src/ccs_import.rs
@@ -88,6 +88,7 @@ pub fn relay_profile_from_ccs(
         protocol: provider.protocol,
         relay_mode: RelayMode::PureApi,
         official_mix_api_key: false,
+        hide_official_usage_alert: false,
         test_model: String::new(),
         config_contents: provider.config_contents.clone(),
         auth_contents: provider.auth_contents.clone(),

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -1162,6 +1162,9 @@ async fn handle_helper_connection(
                 "status": "ok",
                 "message": "后端已连接",
                 "version": crate::version::VERSION,
+                "hideOfficialUsageAlert": crate::assets::hide_official_usage_alert_config(
+                    &crate::settings::SettingsStore::default().load().unwrap_or_default()
+                ),
                 "transport": "http-helper"
             }))?,
             "application/json; charset=utf-8".to_string(),

--- a/crates/codex-plus-core/src/provider_import.rs
+++ b/crates/codex-plus-core/src/provider_import.rs
@@ -190,6 +190,7 @@ fn relay_profile_from_request(
         protocol: relay_protocol(&request.wire_api),
         relay_mode: relay_mode(&request.relay_mode),
         official_mix_api_key: false,
+        hide_official_usage_alert: false,
         test_model: String::new(),
         config_contents: request.config_contents.clone(),
         auth_contents: request.auth_contents.clone(),

--- a/crates/codex-plus-core/src/routes.rs
+++ b/crates/codex-plus-core/src/routes.rs
@@ -179,7 +179,10 @@ pub async fn handle_bridge_request(
         "/devtools/open" => ctx.runtime.open_devtools().await,
         "/manager/open" => ctx.runtime.open_manager().await,
         "/manager/open-transient" => ctx.runtime.open_transient_manager().await,
-        "/backend/status" => ctx.runtime.backend_status().await,
+        "/backend/status" => backend_status_value(
+            ctx.runtime.backend_status().await,
+            ctx.settings.get_settings().await,
+        ),
         "/codex-model-catalog" | "/codex-config-model" => ctx.runtime.codex_model_catalog().await,
         "/diagnostics/log" => diagnostic_log_value(payload.clone()),
         "/llm-proxy" => llm_proxy_value(payload.clone()).await,
@@ -648,6 +651,20 @@ async fn settings_value(
     let settings = result?;
     let codex_app_version = ctx.settings.codex_app_version().await.unwrap_or_default();
     settings_payload_value(settings, codex_app_version)
+}
+
+fn backend_status_value(
+    status: anyhow::Result<Value>,
+    settings: anyhow::Result<BackendSettings>,
+) -> anyhow::Result<Value> {
+    let mut status = status?;
+    if let Some(object) = status.as_object_mut() {
+        let hide = settings
+            .map(|settings| crate::assets::hide_official_usage_alert_config(&settings))
+            .unwrap_or(false);
+        object.insert("hideOfficialUsageAlert".to_string(), Value::Bool(hide));
+    }
+    Ok(status)
 }
 
 fn result_value<T>(result: anyhow::Result<T>) -> anyhow::Result<Value>

--- a/crates/codex-plus-core/src/settings.rs
+++ b/crates/codex-plus-core/src/settings.rs
@@ -61,6 +61,8 @@ pub struct RelayProfile {
     pub relay_mode: RelayMode,
     #[serde(rename = "officialMixApiKey", default)]
     pub official_mix_api_key: bool,
+    #[serde(rename = "hideOfficialUsageAlert", default)]
+    pub hide_official_usage_alert: bool,
     #[serde(rename = "testModel", default)]
     pub test_model: String,
     #[serde(rename = "configContents", default)]
@@ -173,6 +175,7 @@ impl Default for RelayProfile {
             protocol: RelayProtocol::Responses,
             relay_mode: RelayMode::Official,
             official_mix_api_key: false,
+            hide_official_usage_alert: false,
             test_model: String::new(),
             config_contents: String::new(),
             auth_contents: String::new(),
@@ -596,6 +599,7 @@ impl BackendSettings {
                 protocol: RelayProtocol::Responses,
                 relay_mode: RelayMode::MixedApi,
                 official_mix_api_key: true,
+                hide_official_usage_alert: false,
                 test_model: String::new(),
                 config_contents: String::new(),
                 auth_contents: String::new(),
@@ -648,6 +652,7 @@ impl BackendSettings {
             protocol: RelayProtocol::Responses,
             relay_mode: RelayMode::Official,
             official_mix_api_key: false,
+            hide_official_usage_alert: false,
             test_model: String::new(),
             config_contents: String::new(),
             auth_contents: String::new(),
@@ -1720,6 +1725,7 @@ mod tests {
 
         assert_eq!(profile.relay_mode, RelayMode::Official);
         assert!(!profile.official_mix_api_key);
+        assert!(!profile.hide_official_usage_alert);
         assert!(profile.test_model.is_empty());
     }
 
@@ -1885,6 +1891,7 @@ base_url = "http://127.0.0.1:57321/v1"
                 name: "官方".to_string(),
                 relay_mode: RelayMode::Official,
                 official_mix_api_key: false,
+                hide_official_usage_alert: false,
                 model: "gpt-5.5".to_string(),
                 base_url: "https://relay.example/v1".to_string(),
                 api_key: "sk-test".to_string(),
@@ -1923,6 +1930,7 @@ requires_openai_auth = true
                 name: "官方混入".to_string(),
                 relay_mode: RelayMode::Official,
                 official_mix_api_key: true,
+                hide_official_usage_alert: false,
                 model: "gpt-5.5".to_string(),
                 base_url: "https://relay.example/v1".to_string(),
                 api_key: "sk-mix".to_string(),
@@ -1985,6 +1993,7 @@ experimental_bearer_token = "sk-mix"
                     name: "官方混入".to_string(),
                     relay_mode: RelayMode::Official,
                     official_mix_api_key: true,
+                    hide_official_usage_alert: false,
                     config_contents: r#"model_provider = "custom"
 
 [model_providers.other]

--- a/crates/codex-plus-core/tests/bridge_routes.rs
+++ b/crates/codex-plus-core/tests/bridge_routes.rs
@@ -435,7 +435,7 @@ async fn runtime_status_devtools_repair_and_ads_routes_are_dispatched() {
     );
     assert_eq!(
         handle_bridge_request(ctx.clone(), "/backend/status", json!({})).await,
-        json!({"status": "ok", "message": "后端已连接", "version": codex_plus_core::version::VERSION})
+        json!({"status": "ok", "message": "后端已连接", "version": codex_plus_core::version::VERSION, "hideOfficialUsageAlert": false})
     );
     assert_eq!(
         handle_bridge_request(ctx.clone(), "/ads", json!({})).await,
@@ -514,6 +514,29 @@ async fn runtime_status_devtools_repair_and_ads_routes_are_dispatched() {
         .await,
         json!({"status": "ok", "removed": 1})
     );
+}
+
+#[tokio::test]
+async fn backend_status_includes_active_official_usage_alert_setting() {
+    let settings = BackendSettings {
+        active_relay_id: "official".to_string(),
+        relay_profiles: vec![codex_plus_core::settings::RelayProfile {
+            id: "official".to_string(),
+            relay_mode: codex_plus_core::settings::RelayMode::Official,
+            hide_official_usage_alert: true,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let ctx = BridgeContext::new(
+        Arc::new(FakeSettings::with_settings(settings)),
+        Arc::new(FakeRuntime::default()),
+        Arc::new(FakeData::default()),
+    );
+
+    let result = handle_bridge_request(ctx, "/backend/status", json!({})).await;
+
+    assert_eq!(result["hideOfficialUsageAlert"], true);
 }
 
 #[tokio::test]
@@ -814,7 +837,7 @@ async fn core_runtime_reload_evaluates_enabled_user_bundle_and_status_is_ok() {
 
     assert_eq!(
         status,
-        json!({"status": "ok", "message": "后端已连接", "version": codex_plus_core::version::VERSION})
+        json!({"status": "ok", "message": "后端已连接", "version": codex_plus_core::version::VERSION, "hideOfficialUsageAlert": false})
     );
     assert_eq!(reloaded["scripts"][0]["key"], "builtin:demo.js");
     let evaluated = evaluated.lock().unwrap();

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -449,6 +449,52 @@ fn injection_script_exposes_image_overlay_config() {
 }
 
 #[test]
+fn official_login_usage_alert_setting_controls_renderer_injection() {
+    use codex_plus_core::settings::{RelayMode, RelayProfile};
+
+    let settings = |relay_mode, hide_official_usage_alert, official_mix_api_key| {
+        codex_plus_core::settings::BackendSettings {
+            active_relay_id: "official".to_string(),
+            relay_profiles: vec![RelayProfile {
+                id: "official".to_string(),
+                relay_mode,
+                official_mix_api_key,
+                hide_official_usage_alert,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    };
+
+    assert!(
+        assets::injection_script_with_settings(57321, &settings(RelayMode::Official, true, false))
+            .contains("window.__CODEX_PLUS_HIDE_OFFICIAL_USAGE_ALERT__ = true;")
+    );
+    assert!(
+        assets::injection_script_with_settings(57321, &settings(RelayMode::Official, true, true))
+            .contains("window.__CODEX_PLUS_HIDE_OFFICIAL_USAGE_ALERT__ = true;")
+    );
+    assert!(
+        assets::injection_script_with_settings(57321, &settings(RelayMode::Official, false, false))
+            .contains("window.__CODEX_PLUS_HIDE_OFFICIAL_USAGE_ALERT__ = false;")
+    );
+    assert!(
+        assets::injection_script_with_settings(57321, &settings(RelayMode::PureApi, true, false))
+            .contains("window.__CODEX_PLUS_HIDE_OFFICIAL_USAGE_ALERT__ = false;")
+    );
+}
+
+#[test]
+fn usage_alert_hider_uses_sidebar_semantics_instead_of_percentage_copy() {
+    let script = assets::injection_script(57321);
+
+    assert!(script.contains("officialUsageAlertCards"));
+    assert!(script.contains("progress[max=\"100\"]"));
+    assert!(script.contains("dismiss usage alert|关闭使用量提醒"));
+    assert!(script.contains("codexPlusUsageAlertHidden"));
+}
+
+#[test]
 fn injection_script_installs_image_overlay_from_data_uri() {
     let script = assets::injection_script(57321);
 
@@ -2081,6 +2127,8 @@ fn manager_ui_exposes_pure_api_relay_mode_button() {
         std::fs::read_to_string(repo.join("apps/codex-plus-manager/src-tauri/src/lib.rs")).unwrap();
 
     assert!(source.contains("官方混入 API Key"));
+    assert!(source.contains("关闭官方低额度提示"));
+    assert!(source.contains("hideOfficialUsageAlert"));
     assert!(source.contains("纯 API"));
     assert!(source.contains("apply_pure_api_injection"));
     assert!(commands.contains("commands::apply_pure_api_injection"));

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -820,6 +820,7 @@ async fn default_helper_serves_backend_status_over_http() {
     let payload: serde_json::Value = response.json().await.unwrap();
     assert_eq!(payload["status"], "ok");
     assert_eq!(payload["transport"], "http-helper");
+    assert!(payload["hideOfficialUsageAlert"].is_boolean());
 
     let repair_response = client
         .post(format!("http://127.0.0.1:{port}/backend/repair"))
@@ -1167,6 +1168,7 @@ async fn official_mix_responses_profile_starts_fixed_protocol_proxy_without_enha
             id: "official-mix".to_string(),
             relay_mode: RelayMode::Official,
             official_mix_api_key: true,
+            hide_official_usage_alert: false,
             protocol: RelayProtocol::Responses,
             ..RelayProfile::default()
         }],
@@ -1208,6 +1210,7 @@ async fn official_mix_responses_profile_keeps_proxy_when_profile_switching_is_di
             id: "official-mix".to_string(),
             relay_mode: RelayMode::Official,
             official_mix_api_key: true,
+            hide_official_usage_alert: false,
             protocol: RelayProtocol::Responses,
             ..RelayProfile::default()
         }],
@@ -1446,6 +1449,7 @@ async fn launch_starts_helper_when_chat_protocol_proxy_is_enabled() {
             protocol: RelayProtocol::ChatCompletions,
             relay_mode: codex_plus_core::settings::RelayMode::MixedApi,
             official_mix_api_key: false,
+            hide_official_usage_alert: false,
             test_model: String::new(),
             config_contents: String::new(),
             auth_contents: String::new(),

--- a/crates/codex-plus-core/tests/protocol_proxy.rs
+++ b/crates/codex-plus-core/tests/protocol_proxy.rs
@@ -193,6 +193,7 @@ async fn responses_compact_request_keeps_compact_path_upstream() {
             api_key: "sk-compact".to_string(),
             relay_mode: RelayMode::Official,
             official_mix_api_key: true,
+            hide_official_usage_alert: false,
             ..RelayProfile::default()
         }],
         ..BackendSettings::default()

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -518,6 +518,7 @@ fn official_mix_api_profile_does_not_generate_auth_api_key() {
     let mut profile = RelayProfile {
         relay_mode: RelayMode::Official,
         official_mix_api_key: true,
+        hide_official_usage_alert: false,
         base_url: "https://relay.example/v1".to_string(),
         api_key: "sk-mix".to_string(),
         ..RelayProfile::default()
@@ -571,6 +572,7 @@ fn official_mix_profile_preserves_user_openai_base_url_override() {
     let mut profile = RelayProfile {
         relay_mode: RelayMode::Official,
         official_mix_api_key: true,
+        hide_official_usage_alert: false,
         base_url: "https://relay.example/v1".to_string(),
         api_key: "sk-mix".to_string(),
         config_contents: r#"openai_base_url = "https://user-openai.example/v1"
@@ -595,6 +597,7 @@ fn official_mix_api_profile_does_not_take_api_key_from_auth() {
     let mut profile = RelayProfile {
         relay_mode: RelayMode::Official,
         official_mix_api_key: true,
+        hide_official_usage_alert: false,
         auth_contents: r#"{"OPENAI_API_KEY":"sk-pure-api"}"#.to_string(),
         config_contents: r#"model_provider = "custom"
 
@@ -622,6 +625,7 @@ fn official_mix_api_profile_removes_auth_api_key_on_storage() {
     let mut profile = RelayProfile {
         relay_mode: RelayMode::Official,
         official_mix_api_key: true,
+        hide_official_usage_alert: false,
         api_key: "sk-official-mix".to_string(),
         base_url: "https://relay.example/v1".to_string(),
         auth_contents: r#"{"OPENAI_API_KEY":"sk-pure-api","auth_mode":"chatgpt","tokens":{"access_token":"official"}}"#.to_string(),
@@ -2572,6 +2576,7 @@ requires_openai_auth = true
         id: "official".to_string(),
         relay_mode: RelayMode::Official,
         official_mix_api_key: false,
+        hide_official_usage_alert: false,
         config_contents: String::new(),
         auth_contents: r#"{"auth_mode":"chatgpt","tokens":{"access_token":"official"}}"#
             .to_string(),
@@ -2615,6 +2620,7 @@ experimental_bearer_token = "sk-mix"
         id: "official".to_string(),
         relay_mode: RelayMode::Official,
         official_mix_api_key: false,
+        hide_official_usage_alert: false,
         config_contents: String::new(),
         auth_contents: r#"{"auth_mode":"chatgpt","tokens":{"access_token":"old"}}"#.to_string(),
         ..RelayProfile::default()
@@ -2656,6 +2662,7 @@ requires_openai_auth = true
         id: "official".to_string(),
         relay_mode: RelayMode::Official,
         official_mix_api_key: false,
+        hide_official_usage_alert: false,
         config_contents: String::new(),
         auth_contents: r#"{"auth_mode":"chatgpt","tokens":{"access_token":"official"}}"#
             .to_string(),
@@ -2698,6 +2705,7 @@ requires_openai_auth = true
         id: "official".to_string(),
         relay_mode: RelayMode::Official,
         official_mix_api_key: false,
+        hide_official_usage_alert: false,
         config_contents: String::new(),
         auth_contents: r#"{"auth_mode":"chatgpt","tokens":{"access_token":"official"}}"#
             .to_string(),
@@ -2741,6 +2749,7 @@ experimental_bearer_token = "sk-saved-mix"
         id: "official-mix".to_string(),
         relay_mode: RelayMode::Official,
         official_mix_api_key: true,
+        hide_official_usage_alert: false,
         config_contents: r#"model = "gpt-5"
 model_provider = "custom"
 
@@ -2800,6 +2809,7 @@ experimental_bearer_token = "333333333333333333333"
         id: "official-mix".to_string(),
         relay_mode: RelayMode::Official,
         official_mix_api_key: true,
+        hide_official_usage_alert: false,
         config_contents: r#"model = "gpt-5"
 model_provider = "custom"
 
@@ -3313,6 +3323,7 @@ fn apply_official_mix_profile_clears_live_auth_api_key_and_keeps_login() {
         id: "official-mix".to_string(),
         relay_mode: RelayMode::Official,
         official_mix_api_key: true,
+        hide_official_usage_alert: false,
         config_contents: r#"model = "gpt-5"
 model_provider = "custom"
 
@@ -3383,6 +3394,7 @@ fn apply_official_mix_profile_keeps_config_token_when_api_key_field_is_empty() {
         id: "official-mix".to_string(),
         relay_mode: RelayMode::Official,
         official_mix_api_key: true,
+        hide_official_usage_alert: false,
         config_contents: r#"model = "gpt-5"
 model_provider = "custom"
 

--- a/crates/codex-plus-core/tests/relay_switch.rs
+++ b/crates/codex-plus-core/tests/relay_switch.rs
@@ -268,6 +268,7 @@ goals = true
         name: "官方".to_string(),
         relay_mode: RelayMode::Official,
         official_mix_api_key: false,
+        hide_official_usage_alert: false,
         auth_contents: r#"{"auth_mode":"chatgpt","tokens":{"access_token":"official"}}"#
             .to_string(),
         ..RelayProfile::default()


### PR DESCRIPTION
## What changed

- Add an opt-in **Hide official low-usage alert** setting for official-login provider profiles.
- Keep the option disabled by default and inactive for pure API and aggregate profiles.
- Hide only the official sidebar usage-alert card, identified by its live-region, progress element, and dismiss-button semantics.
- Keep the lower-left account menu available for checking the official quota.
- Refresh the active profile setting through the existing backend heartbeat, so saving or switching profiles updates a running Codex window without a restart.

## Why

In official-login profiles, including configurations that mix in an API key, the official low-usage card can repeatedly appear even when that quota is not the user's primary request path. The account menu already provides an on-demand quota view, so this adds a narrowly scoped preference without changing the default Codex behavior.

The implementation does not remove, move, or click React-owned nodes. It applies a controlled marker to matched alerts, clears stale markers on every refresh, and restores the upstream presentation when the setting is disabled. If the official DOM structure cannot be identified reliably, it leaves the UI unchanged.

Closes #1734.

## Validation

- `npm test` (56 passed)
- `npm run check`
- `npm run vite:build`
- `cargo check -p codex-plus-launcher`
- `cargo test -p codex-plus-core`
- `cargo test --workspace`
- `git diff --check`