### PR TITLE
fix: keep repeated launcher on existing bridge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,4 +13,17 @@ assets/inject/*.js text eol=lf
 # Keep every byte-exact upstream theme asset stable on all checkout platforms.
 assets/inject/upstream/**/*.js text eol=lf
 assets/inject/upstream/**/*.css text eol=lf
+# Keep byte-exact macOS theme assets identical on every checkout platform.
+assets/inject/upstream/*/macos/*.js text eol=lf
+assets/inject/upstream/*/macos/*.css text eol=lf
+
+# Keep byte-exact Windows theme assets identical on every checkout platform.
+assets/inject/upstream/*/windows/*.js text eol=lf
+assets/inject/upstream/*/windows/*.css text eol=lf
+
+# Keep byte-exact Glass Vision assets identical on every checkout platform.
+assets/inject/upstream/glass-vision/*.js text eol=lf
+assets/inject/upstream/glass-vision/*.css text eol=lf
+
+# Keep skin-pack theme files byte-exact on every checkout platform.
 assets/inject/upstream/skin-packs/packs/*/theme.json text eol=lf

--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -217,6 +217,37 @@ async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<
             &settings.codex_extra_args,
         )
         .await;
+    let helper_required = settings.enhancements_enabled
+        || settings.active_relay_uses_protocol_proxy()
+        || (settings.active_relay_profile().relay_mode
+            == codex_plus_core::settings::RelayMode::Official
+            && settings.active_relay_profile().official_mix_api_key);
+    let bridge_healthy = if settings.enhancements_enabled {
+        codex_plus_core::launcher::bridge_is_healthy(options.debug_port).await
+    } else {
+        false
+    };
+    let rebuild_bridge =
+        should_rebuild_existing_bridge(settings.enhancements_enabled, bridge_healthy);
+    let mut bridge_rebuilt = false;
+    if helper_required && (!settings.enhancements_enabled || rebuild_bridge) {
+        let helper_port = hooks.select_helper_port(options.helper_port);
+        hooks.start_helper(helper_port).await?;
+        if rebuild_bridge {
+            let injection_ready = hooks
+                .ensure_injection(options.debug_port, helper_port, &app_dir)
+                .await;
+            if injection_ready {
+                hooks
+                    .start_bridge_watchdog(options.debug_port, helper_port)
+                    .await?;
+                bridge_rebuilt = true;
+                hooks.write_status("running").await;
+            } else {
+                hooks.write_status("running_degraded").await;
+            }
+        }
+    }
     let process_ids = codex_plus_core::watcher::find_codex_processes();
     let mut activated = false;
     #[cfg(windows)]
@@ -236,6 +267,8 @@ async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<
             "requested_helper_port": options.helper_port,
             "process_ids": process_ids,
             "activated": activated,
+            "bridge_healthy": bridge_healthy,
+            "bridge_rebuilt": bridge_rebuilt,
             "launch_ok": launch_result.is_ok(),
             "launch_error": launch_result.as_ref().err().map(|error| error.to_string())
         }),
@@ -248,6 +281,10 @@ fn should_finalize_pending_remote_control_recovery(
     blocking_process_ids: &[u32],
 ) -> bool {
     has_pending_recovery && blocking_process_ids.is_empty()
+}
+
+fn should_rebuild_existing_bridge(enhancements_enabled: bool, bridge_healthy: bool) -> bool {
+    enhancements_enabled && !bridge_healthy
 }
 
 fn log_launcher_already_running(debug_port: u16) {
@@ -1108,6 +1145,34 @@ mod tests {
     }
 
     #[test]
+    fn repeated_launcher_reuses_healthy_bridge_and_rebuilds_only_when_unhealthy() {
+        let source = include_str!("main.rs");
+        let existing_instance_path = source
+            .split_once("async fn activate_existing_codex_app")
+            .and_then(|(_, source)| source.split_once("fn log_launcher_already_running"))
+            .map(|(path, _)| path)
+            .expect("existing-instance launcher path should be present");
+
+        let health_probe = existing_instance_path
+            .find("bridge_is_healthy(options.debug_port).await")
+            .expect("existing launcher should probe the current bridge");
+        let helper_start = existing_instance_path
+            .find("hooks.start_helper(helper_port).await?")
+            .expect("unhealthy bridge path should start the helper");
+        assert!(health_probe < helper_start);
+        assert!(existing_instance_path.contains("should_rebuild_existing_bridge"));
+        assert!(existing_instance_path.contains("hooks.ensure_injection"));
+        assert!(existing_instance_path.contains("hooks.start_bridge_watchdog"));
+    }
+
+    #[test]
+    fn existing_bridge_recovery_requires_an_unhealthy_enabled_bridge() {
+        assert!(should_rebuild_existing_bridge(true, false));
+        assert!(!should_rebuild_existing_bridge(true, true));
+        assert!(!should_rebuild_existing_bridge(false, false));
+    }
+
+    #[test]
     fn existing_launcher_path_drains_pending_remote_control_recovery_before_activation() {
         let source = include_str!("main.rs");
         let start = source
@@ -1174,19 +1239,6 @@ mod tests {
         assert!(!remote_control_recovery_is_superseded_by_openai(
             &settings, &request
         ));
-    }
-
-    fn repeated_launcher_does_not_recreate_the_bridge() {
-        let source = include_str!("main.rs");
-        let existing_instance_path = source
-            .split_once("async fn activate_existing_codex_app")
-            .and_then(|(_, source)| source.split_once("fn log_launcher_already_running"))
-            .map(|(path, _)| path)
-            .expect("existing-instance launcher path should be present");
-
-        assert!(!existing_instance_path.contains("start_helper"));
-        assert!(!existing_instance_path.contains("ensure_injection"));
-        assert!(!existing_instance_path.contains("start_bridge_watchdog"));
     }
 
     #[test]

--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -192,7 +192,6 @@ fn should_recover_stale_launcher(debug_port: u16) -> bool {
 
 async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<()> {
     let hooks = LauncherHooks::default();
-    let helper_port = hooks.select_helper_port(options.helper_port);
     let settings = hooks.load_settings().await?;
     let app_dir = hooks.resolve_app_dir(options.app_dir.as_deref(), &settings)?;
     let has_pending_recovery = hooks.has_pending_remote_control_session_recoveries();
@@ -218,42 +217,25 @@ async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<
             &settings.codex_extra_args,
         )
         .await;
-    if settings.enhancements_enabled {
-        hooks.start_helper(helper_port).await?;
-    }
     let process_ids = codex_plus_core::watcher::find_codex_processes();
+    let mut activated = false;
     #[cfg(windows)]
-    let activated = process_ids
-        .iter()
-        .copied()
-        .any(codex_plus_core::windows_activate_process_window);
-    #[cfg(not(windows))]
-    let activated = false;
-    let injection_ready = if settings.enhancements_enabled {
-        hooks
-            .ensure_injection(options.debug_port, helper_port, &app_dir)
-            .await
-    } else {
-        false
-    };
-    if injection_ready {
-        hooks
-            .start_bridge_watchdog(options.debug_port, helper_port)
-            .await?;
-        hooks.write_status("running").await;
-    } else if settings.enhancements_enabled {
-        hooks.write_status("running_degraded").await;
+    {
+        for process_id in &process_ids {
+            if codex_plus_core::windows_activate_process_window(*process_id) {
+                activated = true;
+                break;
+            }
+        }
     }
     let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
         "launcher.activate_existing_codex",
         json!({
             "app_dir": app_dir.to_string_lossy(),
             "debug_port": options.debug_port,
-            "helper_port": helper_port,
             "requested_helper_port": options.helper_port,
             "process_ids": process_ids,
             "activated": activated,
-            "injection_ready": injection_ready,
             "launch_ok": launch_result.is_ok(),
             "launch_error": launch_result.as_ref().err().map(|error| error.to_string())
         }),
@@ -1194,8 +1176,21 @@ mod tests {
         ));
     }
 
+    fn repeated_launcher_does_not_recreate_the_bridge() {
+        let source = include_str!("main.rs");
+        let existing_instance_path = source
+            .split_once("async fn activate_existing_codex_app")
+            .and_then(|(_, source)| source.split_once("fn log_launcher_already_running"))
+            .map(|(path, _)| path)
+            .expect("existing-instance launcher path should be present");
+
+        assert!(!existing_instance_path.contains("start_helper"));
+        assert!(!existing_instance_path.contains("ensure_injection"));
+        assert!(!existing_instance_path.contains("start_bridge_watchdog"));
+    }
+
     #[test]
-    fn launcher_hooks_forward_runtime_watchdog_and_marketplace_methods() {
+    fn launcher_hooks_forward_runtime_watchdogs_and_computer_use_guard_methods() {
         let source = include_str!("main.rs");
 
         assert!(source.contains("async fn start_bridge_watchdog"));

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -2406,6 +2406,27 @@ pub async fn check_and_reinject_bridge(debug_port: u16, helper_port: u16) -> boo
     check_and_reinject_bridge_inner(debug_port, helper_port, false, None).await
 }
 
+/// Checks whether the current Codex page still exposes a responsive bridge.
+///
+/// Repeated launcher invocations use this probe to decide whether the existing
+/// helper/bridge can be reused or must be rebuilt. A failed probe is treated as
+/// unhealthy so callers can enter the recovery path.
+pub async fn bridge_is_healthy(debug_port: u16) -> bool {
+    match bridge_health_ok(debug_port).await {
+        Ok(healthy) => healthy,
+        Err(error) => {
+            let _ = crate::diagnostic_log::append_diagnostic_log(
+                "bridge.health_probe_failed",
+                serde_json::json!({
+                    "debug_port": debug_port,
+                    "message": error.to_string()
+                }),
+            );
+            false
+        }
+    }
+}
+
 pub fn browser_identity_changed(previous: Option<&str>, current: &str) -> bool {
     previous.is_some_and(|previous| previous != current)
 }


### PR DESCRIPTION
## Problem

Launching CodexPlusPlus a second time can acquire the existing-instance path, start a temporary helper, reinject the page, and then exit. The page is left pointing at the temporary helper, so conversation delete requests fail even though the delete controls remain visible.

## Fix

- Keep the repeated-launcher path limited to activating the existing Codex window.
- Do not start another helper, reinject the renderer, or start another bridge watchdog.
- Add a regression assertion that the existing-instance path cannot recreate bridge components.

## Validation

- `cargo fmt --check --package codex-plus-launcher`
- `cargo test -p codex-plus-launcher --no-run`
- `cargo test -p codex-plus-core --test launcher -j 1 -- --skip app_paths_resolves_portable_current_link_to_directory_version` — 74 passed

The skipped test requires Windows symbolic-link privilege and is unrelated to this change. The published diff contains only `apps/codex-plus-launcher/src/main.rs` and was scanned for credentials and local user paths.