### PR TITLE
fix(build): improve cross-platform build reliability

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,9 @@
 *.sh text eol=lf
 .github/workflows/*.yml text eol=lf
 
+# First-party scripts are embedded with include_str! and inspected by source-contract tests.
+assets/inject/*.js text eol=lf
+
 # Keep every byte-exact upstream theme asset stable on all checkout platforms.
 assets/inject/upstream/**/*.js text eol=lf
 assets/inject/upstream/**/*.css text eol=lf

--- a/scripts/installer/macos/package-dmg.sh
+++ b/scripts/installer/macos/package-dmg.sh
@@ -145,5 +145,32 @@ verify_app "$STAGE/Codex++ 管理工具.app"
 
 ln -s /Applications "$STAGE/Applications"
 
-hdiutil create -volname "Codex++" -srcfolder "$STAGE" -ov -format UDZO "$DMG"
+DMG_WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/codex-plus-plus-dmg.XXXXXX")"
+DMG_WORK_PATH="$DMG_WORK_DIR/$(basename "$DMG")"
+DMG_CREATED=false
+
+cleanup_dmg_work_dir() {
+  rm -f "$DMG_WORK_PATH"
+  rmdir "$DMG_WORK_DIR" 2>/dev/null || true
+}
+
+trap cleanup_dmg_work_dir EXIT
+
+for attempt in 1 2 3; do
+  if hdiutil create -volname "Codex++" -srcfolder "$STAGE" -ov -format UDZO "$DMG_WORK_PATH"; then
+    mv "$DMG_WORK_PATH" "$DMG"
+    DMG_CREATED=true
+    break
+  fi
+
+  if [ "$attempt" -lt 3 ]; then
+    sleep "$((attempt * 2))"
+  fi
+done
+
+if [ "$DMG_CREATED" != true ]; then
+  echo "error: failed to create DMG after 3 attempts" >&2
+  exit 1
+fi
+
 echo "$DMG"


### PR DESCRIPTION
## 变更概述

提升跨平台构建与 macOS DMG 打包流程的稳定性，不改变产品运行逻辑。

## 主要内容

- 固定编译期嵌入的注入脚本使用 LF 换行，避免 Windows checkout 转换为 CRLF 后导致源码契约测试失败。
- 为 macOS DMG 创建流程增加临时输出路径和有限重试，降低瞬时 `Resource busy` 对构建结果的影响。
- 保持现有测试断言和 CI 工作流不变。

## 验证

- 注入脚本 LF 换行检查通过。
- DMG 打包脚本 Shell 语法检查通过。
- macOS arm64、macOS x64 和 Windows 构建均已通过。
