### PR TITLE
fix: 保存后立即应用供应商模型变更 / apply provider model changes immediately

### DIFF
--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -95,7 +95,7 @@ import {
   type ImageHandling,
   type ModelWindowRow,
 } from "./model-windows";
-import { relayAuthForLiveDraft } from "./relay-live-files";
+import { relayAuthForLiveDraft, shouldBackfillRelayProfileBeforeSwitch } from "./relay-live-files";
 import { resolveProviderSyncCompletion } from "./provider-sync-flow";
 import { resolveLaunchStatus } from "./launch-status";
 import {
@@ -2584,8 +2584,8 @@ export function App() {
     next: BackendSettings,
     previousActiveRelayId: string,
   ): Promise<BackendSettings> => {
+    if (!shouldBackfillRelayProfileBeforeSwitch(previousActiveRelayId, next.activeRelayId)) return next;
     const profileId = previousActiveRelayId.trim();
-    if (!profileId) return next;
     const result = await run(() =>
       call<SettingsBackfillResult>("backfill_relay_profile_from_live", {
         request: { settings: next, profileId },
@@ -6611,12 +6611,7 @@ function RelayProfileDetail({
     const savedProfile = savedSettings.relayProfiles.find((candidate) => candidate.id === normalizedDraft.id)
       ?? normalizedDraft;
     if (isActive && savedSettings.relayProfilesEnabled && relayProfileUsesLiveFiles(savedProfile)) {
-      await actions.saveRelayFile(
-        "config",
-        effectiveRelayConfigPreview(savedProfile, savedSettings, savedProfile),
-        true,
-      );
-      await actions.saveRelayFile("auth", savedProfile.authContents, true);
+      await actions.switchRelayProfile(savedSettings, savedSettings.activeRelayId);
     }
     onSaved?.();
   };
@@ -7051,6 +7046,17 @@ function RelayProfileEditor({
                 >
                   <Download className="h-4 w-4" />
                   {t("从上游获取")}
+                </Button>
+                <Button
+                  disabled={!modelWindowRows.some((row) => row.model.trim())}
+                  onClick={() => setModelWindowRows([{ model: "", window: "", imageHandling: "send-as-is" }])}
+                  size="sm"
+                  title={t("清空模型")}
+                  type="button"
+                  variant="outline"
+                >
+                  <Trash2 className="h-4 w-4" />
+                  {t("清空模型")}
                 </Button>
               </div>
             </div>

--- a/apps/codex-plus-manager/src/i18n-en.ts
+++ b/apps/codex-plus-manager/src/i18n-en.ts
@@ -709,6 +709,7 @@ export const EN_PLAIN: Record<string, string> = {
   "添加供应商": "Add provider",
   "添加模型": "Add model",
   "添加聚合供应商": "Add aggregate provider",
+  "清空模型": "Clear models",
   "清空选择": "Clear selection",
   "清除保存路径": "Clear saved path",
   "清理幽灵任务索引": "Clean up ghost task index",

--- a/apps/codex-plus-manager/src/model-routes.test.ts
+++ b/apps/codex-plus-manager/src/model-routes.test.ts
@@ -47,7 +47,7 @@ test("model route inputs keep focus while editing and label the example placehol
   assert.match(source, /relayModelRoutesSettingsValidation\(validationSettings\)/);
   assert.match(
     source,
-    /if \(requiresRestart\) \{[\s\S]*?actions\.restart\(true\)[\s\S]*?return;[\s\S]*?actions\.saveRelayFile/,
+    /if \(requiresRestart\) \{[\s\S]*?actions\.restart\(true\)[\s\S]*?return;[\s\S]*?actions\.switchRelayProfile\(savedSettings, savedSettings\.activeRelayId\)/,
   );
 });
 

--- a/apps/codex-plus-manager/src/relay-live-files.test.ts
+++ b/apps/codex-plus-manager/src/relay-live-files.test.ts
@@ -1,6 +1,17 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
-import { relayAuthForLiveDraft } from "./relay-live-files.ts";
+import { relayAuthForLiveDraft, shouldBackfillRelayProfileBeforeSwitch } from "./relay-live-files.ts";
+
+describe("shouldBackfillRelayProfileBeforeSwitch", () => {
+  it("backfills live files only when switching to a different provider", () => {
+    assert.strictEqual(shouldBackfillRelayProfileBeforeSwitch("provider-a", "provider-b"), true);
+    assert.strictEqual(shouldBackfillRelayProfileBeforeSwitch("provider-a", "provider-a"), false);
+  });
+
+  it("does not backfill without a previous active provider", () => {
+    assert.strictEqual(shouldBackfillRelayProfileBeforeSwitch("  ", "provider-a"), false);
+  });
+});
 
 describe("relayAuthForLiveDraft", () => {
   it("preserves the complete pure API provider auth snapshot", () => {

--- a/apps/codex-plus-manager/src/relay-live-files.ts
+++ b/apps/codex-plus-manager/src/relay-live-files.ts
@@ -1,3 +1,11 @@
+export function shouldBackfillRelayProfileBeforeSwitch(
+  previousActiveRelayId: string,
+  nextActiveRelayId: string,
+): boolean {
+  const previousId = previousActiveRelayId.trim();
+  return previousId.length > 0 && previousId !== nextActiveRelayId.trim();
+}
+
 export type RelayProfileFileSnapshot = {
   relayMode: "official" | "pureApi" | "mixedApi" | "aggregate";
   authContents: string;


### PR DESCRIPTION
## 中文

### 修复内容

- 修复编辑供应商时，新添加的模型保存后不会立即生效的问题。旧版本需要切换到其他供应商再切换回来；修复后点击保存即可立即应用。
- 在供应商模型列表中新增“一键清空模型”功能，可同时清空模型、上下文窗口和图片处理配置。

### 实现说明

- 保存当前供应商后复用完整的供应商应用流程，使模型 catalog 立即重新生成。
- 同一供应商重新应用时跳过旧 live 文件回填，避免覆盖刚保存的模型配置。
- 清空操作保留一个空白模型输入行，并在没有有效模型时禁用按钮。

### 验证

- `npm run check`
- `npm test`（63 条测试通过）
- `npm run vite:build`

---

## English

### What Changed

- Fixed an issue where newly added models did not take effect immediately after saving an edited provider. Previously, users had to switch to another provider and then switch back; saving now applies the changes immediately.
- Added a one-click **Clear models** action to the provider model list. It clears the models, context-window settings, and image-handling settings together.

### Implementation

- Reuses the complete provider application flow after saving the active provider so the model catalog is regenerated immediately.
- Skips stale live-file backfill when reapplying the same provider, preventing newly saved model settings from being overwritten.
- Keeps one empty model input row after clearing and disables the action when there are no valid models.

### Verification

- `npm run check`
- `npm test` (63 tests passed)
- `npm run vite:build`