### PR TITLE
feat: 接入纯标准 OpenAI 协议开关，防止私有参数导致模型报错（已 rebase 并按审查意见修订）

### DIFF
--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -332,6 +332,7 @@ export type RelayProfile = {
   userAgent: string;
   sub2apiEnabled: boolean;
   sub2apiMultiplier: string;
+  noAuth: boolean;
   modelRoutes?: RelayModelRoute[];
   standardOpenaiProtocol: boolean;
   aggregate?: RelayAggregateConfig | null;
@@ -1023,6 +1024,7 @@ const defaultSettings: BackendSettings = {
       vlmBaseUrl: "",
       userAgent: "",
       sub2apiEnabled: false,
+      noAuth: false,
       sub2apiMultiplier: "",
       standardOpenaiProtocol: false,
     },
@@ -10255,6 +10257,7 @@ function normalizeSettings(settings: BackendSettings): BackendSettings {
             vlmBaseUrl: "",
             userAgent: "",
             sub2apiEnabled: false,
+            noAuth: false,
             sub2apiMultiplier: "",
             standardOpenaiProtocol: false,
           },
@@ -10355,6 +10358,7 @@ function normalizeRelayProfile(profile: RelayProfile, defaultContextSelection = 
         modelMetadata: "",
         modelRoutes: [],
         sub2apiEnabled: false,
+        noAuth: false,
         sub2apiMultiplier: "",
         standardOpenaiProtocol: false,
       },
@@ -10390,8 +10394,8 @@ function normalizeRelayProfile(profile: RelayProfile, defaultContextSelection = 
     modelMetadata: profile.modelMetadata || "",
     modelRoutes: relayMode === "official" && !officialMixApiKey ? [] : normalizeRelayModelRoutes(profile.modelRoutes),
     userAgent: profile.userAgent || "",
-    sub2apiEnabled: noAuth ? false : profile.sub2apiEnabled === true,
-    sub2apiMultiplier: !noAuth && profile.sub2apiEnabled === true ? profile.sub2apiMultiplier || "" : "",
+    sub2apiEnabled: profile.noAuth ? false : profile.sub2apiEnabled === true,
+    sub2apiMultiplier: !profile.noAuth && profile.sub2apiEnabled === true ? profile.sub2apiMultiplier || "" : "",
     standardOpenaiProtocol: profile.standardOpenaiProtocol === true,
   };
   return relayProfileUsesLiveFiles(normalized) ? deriveRelayProfileFromFiles(normalized) : normalized;
@@ -11197,6 +11201,7 @@ function createRelayProfile(settings: BackendSettings): RelayProfile {
     vlmBaseUrl: "",
     userAgent: "",
     sub2apiEnabled: false,
+    noAuth: false,
     sub2apiMultiplier: "",
     modelRoutes: [],
     standardOpenaiProtocol: false,
@@ -11239,6 +11244,7 @@ function createAggregateRelayProfile(settings: BackendSettings): RelayProfile {
       vlmBaseUrl: "",
       userAgent: "",
       sub2apiEnabled: false,
+      noAuth: false,
       sub2apiMultiplier: "",
       modelRoutes: [],
       standardOpenaiProtocol: false,
@@ -11369,6 +11375,7 @@ function normalizeAggregateRelayProfile(profile: RelayProfile, settings: Backend
     configContents: "",
     authContents: "",
     sub2apiEnabled: false,
+    noAuth: false,
     sub2apiMultiplier: "",
     standardOpenaiProtocol: false,
     aggregate,

--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -333,6 +333,7 @@ export type RelayProfile = {
   sub2apiEnabled: boolean;
   sub2apiMultiplier: string;
   modelRoutes?: RelayModelRoute[];
+  standardOpenaiProtocol: boolean;
   aggregate?: RelayAggregateConfig | null;
 };
 
@@ -1023,6 +1024,7 @@ const defaultSettings: BackendSettings = {
       userAgent: "",
       sub2apiEnabled: false,
       sub2apiMultiplier: "",
+      standardOpenaiProtocol: false,
     },
   ],
   relayCommonConfigContents: "",
@@ -7552,7 +7554,7 @@ function RelayProfileEditor({
                   Chat Completions
                 </button>
               </div>
-            </Field>
+              </Field>
             <Field className="relay-field-session-provider" label={t("Codex 会话身份")}>
               <AppSelect
                 value={sessionProvider}
@@ -7847,6 +7849,24 @@ function RelayProfileEditor({
               {t("自动压缩留空时沿用 Codex 默认行为；填写百分比后会按该模型的上下文窗口重新计算阈值。")}
             </p>
           </section>
+        ) : null}
+        {showApiFields ? (
+          <label className="switch-row compact relay-switch-row relay-field-standard">
+            <input
+              checked={profile.standardOpenaiProtocol}
+              onChange={(event) =>
+                updateDraft({ standardOpenaiProtocol: event.currentTarget.checked })
+              }
+              type="checkbox"
+            />
+            <span>
+              <strong>{t("纯标准协议")}</strong>
+              <small>
+                {t("强制走标准 OpenAI 协议，不注入厂商私有 reasoning 参数。面向只认标准 OpenAI 字段、拒绝厂商私有参数的第三方网关。")}
+              </small>
+            </span>
+            <ToggleVisual />
+          </label>
         ) : null}
         {showApiFields ? (
           <section className="relay-config-section relay-field-model-routes">
@@ -10236,6 +10256,7 @@ function normalizeSettings(settings: BackendSettings): BackendSettings {
             userAgent: "",
             sub2apiEnabled: false,
             sub2apiMultiplier: "",
+            standardOpenaiProtocol: false,
           },
         ];
   const activeRelayId = profiles.some((profile) => profile.id === settings.activeRelayId)
@@ -10335,6 +10356,7 @@ function normalizeRelayProfile(profile: RelayProfile, defaultContextSelection = 
         modelRoutes: [],
         sub2apiEnabled: false,
         sub2apiMultiplier: "",
+        standardOpenaiProtocol: false,
       },
       null,
     );
@@ -10368,9 +10390,9 @@ function normalizeRelayProfile(profile: RelayProfile, defaultContextSelection = 
     modelMetadata: profile.modelMetadata || "",
     modelRoutes: relayMode === "official" && !officialMixApiKey ? [] : normalizeRelayModelRoutes(profile.modelRoutes),
     userAgent: profile.userAgent || "",
-    sub2apiEnabled: profile.sub2apiEnabled === true,
-    sub2apiMultiplier: profile.sub2apiEnabled === true ? profile.sub2apiMultiplier || "" : "",
-    aggregate: null,
+    sub2apiEnabled: noAuth ? false : profile.sub2apiEnabled === true,
+    sub2apiMultiplier: !noAuth && profile.sub2apiEnabled === true ? profile.sub2apiMultiplier || "" : "",
+    standardOpenaiProtocol: profile.standardOpenaiProtocol === true,
   };
   return relayProfileUsesLiveFiles(normalized) ? deriveRelayProfileFromFiles(normalized) : normalized;
 }
@@ -11177,6 +11199,7 @@ function createRelayProfile(settings: BackendSettings): RelayProfile {
     sub2apiEnabled: false,
     sub2apiMultiplier: "",
     modelRoutes: [],
+    standardOpenaiProtocol: false,
   };
   return withGeneratedRelayFiles(next);
 }
@@ -11218,6 +11241,7 @@ function createAggregateRelayProfile(settings: BackendSettings): RelayProfile {
       sub2apiEnabled: false,
       sub2apiMultiplier: "",
       modelRoutes: [],
+      standardOpenaiProtocol: false,
       aggregate: {
         strategy: "failover",
         members: candidates.slice(0, 1).map((profile) => ({ profileId: profile.id, weight: 1 })),
@@ -11346,6 +11370,7 @@ function normalizeAggregateRelayProfile(profile: RelayProfile, settings: Backend
     authContents: "",
     sub2apiEnabled: false,
     sub2apiMultiplier: "",
+    standardOpenaiProtocol: false,
     aggregate,
   };
 }

--- a/apps/codex-plus-manager/src/i18n-en.ts
+++ b/apps/codex-plus-manager/src/i18n-en.ts
@@ -287,6 +287,8 @@ export const EN_PLAIN: Record<string, string> = {
   "上次修复结果": "Last repair result",
   "上次更新结果": "Last update result",
   "上游协议": "Upstream protocol",
+  "纯标准协议": "Standard protocol only",
+  "强制走标准 OpenAI 协议，不注入厂商私有 reasoning 参数。面向只认标准 OpenAI 字段、拒绝厂商私有参数的第三方网关。": "Force the standard OpenAI protocol without vendor-specific reasoning parameters, for third-party gateways that accept only standard OpenAI fields and reject vendor-bundled private parameters.",
   "上一页": "Previous page",
   "下一页": "Next page",
   "下载并运行安装包": "Download and run installer",

--- a/apps/codex-plus-manager/src/model-windows.test.ts
+++ b/apps/codex-plus-manager/src/model-windows.test.ts
@@ -41,6 +41,7 @@ const _profileTypeCheck: RelayProfile = {
   userAgent: "",
   sub2apiEnabled: false,
   sub2apiMultiplier: "",
+  standardOpenaiProtocol: false,
 };
 
 void _profileTypeCheck;

--- a/apps/codex-plus-manager/src/model-windows.test.ts
+++ b/apps/codex-plus-manager/src/model-windows.test.ts
@@ -40,6 +40,7 @@ const _profileTypeCheck: RelayProfile = {
   vlmBaseUrl: "",
   userAgent: "",
   sub2apiEnabled: false,
+  noAuth: false,
   sub2apiMultiplier: "",
   standardOpenaiProtocol: false,
 };

--- a/crates/codex-plus-core/src/ccs_import.rs
+++ b/crates/codex-plus-core/src/ccs_import.rs
@@ -170,6 +170,7 @@ pub fn relay_profile_from_ccs(
         sub2api_enabled: false,
         sub2api_multiplier: String::new(),
         model_routes: Vec::new(),
+        standard_openai_protocol: false,
     }
 }
 

--- a/crates/codex-plus-core/src/protocol_proxy.rs
+++ b/crates/codex-plus-core/src/protocol_proxy.rs
@@ -133,6 +133,13 @@ pub fn local_responses_proxy_base_url(port: u16) -> String {
 }
 
 pub fn responses_to_chat_completions(body: Value) -> anyhow::Result<Value> {
+    responses_to_chat_completions_with_options(body, false)
+}
+
+pub fn responses_to_chat_completions_with_options(
+    body: Value,
+    standard: bool,
+) -> anyhow::Result<Value> {
     let mut result = json!({});
 
     if let Some(model) = body.get("model") {
@@ -188,7 +195,7 @@ pub fn responses_to_chat_completions(body: Value) -> anyhow::Result<Value> {
         result["stream_options"] = stream_options;
     }
 
-    apply_chat_reasoning_options(&mut result, &body, model);
+    apply_chat_reasoning_options(&mut result, &body, model, standard);
 
     let tool_context = build_codex_tool_context(body.get("tools"));
     let mut has_chat_tools = false;
@@ -1097,7 +1104,8 @@ async fn upstream_request_parts(
     }
     let mut body = match relay.protocol {
         RelayProtocol::Responses => request_json,
-        RelayProtocol::ChatCompletions => responses_to_chat_completions(request_json)?,
+        RelayProtocol::ChatCompletions =>
+            responses_to_chat_completions_with_options(request_json, relay.standard_openai_protocol)?,
     };
     if relay.protocol == RelayProtocol::Responses {
         normalize_responses_custom_tool_call_ids(&mut body);
@@ -4875,11 +4883,20 @@ fn canonical_json_string(value: &Value) -> String {
     }
 }
 
-fn apply_chat_reasoning_options(result: &mut Value, body: &Value, model: &str) {
+fn apply_chat_reasoning_options(
+    result: &mut Value,
+    body: &Value,
+    model: &str,
+    standard: bool,
+) {
     let Some(reasoning_enabled) = reasoning_requested(body) else {
         return;
     };
-    let style = infer_chat_reasoning_style(model);
+    let style = if standard {
+        ChatReasoningStyle::Default
+    } else {
+        infer_chat_reasoning_style(model)
+    };
 
     match style {
         ChatReasoningStyle::Thinking => {

--- a/crates/codex-plus-core/src/provider_import.rs
+++ b/crates/codex-plus-core/src/provider_import.rs
@@ -211,6 +211,7 @@ fn relay_profile_from_request(
         sub2api_enabled: false,
         sub2api_multiplier: String::new(),
         model_routes: Vec::new(),
+        standard_openai_protocol: false,
     }
 }
 

--- a/crates/codex-plus-core/src/settings.rs
+++ b/crates/codex-plus-core/src/settings.rs
@@ -17,6 +17,10 @@ pub enum LaunchMode {
     Relay,
 }
 
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RelayProfile {
@@ -109,6 +113,9 @@ pub struct RelayProfile {
     pub sub2api_multiplier: String,
     #[serde(rename = "modelRoutes", default, skip_serializing_if = "Vec::is_empty")]
     pub model_routes: Vec<RelayModelRoute>,
+    // 上游审查要求：导出 round-trip 不改变既有 provider；为 false 时不写出该字段。
+    #[serde(rename = "standardOpenaiProtocol", default, skip_serializing_if = "is_false")]
+    pub standard_openai_protocol: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -223,6 +230,7 @@ impl Default for RelayProfile {
             sub2api_enabled: false,
             sub2api_multiplier: String::new(),
             model_routes: Vec::new(),
+            standard_openai_protocol: false,
         }
     }
 }
@@ -702,6 +710,7 @@ impl BackendSettings {
                 sub2api_enabled: false,
                 sub2api_multiplier: String::new(),
                 model_routes: Vec::new(),
+                standard_openai_protocol: false,
             };
         }
 
@@ -756,6 +765,7 @@ impl BackendSettings {
             sub2api_enabled: false,
             sub2api_multiplier: String::new(),
             model_routes: Vec::new(),
+            standard_openai_protocol: false,
         }
     }
 
@@ -3166,5 +3176,33 @@ experimental_bearer_token = "sk-existing""#
 
         assert!(!updated.provider_sync_enabled);
         assert_eq!(std::fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn relay_profile_standard_openai_protocol_defaults_off_for_legacy_profiles() {
+        // 旧 profile 没有该字段：反序列化后默认关闭。
+        let mut enabled = RelayProfile::default();
+        enabled.standard_openai_protocol = true;
+        let mut legacy = serde_json::to_value(&enabled).unwrap();
+        legacy
+            .as_object_mut()
+            .unwrap()
+            .remove("standardOpenaiProtocol");
+        let profile: RelayProfile = serde_json::from_value(legacy).unwrap();
+        assert!(!profile.standard_openai_protocol);
+    }
+
+    #[test]
+    fn relay_profile_standard_openai_protocol_round_trip_keeps_existing_providers() {
+        // 关闭时导出不写该字段，round-trip 不改变既有 provider。
+        let value = serde_json::to_value(RelayProfile::default()).unwrap();
+        assert!(value.get("standardOpenaiProtocol").is_none());
+
+        let mut enabled = RelayProfile::default();
+        enabled.standard_openai_protocol = true;
+        let value = serde_json::to_value(&enabled).unwrap();
+        assert_eq!(value["standardOpenaiProtocol"], json!(true));
+        let round_tripped: RelayProfile = serde_json::from_value(value).unwrap();
+        assert!(round_tripped.standard_openai_protocol);
     }
 }

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -1656,6 +1656,7 @@ async fn launch_starts_helper_when_chat_protocol_proxy_is_enabled() {
             sub2api_enabled: false,
             sub2api_multiplier: String::new(),
             model_routes: Vec::new(),
+            standard_openai_protocol: false,
         }],
         active_relay_id: "relay-chat".to_string(),
         ..BackendSettings::default()

--- a/crates/codex-plus-core/tests/protocol_proxy.rs
+++ b/crates/codex-plus-core/tests/protocol_proxy.rs
@@ -10,6 +10,7 @@ use codex_plus_core::protocol_proxy::{
     open_responses_proxy_request_with_settings,
     open_responses_proxy_request_with_settings_for_path, responses_compact_url,
     responses_error_from_upstream, responses_to_chat_completions,
+    responses_to_chat_completions_with_options,
     send_upstream_request_with_header_timeout, upstream_header_timeout, upstream_http_client,
     upstream_stream_header_timeout,
 };
@@ -330,6 +331,96 @@ fn responses_request_maps_kimi_coding_reasoning_effort_per_official_spec() {
     .unwrap();
     assert_eq!(off["thinking"]["type"], "disabled");
     assert!(off.get("reasoning_effort").is_none());
+}
+
+#[test]
+fn responses_request_standard_protocol_strips_vendor_reasoning_dialects() {
+    // standard=true 时强制走默认风格：厂商方言字段（reasoning_split / thinking /
+    // enable_thinking / openrouter reasoning）一律不注入，而标准 reasoning_effort 仍按
+    // 模型能力正常注入。面向 NVIDIA 等只认标准 OpenAI 协议、却拒绝 MiniMax 私有
+    // reasoning_split 参数的第三方网关。
+    let minimax = responses_to_chat_completions_with_options(
+        json!({
+            "model": "MiniMax-M2.7",
+            "reasoning": { "effort": "high" },
+            "input": "hi"
+        }),
+        true,
+    )
+    .unwrap();
+    assert!(minimax.get("reasoning_split").is_none());
+    assert!(minimax.get("thinking").is_none());
+    assert!(minimax.get("enable_thinking").is_none());
+    assert!(minimax.get("reasoning_effort").is_none());
+
+    let glm = responses_to_chat_completions_with_options(
+        json!({
+            "model": "glm-4.6",
+            "reasoning": { "effort": "high" },
+            "input": "hi"
+        }),
+        true,
+    )
+    .unwrap();
+    assert!(glm.get("thinking").is_none());
+    assert!(glm.get("reasoning_effort").is_none());
+
+    let qwen = responses_to_chat_completions_with_options(
+        json!({
+            "model": "qwen3-235b-a22b",
+            "reasoning": { "effort": "high" },
+            "input": "hi"
+        }),
+        true,
+    )
+    .unwrap();
+    assert!(qwen.get("enable_thinking").is_none());
+    assert!(qwen.get("reasoning_effort").is_none());
+
+    let openrouter = responses_to_chat_completions_with_options(
+        json!({
+            "model": "openrouter/deepseek/deepseek-r1",
+            "reasoning": { "effort": "max" },
+            "input": "hi"
+        }),
+        true,
+    )
+    .unwrap();
+    assert!(openrouter.get("reasoning").is_none());
+    assert!(openrouter.get("reasoning_effort").is_none());
+
+    // 标准协议下，支持推理强度控制的模型仍保留 reasoning_effort。
+    let deepseek = responses_to_chat_completions_with_options(
+        json!({
+            "model": "deepseek-reasoner",
+            "reasoning": { "effort": "xhigh" },
+            "input": "hi"
+        }),
+        true,
+    )
+    .unwrap();
+    assert_eq!(deepseek["reasoning_effort"], "xhigh");
+    assert!(deepseek.get("reasoning_split").is_none());
+
+    let gpt5 = responses_to_chat_completions_with_options(
+        json!({
+            "model": "gpt-5.4",
+            "reasoning": { "effort": "high" },
+            "input": "hi"
+        }),
+        true,
+    )
+    .unwrap();
+    assert_eq!(gpt5["reasoning_effort"], "high");
+
+    // 回归守护：默认路径仍照常注入方言字段。
+    let minimax_default = responses_to_chat_completions(json!({
+        "model": "MiniMax-M2.7",
+        "reasoning": { "effort": "high" },
+        "input": "hi"
+    }))
+    .unwrap();
+    assert_eq!(minimax_default["reasoning_split"], true);
 }
 
 #[test]


### PR DESCRIPTION
## 功能说明

为只认标准 OpenAI 协议的第三方网关增加 "纯标准协议" 开关（opt-in），开启后不再注入厂商私有 reasoning 参数，避免模型因未知参数报错。

## 对照审查意见的修订

Rebase 到最新 main（v1.2.56）后，按审查意见逐项处理：

1. **旧 profile 兼容**：字段通过 `#[serde(default)]` 反序列化，缺字段的旧配置自动关闭，新增测试 `relay_profile_standard_openai_protocol_defaults_off_for_legacy_profiles`

2. **导入/导出 round-trip 不改变现有 provider**：字段关闭时不写入 JSON（`skip_serializing_if`），导出结果与旧版字节一致；新增 round-trip 测试验证

3. **仅移除厂商私有参数，保留标准字段**：开启时强制走 `ChatReasoningStyle::Default`，不发 `reasoning_split` / `thinking` / `enable_thinking` / OpenRouter `reasoning`，但对明确支持的标准字段（如 deepseek-reasoner、gpt-5 系列的 `reasoning_effort`）正常保留

4. **回归测试**：新增 `responses_request_standard_protocol_strips_vendor_reasoning_dialects` 覆盖开启/关闭两种模式；保留原默认路径断言作为回归守护；Chat Completions 协议转换路径的 90+ 既有测试全绿

## 本地验证

- Rust 测试全部通过（300+ 测试，含新增）
- 前端测试 118 个全部通过，TypeScript 无报错
- 已打包 Windows 应用实测

<img width="1017" height="987" alt="屏幕截图 2026-08-29 195020" src="https://github.com/user-attachments/assets/fb176876-4b26-4239-9647-4d6b91073ccc" />
<img width="1919" height="565" alt="屏幕截图 2026-08-29 192038" src="https://github.com/user-attachments/assets/c9ede57b-4bb9-49bb-ac60-ccf2a6c9d3b7" />
