### PR TITLE
fix(provider-sync): fully isolate subagent history repair

### DIFF
--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -135,6 +135,13 @@ struct SessionChanges {
     changes: Vec<SessionChange>,
     skipped_locked_rollout_files: Vec<PathBuf>,
     encrypted_content_counts: HashMap<String, usize>,
+    subagent_thread_ids: HashSet<String>,
+}
+
+#[derive(Debug, Default)]
+struct ProviderSyncThreadKinds {
+    subagent_thread_ids: HashSet<String>,
+    explicit_user_thread_ids: HashSet<String>,
 }
 
 #[derive(Debug, Default)]
@@ -606,8 +613,15 @@ pub fn run_provider_sync_with_target(
     }
     let sync_result = (|| -> anyhow::Result<ProviderSyncResult> {
         let sqlite_paths = provider_sync_db_paths(&home);
-        let excluded_thread_ids = sqlite_subagent_thread_ids(&sqlite_paths)?;
-        let collected = collect_session_changes(&home, &target_provider, &excluded_thread_ids)?;
+        let thread_kinds = sqlite_provider_sync_thread_kinds(&sqlite_paths)?;
+        let collected = collect_session_changes(
+            &home,
+            &target_provider,
+            &thread_kinds.subagent_thread_ids,
+            &thread_kinds.explicit_user_thread_ids,
+        )?;
+        let mut subagent_thread_ids = thread_kinds.subagent_thread_ids;
+        subagent_thread_ids.extend(collected.subagent_thread_ids.iter().cloned());
         let encrypted_content_warning =
             build_encrypted_content_warning(&collected.encrypted_content_counts, &target_provider);
         let rewrite_changes = collected
@@ -635,6 +649,7 @@ pub fn run_provider_sync_with_target(
             &target_provider,
             &thread_ids_with_user_events,
             &cwd_by_thread_id,
+            &subagent_thread_ids,
         )?;
         let catalog_repair_count =
             count_local_thread_catalog_repairs(&sqlite_paths, &target_provider)?;
@@ -665,6 +680,7 @@ pub fn run_provider_sync_with_target(
                 &target_provider,
                 &thread_ids_with_user_events,
                 &cwd_by_thread_id,
+                &subagent_thread_ids,
             )?;
             let mut sqlite_updates = sqlite_updates;
             let catalog_repairs =
@@ -1006,6 +1022,7 @@ fn collect_session_changes(
     home: &Path,
     target_provider: &str,
     excluded_thread_ids: &HashSet<String>,
+    explicit_user_thread_ids: &HashSet<String>,
 ) -> anyhow::Result<SessionChanges> {
     let mut collected = SessionChanges::default();
     for path in rollout_files(home)? {
@@ -1021,10 +1038,21 @@ fn collect_session_changes(
         if rewrite.session_meta_count == 0 {
             continue;
         }
-        if rewrite
+        let is_explicit_user = rewrite
             .thread_id
             .as_ref()
-            .is_some_and(|thread_id| excluded_thread_ids.contains(thread_id))
+            .is_some_and(|thread_id| explicit_user_thread_ids.contains(thread_id));
+        if !is_explicit_user && rollout_session_meta_marks_non_root_agent(&text) {
+            if let Some(thread_id) = &rewrite.thread_id {
+                collected.subagent_thread_ids.insert(thread_id.clone());
+            }
+            continue;
+        }
+        if !is_explicit_user
+            && rewrite
+                .thread_id
+                .as_ref()
+                .is_some_and(|thread_id| excluded_thread_ids.contains(thread_id))
         {
             continue;
         }
@@ -1051,6 +1079,19 @@ fn collect_session_changes(
         });
     }
     Ok(collected)
+}
+
+fn rollout_session_meta_marks_non_root_agent(text: &str) -> bool {
+    text.lines().any(|line| {
+        let Ok(record) = serde_json::from_str::<Value>(line) else {
+            return false;
+        };
+        record.get("type").and_then(Value::as_str) == Some("session_meta")
+            && record
+                .get("payload")
+                .and_then(|payload| payload.get("source"))
+                .is_some_and(source_value_marks_non_root_agent)
+    })
 }
 
 fn remote_control_rollout_for_thread(
@@ -2015,8 +2056,10 @@ fn sqlite_provider_ids(path: &Path) -> anyhow::Result<Vec<String>> {
     Ok(sorted_provider_ids(ids))
 }
 
-fn sqlite_subagent_thread_ids(paths: &[PathBuf]) -> anyhow::Result<HashSet<String>> {
-    let mut ids = HashSet::new();
+fn sqlite_provider_sync_thread_kinds(
+    paths: &[PathBuf],
+) -> anyhow::Result<ProviderSyncThreadKinds> {
+    let mut kinds = ProviderSyncThreadKinds::default();
     for path in paths {
         if !path.exists() {
             continue;
@@ -2031,14 +2074,50 @@ fn sqlite_subagent_thread_ids(paths: &[PathBuf]) -> anyhow::Result<HashSet<Strin
             }
             let sql =
                 format!("SELECT DISTINCT {column} FROM {table} WHERE COALESCE({column}, '') <> ''");
-            ids.extend(
+            kinds.subagent_thread_ids.extend(
                 db.prepare(&sql)?
                     .query_map([], |row| row.get::<_, String>(0))?
                     .collect::<rusqlite::Result<HashSet<_>>>()?,
             );
         }
+
+        for (table, id_column, source_column) in [
+            ("threads", "id", "source"),
+            ("local_thread_catalog", "thread_id", "source_kind"),
+        ] {
+            let columns = table_columns(&db, table)?;
+            if !columns.contains(id_column) {
+                continue;
+            }
+            let source = text_expr(&columns, source_column, "''");
+            let thread_source = text_expr(&columns, "thread_source", "NULL");
+            let sql = format!(
+                "SELECT {id_column}, {source}, {thread_source} FROM {table} WHERE COALESCE({id_column}, '') <> ''"
+            );
+            let mut stmt = db.prepare(&sql)?;
+            let rows = stmt.query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1).unwrap_or_default(),
+                    row.get::<_, Option<String>>(2).unwrap_or(None),
+                ))
+            })?;
+            for row in rows {
+                let (thread_id, source, thread_source) = row?;
+                if thread_source_is_user(thread_source.as_deref()) {
+                    kinds.explicit_user_thread_ids.insert(thread_id);
+                } else if thread_source_marks_non_root(thread_source.as_deref())
+                    || source_marks_non_root_agent(&source)
+                {
+                    kinds.subagent_thread_ids.insert(thread_id);
+                }
+            }
+        }
     }
-    Ok(ids)
+    kinds
+        .subagent_thread_ids
+        .retain(|thread_id| !kinds.explicit_user_thread_ids.contains(thread_id));
+    Ok(kinds)
 }
 
 fn subagent_filter(db: &Connection, id_expr: &str) -> anyhow::Result<String> {
@@ -2172,11 +2251,33 @@ fn rollout_thread_provider_state(text: &str) -> Option<(String, HashSet<String>)
     thread_id.map(|thread_id| (thread_id, providers))
 }
 
+fn provider_update_thread_ids(
+    db: &Connection,
+    table: &str,
+    id_column: &str,
+    target_provider: &str,
+    excluded_thread_ids: &HashSet<String>,
+) -> anyhow::Result<Vec<String>> {
+    let sql = format!(
+        "SELECT {id_column} FROM {table} WHERE COALESCE({id_column}, '') <> '' AND COALESCE(model_provider, '') <> ?1"
+    );
+    let mut stmt = db.prepare(&sql)?;
+    let mut thread_ids = Vec::new();
+    for item in stmt.query_map([target_provider], |row| row.get::<_, String>(0))? {
+        let thread_id = item?;
+        if !excluded_thread_ids.contains(&thread_id) {
+            thread_ids.push(thread_id);
+        }
+    }
+    Ok(thread_ids)
+}
+
 fn count_sqlite_updates(
     path: &Path,
     target_provider: &str,
     user_event_thread_ids: &HashSet<String>,
     cwd_by_thread_id: &HashMap<String, String>,
+    excluded_thread_ids: &HashSet<String>,
 ) -> anyhow::Result<usize> {
     if !path.exists() {
         return Ok(0);
@@ -2184,25 +2285,32 @@ fn count_sqlite_updates(
     let db = Connection::open(path)?;
     let columns = table_columns(&db, "threads")?;
     let catalog_columns = table_columns(&db, "local_thread_catalog")?;
-    let thread_filter = subagent_filter(&db, "threads.id")?;
-    let catalog_filter = subagent_filter(&db, "local_thread_catalog.thread_id")?;
     let mut total = 0;
-    if columns.contains("model_provider") {
-        total += db.query_row(
-            &format!("SELECT COUNT(*) FROM threads WHERE COALESCE(model_provider, '') <> ?1{thread_filter}"),
-            [target_provider],
-            |row| row.get::<_, i64>(0),
-        )? as usize;
+    if columns.contains("id") && columns.contains("model_provider") {
+        total += provider_update_thread_ids(
+            &db,
+            "threads",
+            "id",
+            target_provider,
+            excluded_thread_ids,
+        )?
+        .len();
     }
-    if catalog_columns.contains("model_provider") {
-        total += db.query_row(
-            &format!("SELECT COUNT(*) FROM local_thread_catalog WHERE COALESCE(model_provider, '') <> ?1{catalog_filter}"),
-            [target_provider],
-            |row| row.get::<_, i64>(0),
-        )? as usize;
+    if catalog_columns.contains("thread_id") && catalog_columns.contains("model_provider") {
+        total += provider_update_thread_ids(
+            &db,
+            "local_thread_catalog",
+            "thread_id",
+            target_provider,
+            excluded_thread_ids,
+        )?
+        .len();
     }
     if columns.contains("has_user_event") {
         for thread_id in user_event_thread_ids {
+            if excluded_thread_ids.contains(thread_id) {
+                continue;
+            }
             total += db.query_row(
                 "SELECT COUNT(*) FROM threads WHERE id = ?1 AND COALESCE(has_user_event, 0) <> 1",
                 [thread_id],
@@ -2212,6 +2320,9 @@ fn count_sqlite_updates(
     }
     if columns.contains("cwd") {
         for (thread_id, cwd) in cwd_by_thread_id {
+            if excluded_thread_ids.contains(thread_id) {
+                continue;
+            }
             total += db.query_row(
                 "SELECT COUNT(*) FROM threads WHERE id = ?1 AND COALESCE(cwd, '') <> ?2",
                 (thread_id, cwd),
@@ -2227,6 +2338,7 @@ fn count_sqlite_updates_for_paths(
     target_provider: &str,
     user_event_thread_ids: &HashSet<String>,
     cwd_by_thread_id: &HashMap<String, String>,
+    excluded_thread_ids: &HashSet<String>,
 ) -> anyhow::Result<usize> {
     let mut total = 0;
     for path in paths {
@@ -2235,6 +2347,7 @@ fn count_sqlite_updates_for_paths(
             target_provider,
             user_event_thread_ids,
             cwd_by_thread_id,
+            excluded_thread_ids,
         )?;
     }
     Ok(total)
@@ -2245,6 +2358,7 @@ fn apply_sqlite_update(
     target_provider: &str,
     user_event_thread_ids: &HashSet<String>,
     cwd_by_thread_id: &HashMap<String, String>,
+    excluded_thread_ids: &HashSet<String>,
 ) -> anyhow::Result<SqliteUpdateCounts> {
     if !path.exists() {
         return Ok(SqliteUpdateCounts::default());
@@ -2252,27 +2366,44 @@ fn apply_sqlite_update(
     let mut db = Connection::open(path)?;
     let columns = table_columns(&db, "threads")?;
     let catalog_columns = table_columns(&db, "local_thread_catalog")?;
-    let thread_filter = subagent_filter(&db, "threads.id")?;
-    let catalog_filter = subagent_filter(&db, "local_thread_catalog.thread_id")?;
     if !columns.contains("model_provider") && !catalog_columns.contains("model_provider") {
         return Ok(SqliteUpdateCounts::default());
     }
     let tx = db.transaction()?;
     let mut counts = SqliteUpdateCounts::default();
-    if columns.contains("model_provider") {
-        counts.provider_rows += tx.execute(
-            &format!("UPDATE threads SET model_provider = ?1 WHERE COALESCE(model_provider, '') <> ?1{thread_filter}"),
-            [target_provider],
-        )?;
+    if columns.contains("id") && columns.contains("model_provider") {
+        for thread_id in provider_update_thread_ids(
+            &tx,
+            "threads",
+            "id",
+            target_provider,
+            excluded_thread_ids,
+        )? {
+            counts.provider_rows += tx.execute(
+                "UPDATE threads SET model_provider = ?1 WHERE id = ?2 AND COALESCE(model_provider, '') <> ?1",
+                (target_provider, thread_id),
+            )?;
+        }
     }
-    if catalog_columns.contains("model_provider") {
-        counts.provider_rows += tx.execute(
-            &format!("UPDATE local_thread_catalog SET model_provider = ?1 WHERE COALESCE(model_provider, '') <> ?1{catalog_filter}"),
-            [target_provider],
-        )?;
+    if catalog_columns.contains("thread_id") && catalog_columns.contains("model_provider") {
+        for thread_id in provider_update_thread_ids(
+            &tx,
+            "local_thread_catalog",
+            "thread_id",
+            target_provider,
+            excluded_thread_ids,
+        )? {
+            counts.provider_rows += tx.execute(
+                "UPDATE local_thread_catalog SET model_provider = ?1 WHERE thread_id = ?2 AND COALESCE(model_provider, '') <> ?1",
+                (target_provider, thread_id),
+            )?;
+        }
     }
     if columns.contains("has_user_event") {
         for thread_id in user_event_thread_ids {
+            if excluded_thread_ids.contains(thread_id) {
+                continue;
+            }
             counts.user_event_rows += tx.execute(
                 "UPDATE threads SET has_user_event = 1 WHERE id = ?1 AND COALESCE(has_user_event, 0) <> 1",
                 [thread_id],
@@ -2281,6 +2412,9 @@ fn apply_sqlite_update(
     }
     if columns.contains("cwd") {
         for (thread_id, cwd) in cwd_by_thread_id {
+            if excluded_thread_ids.contains(thread_id) {
+                continue;
+            }
             counts.cwd_rows += tx.execute(
                 "UPDATE threads SET cwd = ?1 WHERE id = ?2 AND COALESCE(cwd, '') <> ?1",
                 (cwd, thread_id),
@@ -2296,6 +2430,7 @@ fn apply_sqlite_update_for_paths(
     target_provider: &str,
     user_event_thread_ids: &HashSet<String>,
     cwd_by_thread_id: &HashMap<String, String>,
+    excluded_thread_ids: &HashSet<String>,
 ) -> anyhow::Result<SqliteUpdateCounts> {
     let mut total = SqliteUpdateCounts::default();
     for path in paths {
@@ -2304,6 +2439,7 @@ fn apply_sqlite_update_for_paths(
             target_provider,
             user_event_thread_ids,
             cwd_by_thread_id,
+            excluded_thread_ids,
         )?);
     }
     Ok(total)
@@ -2768,13 +2904,18 @@ fn source_marks_non_root_agent(source: &str) -> bool {
     if source_text_marks_non_root_agent(source) {
         return true;
     }
-    match serde_json::from_str::<Value>(source) {
-        Ok(Value::Object(object)) => {
+    serde_json::from_str::<Value>(source)
+        .is_ok_and(|source| source_value_marks_non_root_agent(&source))
+}
+
+fn source_value_marks_non_root_agent(source: &Value) -> bool {
+    match source {
+        Value::Object(object) => {
             object.contains_key("sub_agent")
                 || object.contains_key("subagent")
                 || object.contains_key("internal")
         }
-        Ok(Value::String(value)) => source_text_marks_non_root_agent(&value),
+        Value::String(value) => source_text_marks_non_root_agent(value),
         _ => false,
     }
 }

--- a/crates/codex-plus-data/tests/provider_sync.rs
+++ b/crates/codex-plus-data/tests/provider_sync.rs
@@ -56,6 +56,21 @@ fn write_rollout(path: &Path, provider: &str, thread_id: &str, cwd: &str) {
     fs::write(path, format!("{first}\n{event}\n")).unwrap();
 }
 
+fn write_subagent_rollout(path: &Path, provider: &str, thread_id: &str, cwd: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let first = json!({
+        "type": "session_meta",
+        "payload": {
+            "id": thread_id,
+            "model_provider": provider,
+            "cwd": cwd,
+            "source": { "subagent": { "thread_spawn": { "depth": 1 } } }
+        }
+    });
+    let event = json!({"type": "event_msg", "payload": {"type": "user_message"}});
+    fs::write(path, format!("{first}\n{event}\n")).unwrap();
+}
+
 fn session_index_line(id: &str, title: &str) -> String {
     json!({
         "id": id,
@@ -438,7 +453,7 @@ fn provider_sync_ignores_spawned_subagent_threads() {
     let parent_rollout = home.join("sessions/2026/rollout-parent.jsonl");
     let child_rollout = home.join("sessions/2026/rollout-child.jsonl");
     write_rollout(&parent_rollout, "openai", "parent", "C:/workspace");
-    write_rollout(&child_rollout, "openai", "child", "C:/workspace");
+    write_rollout(&child_rollout, "openai", "child", "C:/child-new");
     let state = home.join("state_5.sqlite");
     let db = Connection::open(&state).unwrap();
     db.execute(
@@ -457,7 +472,7 @@ fn provider_sync_ignores_spawned_subagent_threads() {
     )
     .unwrap();
     db.execute(
-        "INSERT INTO threads VALUES ('child', 'openai', 0, 1, 'C:/workspace')",
+        "INSERT INTO threads VALUES ('child', 'openai', 0, 0, 'C:/child-old')",
         [],
     )
     .unwrap();
@@ -482,14 +497,136 @@ fn provider_sync_ignores_spawned_subagent_threads() {
     .unwrap();
     assert_eq!(child_first["payload"]["model_provider"], "openai");
     let db = Connection::open(state).unwrap();
-    let child_provider: String = db
+    let child: (String, i64, String) = db
         .query_row(
-            "SELECT model_provider FROM threads WHERE id = 'child'",
+            "SELECT model_provider, has_user_event, cwd FROM threads WHERE id = 'child'",
             [],
-            |row| row.get(0),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )
         .unwrap();
-    assert_eq!(child_provider, "openai");
+    assert_eq!(
+        child,
+        ("openai".to_string(), 0, "C:/child-old".to_string())
+    );
+}
+
+#[test]
+fn provider_sync_preserves_marked_subagents_and_explicit_user_priority() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    fs::create_dir(&home).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+
+    let structured_rollout = home.join("sessions/2026/rollout-structured-child.jsonl");
+    let rollout_child = home.join("sessions/2026/rollout-source-child.jsonl");
+    let marked_rollout = home.join("sessions/2026/rollout-marked-child.jsonl");
+    let explicit_user_rollout = home.join("sessions/2026/rollout-explicit-user.jsonl");
+    write_rollout(
+        &structured_rollout,
+        "openai",
+        "structured-child",
+        "C:/structured-new",
+    );
+    write_subagent_rollout(
+        &rollout_child,
+        "openai",
+        "rollout-child",
+        "C:/rollout-new",
+    );
+    write_rollout(
+        &marked_rollout,
+        "openai",
+        "marked-child",
+        "C:/marked-new",
+    );
+    write_subagent_rollout(
+        &explicit_user_rollout,
+        "openai",
+        "explicit-user",
+        "C:/user-new",
+    );
+
+    let state = home.join("state_5.sqlite");
+    let db = Connection::open(&state).unwrap();
+    db.execute(
+        "CREATE TABLE threads (
+            id TEXT PRIMARY KEY, model_provider TEXT, archived INTEGER, has_user_event INTEGER,
+            cwd TEXT, source TEXT, thread_source TEXT
+        )",
+        [],
+    )
+    .unwrap();
+    let structured_source = json!({"subagent": {"thread_spawn": {"depth": 1}}}).to_string();
+    for (id, cwd, source, thread_source) in [
+        (
+            "structured-child",
+            "C:/structured-old",
+            structured_source.as_str(),
+            None,
+        ),
+        ("rollout-child", "C:/rollout-old", "cli", None),
+        ("marked-child", "C:/marked-old", "cli", Some("subagent")),
+        (
+            "explicit-user",
+            "C:/user-old",
+            structured_source.as_str(),
+            Some("user"),
+        ),
+    ] {
+        db.execute(
+            "INSERT INTO threads VALUES (?1, 'openai', 0, 0, ?2, ?3, ?4)",
+            rusqlite::params![id, cwd, source, thread_source],
+        )
+        .unwrap();
+    }
+    db.execute(
+        "CREATE TABLE thread_spawn_edges (parent_thread_id TEXT, child_thread_id TEXT)",
+        [],
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO thread_spawn_edges VALUES ('parent', 'explicit-user')",
+        [],
+    )
+    .unwrap();
+    drop(db);
+
+    let result = run_provider_sync(Some(&home));
+
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert_eq!(result.changed_session_files, 1);
+    for (path, provider) in [
+        (&structured_rollout, "openai"),
+        (&rollout_child, "openai"),
+        (&marked_rollout, "openai"),
+        (&explicit_user_rollout, "apigather"),
+    ] {
+        let first: serde_json::Value = serde_json::from_str(
+            fs::read_to_string(path).unwrap().lines().next().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(first["payload"]["model_provider"], provider);
+    }
+
+    let db = Connection::open(state).unwrap();
+    for (id, expected) in [
+        (
+            "structured-child",
+            ("openai", 0_i64, "C:/structured-old"),
+        ),
+        ("rollout-child", ("openai", 0_i64, "C:/rollout-old")),
+        ("marked-child", ("openai", 0_i64, "C:/marked-old")),
+        ("explicit-user", ("apigather", 1_i64, "C:/user-new")),
+    ] {
+        let actual: (String, i64, String) = db
+            .query_row(
+                "SELECT model_provider, has_user_event, cwd FROM threads WHERE id = ?1",
+                [id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(actual, (expected.0.to_string(), expected.1, expected.2.to_string()));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR prevents provider history repair from mutating internal Codex
subagent threads.

It excludes non-root threads from:

- rollout `model_provider` rewrites
- SQLite `model_provider` updates
- `has_user_event` updates
- `cwd` updates

Explicit `thread_source = user` markers remain authoritative, so normal
user-owned threads are still repaired.

## Detection

Non-root threads are detected through:

- rollout `session_meta.source`
- SQLite `source` and `thread_source`
- `thread_spawn_edges.child_thread_id`
- existing agent-job references

Regression coverage includes structured source metadata, rollout-only
subagents, legacy spawn edges, and explicit user-marker precedence.

## Validation

- `cargo test -p codex-plus-data --test provider_sync`: 40 passed
- `git diff --check`: passed