### PR TITLE
fix(windows): restore file drag-and-drop / 恢复文件拖拽

### DIFF
--- a/apps/codex-plus-manager/src-tauri/tests/windows_subsystem.rs
+++ b/apps/codex-plus-manager/src-tauri/tests/windows_subsystem.rs
@@ -95,7 +95,7 @@ fn launcher_binary_embeds_codex_icon_resource() {
 }
 
 #[test]
-fn windows_binaries_request_administrator_privileges() {
+fn windows_binaries_run_as_invoker_without_administrator_privileges() {
     let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let manager_build =
         std::fs::read_to_string(manifest_dir.join("build.rs")).expect("read manager build.rs");
@@ -118,9 +118,12 @@ fn windows_binaries_request_administrator_privileges() {
 
     assert!(manager_build.contains("windows-app-manifest.xml"));
     assert!(launcher_build.contains("windows-app-manifest.xml"));
-    assert!(windows_manifest.contains("requireAdministrator"));
+    // Elevated launcher processes also elevate Codex, so Explorer file drops are blocked by UIPI.
+    assert!(windows_manifest.contains("asInvoker"));
+    assert!(!windows_manifest.contains("requireAdministrator"));
     assert!(windows_manifest.contains("Microsoft.Windows.Common-Controls"));
-    assert!(windows_installer.contains("RequestExecutionLevel admin"));
+    assert!(windows_installer.contains("RequestExecutionLevel user"));
+    assert!(!windows_installer.contains("RequestExecutionLevel admin"));
 }
 
 #[test]

--- a/apps/codex-plus-manager/src-tauri/windows-app-manifest.xml
+++ b/apps/codex-plus-manager/src-tauri/windows-app-manifest.xml
@@ -15,7 +15,7 @@
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>
-        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
       </requestedPrivileges>
     </security>
   </trustInfo>

--- a/scripts/installer/windows/CodexPlusPlus.nsi
+++ b/scripts/installer/windows/CodexPlusPlus.nsi
@@ -10,7 +10,7 @@ Name "Codex++"
 OutFile "${ROOT}\dist\windows\CodexPlusPlus-${VERSION}-windows-x64-setup.exe"
 InstallDir "$LOCALAPPDATA\Programs\Codex++"
 InstallDirRegKey HKCU "Software\Codex++" "InstallDir"
-RequestExecutionLevel admin
+RequestExecutionLevel user
 SetCompressor /SOLID lzma
 
 !define MUI_ICON "${ROOT}\apps\codex-plus-manager\src-tauri\icons\icon.ico"


### PR DESCRIPTION
## Summary / 概要

- Run the Windows manager and launcher with `asInvoker` instead of `requireAdministrator`.
- Change the per-user NSIS installer to `RequestExecutionLevel user`.
- Add regression coverage to prevent administrator execution levels from being reintroduced.

- 将 Windows 管理器和启动器从 `requireAdministrator` 改为 `asInvoker`。
- 将当前用户范围的 NSIS 安装器改为 `RequestExecutionLevel user`。
- 增加回归测试，防止后续重新引入管理员执行权限。

## Root Cause / 根因

Codex++ embedded a `requireAdministrator` manifest in both Windows binaries. Codex launched through Codex++ therefore ran at a higher integrity level than Windows Explorer. Windows UIPI blocked file drag-and-drop across that integrity boundary, so the cursor displayed the prohibited icon.

Codex++ 的两个 Windows 可执行文件都嵌入了 `requireAdministrator` 清单，导致经 Codex++ 启动的 Codex 完整性级别高于 Windows Explorer。Windows UIPI 会阻止跨完整性级别的文件拖放，因此鼠标显示禁止图标。

## Verification / 验证

- `cargo test -p codex-plus-manager --test windows_subsystem`: 22 passed
- Focused regression test: 1 passed
- `npm run vite:build`: passed
- `cargo build --release -p codex-plus-manager -p codex-plus-launcher`: passed
- Verified both generated EXEs contain `asInvoker` and do not contain `requireAdministrator`.

- Windows 子系统测试 22 项全部通过。
- 聚焦回归测试通过。
- 前端生产构建和两个 Windows Release 可执行文件构建通过。
- 已确认两个生成的 EXE 均包含 `asInvoker`，且不包含 `requireAdministrator`。

Fixes #560