### PR TITLE
fix(inject): remove stale project move styles

### DIFF
--- a/apps/codex-plus-manager/src/renderer-inject.test.ts
+++ b/apps/codex-plus-manager/src/renderer-inject.test.ts
@@ -78,6 +78,42 @@ function usageAlertRuntime(renderer: string, cards: FakeElement[], managed: Fake
   return { runtime: create(windowValue, document, FakeElement), selectors, windowValue };
 }
 
+function installRendererStyle(renderer: string) {
+  const start = renderer.indexOf("  function installStyle()");
+  const end = renderer.indexOf("\n  function defaultCodexPlusSettings", start);
+  assert.ok(start >= 0 && end > start);
+  const source = renderer.slice(start, end);
+  const requiredNames = new Set([
+    "styleId",
+    "codexDeleteStyleVersion",
+    ...Array.from(source.matchAll(/\$\{([A-Za-z_$][A-Za-z0-9_$]*)/g), (match) => match[1]),
+  ]);
+  const declarations = Array.from(requiredNames, (name) => {
+    const declaration = renderer.match(new RegExp(`^  const ${name} = .+;$`, "m"))
+      ?? renderer.match(new RegExp(`^  const ${name} = [\\s\\S]*?^  };$`, "m"));
+    assert.ok(declaration, `missing renderer declaration for ${name}`);
+    return declaration[0];
+  }).join("\n");
+  const appended: Array<{ dataset: Record<string, string>; id?: string; textContent?: string }> = [];
+  const document = {
+    getElementById() {
+      return null;
+    },
+    createElement() {
+      return { dataset: {} };
+    },
+    documentElement: {
+      appendChild(node: (typeof appended)[number]) {
+        appended.push(node);
+      },
+    },
+  };
+  const install = new Function("document", `${declarations}\n${source}\ninstallStyle();`) as (documentValue: typeof document) => void;
+
+  install(document);
+  return appended;
+}
+
 describe("renderer injection header compatibility", () => {
   it("anchors the Codex++ menu to current and legacy application top bars only", async () => {
     const renderer = await readFile(new URL("../../../assets/inject/renderer-inject.js", import.meta.url), "utf8");
@@ -95,6 +131,15 @@ describe("renderer injection header compatibility", () => {
     assert.match(renderer, /!window\.electronBridge/);
     assert.ok(renderer.includes("/^app:\\\/\\\/\\-\\//i.test(window.location.href)"));
     assert.match(renderer, /codexPlusIsNodeTestHarness/);
+  });
+
+  it("initializes renderer styles without unresolved template identifiers", async () => {
+    const renderer = await readFile(new URL("../../../assets/inject/renderer-inject.js", import.meta.url), "utf8");
+
+    const appended = installRendererStyle(renderer);
+
+    assert.equal(appended.length, 1);
+    assert.match(appended[0].textContent ?? "", /#codex-plus-menu/);
   });
 
   it("hides only the official usage alert and restores it without changing upstream styles", async () => {

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -776,46 +776,7 @@
         pointer-events: none;
         white-space: nowrap;
       }
-      .${projectMoveOverlayClass} {
-        position: fixed;
-        inset: 0;
-        z-index: 2147483200;
-        background: rgba(15,23,42,.28);
-      }
-      .codex-project-move-panel {
-        position: fixed;
-        width: min(360px, calc(100vw - 32px));
-        max-height: min(520px, calc(100vh - 32px));
-        overflow: hidden;
-        border: 1px solid rgba(15,23,42,.14);
-        border-radius: 10px;
-        background: #ffffff;
-        color: #111827;
-        font: 13px system-ui, sans-serif;
-        box-shadow: 0 18px 60px rgba(15,23,42,.25);
-      }
-      .codex-project-move-header { border-bottom: 1px solid #e5e7eb; padding: 10px 12px; }
-      .codex-project-move-title { font-weight: 650; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-      .codex-project-move-list { max-height: min(440px, calc(100vh - 110px)); overflow-y: auto; padding: 6px; }
-      .codex-project-move-item {
-        display: block;
-        width: 100%;
-        border: 0;
-        border-radius: 7px;
-        background: transparent;
-        color: #111827;
-        padding: 8px 9px;
-        text-align: left;
-        cursor: pointer;
-      }
-      .codex-project-move-item:hover,
-      .codex-project-move-item:focus-visible { background: #f3f4f6; outline: none; }
-      .codex-project-move-item-title { font-weight: 550; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-      .codex-project-move-item-path { margin-top: 2px; color: #6b7280; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-      .codex-project-move-empty { padding: 18px 12px; color: #6b7280; text-align: center; }
-      .codex-project-move-hidden { display: none !important; }
       [data-codex-plus-usage-alert-hidden="true"] { display: none !important; }
-      [data-codex-project-move-injected-list="true"] { display: flex; flex-direction: column; }
       .codex-archive-delete-all {
         border: 1px solid #ef4444;
         border-radius: 7px;


### PR DESCRIPTION
## Summary

- Remove stale project-move CSS that references the deleted projectMoveOverlayClass symbol.
- Add a regression test that executes installStyle() so a missing template variable cannot abort the renderer injector again.

## Root cause

In v1.2.48, installStyle() throws a ReferenceError before the injector reaches installCodexPlusMenu(). This removes the Codex++ menu and other downstream renderer enhancements.

Fixes #1874

This may also address the missing session actions reported in #1875.

## Validation

- npm test (62 passing)
- npm run check
- npm run vite:build
- cargo test -p codex-plus-core --test cdp_bridge (101 passing)
- Rebuilt and manually verified the Windows launcher: the Codex++ menu renders, backend status is ok, and the anomaly scan reports 0 findings.

## Baseline note

The current upstream main workflow is already red in the untouched launcher test tests::watchdog_reuses_bridge_context_with_data_service. This PR does not modify apps/codex-plus-launcher/src/main.rs.