### PR TITLE
feat(stepwise): support multiple upstream protocols

### DIFF
--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -4055,6 +4055,9 @@ pub async fn test_relay_profile(profile: RelayProfile) -> CommandResult<RelayPro
 pub async fn test_stepwise_settings(
     settings: BackendSettings,
 ) -> CommandResult<StepwiseTestPayload> {
+    let configured_protocol = codex_plus_core::settings::normalize_stepwise_protocol(
+        &settings.codex_app_stepwise_protocol,
+    );
     match codex_plus_core::stepwise::test_connection(&settings).await {
         Ok(result) => {
             let error = result
@@ -4067,9 +4070,17 @@ pub async fn test_stepwise_settings(
                 .and_then(Value::as_array)
                 .map(Vec::len)
                 .unwrap_or_default();
+            let protocol = result
+                .get("protocol")
+                .and_then(Value::as_str)
+                .unwrap_or(&configured_protocol)
+                .to_string();
             if error.is_empty() {
                 ok(
-                    &format!("Stepwise 连接正常，测试返回 {item_count} 条建议。"),
+                    &format!(
+                        "Stepwise 连接正常（{}），测试返回 {item_count} 条建议。",
+                        stepwise_protocol_label(&protocol)
+                    ),
                     StepwiseTestPayload { item_count, error },
                 )
             } else {
@@ -4086,6 +4097,16 @@ pub async fn test_stepwise_settings(
                 error: error.to_string(),
             },
         ),
+    }
+}
+
+fn stepwise_protocol_label(protocol: &str) -> &str {
+    match protocol {
+        "chat_completions" => "Chat Completions",
+        "responses" => "Responses",
+        "anthropic_messages" => "Anthropic Messages",
+        "auto" => "自动兼容",
+        _ => protocol,
     }
 }
 

--- a/crates/codex-plus-core/src/settings.rs
+++ b/crates/codex-plus-core/src/settings.rs
@@ -424,6 +424,12 @@ pub struct BackendSettings {
         deserialize_with = "empty_as_default_stepwise_api_key_env"
     )]
     pub codex_app_stepwise_api_key_env: String,
+    #[serde(
+        rename = "codexAppStepwiseProtocol",
+        default = "default_stepwise_protocol",
+        deserialize_with = "deserialize_stepwise_protocol"
+    )]
+    pub codex_app_stepwise_protocol: String,
     #[serde(rename = "codexAppStepwiseModel", default)]
     pub codex_app_stepwise_model: String,
     #[serde(
@@ -565,6 +571,7 @@ impl Default for BackendSettings {
             codex_app_stepwise_base_url: String::new(),
             codex_app_stepwise_api_key: String::new(),
             codex_app_stepwise_api_key_env: default_stepwise_api_key_env(),
+            codex_app_stepwise_protocol: default_stepwise_protocol(),
             codex_app_stepwise_model: String::new(),
             codex_app_stepwise_max_items: default_stepwise_max_items(),
             codex_app_stepwise_max_input_chars: default_stepwise_max_input_chars(),
@@ -739,6 +746,19 @@ impl BackendSettings {
 
 pub fn default_stepwise_api_key_env() -> String {
     "CODEX_STEPWISE_API_KEY".to_string()
+}
+
+pub fn default_stepwise_protocol() -> String {
+    "chat_completions".to_string()
+}
+
+pub fn normalize_stepwise_protocol(value: &str) -> String {
+    match value.trim() {
+        "chat_completions" | "responses" | "anthropic_messages" | "auto" => {
+            value.trim().to_string()
+        }
+        _ => default_stepwise_protocol(),
+    }
 }
 
 pub fn default_stepwise_max_items() -> u8 {
@@ -935,6 +955,15 @@ where
     Ok(value
         .filter(|value| !value.is_empty())
         .unwrap_or_else(default_stepwise_api_key_env))
+}
+
+fn deserialize_stepwise_protocol<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<String>::deserialize(deserializer)?
+        .map(|value| normalize_stepwise_protocol(&value))
+        .unwrap_or_else(default_stepwise_protocol))
 }
 
 fn deserialize_image_overlay_opacity<'de, D>(deserializer: D) -> Result<u8, D::Error>
@@ -1179,6 +1208,15 @@ fn merge_known_setting_fields(target: &mut Map<String, Value>, source: &Map<Stri
             } else {
                 value.trim().to_string()
             }),
+        );
+    }
+    if let Some(value) = source
+        .get("codexAppStepwiseProtocol")
+        .and_then(Value::as_str)
+    {
+        target.insert(
+            "codexAppStepwiseProtocol".to_string(),
+            Value::String(normalize_stepwise_protocol(value)),
         );
     }
     if let Some(value) = source.get("codexAppStepwiseModel").and_then(Value::as_str) {
@@ -1509,6 +1547,8 @@ fn normalize_settings_config_sections(mut settings: BackendSettings) -> BackendS
         } else {
             settings.codex_app_stepwise_api_key_env.trim().to_string()
         };
+    settings.codex_app_stepwise_protocol =
+        normalize_stepwise_protocol(&settings.codex_app_stepwise_protocol);
     settings.codex_app_stepwise_model = settings.codex_app_stepwise_model.trim().to_string();
     settings.weixin_connect_base_url = settings
         .weixin_connect_base_url
@@ -1720,6 +1760,7 @@ mod tests {
             settings.codex_app_stepwise_api_key_env,
             "CODEX_STEPWISE_API_KEY"
         );
+        assert_eq!(settings.codex_app_stepwise_protocol, "chat_completions");
         assert!(settings.codex_app_stepwise_model.is_empty());
         assert_eq!(settings.codex_app_stepwise_max_items, 6);
         assert_eq!(settings.codex_app_stepwise_max_input_chars, 6000);
@@ -1733,6 +1774,32 @@ mod tests {
         assert!(settings.weixin_connect_token.is_empty());
         assert_eq!(settings.weixin_connect_sandbox, "read-only");
     }
+
+    #[test]
+    fn settings_deserialize_normalizes_stepwise_protocol_and_supports_legacy_missing_field() {
+        let defaults: BackendSettings = serde_json::from_str("{}").unwrap();
+        assert_eq!(defaults.codex_app_stepwise_protocol, "chat_completions");
+
+        for protocol in [
+            "chat_completions",
+            "responses",
+            "anthropic_messages",
+            "auto",
+        ] {
+            let settings: BackendSettings = serde_json::from_value(json!({
+                "codexAppStepwiseProtocol": format!(" {protocol} ")
+            }))
+            .unwrap();
+            assert_eq!(settings.codex_app_stepwise_protocol, protocol);
+        }
+
+        let invalid: BackendSettings = serde_json::from_value(json!({
+            "codexAppStepwiseProtocol": "unsupported"
+        }))
+        .unwrap();
+        assert_eq!(invalid.codex_app_stepwise_protocol, "chat_completions");
+    }
+
 
     #[test]
     fn settings_deserialize_ignores_removed_cli_wrapper_keys() {
@@ -2254,6 +2321,34 @@ experimental_bearer_token = "sk-existing""#
             "target"
         );
     }
+
+    #[test]
+    fn settings_store_persists_and_normalizes_stepwise_protocol() {
+        let dir = temp_dir();
+        let store = SettingsStore::new(dir.join("settings.json"));
+
+        let updated = store
+            .update(json!({
+                "codexAppStepwiseProtocol": "responses"
+            }))
+            .unwrap();
+        assert_eq!(updated.codex_app_stepwise_protocol, "responses");
+        assert_eq!(
+            store.load().unwrap().codex_app_stepwise_protocol,
+            "responses"
+        );
+
+        let invalid = store
+            .update(json!({
+                "codexAppStepwiseProtocol": "not-a-protocol"
+            }))
+            .unwrap();
+        assert_eq!(invalid.codex_app_stepwise_protocol, "chat_completions");
+        let saved: Value =
+            serde_json::from_str(&std::fs::read_to_string(store.path).unwrap()).unwrap();
+        assert_eq!(saved["codexAppStepwiseProtocol"], "chat_completions");
+    }
+
 
     #[test]
     fn settings_store_save_load_roundtrip_preserves_aggregate_relay_settings() {

--- a/crates/codex-plus-core/src/stepwise.rs
+++ b/crates/codex-plus-core/src/stepwise.rs
@@ -1,13 +1,46 @@
 use std::time::Duration;
 
 use anyhow::Context;
-use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
+use reqwest::StatusCode;
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::settings::BackendSettings;
 
 const MAX_PROMPT_LENGTH: usize = 420;
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StepwiseProtocol {
+    ChatCompletions,
+    Responses,
+    AnthropicMessages,
+}
+
+impl StepwiseProtocol {
+    fn from_setting(value: &str) -> Self {
+        match value {
+            "responses" => Self::Responses,
+            "anthropic_messages" => Self::AnthropicMessages,
+            _ => Self::ChatCompletions,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ChatCompletions => "chat_completions",
+            Self::Responses => "responses",
+            Self::AnthropicMessages => "anthropic_messages",
+        }
+    }
+}
+
+struct StepwiseUpstreamRequest {
+    endpoint: String,
+    headers: HeaderMap,
+    body: Value,
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -38,6 +71,7 @@ pub struct StepwisePublicSettings {
     pub api_key_configured: bool,
     pub api_key_env: String,
     pub api_key_env_configured: bool,
+    pub protocol: String,
     pub model: String,
     pub max_items: u8,
     pub max_input_chars: u32,
@@ -55,6 +89,7 @@ pub fn public_settings(settings: &BackendSettings) -> StepwisePublicSettings {
         api_key_env_configured: std::env::var(settings.codex_app_stepwise_api_key_env.trim())
             .map(|value| !value.trim().is_empty())
             .unwrap_or(false),
+        protocol: settings.codex_app_stepwise_protocol.clone(),
         model: settings.codex_app_stepwise_model.clone(),
         max_items: settings.codex_app_stepwise_max_items,
         max_input_chars: settings.codex_app_stepwise_max_input_chars,
@@ -102,6 +137,12 @@ pub fn settings_with_payload(mut settings: BackendSettings, payload: &Value) -> 
         };
     }
     if let Some(value) = raw_settings
+        .get("codexAppStepwiseProtocol")
+        .and_then(Value::as_str)
+    {
+        settings.codex_app_stepwise_protocol = crate::settings::normalize_stepwise_protocol(value);
+    }
+    if let Some(value) = raw_settings
         .get("codexAppStepwiseModel")
         .and_then(Value::as_str)
     {
@@ -143,8 +184,15 @@ pub async fn generate(
     request: StepwiseRequest,
     settings: &BackendSettings,
 ) -> anyhow::Result<Value> {
+    let configured_protocol =
+        crate::settings::normalize_stepwise_protocol(&settings.codex_app_stepwise_protocol);
     if !settings.codex_app_stepwise_enabled {
-        return Ok(json!({ "status": "ok", "disabled": true, "items": [] }));
+        return Ok(json!({
+            "status": "ok",
+            "disabled": true,
+            "protocol": configured_protocol,
+            "items": []
+        }));
     }
 
     let base_url = settings
@@ -156,64 +204,269 @@ pub async fn generate(
     let max_items = settings.codex_app_stepwise_max_items;
 
     if max_items == 0 {
-        return Ok(json!({ "status": "ok", "items": [] }));
+        return Ok(json!({
+            "status": "ok",
+            "protocol": configured_protocol,
+            "items": []
+        }));
     }
     if base_url.is_empty() || model.is_empty() {
-        return Ok(json!({
-            "status": "failed",
-            "items": [],
-            "error": "Stepwise Base URL or Model is not configured"
-        }));
+        return Ok(failed_result(
+            &configured_protocol,
+            "Stepwise Base URL or Model is not configured",
+        ));
     }
     if api_key.is_empty() {
-        return Ok(json!({
-            "status": "failed",
-            "items": [],
-            "error": "Stepwise API Key is not configured"
-        }));
+        return Ok(failed_result(
+            &configured_protocol,
+            "Stepwise API Key is not configured",
+        ));
     }
 
     let client = crate::http_client::proxied_client("")?;
     let timeout = Duration::from_millis(settings.codex_app_stepwise_timeout_ms);
+    let protocols = stepwise_protocols(&configured_protocol);
+    let auto_protocol = configured_protocol == "auto";
+    let mut protocol_errors = Vec::new();
+
+    for (index, protocol) in protocols.iter().copied().enumerate() {
+        let has_next_protocol = index + 1 < protocols.len();
+        let upstream =
+            match build_upstream_request(protocol, base_url, &api_key, model, &request, settings) {
+                Ok(upstream) => upstream,
+                Err(error) => {
+                    return Ok(failed_result(
+                        protocol.as_str(),
+                        format!(
+                            "failed to build Stepwise {} request: {error}",
+                            protocol.as_str()
+                        ),
+                    ));
+                }
+            };
+        let response = match client
+            .post(&upstream.endpoint)
+            .headers(upstream.headers)
+            .timeout(timeout)
+            .json(&upstream.body)
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                return Ok(failed_result(
+                    protocol.as_str(),
+                    format!(
+                        "failed to request Stepwise {} API: {error}",
+                        protocol.as_str()
+                    ),
+                ));
+            }
+        };
+
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        if auto_protocol
+            && matches!(
+                status,
+                StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
+            )
+        {
+            protocol_errors.push(format!(
+                "{} returned upstream {}",
+                protocol.as_str(),
+                status.as_u16()
+            ));
+            if has_next_protocol {
+                continue;
+            }
+            break;
+        }
+        if !status.is_success() {
+            return Ok(failed_result(
+                protocol.as_str(),
+                format!(
+                    "Stepwise upstream {}: {}",
+                    status.as_u16(),
+                    redact_secret(&text, &api_key)
+                ),
+            ));
+        }
+
+        let data: Value = match serde_json::from_str(&text) {
+            Ok(data) => data,
+            Err(error) => {
+                if auto_protocol {
+                    protocol_errors.push(format!(
+                        "{} returned invalid JSON: {error}",
+                        protocol.as_str()
+                    ));
+                    if has_next_protocol {
+                        continue;
+                    }
+                    break;
+                }
+                return Ok(failed_result(
+                    protocol.as_str(),
+                    format!("failed to parse Stepwise API response: {error}"),
+                ));
+            }
+        };
+        if auto_protocol && !matches_stepwise_protocol_response(protocol, &data) {
+            protocol_errors.push(format!(
+                "{} returned an incompatible response shape",
+                protocol.as_str()
+            ));
+            if has_next_protocol {
+                continue;
+            }
+            break;
+        }
+        return Ok(json!({
+            "status": "ok",
+            "protocol": protocol.as_str(),
+            "items": extract_stepwise_items(&data, max_items)
+        }));
+    }
+
+    let details = if protocol_errors.is_empty() {
+        String::new()
+    } else {
+        format!(": {}", protocol_errors.join("; "))
+    };
+    Ok(failed_result(
+        &configured_protocol,
+        format!("Stepwise could not find a supported upstream protocol{details}"),
+    ))
+}
+
+fn stepwise_protocols(value: &str) -> Vec<StepwiseProtocol> {
+    if value == "auto" {
+        vec![
+            StepwiseProtocol::ChatCompletions,
+            StepwiseProtocol::Responses,
+            StepwiseProtocol::AnthropicMessages,
+        ]
+    } else {
+        vec![StepwiseProtocol::from_setting(value)]
+    }
+}
+
+fn matches_stepwise_protocol_response(protocol: StepwiseProtocol, data: &Value) -> bool {
+    if stepwise_items_value(data).is_some() {
+        return true;
+    }
+    match protocol {
+        StepwiseProtocol::ChatCompletions => data.get("choices").is_some_and(Value::is_array),
+        StepwiseProtocol::Responses => {
+            data.get("output_text").is_some() || data.get("output").is_some_and(Value::is_array)
+        }
+        StepwiseProtocol::AnthropicMessages => data.get("content").is_some_and(Value::is_array),
+    }
+}
+
+fn build_upstream_request(
+    protocol: StepwiseProtocol,
+    base_url: &str,
+    api_key: &str,
+    model: &str,
+    request: &StepwiseRequest,
+    settings: &BackendSettings,
+) -> anyhow::Result<StepwiseUpstreamRequest> {
+    let messages = build_messages(request, settings);
     let mut headers = HeaderMap::new();
     headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+    let (endpoint, body) = match protocol {
+        StepwiseProtocol::ChatCompletions => {
+            insert_bearer_header(&mut headers, api_key)?;
+            (
+                format!("{base_url}/chat/completions"),
+                json!({
+                    "model": model,
+                    "messages": messages,
+                    "temperature": 0.2,
+                    "max_tokens": settings.codex_app_stepwise_max_output_tokens,
+                    "response_format": { "type": "json_object" },
+                }),
+            )
+        }
+        StepwiseProtocol::Responses => {
+            insert_bearer_header(&mut headers, api_key)?;
+            (
+                format!("{base_url}/responses"),
+                json!({
+                    "model": model,
+                    "input": messages,
+                    "max_output_tokens": settings.codex_app_stepwise_max_output_tokens,
+                }),
+            )
+        }
+        StepwiseProtocol::AnthropicMessages => {
+            headers.insert(
+                HeaderName::from_static("x-api-key"),
+                HeaderValue::from_str(api_key)
+                    .context("failed to build Stepwise API key header")?,
+            );
+            headers.insert(
+                HeaderName::from_static("anthropic-version"),
+                HeaderValue::from_static(ANTHROPIC_VERSION),
+            );
+            let system = messages
+                .first()
+                .and_then(|message| message.get("content"))
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let messages = messages
+                .into_iter()
+                .filter(|message| message.get("role").and_then(Value::as_str) != Some("system"))
+                .collect::<Vec<_>>();
+            (
+                format!("{base_url}/messages"),
+                json!({
+                    "model": model,
+                    "system": system,
+                    "messages": messages,
+                    "max_tokens": settings.codex_app_stepwise_max_output_tokens,
+                }),
+            )
+        }
+    };
+
+    Ok(StepwiseUpstreamRequest {
+        endpoint,
+        headers,
+        body,
+    })
+}
+
+fn insert_bearer_header(headers: &mut HeaderMap, api_key: &str) -> anyhow::Result<()> {
     headers.insert(
         AUTHORIZATION,
         HeaderValue::from_str(&format!("Bearer {api_key}"))
             .context("failed to build Stepwise authorization header")?,
     );
+    Ok(())
+}
 
-    let response = client
-        .post(format!("{base_url}/chat/completions"))
-        .headers(headers)
-        .timeout(timeout)
-        .json(&json!({
-            "model": model,
-            "messages": build_messages(&request, settings),
-            "temperature": 0.2,
-            "max_tokens": settings.codex_app_stepwise_max_output_tokens,
-            "response_format": { "type": "json_object" },
-        }))
-        .send()
-        .await
-        .context("failed to request Stepwise API")?;
+fn failed_result(protocol: &str, error: impl Into<String>) -> Value {
+    json!({
+        "status": "failed",
+        "protocol": protocol,
+        "items": [],
+        "error": error.into()
+    })
+}
 
-    let status = response.status();
-    let text = response.text().await.unwrap_or_default();
-    if !status.is_success() {
-        return Ok(json!({
-            "status": "failed",
-            "items": [],
-            "error": format!("Stepwise upstream {}: {}", status.as_u16(), text.chars().take(240).collect::<String>())
-        }));
-    }
-
-    let data: Value =
-        serde_json::from_str(&text).context("failed to parse Stepwise API response")?;
-    Ok(json!({
-        "status": "ok",
-        "items": extract_stepwise_items(&data, max_items)
-    }))
+fn redact_secret(value: &str, secret: &str) -> String {
+    let secret = secret.trim();
+    let value = if secret.is_empty() {
+        value.to_string()
+    } else {
+        value.replace(secret, "[redacted]")
+    };
+    value.chars().take(240).collect()
 }
 
 pub async fn test_connection(settings: &BackendSettings) -> anyhow::Result<Value> {
@@ -330,22 +583,55 @@ fn stepwise_payload_candidates(data: &Value) -> Vec<Value> {
         .and_then(|choice| choice.get("message"))
         .and_then(|message| message.get("content"))
     {
-        candidates.push(content.clone());
-        if let Some(parsed) = parse_json_value(content) {
-            candidates.push(parsed);
+        if let Some(parts) = content.as_array() {
+            for part in parts {
+                if let Some(text) = part.get("text") {
+                    push_payload_candidate(&mut candidates, text);
+                }
+            }
+        } else {
+            push_payload_candidate(&mut candidates, content);
+        }
+    }
+
+    if let Some(output_text) = data.get("output_text") {
+        push_payload_candidate(&mut candidates, output_text);
+    }
+
+    if let Some(output) = data.get("output").and_then(Value::as_array) {
+        for item in output {
+            if let Some(content) = item.get("content").and_then(Value::as_array) {
+                for part in content {
+                    if let Some(text) = part.get("text") {
+                        push_payload_candidate(&mut candidates, text);
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(content) = data.get("content").and_then(Value::as_array) {
+        for part in content {
+            if let Some(text) = part.get("text") {
+                push_payload_candidate(&mut candidates, text);
+            }
         }
     }
 
     for key in ["output", "response", "data", "result"] {
         if let Some(value) = data.get(key) {
-            candidates.push(value.clone());
-            if let Some(parsed) = parse_json_value(value) {
-                candidates.push(parsed);
-            }
+            push_payload_candidate(&mut candidates, value);
         }
     }
 
     candidates
+}
+
+fn push_payload_candidate(candidates: &mut Vec<Value>, value: &Value) {
+    candidates.push(value.clone());
+    if let Some(parsed) = parse_json_value(value) {
+        candidates.push(parsed);
+    }
 }
 
 fn stepwise_items_value(value: &Value) -> Option<Value> {
@@ -427,9 +713,35 @@ fn normalize_spaces(value: &str) -> String {
     value.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const TEST_API_KEY: &str = "sk-stepwise-test";
+
+    fn test_request() -> StepwiseRequest {
+        StepwiseRequest {
+            last_user_message: "请继续检查协议兼容性。".to_string(),
+            last_assistant_message: "已完成基础实现。".to_string(),
+            thread_title: "协议兼容测试".to_string(),
+            page_url: "https://example.test/thread".to_string(),
+        }
+    }
+
+    fn test_settings(base_url: String, protocol: &str) -> BackendSettings {
+        BackendSettings {
+            codex_app_stepwise_enabled: true,
+            codex_app_stepwise_base_url: base_url,
+            codex_app_stepwise_api_key: TEST_API_KEY.to_string(),
+            codex_app_stepwise_protocol: protocol.to_string(),
+            codex_app_stepwise_model: "stepwise-test".to_string(),
+            codex_app_stepwise_timeout_ms: 2000,
+            ..BackendSettings::default()
+        }
+    }
 
     #[test]
     fn clamp_items_dedupes_and_limits() {
@@ -468,6 +780,25 @@ mod tests {
     }
 
     #[test]
+    fn extracts_items_from_chat_completions_text_blocks() {
+        let response = json!({
+            "choices": [{
+                "message": {
+                    "content": [{
+                        "type": "text",
+                        "text": "{\"items\":[{\"prompt\":\"解析文本块里的建议\"}]}"
+                    }]
+                }
+            }]
+        });
+
+        let items = extract_stepwise_items(&response, 6);
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].prompt, "解析文本块里的建议");
+    }
+
+    #[test]
     fn prompt_contains_language_policy() {
         let settings = BackendSettings {
             codex_app_stepwise_max_items: 4,
@@ -502,6 +833,7 @@ mod tests {
                     "codexAppStepwiseBaseUrl": "https://api.example.test/v1/",
                     "codexAppStepwiseApiKey": " sk-test ",
                     "codexAppStepwiseApiKeyEnv": "",
+                    "codexAppStepwiseProtocol": "responses",
                     "codexAppStepwiseModel": " stepwise-mini ",
                     "codexAppStepwiseMaxItems": 9,
                     "codexAppStepwiseMaxInputChars": 999999,
@@ -522,10 +854,274 @@ mod tests {
             settings.codex_app_stepwise_api_key_env,
             crate::settings::default_stepwise_api_key_env()
         );
+        assert_eq!(settings.codex_app_stepwise_protocol, "responses");
         assert_eq!(settings.codex_app_stepwise_model, "stepwise-mini");
         assert_eq!(settings.codex_app_stepwise_max_items, 6);
         assert_eq!(settings.codex_app_stepwise_max_input_chars, 24000);
         assert_eq!(settings.codex_app_stepwise_max_output_tokens, 100);
         assert_eq!(settings.codex_app_stepwise_timeout_ms, 60000);
+    }
+
+    #[tokio::test]
+    async fn generate_uses_chat_completions_protocol_and_parses_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "message": {
+                        "content": "{\"items\":[{\"label\":\"继续\",\"prompt\":\"继续检查\"}]}"
+                    }
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let result = generate(
+            test_request(),
+            &test_settings(server.uri(), "chat_completions"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["protocol"], "chat_completions");
+        assert_eq!(result["items"][0]["label"], "继续");
+        assert_eq!(result["items"][0]["prompt"], "继续检查");
+
+        let requests = server.received_requests().await.unwrap();
+        let request = &requests[0];
+        assert_eq!(
+            request
+                .headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer sk-stepwise-test")
+        );
+        let body: Value = request.body_json().unwrap();
+        assert_eq!(body["model"], "stepwise-test");
+        assert_eq!(body["response_format"]["type"], "json_object");
+        assert!(body["messages"].is_array());
+    }
+
+    #[tokio::test]
+    async fn generate_uses_responses_protocol_and_parses_output_text() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "output_text": "{\"items\":[{\"prompt\":\"检查 Responses 接口\"}]}"
+            })))
+            .mount(&server)
+            .await;
+
+        let result = generate(test_request(), &test_settings(server.uri(), "responses"))
+            .await
+            .unwrap();
+
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["protocol"], "responses");
+        assert_eq!(result["items"][0]["prompt"], "检查 Responses 接口");
+
+        let requests = server.received_requests().await.unwrap();
+        let request = &requests[0];
+        assert_eq!(
+            request
+                .headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer sk-stepwise-test")
+        );
+        let body: Value = request.body_json().unwrap();
+        assert_eq!(body["model"], "stepwise-test");
+        assert!(body["input"].is_array());
+        assert_eq!(body["max_output_tokens"], 500);
+    }
+
+    #[tokio::test]
+    async fn generate_uses_anthropic_messages_protocol_and_parses_content() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "content": [{
+                    "type": "text",
+                    "text": "{\"items\":[{\"prompt\":\"检查 Anthropic Messages 接口\"}]}"
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let result = generate(
+            test_request(),
+            &test_settings(server.uri(), "anthropic_messages"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["protocol"], "anthropic_messages");
+        assert_eq!(result["items"][0]["prompt"], "检查 Anthropic Messages 接口");
+
+        let requests = server.received_requests().await.unwrap();
+        let request = &requests[0];
+        assert_eq!(
+            request
+                .headers
+                .get("x-api-key")
+                .and_then(|value| value.to_str().ok()),
+            Some(TEST_API_KEY)
+        );
+        assert_eq!(
+            request
+                .headers
+                .get("anthropic-version")
+                .and_then(|value| value.to_str().ok()),
+            Some("2023-06-01")
+        );
+        assert!(request.headers.get("authorization").is_none());
+        let body: Value = request.body_json().unwrap();
+        assert_eq!(body["model"], "stepwise-test");
+        assert!(
+            body["system"]
+                .as_str()
+                .is_some_and(|value| value.contains("strict JSON"))
+        );
+        assert!(body["messages"].is_array());
+        assert_eq!(body["max_tokens"], 500);
+    }
+
+    #[tokio::test]
+    async fn auto_protocol_falls_back_on_unsupported_endpoint_statuses() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(ResponseTemplate::new(405))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/messages"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "content": [{
+                    "type": "text",
+                    "text": "{\"items\":[{\"prompt\":\"自动兼容成功\"}]}"
+                }]
+            })))
+            .mount(&server)
+            .await;
+
+        let result = generate(test_request(), &test_settings(server.uri(), "auto"))
+            .await
+            .unwrap();
+
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["protocol"], "anthropic_messages");
+        assert_eq!(result["items"][0]["prompt"], "自动兼容成功");
+
+        let requests = server.received_requests().await.unwrap();
+        let paths = requests
+            .iter()
+            .map(|request| request.url.path())
+            .collect::<Vec<_>>();
+        assert_eq!(paths, vec!["/chat/completions", "/responses", "/messages"]);
+    }
+
+    #[tokio::test]
+    async fn auto_protocol_falls_back_on_success_with_empty_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "output_text": "{\"items\":[{\"prompt\":\"Responses 回退成功\"}]}"
+            })))
+            .mount(&server)
+            .await;
+
+        let result = generate(test_request(), &test_settings(server.uri(), "auto"))
+            .await
+            .unwrap();
+
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["protocol"], "responses");
+        assert_eq!(result["items"][0]["prompt"], "Responses 回退成功");
+
+        let requests = server.received_requests().await.unwrap();
+        let paths = requests
+            .iter()
+            .map(|request| request.url.path())
+            .collect::<Vec<_>>();
+        assert_eq!(paths, vec!["/chat/completions", "/responses"]);
+    }
+
+    #[tokio::test]
+    async fn auto_protocol_falls_back_on_incompatible_response_shape() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "unexpected": true
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "output_text": "{\"items\":[{\"prompt\":\"协议结构回退成功\"}]}"
+            })))
+            .mount(&server)
+            .await;
+
+        let result = generate(test_request(), &test_settings(server.uri(), "auto"))
+            .await
+            .unwrap();
+
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["protocol"], "responses");
+        assert_eq!(result["items"][0]["prompt"], "协议结构回退成功");
+        assert_eq!(server.received_requests().await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn auto_protocol_does_not_fallback_on_auth_rate_limit_or_server_errors() {
+        for status in [401, 403, 429, 500] {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/chat/completions"))
+                .respond_with(
+                    ResponseTemplate::new(status)
+                        .set_body_string(format!("upstream rejected {TEST_API_KEY}")),
+                )
+                .mount(&server)
+                .await;
+            Mock::given(method("POST"))
+                .and(path("/responses"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "output_text": "{\"items\":[{\"prompt\":\"不应被调用\"}]}"
+                })))
+                .mount(&server)
+                .await;
+
+            let result = generate(test_request(), &test_settings(server.uri(), "auto"))
+                .await
+                .unwrap();
+
+            assert_eq!(result["status"], "failed");
+            assert_eq!(result["protocol"], "chat_completions");
+            let error = result["error"].as_str().unwrap();
+            assert!(error.contains(&status.to_string()));
+            assert!(!error.contains(TEST_API_KEY));
+            assert!(error.contains("[redacted]"));
+            assert_eq!(server.received_requests().await.unwrap().len(), 1);
+        }
     }
 }

--- a/crates/codex-plus-core/tests/bridge_routes.rs
+++ b/crates/codex-plus-core/tests/bridge_routes.rs
@@ -327,6 +327,7 @@ async fn stepwise_routes_use_settings_service() {
         json!({
             "status": "ok",
             "disabled": true,
+            "protocol": "chat_completions",
             "items": []
         })
     );
@@ -335,6 +336,7 @@ async fn stepwise_routes_use_settings_service() {
         json!({
             "status": "ok",
             "disabled": true,
+            "protocol": "chat_completions",
             "items": []
         })
     );


### PR DESCRIPTION
## 变更概述

扩展 Stepwise 的上游协议兼容能力，使不同供应商可以通过统一配置接入。

## 主要内容

- 支持 Chat Completions、Responses 和 Anthropic Messages 三种协议。
- 增加自动兼容模式，并在端点不存在、响应为空、JSON 无效或响应结构不匹配时尝试下一种协议。
- 统一不同协议的请求构造、结果提取和错误处理。
- 在 Manager 连接测试结果中显示实际使用的协议。
- 补充协议配置、请求、响应解析和自动回退测试。

## 验证

- `cargo test -p codex-plus-core stepwise --lib`：15/15
- `cargo test -p codex-plus-core --test bridge_routes`：30/30
- `cargo check -p codex-plus-manager -p codex-plus-core`：通过

Fixes #1445
