### PR TITLE
fix(test): use valid backend status route

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -1130,7 +1130,8 @@ mod tests {
 
         hooks.bridge_context(9229, &test_dir).await.unwrap();
         let ctx = hooks.watchdog_bridge_context().unwrap();
-        let result = codex_plus_core::routes::handle_bridge_request(ctx, "/backend-status", json!({})).await;
+        let result =
+            codex_plus_core::routes::handle_bridge_request(ctx, "/backend/status", json!({})).await;
 
         assert_ne!(result["message"], "Unknown bridge path");
     }


### PR DESCRIPTION
## Summary

- update the launcher watchdog regression test to call the registered `/backend/status` route
- restore a green Windows Rust test stage without changing production behavior

## Root cause

The v1.2.48 cleanup replaced the removed `/move-thread-workspace` test request with `/backend-status`. The route dispatcher registers the endpoint as `/backend/status`, so the test always fell through to `Unknown bridge path` and failed on the untouched upstream `main` branch.

## Impact

The Windows artifact workflow can proceed past `cargo test --workspace` again. This change only corrects the test route; runtime code is unchanged.

## Validation

- `cargo test -p codex-plus-launcher tests::watchdog_reuses_bridge_context_with_data_service -- --exact`
- frontend `npm test` (61 passed)
- frontend `npm run check`
- frontend `npm run vite:build`
- `cargo test --workspace`
- `git diff --check`

`cargo fmt --all -- --check` still reports pre-existing formatting differences across upstream `main`; this PR formats its changed line without modifying unrelated files.
