### PR TITLE
fix(provider-sync): clean subagent catalog rows and recover stale locks

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -372,6 +372,7 @@ impl LaunchHooks for LauncherHooks {
                             sqlite_user_event_rows_updated: 0,
                             sqlite_cwd_rows_updated: 0,
                             sqlite_catalog_rows_inserted: 0,
+                            sqlite_catalog_rows_removed: 0,
                             updated_workspace_roots: 0,
                             skipped_locked_rollout_files: Vec::new(),
                             encrypted_content_warning: None,

--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -2397,37 +2397,65 @@ pub async fn sync_providers_now(target_provider: Option<String>) -> CommandResul
                     "manager.sync_providers_now.after",
                 );
             }
-            ok(
-                &format!(
-                    "供应商已同步一次：{} 个会话文件，{} 行索引，跳过 {} 个占用文件。",
-                    sync.changed_session_files,
-                    sync.sqlite_rows_updated,
-                    sync.skipped_locked_rollout_files.len()
-                ),
+            let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+                "manager.provider_sync.completed",
                 json!({
-                    "syncStatus": sync.status,
-                    "targetProvider": sync.target_provider,
+                    "status": sync.status.clone(),
                     "changedSessionFiles": sync.changed_session_files,
-                    "skippedLockedRolloutFiles": sync.skipped_locked_rollout_files,
                     "sqliteRowsUpdated": sync.sqlite_rows_updated,
-                    "sqliteProviderRowsUpdated": sync.sqlite_provider_rows_updated,
-                    "sqliteUserEventRowsUpdated": sync.sqlite_user_event_rows_updated,
-                    "sqliteCwdRowsUpdated": sync.sqlite_cwd_rows_updated,
                     "sqliteCatalogRowsInserted": sync.sqlite_catalog_rows_inserted,
                     "sqliteCatalogRowsRemoved": sync.sqlite_catalog_rows_removed,
-                    "updatedWorkspaceRoots": sync.updated_workspace_roots,
-                    "encryptedContentWarning": sync.encrypted_content_warning,
-                    "backupDir": sync.backup_dir,
-                    "syncMessage": sync.message,
+                    "skippedLockedRolloutFiles": sync.skipped_locked_rollout_files.len(),
                 }),
-            )
+            );
+            provider_sync_command_result(sync)
         }
-        Err(error) => failed(&format!("供应商同步失败：{error}"), json!({})),
+        Err(error) => {
+            let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+                "manager.provider_sync.failed",
+                json!({ "message": error.to_string() }),
+            );
+            failed(&format!("供应商同步失败：{error}"), json!({}))
+        }
     }
 }
 
 fn is_success_sync_status(status: &codex_plus_data::ProviderSyncStatus) -> bool {
     matches!(status, codex_plus_data::ProviderSyncStatus::Synced)
+}
+
+fn provider_sync_command_result(
+    sync: codex_plus_data::ProviderSyncResult,
+) -> CommandResult<Value> {
+    let succeeded = is_success_sync_status(&sync.status);
+    let success_message = format!(
+        "供应商已同步一次：{} 个会话文件，{} 行索引，跳过 {} 个占用文件。",
+        sync.changed_session_files,
+        sync.sqlite_rows_updated,
+        sync.skipped_locked_rollout_files.len()
+    );
+    let failure_message = format!("历史会话修复未执行：{}", sync.message);
+    let payload = json!({
+        "syncStatus": sync.status,
+        "targetProvider": sync.target_provider,
+        "changedSessionFiles": sync.changed_session_files,
+        "skippedLockedRolloutFiles": sync.skipped_locked_rollout_files,
+        "sqliteRowsUpdated": sync.sqlite_rows_updated,
+        "sqliteProviderRowsUpdated": sync.sqlite_provider_rows_updated,
+        "sqliteUserEventRowsUpdated": sync.sqlite_user_event_rows_updated,
+        "sqliteCwdRowsUpdated": sync.sqlite_cwd_rows_updated,
+        "sqliteCatalogRowsInserted": sync.sqlite_catalog_rows_inserted,
+        "sqliteCatalogRowsRemoved": sync.sqlite_catalog_rows_removed,
+        "updatedWorkspaceRoots": sync.updated_workspace_roots,
+        "encryptedContentWarning": sync.encrypted_content_warning,
+        "backupDir": sync.backup_dir,
+        "syncMessage": sync.message,
+    });
+    if succeeded {
+        ok(&success_message, payload)
+    } else {
+        failed(&failure_message, payload)
+    }
 }
 
 fn persist_provider_sync_selection(provider: &str) {
@@ -4772,6 +4800,51 @@ mod tests {
 
         assert_eq!(result.status, "ok");
         assert!(!result.payload.version.is_empty());
+    }
+
+    fn provider_sync_result_for_test(
+        status: codex_plus_data::ProviderSyncStatus,
+        message: &str,
+    ) -> codex_plus_data::ProviderSyncResult {
+        codex_plus_data::ProviderSyncResult {
+            status,
+            message: message.to_string(),
+            target_provider: "custom".to_string(),
+            backup_dir: None,
+            changed_session_files: 0,
+            skipped_locked_rollout_files: Vec::new(),
+            sqlite_rows_updated: 0,
+            sqlite_provider_rows_updated: 0,
+            sqlite_user_event_rows_updated: 0,
+            sqlite_cwd_rows_updated: 0,
+            sqlite_catalog_rows_inserted: 0,
+            sqlite_catalog_rows_removed: 0,
+            updated_workspace_roots: 0,
+            encrypted_content_warning: None,
+        }
+    }
+
+    #[test]
+    fn provider_sync_skipped_is_reported_as_command_failure() {
+        let result = provider_sync_command_result(provider_sync_result_for_test(
+            codex_plus_data::ProviderSyncStatus::Skipped,
+            "Provider sync lock exists",
+        ));
+
+        assert_eq!(result.status, "failed");
+        assert!(result.message.contains("Provider sync lock exists"));
+        assert_eq!(result.payload["syncStatus"], "skipped");
+    }
+
+    #[test]
+    fn provider_sync_synced_is_reported_as_command_success() {
+        let result = provider_sync_command_result(provider_sync_result_for_test(
+            codex_plus_data::ProviderSyncStatus::Synced,
+            "Provider sync complete",
+        ));
+
+        assert_eq!(result.status, "ok");
+        assert_eq!(result.payload["syncStatus"], "synced");
     }
 
     #[test]

--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -2414,6 +2414,7 @@ pub async fn sync_providers_now(target_provider: Option<String>) -> CommandResul
                     "sqliteUserEventRowsUpdated": sync.sqlite_user_event_rows_updated,
                     "sqliteCwdRowsUpdated": sync.sqlite_cwd_rows_updated,
                     "sqliteCatalogRowsInserted": sync.sqlite_catalog_rows_inserted,
+                    "sqliteCatalogRowsRemoved": sync.sqlite_catalog_rows_removed,
                     "updatedWorkspaceRoots": sync.updated_workspace_roots,
                     "encryptedContentWarning": sync.encrypted_content_warning,
                     "backupDir": sync.backup_dir,

--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -584,6 +584,7 @@ type ProviderSyncPayload = {
   sqliteUserEventRowsUpdated?: number;
   sqliteCwdRowsUpdated?: number;
   sqliteCatalogRowsInserted?: number;
+  sqliteCatalogRowsRemoved?: number;
   updatedWorkspaceRoots?: number;
   prunedSessionIndexEntries?: number;
   encryptedContentWarning?: string | null;
@@ -714,17 +715,22 @@ function providerSyncProgressMessage(result: CommandResult<ProviderSyncPayload>)
   const changed = result.changedSessionFiles ?? 0;
   const rows = result.sqliteRowsUpdated ?? 0;
   const insertedCatalogRows = result.sqliteCatalogRowsInserted ?? 0;
+  const removedCatalogRows = result.sqliteCatalogRowsRemoved ?? 0;
   const pruned = result.prunedSessionIndexEntries ?? 0;
   const target = result.targetProvider || t("当前 provider");
   const skipped = result.skippedLockedRolloutFiles?.length ?? 0;
   const prunedText = pruned ? tf("，清理 {0} 条失效任务索引", [pruned]) : "";
   const skippedText = skipped ? tf("，跳过 {0} 个占用文件", [skipped]) : "";
   const catalogText = insertedCatalogRows ? tf("，补齐 {0} 条侧边栏索引", [insertedCatalogRows]) : "";
-  return tf("已同步到 {0}：修复 {1} 个会话文件，更新 {2} 行数据库索引{3}{4}{5}。", [
+  const catalogCleanupText = removedCatalogRows
+    ? tf("，清理 {0} 条误列的子任务侧边栏索引", [removedCatalogRows])
+    : "";
+  return tf("已同步到 {0}：修复 {1} 个会话文件，更新 {2} 行数据库索引{3}{4}{5}{6}。", [
     target,
     changed,
     rows,
     catalogText,
+    catalogCleanupText,
     prunedText,
     skippedText,
   ]);

--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -576,6 +576,7 @@ type RemoveEnvConflictsResult = CommandResult<{
 
 type ProviderSyncPayload = {
   syncStatus?: string;
+  syncMessage?: string;
   targetProvider?: string;
   changedSessionFiles?: number;
   skippedLockedRolloutFiles?: string[];
@@ -588,6 +589,7 @@ type ProviderSyncPayload = {
   updatedWorkspaceRoots?: number;
   prunedSessionIndexEntries?: number;
   encryptedContentWarning?: string | null;
+  backupDir?: string | null;
 };
 
 type SessionIndexCleanupCandidate = {
@@ -2105,9 +2107,17 @@ export function App() {
         call<CommandResult<ProviderSyncPayload>>("sync_providers_now", { targetProvider }),
       );
       if (result) {
-        let finalResult = result;
+        const syncSucceeded = isSuccessStatus(result.status) && result.syncStatus === "synced";
+        let finalResult =
+          isSuccessStatus(result.status) && !syncSucceeded
+            ? {
+                ...result,
+                status: "failed",
+                message: result.syncMessage || t("历史会话修复失败，请查看错误提示后重试。"),
+              }
+            : result;
         let cleanupFailure: { status: Status; message: string } | null = null;
-        if (isSuccessStatus(result.status)) {
+        if (syncSucceeded) {
           const preview = await run(() =>
             call<CommandResult<SessionIndexCleanupPreviewPayload>>("preview_session_index_cleanup"),
           );
@@ -2152,7 +2162,7 @@ export function App() {
               : completion.result.message),
           result: completion.result,
         });
-        if (targetProvider) {
+        if (targetProvider && syncSucceeded) {
           const next = {
             ...settingsForm,
             providerSyncLastSelectedProvider: targetProvider,

--- a/apps/codex-plus-manager/src/i18n-en.ts
+++ b/apps/codex-plus-manager/src/i18n-en.ts
@@ -846,6 +846,9 @@ export const EN_PLAIN: Record<string, string> = {
 export const EN_TEMPLATE: Record<string, string> = {
   "作者：{0} · {1}": "Author: {0} · {1}",
   "清单更新于 {0}，安装后会保存到“我的主题”。": "Manifest updated {0}. Installed themes are saved under My themes.",
+  "，补齐 {0} 条侧边栏索引": ", added {0} missing sidebar index entry/entries",
+  "，清理 {0} 条误列的子任务侧边栏索引":
+    ", removed {0} incorrectly listed subtask sidebar index entry/entries",
   "，清理 {0} 条失效任务索引": ", pruned {0} stale task index entry/entries",
   "\n...以及另外 {0} 个会话": "\n...and {0} more session(s)",
   "{0}（{1}）": "{0} ({1})",
@@ -889,8 +892,8 @@ export const EN_TEMPLATE: Record<string, string> = {
   "已删除 {0} 个会话。": "Deleted {0} session(s).",
   "已删除 {0} 个，失败 {1} 个：{2}": "Deleted {0}, failed {1}: {2}",
   "已加载 {0} 条推荐": "Loaded {0} recommendation(s)",
-  "已同步到 {0}：修复 {1} 个会话文件，更新 {2} 行数据库索引{3}{4}。":
-    "Synced to {0}: repaired {1} session file(s) and updated {2} database index row(s){3}{4}.",
+  "已同步到 {0}：修复 {1} 个会话文件，更新 {2} 行数据库索引{3}{4}{5}{6}。":
+    "Synced to {0}: repaired {1} session file(s) and updated {2} database index row(s){3}{4}{5}{6}.",
   "已安装 {0}": "Installed {0}",
   "已缓存 {0} 个插件 / {1} 个技能。": "Cached {0} plugin(s) / {1} skill(s).",
   "已运行 {0} 分钟": "Running for {0} minute(s)",

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -10311,7 +10311,6 @@
   function scheduleScan(mutations) {
     window.__codexSessionDeleteLastMutations = mutations;
     scheduleZedRemoteMenuRefresh(mutations);
-    schedulePluginAutoExpand();
     if (!shouldScheduleScan(mutations)) return;
     if (window.__codexSessionDeleteScanPending) return;
     window.__codexSessionDeleteScanPending = true;

--- a/crates/codex-plus-core/src/watcher.rs
+++ b/crates/codex-plus-core/src/watcher.rs
@@ -154,6 +154,64 @@ pub fn process_ids_still_running(
 }
 
 #[cfg(windows)]
+pub fn process_id_is_running(process_id: u32) -> Option<bool> {
+    if process_id == 0 {
+        return Some(false);
+    }
+    let processes = crate::windows_integration::enumerate_processes();
+    if processes.is_empty() {
+        return None;
+    }
+    Some(
+        processes
+            .iter()
+            .any(|process| process.process_id == process_id),
+    )
+}
+
+#[cfg(target_os = "linux")]
+pub fn process_id_is_running(process_id: u32) -> Option<bool> {
+    if process_id == 0 {
+        return Some(false);
+    }
+    match std::fs::metadata(Path::new("/proc").join(process_id.to_string())) {
+        Ok(_) => Some(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Some(false),
+        Err(_) => None,
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn process_id_is_running(process_id: u32) -> Option<bool> {
+    if process_id == 0 {
+        return Some(false);
+    }
+    let process_id_arg = process_id.to_string();
+    let output = Command::new("ps")
+        .args(["-p", process_id_arg.as_str(), "-o", "pid="])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return match output.status.code() {
+            Some(1) => Some(false),
+            _ => None,
+        };
+    }
+    let process_ids = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| value.trim().parse::<u32>())
+        .collect::<Result<Vec<_>, _>>()
+        .ok()?;
+    Some(process_ids.contains(&process_id))
+}
+
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
+pub fn process_id_is_running(_process_id: u32) -> Option<bool> {
+    None
+}
+
+#[cfg(windows)]
 pub fn install_watcher(launcher_path: &Path, debug_port: u16) -> anyhow::Result<()> {
     let plan = build_watcher_install_plan(launcher_path.to_path_buf(), debug_port);
     crate::windows_integration::set_current_user_string_value(

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -868,6 +868,7 @@ fn injection_script_skips_plugin_patch_work_in_relay_mode() {
 fn injection_script_omits_plugin_auto_expand() {
     let script = assets::injection_script(57321);
 
+    assert!(!script.contains("schedulePluginAutoExpand"));
     assert!(!script.contains("pluginAutoExpand"));
     assert!(!script.contains("codexPluginAutoExpand"));
     assert!(!script.contains("plugin_auto_expand"));

--- a/crates/codex-plus-core/tests/watcher.rs
+++ b/crates/codex-plus-core/tests/watcher.rs
@@ -1,7 +1,8 @@
 use codex_plus_core::watcher::{
     build_spawn_launcher_command, build_watcher_install_plan, cdp_listening, codex_process_ids,
     disable_watcher_at, enable_watcher_at, filter_killable_launcher_processes,
-    process_ids_still_running, should_recover_stale_launcher, watcher_disabled_flag,
+    process_id_is_running, process_ids_still_running, should_recover_stale_launcher,
+    watcher_disabled_flag,
 };
 
 #[cfg(windows)]
@@ -140,6 +141,13 @@ fn stop_wait_tracks_only_expected_process_ids() {
         process_ids_still_running(&[10, 20, 30], [5, 20, 40, 30]),
         vec![20, 30]
     );
+}
+
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
+#[test]
+fn process_liveness_distinguishes_current_and_missing_processes() {
+    assert_eq!(process_id_is_running(std::process::id()), Some(true));
+    assert_eq!(process_id_is_running(u32::MAX), Some(false));
 }
 
 #[cfg(windows)]

--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -2535,7 +2535,7 @@ fn collect_catalog_marked_non_root_thread_ids(
     paths: &[PathBuf],
     spawned_child_ids: &HashSet<String>,
 ) -> anyhow::Result<HashMap<PathBuf, HashSet<String>>> {
-    let mut thread_ids_by_path = HashMap::new();
+    let mut thread_ids_by_path: HashMap<PathBuf, HashSet<String>> = HashMap::new();
     for path in paths {
         if !path.exists() {
             continue;

--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -38,6 +38,8 @@ pub struct ProviderSyncResult {
     pub sqlite_user_event_rows_updated: usize,
     pub sqlite_cwd_rows_updated: usize,
     pub sqlite_catalog_rows_inserted: usize,
+    #[serde(default)]
+    pub sqlite_catalog_rows_removed: usize,
     pub updated_workspace_roots: usize,
     pub encrypted_content_warning: Option<String>,
 }
@@ -149,6 +151,7 @@ struct SqliteUpdateCounts {
     user_event_rows: usize,
     cwd_rows: usize,
     catalog_insert_rows: usize,
+    catalog_remove_rows: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -165,6 +168,48 @@ struct CatalogRepairThread {
     thread_source: Option<String>,
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct CatalogRepairCounts {
+    inserted_rows: usize,
+    removed_rows: usize,
+}
+
+impl CatalogRepairCounts {
+    fn total(&self) -> usize {
+        self.inserted_rows + self.removed_rows
+    }
+
+    fn add(&mut self, other: Self) {
+        self.inserted_rows += other.inserted_rows;
+        self.removed_rows += other.removed_rows;
+    }
+}
+
+#[derive(Debug, Default)]
+struct CatalogRepairPlan {
+    threads: HashMap<String, CatalogRepairThread>,
+    non_root_thread_ids: HashSet<String>,
+    catalog_non_root_thread_ids: HashMap<PathBuf, HashSet<String>>,
+}
+
+impl CatalogRepairPlan {
+    fn has_cleanup_candidates(&self) -> bool {
+        !self.non_root_thread_ids.is_empty()
+            || self
+                .catalog_non_root_thread_ids
+                .values()
+                .any(|thread_ids| !thread_ids.is_empty())
+    }
+
+    fn cleanup_thread_ids_for_path(&self, path: &Path) -> HashSet<String> {
+        let mut thread_ids = self.non_root_thread_ids.clone();
+        if let Some(catalog_thread_ids) = self.catalog_non_root_thread_ids.get(path) {
+            thread_ids.extend(catalog_thread_ids.iter().cloned());
+        }
+        thread_ids
+    }
+}
+
 enum RemoteControlRolloutLookup {
     Ready(PathBuf),
     Archived,
@@ -174,7 +219,11 @@ enum RemoteControlRolloutLookup {
 
 impl SqliteUpdateCounts {
     fn total(&self) -> usize {
-        self.provider_rows + self.user_event_rows + self.cwd_rows + self.catalog_insert_rows
+        self.provider_rows
+            + self.user_event_rows
+            + self.cwd_rows
+            + self.catalog_insert_rows
+            + self.catalog_remove_rows
     }
 
     fn add(&mut self, other: Self) {
@@ -182,6 +231,7 @@ impl SqliteUpdateCounts {
         self.user_event_rows += other.user_event_rows;
         self.cwd_rows += other.cwd_rows;
         self.catalog_insert_rows += other.catalog_insert_rows;
+        self.catalog_remove_rows += other.catalog_remove_rows;
     }
 }
 
@@ -402,7 +452,7 @@ pub fn run_remote_control_session_finalization_for_thread_with_target(
             return Ok(deferred);
         }
         let thread_ids = HashSet::from([thread_id.to_string()]);
-        let catalog_insert_rows = repair_missing_local_thread_catalog_rows_for_threads(
+        let catalog_repairs = repair_missing_local_thread_catalog_rows_for_threads(
             &sqlite_paths,
             target_provider,
             &thread_ids,
@@ -412,7 +462,8 @@ pub fn run_remote_control_session_finalization_for_thread_with_target(
             target_provider,
             &thread_ids,
         )?;
-        sqlite_updates.catalog_insert_rows = catalog_insert_rows;
+        sqlite_updates.catalog_insert_rows = catalog_repairs.inserted_rows;
+        sqlite_updates.catalog_remove_rows = catalog_repairs.removed_rows;
         prune_backups(&home)?;
         let mut synced = result(
             ProviderSyncStatus::Synced,
@@ -424,6 +475,7 @@ pub fn run_remote_control_session_finalization_for_thread_with_target(
         );
         synced.sqlite_provider_rows_updated = sqlite_updates.provider_rows;
         synced.sqlite_catalog_rows_inserted = sqlite_updates.catalog_insert_rows;
+        synced.sqlite_catalog_rows_removed = sqlite_updates.catalog_remove_rows;
         Ok(synced)
     })();
     let _ = release_lock(&lock_dir);
@@ -460,7 +512,7 @@ fn run_remote_control_catalog_recovery_for_threads(
         ));
     }
 
-    let catalog_insert_rows = repair_missing_local_thread_catalog_rows_for_threads(
+    let catalog_repairs = repair_missing_local_thread_catalog_rows_for_threads(
         sqlite_paths,
         target_provider,
         &thread_ids,
@@ -473,10 +525,11 @@ fn run_remote_control_catalog_recovery_for_threads(
         target_provider,
         None,
         0,
-        provider_rows + catalog_insert_rows,
+        provider_rows + catalog_repairs.total(),
     );
     synced.sqlite_provider_rows_updated = provider_rows;
-    synced.sqlite_catalog_rows_inserted = catalog_insert_rows;
+    synced.sqlite_catalog_rows_inserted = catalog_repairs.inserted_rows;
+    synced.sqlite_catalog_rows_removed = catalog_repairs.removed_rows;
     Ok(synced)
 }
 
@@ -553,13 +606,13 @@ pub fn run_provider_sync_with_target(
             &thread_ids_with_user_events,
             &cwd_by_thread_id,
         )?;
-        let catalog_insert_count =
-            count_missing_local_thread_catalog_rows(&sqlite_paths, &target_provider)?;
+        let catalog_repair_count =
+            count_local_thread_catalog_repairs(&sqlite_paths, &target_provider)?;
         let global_state_update_count =
             count_global_state_updates(&home.join(".codex-global-state.json"))?;
         if rewrite_changes.is_empty()
             && sqlite_update_count == 0
-            && catalog_insert_count == 0
+            && catalog_repair_count == 0
             && global_state_update_count == 0
         {
             let mut synced = result(
@@ -584,8 +637,10 @@ pub fn run_provider_sync_with_target(
                 &cwd_by_thread_id,
             )?;
             let mut sqlite_updates = sqlite_updates;
-            sqlite_updates.catalog_insert_rows =
+            let catalog_repairs =
                 repair_missing_local_thread_catalog_rows(&sqlite_paths, &target_provider)?;
+            sqlite_updates.catalog_insert_rows = catalog_repairs.inserted_rows;
+            sqlite_updates.catalog_remove_rows = catalog_repairs.removed_rows;
             let updated_workspace_roots =
                 apply_global_state_update(&home.join(".codex-global-state.json"))?;
             prune_backups(&home)?;
@@ -616,6 +671,7 @@ pub fn run_provider_sync_with_target(
         synced.sqlite_user_event_rows_updated = sqlite_updates.user_event_rows;
         synced.sqlite_cwd_rows_updated = sqlite_updates.cwd_rows;
         synced.sqlite_catalog_rows_inserted = sqlite_updates.catalog_insert_rows;
+        synced.sqlite_catalog_rows_removed = sqlite_updates.catalog_remove_rows;
         synced.updated_workspace_roots = updated_workspace_roots;
         synced.encrypted_content_warning = encrypted_content_warning;
         Ok(synced)
@@ -653,6 +709,7 @@ fn result(
         sqlite_user_event_rows_updated: 0,
         sqlite_cwd_rows_updated: 0,
         sqlite_catalog_rows_inserted: 0,
+        sqlite_catalog_rows_removed: 0,
         updated_workspace_roots: 0,
         encrypted_content_warning: None,
     }
@@ -2211,12 +2268,12 @@ fn apply_remote_control_catalog_updates(
     Ok(total)
 }
 
-fn count_missing_local_thread_catalog_rows(
+fn count_local_thread_catalog_repairs(
     paths: &[PathBuf],
     target_provider: &str,
 ) -> anyhow::Result<usize> {
-    let source_threads = collect_catalog_repair_threads(paths, target_provider, None)?;
-    if source_threads.is_empty() {
+    let plan = collect_catalog_repair_plan(paths, target_provider, None)?;
+    if plan.threads.is_empty() && !plan.has_cleanup_candidates() {
         return Ok(0);
     }
     let mut total = 0;
@@ -2232,8 +2289,13 @@ fn count_missing_local_thread_catalog_rows(
         let Some(host_id) = local_catalog_host_id(&db)? else {
             continue;
         };
-        for thread in source_threads.values() {
+        for thread in plan.threads.values() {
             if !local_catalog_contains_thread(&db, &host_id, &thread.id)? {
+                total += 1;
+            }
+        }
+        for thread_id in plan.cleanup_thread_ids_for_path(path) {
+            if local_catalog_contains_thread(&db, &host_id, &thread_id)? {
                 total += 1;
             }
         }
@@ -2244,7 +2306,7 @@ fn count_missing_local_thread_catalog_rows(
 fn repair_missing_local_thread_catalog_rows(
     paths: &[PathBuf],
     target_provider: &str,
-) -> anyhow::Result<usize> {
+) -> anyhow::Result<CatalogRepairCounts> {
     repair_missing_local_thread_catalog_rows_filtered(paths, target_provider, None, true)
 }
 
@@ -2252,7 +2314,7 @@ fn repair_missing_local_thread_catalog_rows_for_threads(
     paths: &[PathBuf],
     target_provider: &str,
     thread_ids: &HashSet<String>,
-) -> anyhow::Result<usize> {
+) -> anyhow::Result<CatalogRepairCounts> {
     repair_missing_local_thread_catalog_rows_filtered(
         paths,
         target_provider,
@@ -2266,12 +2328,14 @@ fn repair_missing_local_thread_catalog_rows_filtered(
     target_provider: &str,
     thread_ids: Option<&HashSet<String>>,
     update_full_sync_state: bool,
-) -> anyhow::Result<usize> {
-    let source_threads = collect_catalog_repair_threads(paths, target_provider, thread_ids)?;
-    if source_threads.is_empty() {
-        return Ok(0);
+) -> anyhow::Result<CatalogRepairCounts> {
+    let plan = collect_catalog_repair_plan(paths, target_provider, thread_ids)?;
+    if plan.threads.is_empty()
+        && (!update_full_sync_state || !plan.has_cleanup_candidates())
+    {
+        return Ok(CatalogRepairCounts::default());
     }
-    let mut total_inserted = 0;
+    let mut total = CatalogRepairCounts::default();
     for path in paths {
         if !path.exists() {
             continue;
@@ -2297,26 +2361,41 @@ fn repair_missing_local_thread_catalog_rows_filtered(
             placeholders
         );
         let tx = db.transaction()?;
+        let mut removed = 0;
+        if update_full_sync_state {
+            let cleanup_thread_ids = plan.cleanup_thread_ids_for_path(path);
+            let mut non_root_thread_ids = cleanup_thread_ids.iter().collect::<Vec<_>>();
+            non_root_thread_ids.sort();
+            let mut delete = tx.prepare(
+                "DELETE FROM local_thread_catalog WHERE host_id = ?1 AND thread_id = ?2",
+            )?;
+            for thread_id in non_root_thread_ids {
+                removed += delete.execute((&host_id, thread_id))?;
+            }
+            drop(delete);
+        }
         let mut inserted = 0;
         let mut max_source_updated_at = 0.0_f64;
-        let mut threads = source_threads.values().collect::<Vec<_>>();
+        let mut threads = plan.threads.values().collect::<Vec<_>>();
         threads.sort_by(|left, right| left.id.cmp(&right.id));
         for thread in threads {
-            observation_sequence += 1;
+            let next_observation_sequence = observation_sequence + 1;
             let values = local_catalog_insert_values(
                 &insert_columns,
                 &host_id,
                 thread,
-                observation_sequence,
+                next_observation_sequence,
             );
             let affected = tx.execute(&insert_sql, params_from_iter(values))?;
             if affected > 0 {
+                observation_sequence = next_observation_sequence;
                 inserted += affected;
                 max_source_updated_at = max_source_updated_at.max(thread.source_updated_at);
             }
         }
-        if inserted > 0 {
-            update_local_catalog_metadata(&tx, &metadata_columns, inserted)?;
+        let changed = inserted + removed;
+        if changed > 0 {
+            update_local_catalog_metadata(&tx, &metadata_columns, changed)?;
             if update_full_sync_state {
                 update_local_catalog_sync_state(
                     &tx,
@@ -2328,16 +2407,22 @@ fn repair_missing_local_thread_catalog_rows_filtered(
             }
         }
         tx.commit()?;
-        total_inserted += inserted;
+        total.add(CatalogRepairCounts {
+            inserted_rows: inserted,
+            removed_rows: removed,
+        });
     }
-    Ok(total_inserted)
+    Ok(total)
 }
 
-fn collect_catalog_repair_threads(
+fn collect_catalog_repair_plan(
     paths: &[PathBuf],
     target_provider: &str,
     thread_ids: Option<&HashSet<String>>,
-) -> anyhow::Result<HashMap<String, CatalogRepairThread>> {
+) -> anyhow::Result<CatalogRepairPlan> {
+    let spawned_child_ids = collect_spawned_child_thread_ids(paths)?;
+    let mut catalog_non_root_thread_ids =
+        collect_catalog_marked_non_root_thread_ids(paths, &spawned_child_ids)?;
     let mut threads = HashMap::new();
     for path in paths {
         if !path.exists() {
@@ -2382,9 +2467,6 @@ fn collect_catalog_repair_threads(
         })?;
         for item in rows {
             let thread = item?;
-            if thread_ids.is_some_and(|thread_ids| !thread_ids.contains(&thread.id)) {
-                continue;
-            }
             let replace = threads
                 .get(&thread.id)
                 .map(|current: &CatalogRepairThread| {
@@ -2396,7 +2478,156 @@ fn collect_catalog_repair_threads(
             }
         }
     }
-    Ok(threads)
+    if let Some(thread_ids) = thread_ids {
+        threads.retain(|thread_id, _| thread_ids.contains(thread_id));
+    }
+    let explicit_user_thread_ids = threads
+        .values()
+        .filter(|thread| thread_source_is_user(thread.thread_source.as_deref()))
+        .map(|thread| thread.id.clone())
+        .collect::<HashSet<_>>();
+    let non_root_thread_ids = threads
+        .values()
+        .filter(|thread| is_catalog_non_root_agent(thread, &spawned_child_ids))
+        .map(|thread| thread.id.clone())
+        .collect::<HashSet<_>>();
+    // Catalog-only evidence stays path-scoped so one stale database cannot remove another's row.
+    for catalog_thread_ids in catalog_non_root_thread_ids.values_mut() {
+        catalog_thread_ids.retain(|thread_id| {
+            thread_ids
+                .map(|requested| requested.contains(thread_id))
+                .unwrap_or(true)
+                && !explicit_user_thread_ids.contains(thread_id)
+        });
+    }
+    catalog_non_root_thread_ids.retain(|_, thread_ids| !thread_ids.is_empty());
+    threads.retain(|thread_id, _| !non_root_thread_ids.contains(thread_id));
+    Ok(CatalogRepairPlan {
+        threads,
+        non_root_thread_ids,
+        catalog_non_root_thread_ids,
+    })
+}
+
+fn collect_spawned_child_thread_ids(paths: &[PathBuf]) -> anyhow::Result<HashSet<String>> {
+    let mut thread_ids = HashSet::new();
+    for path in paths {
+        if !path.exists() {
+            continue;
+        }
+        let db = Connection::open(path)?;
+        let columns = table_columns(&db, "thread_spawn_edges")?;
+        if !columns.contains("child_thread_id") {
+            continue;
+        }
+        let mut stmt = db.prepare(
+            "SELECT child_thread_id FROM thread_spawn_edges WHERE COALESCE(child_thread_id, '') <> ''",
+        )?;
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        for thread_id in rows {
+            thread_ids.insert(thread_id?);
+        }
+    }
+    Ok(thread_ids)
+}
+
+fn collect_catalog_marked_non_root_thread_ids(
+    paths: &[PathBuf],
+    spawned_child_ids: &HashSet<String>,
+) -> anyhow::Result<HashMap<PathBuf, HashSet<String>>> {
+    let mut thread_ids_by_path = HashMap::new();
+    for path in paths {
+        if !path.exists() {
+            continue;
+        }
+        let db = Connection::open(path)?;
+        let columns = table_columns(&db, "local_thread_catalog")?;
+        if !columns.contains("host_id") || !columns.contains("thread_id") {
+            continue;
+        }
+        let Some(host_id) = local_catalog_host_id(&db)? else {
+            continue;
+        };
+        let source_kind = text_expr(&columns, "source_kind", "''");
+        let thread_source = text_expr(&columns, "thread_source", "NULL");
+        let sql = format!(
+            "SELECT thread_id, {source_kind}, {thread_source} FROM local_thread_catalog WHERE host_id = ?1 AND COALESCE(thread_id, '') <> ''"
+        );
+        let mut stmt = db.prepare(&sql)?;
+        let rows = stmt.query_map([host_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1).unwrap_or_default(),
+                row.get::<_, Option<String>>(2).unwrap_or(None),
+            ))
+        })?;
+        for row in rows {
+            let (thread_id, source_kind, thread_source) = row?;
+            if thread_source_is_user(thread_source.as_deref()) {
+                continue;
+            }
+            if thread_source_marks_non_root(thread_source.as_deref())
+                || source_marks_non_root_agent(&source_kind)
+                || spawned_child_ids.contains(&thread_id)
+            {
+                thread_ids_by_path
+                    .entry(path.clone())
+                    .or_default()
+                    .insert(thread_id);
+            }
+        }
+    }
+    Ok(thread_ids_by_path)
+}
+
+fn is_catalog_non_root_agent(
+    thread: &CatalogRepairThread,
+    spawned_child_ids: &HashSet<String>,
+) -> bool {
+    // The explicit user marker is authoritative over legacy source and spawn-edge fallbacks.
+    if thread_source_is_user(thread.thread_source.as_deref()) {
+        return false;
+    }
+    thread_source_marks_non_root(thread.thread_source.as_deref())
+        || source_marks_non_root_agent(&thread.source_kind)
+        || spawned_child_ids.contains(&thread.id)
+}
+
+fn thread_source_is_user(thread_source: Option<&str>) -> bool {
+    thread_source
+        .map(str::trim)
+        .is_some_and(|value| value.eq_ignore_ascii_case("user"))
+}
+
+fn thread_source_marks_non_root(thread_source: Option<&str>) -> bool {
+    thread_source.map(str::trim).is_some_and(|value| {
+        value.eq_ignore_ascii_case("subagent")
+            || value.eq_ignore_ascii_case("memory_consolidation")
+    })
+}
+
+fn source_marks_non_root_agent(source: &str) -> bool {
+    let source = source.trim();
+    if source_text_marks_non_root_agent(source) {
+        return true;
+    }
+    match serde_json::from_str::<Value>(source) {
+        Ok(Value::Object(object)) => {
+            object.contains_key("sub_agent")
+                || object.contains_key("subagent")
+                || object.contains_key("internal")
+        }
+        Ok(Value::String(value)) => source_text_marks_non_root_agent(&value),
+        _ => false,
+    }
+}
+
+fn source_text_marks_non_root_agent(source: &str) -> bool {
+    let source = source.trim().to_ascii_lowercase();
+    source == "subagent"
+        || source == "internal"
+        || source.starts_with("subagent_")
+        || source.starts_with("internal_")
 }
 
 fn catalog_supports_repair(columns: &HashSet<String>) -> bool {

--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -13,6 +13,13 @@ const SESSION_DIRS: [&str; 2] = ["sessions", "archived_sessions"];
 const BACKUP_KEEP_COUNT: usize = 5;
 const REMOTE_CONTROL_CREATION_WINDOW_SECS: i64 = 15 * 60;
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ProviderSyncLockOwner {
+    pid: u32,
+    started_at: u64,
+}
+
 fn default_codex_home_dir() -> PathBuf {
     codex_plus_core::codex_home::default_codex_home_dir()
 }
@@ -537,6 +544,7 @@ pub fn run_provider_sync_with_target(
     codex_home: Option<&Path>,
     explicit_target_provider: Option<&str>,
 ) -> ProviderSyncResult {
+    let require_stopped_app = codex_home.is_none();
     let home = codex_home
         .map(Path::to_path_buf)
         .unwrap_or_else(default_codex_home_dir);
@@ -564,6 +572,27 @@ pub fn run_provider_sync_with_target(
                 );
             }
         };
+    if require_stopped_app {
+        let running_processes =
+            codex_plus_core::watcher::find_session_index_cleanup_blocking_processes();
+        if !running_processes.is_empty() {
+            return result(
+                ProviderSyncStatus::Skipped,
+                format!(
+                    "Codex App / ChatGPT 仍在运行（进程：{}）；请完全退出 App 后再修复历史会话",
+                    running_processes
+                        .iter()
+                        .map(u32::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+                &target_provider,
+                None,
+                0,
+                0,
+            );
+        }
+    }
     let lock_dir = home.join("tmp/provider-sync.lock");
     if acquire_lock(&lock_dir).is_err() {
         return result(
@@ -905,11 +934,64 @@ fn toml_string_value(raw: &str) -> Option<String> {
 
 fn acquire_lock(path: &Path) -> std::io::Result<()> {
     fs::create_dir_all(path.parent().unwrap_or_else(|| Path::new(".")))?;
+    match create_lock(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let Some((owner, isolated_path)) = isolate_stale_lock(path) else {
+                return Err(error);
+            };
+            match create_lock(path) {
+                Ok(()) => {
+                    let quarantine_cleanup_failed = fs::remove_dir_all(&isolated_path).is_err();
+                    let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
+                        "provider_sync.stale_lock_recovered",
+                        json!({
+                            "owner_pid": owner.pid,
+                            "owner_started_at": owner.started_at,
+                            "quarantine_cleanup_failed": quarantine_cleanup_failed,
+                        }),
+                    );
+                    Ok(())
+                }
+                Err(retry_error) => {
+                    let _ = fs::remove_dir_all(isolated_path);
+                    Err(retry_error)
+                }
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn create_lock(path: &Path) -> std::io::Result<()> {
     fs::create_dir(path)?;
-    fs::write(
+    let write_result = fs::write(
         path.join("owner.json"),
         json!({"pid": std::process::id(), "startedAt": now_secs()}).to_string(),
+    );
+    if let Err(error) = write_result {
+        let _ = fs::remove_dir_all(path);
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn isolate_stale_lock(path: &Path) -> Option<(ProviderSyncLockOwner, PathBuf)> {
+    let owner = serde_json::from_slice::<ProviderSyncLockOwner>(
+        &fs::read(path.join("owner.json")).ok()?,
     )
+    .ok()?;
+    if codex_plus_core::watcher::process_id_is_running(owner.pid) != Some(false) {
+        return None;
+    }
+    let file_name = path.file_name()?.to_string_lossy();
+    let isolated_path = path.with_file_name(format!(
+        "{file_name}.stale-{}-{}",
+        owner.pid,
+        uuid::Uuid::new_v4()
+    ));
+    fs::rename(path, &isolated_path).ok()?;
+    Some((owner, isolated_path))
 }
 
 fn release_lock(path: &Path) -> std::io::Result<()> {

--- a/crates/codex-plus-data/tests/provider_sync.rs
+++ b/crates/codex-plus-data/tests/provider_sync.rs
@@ -1994,6 +1994,71 @@ fn provider_sync_skips_when_home_missing_or_lock_exists_and_prunes_backups() {
     assert_eq!(backups, 5);
 }
 
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
+#[test]
+fn provider_sync_recovers_lock_owned_by_dead_process() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    let lock_dir = home.join("tmp/provider-sync.lock");
+    fs::create_dir_all(&lock_dir).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    fs::write(
+        lock_dir.join("owner.json"),
+        json!({"pid": u32::MAX, "startedAt": 1234}).to_string(),
+    )
+    .unwrap();
+    let log_path = tmp.path().join("codex-plus.log");
+    codex_plus_core::diagnostic_log::set_diagnostic_log_path_for_tests(Some(log_path.clone()));
+
+    let result = run_provider_sync(Some(&home));
+
+    codex_plus_core::diagnostic_log::set_diagnostic_log_path_for_tests(None);
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert!(!lock_dir.exists());
+    assert!(
+        fs::read_to_string(log_path)
+            .unwrap()
+            .contains("provider_sync.stale_lock_recovered")
+    );
+    assert!(fs::read_dir(home.join("tmp")).unwrap().next().is_none());
+}
+
+#[test]
+fn provider_sync_preserves_lock_owned_by_live_process() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    let lock_dir = home.join("tmp/provider-sync.lock");
+    fs::create_dir_all(&lock_dir).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    fs::write(
+        lock_dir.join("owner.json"),
+        json!({"pid": std::process::id(), "startedAt": 1234}).to_string(),
+    )
+    .unwrap();
+
+    let result = run_provider_sync(Some(&home));
+
+    assert_eq!(result.status, ProviderSyncStatus::Skipped);
+    assert!(result.message.to_lowercase().contains("lock"));
+    assert!(lock_dir.exists());
+}
+
+#[test]
+fn provider_sync_preserves_lock_with_malformed_owner() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    let lock_dir = home.join("tmp/provider-sync.lock");
+    fs::create_dir_all(&lock_dir).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    fs::write(lock_dir.join("owner.json"), "{not-json").unwrap();
+
+    let result = run_provider_sync(Some(&home));
+
+    assert_eq!(result.status, ProviderSyncStatus::Skipped);
+    assert!(result.message.to_lowercase().contains("lock"));
+    assert!(lock_dir.exists());
+}
+
 #[test]
 fn provider_sync_preserves_rollout_mtime() {
     let tmp = tempdir().unwrap();

--- a/crates/codex-plus-data/tests/provider_sync.rs
+++ b/crates/codex-plus-data/tests/provider_sync.rs
@@ -666,6 +666,324 @@ fn provider_sync_repairs_missing_local_thread_catalog_rows_from_threads() {
 }
 
 #[test]
+fn provider_sync_catalogs_user_threads_but_skips_subagents() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    let sqlite_dir = home.join("sqlite");
+    fs::create_dir_all(&sqlite_dir).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+
+    let state_db = home.join("state_5.sqlite");
+    let db = Connection::open(&state_db).unwrap();
+    db.execute(
+        "CREATE TABLE threads (
+            id TEXT PRIMARY KEY, model_provider TEXT, archived INTEGER, has_user_event INTEGER,
+            cwd TEXT, title TEXT, rollout_path TEXT, source TEXT, created_at_ms INTEGER,
+            updated_at_ms INTEGER, thread_source TEXT, git_branch TEXT
+        )",
+        [],
+    )
+    .unwrap();
+    for (id, source, thread_source, updated_at) in [
+        ("user-one", "vscode", "user", 200000_i64),
+        (
+            "explicit-user",
+            r#"{"sub_agent":{"other":"review"}}"#,
+            "user",
+            205000_i64,
+        ),
+        ("marked-child", "vscode", "subagent", 210000_i64),
+        (
+            "memory-child",
+            "internal_memory_consolidation",
+            "memory_consolidation",
+            215000_i64,
+        ),
+    ] {
+        db.execute(
+            "INSERT INTO threads VALUES (
+                ?1, 'apigather', 0, 1, 'C:/workspace', 'Same title',
+                ?2, ?3, 100000, ?4, ?5, 'main'
+            )",
+            rusqlite::params![id, format!("C:/{id}.jsonl"), source, updated_at, thread_source],
+        )
+        .unwrap();
+    }
+    db.execute(
+        "INSERT INTO threads VALUES (
+            'null-source-child', 'apigather', 0, 1, 'C:/workspace', 'Same title',
+            'C:/null-source-child.jsonl', '{\"sub_agent\":{\"other\":\"guardian\"}}',
+            100000, 217000, NULL, 'main'
+        )",
+        [],
+    )
+    .unwrap();
+    drop(db);
+
+    let legacy_state_db = sqlite_dir.join("state_5.sqlite");
+    let db = Connection::open(&legacy_state_db).unwrap();
+    db.execute(
+        "CREATE TABLE threads (
+            id TEXT PRIMARY KEY, model_provider TEXT, archived INTEGER, has_user_event INTEGER,
+            cwd TEXT, title TEXT, rollout_path TEXT, source TEXT, created_at_ms INTEGER,
+            updated_at_ms INTEGER, git_branch TEXT
+        )",
+        [],
+    )
+    .unwrap();
+    for (id, source, updated_at) in [
+        ("user-two", "custom-subagent-bridge", 220000_i64),
+        ("malformed-user", r#"{"sub_agent":"#, 221000_i64),
+        ("nested-user", r#"{"origin":"subagent"}"#, 222000_i64),
+        (
+            "source-child",
+            r#"{"subagent":{"other":"guardian"}}"#,
+            230000_i64,
+        ),
+        (
+            "serde-source-child",
+            r#"{"sub_agent":{"other":"review"}}"#,
+            235000_i64,
+        ),
+        ("internal-child", "internal_memory_consolidation", 237000_i64),
+        ("edge-child", "cli", 240000_i64),
+    ] {
+        db.execute(
+            "INSERT INTO threads VALUES (
+                ?1, 'apigather', 0, 1, 'C:/workspace', 'Same title',
+                ?2, ?3, 100000, ?4, 'main'
+            )",
+            rusqlite::params![id, format!("C:/{id}.jsonl"), source, updated_at],
+        )
+        .unwrap();
+    }
+    db.execute(
+        "CREATE TABLE thread_spawn_edges (
+            parent_thread_id TEXT NOT NULL, child_thread_id TEXT NOT NULL, status TEXT
+        )",
+        [],
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO thread_spawn_edges VALUES
+            ('user-one', 'edge-child', 'open'),
+            ('user-one', 'explicit-user', 'open')",
+        [],
+    )
+    .unwrap();
+    drop(db);
+
+    let catalog_db = sqlite_dir.join("codex-dev.db");
+    create_local_thread_catalog_db(&catalog_db, &[]);
+
+    let result = run_provider_sync(Some(&home));
+
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert_eq!(result.sqlite_catalog_rows_inserted, 5);
+    assert_eq!(result.sqlite_catalog_rows_removed, 0);
+    assert_eq!(result.sqlite_rows_updated, 5);
+    let db = Connection::open(&catalog_db).unwrap();
+    let mut stmt = db
+        .prepare("SELECT thread_id FROM local_thread_catalog WHERE host_id = 'local' ORDER BY thread_id")
+        .unwrap();
+    let ids = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(
+        ids,
+        vec![
+            "explicit-user",
+            "malformed-user",
+            "nested-user",
+            "user-one",
+            "user-two",
+        ]
+    );
+    let duplicate_titles = db
+        .query_row(
+            "SELECT COUNT(*) FROM local_thread_catalog WHERE display_title = 'Same title'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(duplicate_titles, 5);
+}
+
+#[test]
+fn provider_sync_prunes_existing_local_subagent_catalog_rows() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    let sqlite_dir = home.join("sqlite");
+    fs::create_dir_all(&sqlite_dir).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+
+    let state_db = home.join("state_5.sqlite");
+    let db = Connection::open(&state_db).unwrap();
+    db.execute(
+        "CREATE TABLE threads (
+            id TEXT PRIMARY KEY, model_provider TEXT, archived INTEGER, has_user_event INTEGER,
+            cwd TEXT, title TEXT, rollout_path TEXT, source TEXT, created_at_ms INTEGER,
+            updated_at_ms INTEGER, thread_source TEXT, git_branch TEXT
+        )",
+        [],
+    )
+    .unwrap();
+    for (id, thread_source) in [("root", "user"), ("child", "subagent")] {
+        db.execute(
+            "INSERT INTO threads VALUES (
+                ?1, 'apigather', 0, 1, 'C:/workspace', ?1,
+                ?2, 'vscode', 100000, 200000, ?3, 'main'
+            )",
+            rusqlite::params![id, format!("C:/{id}.jsonl"), thread_source],
+        )
+        .unwrap();
+    }
+    drop(db);
+
+    let catalog_db = sqlite_dir.join("codex-dev.db");
+    create_local_thread_catalog_db(
+        &catalog_db,
+        &[
+            ("root", "apigather"),
+            ("child", "apigather"),
+            ("orphan", "apigather"),
+            ("stale-child", "apigather"),
+        ],
+    );
+    let secondary_catalog_db = sqlite_dir.join("state_5.sqlite");
+    create_local_thread_catalog_db(
+        &secondary_catalog_db,
+        &[("root", "apigather"), ("stale-child", "apigather")],
+    );
+    let db = Connection::open(&catalog_db).unwrap();
+    db.execute(
+        "UPDATE local_thread_catalog SET source_kind = 'subagent_review', thread_source = 'subagent' WHERE thread_id = 'stale-child'",
+        [],
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO local_thread_catalog_hosts VALUES ('remote', 'ssh')",
+        [],
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO local_thread_catalog (
+            host_id, thread_id, display_title, source_created_at, source_updated_at, cwd,
+            source_kind, source_detail, model_provider, git_branch, observation_sequence,
+            missing_candidate, thread_source
+        ) VALUES ('remote', 'child', 'Remote child', 100, 100, '/remote', 'cli', '',
+            'apigather', NULL, 1, 0, 'subagent')",
+        [],
+    )
+    .unwrap();
+    drop(db);
+
+    let result = run_provider_sync(Some(&home));
+
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert_eq!(result.sqlite_catalog_rows_inserted, 0);
+    assert_eq!(result.sqlite_catalog_rows_removed, 2);
+    assert_eq!(result.sqlite_rows_updated, 2);
+    let backup_dir = result.backup_dir.unwrap();
+    assert!(backup_dir.join("db/sqlite/codex-dev.db").exists());
+
+    let db = Connection::open(&catalog_db).unwrap();
+    let mut stmt = db
+        .prepare(
+            "SELECT host_id, thread_id FROM local_thread_catalog ORDER BY host_id, thread_id",
+        )
+        .unwrap();
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(
+        rows,
+        vec![
+            ("local".to_string(), "orphan".to_string()),
+            ("local".to_string(), "root".to_string()),
+            ("remote".to_string(), "child".to_string()),
+        ]
+    );
+    let revision = db
+        .query_row(
+            "SELECT catalog_revision FROM local_thread_catalog_metadata WHERE id = 1",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(revision, 2);
+    let sync_state = db
+        .query_row(
+            "SELECT watermark_updated_at, initial_build_complete, observation_sequence FROM local_thread_catalog_sync_state WHERE host_id = 'local'",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, f64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert_eq!(sync_state, (100.0, 1, 4));
+    drop(stmt);
+    drop(db);
+    let secondary = Connection::open(&secondary_catalog_db).unwrap();
+    let secondary_stale_row = secondary
+        .query_row(
+            "SELECT thread_source FROM local_thread_catalog WHERE thread_id = 'stale-child'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .unwrap();
+    assert_eq!(secondary_stale_row, "user");
+    let secondary_rows = secondary
+        .prepare("SELECT thread_id FROM local_thread_catalog ORDER BY thread_id")
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(0))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+    assert_eq!(secondary_rows, vec!["root", "stale-child"]);
+    let secondary_revision = secondary
+        .query_row(
+            "SELECT catalog_revision FROM local_thread_catalog_metadata WHERE id = 1",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(secondary_revision, 0);
+    let secondary_sync_state = secondary
+        .query_row(
+            "SELECT watermark_updated_at, initial_build_complete, observation_sequence FROM local_thread_catalog_sync_state WHERE host_id = 'local'",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, f64>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert_eq!(secondary_sync_state, (100.0, 1, 0));
+    drop(secondary);
+
+    let second = run_provider_sync(Some(&home));
+    assert_eq!(second.status, ProviderSyncStatus::Synced);
+    assert_eq!(second.sqlite_catalog_rows_inserted, 0);
+    assert_eq!(second.sqlite_catalog_rows_removed, 0);
+    assert_eq!(second.sqlite_rows_updated, 0);
+    assert!(second.backup_dir.is_none());
+}
+
+#[test]
 fn remote_control_catalog_recovery_for_thread_does_not_touch_other_candidates() {
     let tmp = tempdir().unwrap();
     let home = tmp.path().join(".codex");
@@ -747,6 +1065,99 @@ fn remote_control_catalog_recovery_for_thread_does_not_touch_other_candidates() 
                 .unwrap();
         assert_eq!(first["payload"]["model_provider"], "openai");
     }
+}
+
+#[test]
+fn remote_control_catalog_recovery_does_not_insert_subagent() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    let sqlite_dir = home.join("sqlite");
+    fs::create_dir_all(&sqlite_dir).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"custom\"\n").unwrap();
+
+    let state_db = home.join("state_5.sqlite");
+    let db = Connection::open(&state_db).unwrap();
+    db.execute(
+        "CREATE TABLE threads (
+            id TEXT PRIMARY KEY, model_provider TEXT, archived INTEGER, has_user_event INTEGER,
+            cwd TEXT, title TEXT, rollout_path TEXT, source TEXT, created_at_ms INTEGER,
+            updated_at_ms INTEGER, thread_source TEXT, git_branch TEXT
+        )",
+        [],
+    )
+    .unwrap();
+    for id in ["requested-child", "existing-child"] {
+        db.execute(
+            "INSERT INTO threads VALUES (
+                ?1, 'openai', 0, 1, 'C:/workspace', 'Parent title',
+                ?2, 'vscode', 100000, 200000, 'subagent', NULL
+            )",
+            rusqlite::params![id, format!("C:/{id}.jsonl")],
+        )
+        .unwrap();
+    }
+    drop(db);
+
+    let catalog_db = sqlite_dir.join("codex-dev.db");
+    create_local_thread_catalog_db(&catalog_db, &[("existing-child", "openai")]);
+    Connection::open(&catalog_db)
+        .unwrap()
+        .execute(
+            "UPDATE local_thread_catalog SET source_kind = 'subagent_review', thread_source = 'subagent' WHERE thread_id = 'existing-child'",
+            [],
+        )
+        .unwrap();
+
+    let result = run_remote_control_session_catalog_recovery_for_thread_with_target(
+        Some(&home),
+        "requested-child",
+        "custom",
+    );
+
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert_eq!(result.sqlite_catalog_rows_inserted, 0);
+    assert_eq!(result.sqlite_catalog_rows_removed, 0);
+    assert_eq!(result.sqlite_rows_updated, 0);
+    let catalog = Connection::open(&catalog_db).unwrap();
+    let ids = catalog
+        .prepare("SELECT thread_id FROM local_thread_catalog ORDER BY thread_id")
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(0))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+    assert_eq!(ids, vec!["existing-child"]);
+    drop(catalog);
+
+    let existing = run_remote_control_session_catalog_recovery_for_thread_with_target(
+        Some(&home),
+        "existing-child",
+        "custom",
+    );
+    assert_eq!(existing.status, ProviderSyncStatus::Synced);
+    assert_eq!(existing.sqlite_provider_rows_updated, 1);
+    assert_eq!(existing.sqlite_catalog_rows_inserted, 0);
+    assert_eq!(existing.sqlite_catalog_rows_removed, 0);
+    assert_eq!(existing.sqlite_rows_updated, 1);
+    let catalog = Connection::open(&catalog_db).unwrap();
+    let existing_provider = catalog
+        .query_row(
+            "SELECT model_provider FROM local_thread_catalog WHERE thread_id = 'existing-child'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .unwrap();
+    assert_eq!(existing_provider, "custom");
+    assert_eq!(
+        catalog
+            .query_row(
+                "SELECT COUNT(*) FROM local_thread_catalog WHERE thread_id = 'requested-child'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        0
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- keep Codex internal subagent threads out of `local_thread_catalog`
- remove already-cataloged subagent rows during provider sync while preserving user-created threads
- recover `provider-sync.lock` only when its recorded owner PID is confirmed dead
- surface skipped/disabled sync results as failures instead of reporting a misleading successful repair with zero changes
- block manual repair while Codex/ChatGPT is running and add local diagnostics for lock recovery

## Why

Recent Codex builds persist internal subagent jobs alongside user threads. The provider-sync catalog backfill treated every thread row as a user-facing conversation, so internal jobs could flood the desktop sidebar with repeated titles and make normal conversations difficult to open.

A stale `~/.codex/tmp/provider-sync.lock` could also prevent the cleanup from ever running. The manager previously wrapped that skipped result as `ok`, leaving users with a misleading `0 repaired` message. This is the same stale-lock failure mode reported in #1582 and is related to the catalog/sidebar symptoms discussed in #1587, #1644, and #1669.

## Safety

- subagent detection uses structured thread metadata and recorded spawn relationships
- ambiguous rows remain visible
- only locks with a parseable owner whose PID is confirmed dead are quarantined and recovered
- live, malformed, ownerless, or indeterminate locks remain untouched
- provider sync keeps its existing backup and transaction behavior

## Validation

- `npm test`: 56 passed
- `git diff --check`
- Windows CI: frontend tests, TypeScript check, frontend build, and full Rust workspace tests passed
- macOS arm64/x64 release builds passed

CI run: https://github.com/Creator-hash/CodexPlusPlus/actions/runs/31868954575