### PR TITLE
动态恢复当前 App 的全部内置插件 / Recover all bundled plugins from the current App manifest

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -554,11 +554,39 @@ impl LaunchHooks for LauncherHooks {
         helper_port: u16,
         ctx: BridgeContext,
     ) -> anyhow::Result<()> {
-        inject_with_context(debug_port, helper_port, ctx, self.runtime.clone()).await
+        inject_with_context(debug_port, helper_port, ctx, self.runtime.clone(), None).await
+    }
+
+    async fn inject_bridge_for_app(
+        &self,
+        debug_port: u16,
+        helper_port: u16,
+        ctx: BridgeContext,
+        app_dir: &Path,
+    ) -> anyhow::Result<()> {
+        inject_with_context(
+            debug_port,
+            helper_port,
+            ctx,
+            self.runtime.clone(),
+            Some(app_dir.to_path_buf()),
+        )
+        .await
     }
 
     async fn inject(&self, debug_port: u16, helper_port: u16) -> anyhow::Result<()> {
         self.core.inject(debug_port, helper_port).await
+    }
+
+    async fn inject_for_app(
+        &self,
+        debug_port: u16,
+        helper_port: u16,
+        app_dir: &Path,
+    ) -> anyhow::Result<()> {
+        self.core
+            .inject_for_app(debug_port, helper_port, app_dir)
+            .await
     }
 
     async fn start_bridge_watchdog(&self, debug_port: u16, helper_port: u16) -> anyhow::Result<()> {
@@ -567,9 +595,9 @@ impl LaunchHooks for LauncherHooks {
         let reinjector: BridgeReinjector = Arc::new(move || {
             let ctx = ctx.clone();
             let runtime = runtime.clone();
-            Box::pin(
-                async move { inject_with_context(debug_port, helper_port, ctx, runtime).await },
-            )
+            Box::pin(async move {
+                inject_with_context(debug_port, helper_port, ctx, runtime, None).await
+            })
         });
         self.core.set_bridge_reinjector(reinjector).await;
         self.core
@@ -929,10 +957,19 @@ async fn inject_with_context(
     helper_port: u16,
     ctx: BridgeContext,
     runtime: Arc<LauncherRuntimeService>,
+    app_dir: Option<PathBuf>,
 ) -> anyhow::Result<()> {
     let mut last_error = None;
     for _ in 0..20 {
-        match try_inject_with_context(debug_port, helper_port, ctx.clone(), runtime.clone()).await {
+        match try_inject_with_context(
+            debug_port,
+            helper_port,
+            ctx.clone(),
+            runtime.clone(),
+            app_dir.as_deref(),
+        )
+        .await
+        {
             Ok(()) => return Ok(()),
             Err(error) => {
                 last_error = Some(error);
@@ -957,6 +994,7 @@ async fn try_inject_with_context(
     helper_port: u16,
     ctx: BridgeContext,
     runtime: Arc<LauncherRuntimeService>,
+    app_dir: Option<&Path>,
 ) -> anyhow::Result<()> {
     let targets = codex_plus_core::cdp::list_targets(debug_port).await?;
     let target = codex_plus_core::cdp::pick_injectable_codex_page_target(&targets)?;
@@ -968,7 +1006,11 @@ async fn try_inject_with_context(
     let settings = codex_plus_core::settings::SettingsStore::default()
         .load()
         .unwrap_or_default();
-    let script = codex_plus_core::assets::injection_script_with_settings(helper_port, &settings);
+    let script = codex_plus_core::assets::injection_script_with_settings_and_app_dir(
+        helper_port,
+        &settings,
+        app_dir,
+    );
     let user_bundle = runtime
         .user_scripts
         .build_enabled_bundle()

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -468,7 +468,7 @@
   const codexServiceTierRequestOverrideVersion = "9";
   const codexAppServerModelRequestPatchVersion = "6";
   const codexRemoteSessionRecoveryVersion = "5";
-  const codexPluginMarketplaceUnlockVersion = "15";
+  const codexPluginMarketplaceUnlockVersion = "16";
   const codexThreadScrollMaxEntries = 120;
   const codexThreadScrollSaveThrottleMs = 120;
   const codexThreadScrollRestoreWindowMs = 3200;
@@ -4349,7 +4349,11 @@
 
   function pluginMarketplacePluginKey(plugin) {
     if (!plugin || typeof plugin !== "object") return "";
-    return String(plugin.name || plugin.id || plugin.pluginName || "").trim();
+    const name = String(plugin.name || plugin.pluginName || "").trim();
+    if (name) return name;
+    const id = String(plugin.id || "").trim();
+    const marketplaceSeparator = id.lastIndexOf("@");
+    return marketplaceSeparator > 0 ? id.slice(0, marketplaceSeparator) : id;
   }
 
   function normalizeLocalPluginMarketplacePlugin(plugin, marketplaceName) {
@@ -4367,19 +4371,36 @@
     return cloned;
   }
 
+  function fillMissingPluginMarketplaceMetadata(target, source) {
+    if (!target || !source || typeof target !== "object" || typeof source !== "object") return;
+    for (const key of ["name", "id", "marketplaceName", "marketplacePath", "interface", "keywords", "category", "policy", "source", "installed"]) {
+      if (target[key] != null || source[key] == null) continue;
+      const sourceValue = source[key];
+      target[key] = sourceValue && typeof sourceValue === "object"
+        ? cloneCodexPluginMarketplace(sourceValue)
+        : sourceValue;
+    }
+  }
+
   function mergePluginMarketplacePlugins(target, source) {
     if (!target || !source || !Array.isArray(source.plugins)) return 0;
     if (!Array.isArray(target.plugins)) target.plugins = [];
     const marketplaceName = restorePluginMarketplaceName(target.name || source.name || "");
-    const existing = new Set(target.plugins.map(pluginMarketplacePluginKey).filter(Boolean));
+    const existing = new Map(
+      target.plugins.map((plugin) => [pluginMarketplacePluginKey(plugin), plugin]).filter(([key]) => Boolean(key)),
+    );
     let added = 0;
     source.plugins.forEach((plugin) => {
       const key = pluginMarketplacePluginKey(plugin);
-      if (!key || existing.has(key)) return;
       const cloned = normalizeLocalPluginMarketplacePlugin(plugin, marketplaceName);
-      if (!cloned) return;
+      if (!key || !cloned) return;
+      const current = existing.get(key);
+      if (current) {
+        fillMissingPluginMarketplaceMetadata(current, cloned);
+        return;
+      }
       target.plugins.push(cloned);
-      existing.add(key);
+      existing.set(key, cloned);
       added += 1;
     });
     return added;
@@ -4400,16 +4421,21 @@
     });
     let addedMarketplaces = 0;
     let addedPlugins = 0;
+    let addedAppBundledPlugins = 0;
     localMarketplaces.forEach((marketplace) => {
       const name = restorePluginMarketplaceName(marketplace?.name || "");
       if (!name) return;
+      const appBundled = name === "openai-bundled" && marketplace?.codexPlusSource === "app-bundled";
       const existing = byName.get(name);
       if (existing) {
-        addedPlugins += mergePluginMarketplacePlugins(existing, marketplace);
+        const added = mergePluginMarketplacePlugins(existing, marketplace);
+        addedPlugins += added;
+        if (appBundled) addedAppBundledPlugins += added;
         return;
       }
       const cloned = cloneCodexPluginMarketplace(marketplace);
       if (!cloned) return;
+      delete cloned.codexPlusSource;
       cloned.plugins = Array.isArray(cloned.plugins)
         ? cloned.plugins.map((plugin) => normalizeLocalPluginMarketplacePlugin(plugin, name)).filter(Boolean)
         : [];
@@ -4417,11 +4443,15 @@
       byName.set(name, cloned);
       addedMarketplaces += 1;
       addedPlugins += Array.isArray(cloned.plugins) ? cloned.plugins.length : 0;
+      if (appBundled) addedAppBundledPlugins += Array.isArray(cloned.plugins) ? cloned.plugins.length : 0;
     });
     if (addedMarketplaces > 0 || addedPlugins > 0) {
       sendCodexPlusDiagnostic("plugin_marketplace_local_merged", { addedMarketplaces, addedPlugins });
     }
-    return { addedMarketplaces, addedPlugins };
+    if (addedAppBundledPlugins > 0) {
+      sendCodexPlusDiagnostic("plugin_marketplace_app_bundled_recovered", { addedPlugins: addedAppBundledPlugins });
+    }
+    return { addedMarketplaces, addedPlugins, addedAppBundledPlugins };
   }
 
   function restorePluginMarketplaceName(name) {
@@ -4820,6 +4850,7 @@
       patchResponseData: patchPluginMarketplaceResponseData,
       remoteAuthError: pluginMarketplaceRemoteAuthError,
       localFallback: localPluginMarketplaceFallbackResult,
+      mergeLocal: mergeLocalPluginMarketplaces,
       remoteOnlyFallback: remoteOnlyPluginMarketplaceFallbackResult,
       requestProfile: pluginMarketplaceRequestProfile,
       isBuildFlavorFilter: isCodexPluginBuildFlavorFilter,

--- a/crates/codex-plus-core/src/assets.rs
+++ b/crates/codex-plus-core/src/assets.rs
@@ -1,7 +1,7 @@
 use base64::Engine;
 use serde_json::Map;
 use serde_json::{Value, json};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::settings::BackendSettings;
 
@@ -393,13 +393,30 @@ pub fn hide_official_usage_alert_config(settings: &BackendSettings) -> bool {
 }
 
 pub fn injection_script_with_settings(helper_port: u16, settings: &BackendSettings) -> String {
+    injection_script_with_settings_and_app_dir(helper_port, settings, None)
+}
+
+pub fn injection_script_with_settings_and_app_dir(
+    helper_port: u16,
+    settings: &BackendSettings,
+    app_dir: Option<&Path>,
+) -> String {
+    let resolved_app_dir = if app_dir.is_none() {
+        crate::app_paths::resolve_codex_app_dir_with_saved(
+            None,
+            Some(settings.codex_app_path.as_str()),
+        )
+    } else {
+        None
+    };
+    let app_dir = app_dir.or(resolved_app_dir.as_deref());
     let helper_url = format!("http://127.0.0.1:{helper_port}");
     let image_overlay = image_overlay_config(helper_port, settings);
     let dream_skin_art = dream_skin_art_data_uri(settings);
     let dream_skin_art_signature = dream_skin_art_content_signature(settings);
     let dream_skin_theme = &settings.codex_app_dream_skin_theme_config;
     let dream_skin_target_runtime = dream_skin_target_runtime_script(settings, false);
-    let plugin_marketplaces = local_plugin_marketplaces();
+    let plugin_marketplaces = local_plugin_marketplaces(app_dir);
     let paste_fix = paste_fix_enabled_config(settings);
     let force_chinese_locale = force_chinese_locale_config(settings);
     let fast_startup = fast_startup_config(settings);
@@ -476,42 +493,106 @@ fn dream_skin_content_signature(value: &[u8]) -> String {
     format!("{}-{hash:x}", value.len())
 }
 
-fn local_plugin_marketplaces() -> Value {
+fn local_plugin_marketplaces(app_dir: Option<&Path>) -> Value {
     let home = crate::codex_home::default_codex_home_dir();
-    local_plugin_marketplaces_from_home(&home)
+    local_plugin_marketplaces_from_sources(&home, app_dir)
 }
 
+#[cfg(test)]
 fn local_plugin_marketplaces_from_home(home: &Path) -> Value {
+    local_plugin_marketplaces_from_sources(home, None)
+}
+
+fn local_plugin_marketplaces_from_sources(home: &Path, app_dir: Option<&Path>) -> Value {
     let installed_plugins = installed_plugins_from_config(&home);
     let marketplace_dir = home
         .join(".tmp")
         .join("plugins")
         .join(".agents")
         .join("plugins");
-    let candidates = [
-        marketplace_dir.join("marketplace.json"),
-        marketplace_dir.join("api_marketplace.json"),
-        home.join(".tmp")
-            .join("plugins-remote")
-            .join(".agents")
-            .join("plugins")
-            .join("marketplace.json"),
-    ];
-    let marketplaces = candidates
-        .iter()
-        .filter_map(|path| {
-            let text = std::fs::read_to_string(path).ok()?;
-            let mut marketplace: Value = serde_json::from_str(&text).ok()?;
-            expand_local_plugin_marketplace(&mut marketplace, path, &home, &installed_plugins);
-            if let Some(object) = marketplace.as_object_mut() {
-                object
-                    .entry("path")
-                    .or_insert_with(|| Value::String(path.to_string_lossy().to_string()));
+    let mut candidates = Vec::new();
+    if let Some(app_dir) = app_dir {
+        candidates.extend(
+            app_bundled_plugin_marketplace_paths(app_dir)
+                .into_iter()
+                .map(|path| (path, true)),
+        );
+    }
+    candidates.extend([
+        (marketplace_dir.join("marketplace.json"), false),
+        (marketplace_dir.join("api_marketplace.json"), false),
+        (
+            home.join(".tmp")
+                .join("plugins-remote")
+                .join(".agents")
+                .join("plugins")
+                .join("marketplace.json"),
+            false,
+        ),
+    ]);
+
+    let mut marketplace_names = std::collections::BTreeSet::new();
+    let mut marketplaces = Vec::new();
+    for (path, app_bundled) in candidates {
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(mut marketplace) = serde_json::from_str::<Value>(&text) else {
+            continue;
+        };
+        if app_bundled && !is_app_bundled_plugin_marketplace(&marketplace) {
+            continue;
+        }
+        let Some(name) = marketplace
+            .get("name")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+        else {
+            continue;
+        };
+        if !marketplace_names.insert(name) {
+            continue;
+        }
+        expand_local_plugin_marketplace(&mut marketplace, &path, home, &installed_plugins);
+        if let Some(object) = marketplace.as_object_mut() {
+            object
+                .entry("path")
+                .or_insert_with(|| Value::String(path.to_string_lossy().to_string()));
+            if app_bundled {
+                object.insert(
+                    "codexPlusSource".to_string(),
+                    Value::String("app-bundled".to_string()),
+                );
             }
-            Some(marketplace)
-        })
-        .collect::<Vec<_>>();
+        }
+        marketplaces.push(marketplace);
+    }
     Value::Array(marketplaces)
+}
+
+fn app_bundled_plugin_marketplace_paths(app_dir: &Path) -> [PathBuf; 4] {
+    let relative = Path::new("plugins")
+        .join("openai-bundled")
+        .join(".agents")
+        .join("plugins")
+        .join("marketplace.json");
+    [
+        app_dir.join("resources").join(&relative),
+        app_dir.join("Contents").join("Resources").join(&relative),
+        app_dir.join("resources").join("app").join(&relative),
+        app_dir
+            .join("resources")
+            .join("app.asar.unpacked")
+            .join(&relative),
+    ]
+}
+
+fn is_app_bundled_plugin_marketplace(marketplace: &Value) -> bool {
+    marketplace.get("name").and_then(Value::as_str) == Some("openai-bundled")
+        && marketplace
+            .get("plugins")
+            .and_then(Value::as_array)
+            .is_some_and(|plugins| !plugins.is_empty())
 }
 
 fn expand_local_plugin_marketplace(
@@ -812,5 +893,136 @@ mod tests {
             array[2]["plugins"][0]["marketplacePath"].as_str(),
             Some("openai-curated-remote")
         );
+    }
+
+    #[test]
+    fn local_plugin_marketplaces_includes_every_app_bundled_plugin() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join("home");
+        let app_dir = temp.path().join("Codex");
+        let bundled_root = app_dir
+            .join("resources")
+            .join("plugins")
+            .join("openai-bundled");
+        let marketplace_dir = bundled_root.join(".agents").join("plugins");
+        let future_plugin_dir = bundled_root.join("plugins").join("future-tool");
+        std::fs::create_dir_all(&marketplace_dir).unwrap();
+        std::fs::create_dir_all(future_plugin_dir.join(".codex-plugin")).unwrap();
+        std::fs::write(
+            marketplace_dir.join("marketplace.json"),
+            r#"{"name":"openai-bundled","plugins":[{"name":"future-tool"},{"name":"sites"}]}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            future_plugin_dir.join(".codex-plugin").join("plugin.json"),
+            r#"{"interface":{"displayName":"Future Tool"}}"#,
+        )
+        .unwrap();
+
+        let marketplaces = local_plugin_marketplaces_from_sources(&home, Some(&app_dir));
+        let array = marketplaces.as_array().unwrap();
+
+        assert_eq!(array.len(), 1);
+        assert_eq!(array[0]["name"].as_str(), Some("openai-bundled"));
+        assert_eq!(array[0]["codexPlusSource"].as_str(), Some("app-bundled"));
+        assert_eq!(array[0]["plugins"].as_array().unwrap().len(), 2);
+        assert_eq!(array[0]["plugins"][0]["name"].as_str(), Some("future-tool"));
+        assert_eq!(
+            array[0]["plugins"][0]["interface"]["displayName"].as_str(),
+            Some("Future Tool")
+        );
+        assert_eq!(array[0]["plugins"][1]["name"].as_str(), Some("sites"));
+    }
+
+    #[test]
+    fn local_plugin_marketplaces_ignores_invalid_app_bundled_manifest() {
+        let temp = tempfile::tempdir().unwrap();
+        let app_dir = temp.path().join("Codex");
+        let marketplace_dir = app_dir
+            .join("resources")
+            .join("plugins")
+            .join("openai-bundled")
+            .join(".agents")
+            .join("plugins");
+        std::fs::create_dir_all(&marketplace_dir).unwrap();
+        std::fs::write(
+            marketplace_dir.join("marketplace.json"),
+            r#"{"name":"not-openai-bundled","plugins":[{"name":"browser"}]}"#,
+        )
+        .unwrap();
+
+        let marketplaces = local_plugin_marketplaces_from_sources(temp.path(), Some(&app_dir));
+
+        assert!(marketplaces.as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn injection_script_uses_the_exact_app_bundle_manifest() {
+        let temp = tempfile::tempdir().unwrap();
+        let app_dir = temp.path().join("Explicit Codex");
+        let marketplace_dir = app_dir
+            .join("resources")
+            .join("plugins")
+            .join("openai-bundled")
+            .join(".agents")
+            .join("plugins");
+        std::fs::create_dir_all(&marketplace_dir).unwrap();
+        std::fs::write(
+            marketplace_dir.join("marketplace.json"),
+            r#"{"name":"openai-bundled","plugins":[{"name":"future-exact-app-tool"}]}"#,
+        )
+        .unwrap();
+
+        let script = injection_script_with_settings_and_app_dir(
+            57321,
+            &BackendSettings::default(),
+            Some(&app_dir),
+        );
+
+        assert!(script.contains("future-exact-app-tool"));
+        assert!(script.contains(r#""codexPlusSource":"app-bundled""#));
+    }
+
+    #[test]
+    fn injection_script_falls_back_to_the_saved_app_bundle_manifest() {
+        let temp = tempfile::tempdir().unwrap();
+        #[cfg(windows)]
+        let app_dir = temp.path().join("Saved Codex");
+        #[cfg(not(windows))]
+        let app_dir = temp.path().join("Saved Codex.app");
+        #[cfg(windows)]
+        {
+            std::fs::create_dir_all(&app_dir).unwrap();
+            std::fs::write(app_dir.join("ChatGPT.exe"), []).unwrap();
+        }
+        #[cfg(windows)]
+        let marketplace_dir = app_dir
+            .join("resources")
+            .join("plugins")
+            .join("openai-bundled")
+            .join(".agents")
+            .join("plugins");
+        #[cfg(not(windows))]
+        let marketplace_dir = app_dir
+            .join("Contents")
+            .join("Resources")
+            .join("plugins")
+            .join("openai-bundled")
+            .join(".agents")
+            .join("plugins");
+        std::fs::create_dir_all(&marketplace_dir).unwrap();
+        std::fs::write(
+            marketplace_dir.join("marketplace.json"),
+            r#"{"name":"openai-bundled","plugins":[{"name":"future-saved-app-tool"}]}"#,
+        )
+        .unwrap();
+        let settings = BackendSettings {
+            codex_app_path: app_dir.to_string_lossy().to_string(),
+            ..BackendSettings::default()
+        };
+
+        let script = injection_script_with_settings(57321, &settings);
+
+        assert!(script.contains("future-saved-app-tool"));
     }
 }

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -182,6 +182,14 @@ pub trait LaunchHooks: Send + Sync {
         Ok(None)
     }
     async fn inject(&self, debug_port: u16, helper_port: u16) -> anyhow::Result<()>;
+    async fn inject_for_app(
+        &self,
+        debug_port: u16,
+        helper_port: u16,
+        _app_dir: &Path,
+    ) -> anyhow::Result<()> {
+        self.inject(debug_port, helper_port).await
+    }
     async fn inject_bridge(
         &self,
         debug_port: u16,
@@ -190,11 +198,23 @@ pub trait LaunchHooks: Send + Sync {
     ) -> anyhow::Result<()> {
         self.inject(debug_port, helper_port).await
     }
+    async fn inject_bridge_for_app(
+        &self,
+        debug_port: u16,
+        helper_port: u16,
+        ctx: crate::routes::BridgeContext,
+        _app_dir: &Path,
+    ) -> anyhow::Result<()> {
+        self.inject_bridge(debug_port, helper_port, ctx).await
+    }
     async fn ensure_injection(&self, debug_port: u16, helper_port: u16, app_dir: &Path) -> bool {
         for attempt in 1..=120 {
             let result = match self.bridge_context(debug_port, app_dir).await {
-                Ok(Some(ctx)) => self.inject_bridge(debug_port, helper_port, ctx).await,
-                Ok(None) => self.inject(debug_port, helper_port).await,
+                Ok(Some(ctx)) => {
+                    self.inject_bridge_for_app(debug_port, helper_port, ctx, app_dir)
+                        .await
+                }
+                Ok(None) => self.inject_for_app(debug_port, helper_port, app_dir).await,
                 Err(error) => Err(error),
             };
             match result {
@@ -819,7 +839,15 @@ impl LaunchHooks for DefaultLaunchHooks {
     }
 
     async fn inject(&self, debug_port: u16, helper_port: u16) -> anyhow::Result<()> {
-        retry_injection(debug_port, helper_port).await
+        retry_injection(debug_port, helper_port, None).await
+    }
+    async fn inject_for_app(
+        &self,
+        debug_port: u16,
+        helper_port: u16,
+        app_dir: &Path,
+    ) -> anyhow::Result<()> {
+        retry_injection(debug_port, helper_port, Some(app_dir)).await
     }
     async fn start_bridge_watchdog(&self, debug_port: u16, helper_port: u16) -> anyhow::Result<()> {
         let bridge_reinjector = self.bridge_reinjector.lock().await.clone();
@@ -2293,10 +2321,14 @@ pub fn build_packaged_activation_with_native_menu_inspector(
     })
 }
 
-async fn retry_injection(debug_port: u16, helper_port: u16) -> anyhow::Result<()> {
+async fn retry_injection(
+    debug_port: u16,
+    helper_port: u16,
+    app_dir: Option<&Path>,
+) -> anyhow::Result<()> {
     let mut last_error = None;
     for _ in 0..20 {
-        match try_inject(debug_port, helper_port).await {
+        match try_inject(debug_port, helper_port, app_dir).await {
             Ok(()) => return Ok(()),
             Err(error) => {
                 last_error = Some(error);
@@ -2359,8 +2391,9 @@ async fn check_and_reinject_bridge_inner(
             "browser_identity_changed": browser_identity_changed
         }),
     );
-    let default_reinjector: BridgeReinjector =
-        Arc::new(move || Box::pin(async move { retry_injection(debug_port, helper_port).await }));
+    let default_reinjector: BridgeReinjector = Arc::new(move || {
+        Box::pin(async move { retry_injection(debug_port, helper_port, None).await })
+    });
     let reinject_result = run_bridge_reinjector(bridge_reinjector, default_reinjector).await;
     match reinject_result {
         Ok(()) => {
@@ -2422,7 +2455,11 @@ fn runtime_evaluate_result_is_true(result: &Value) -> bool {
         .unwrap_or(false)
 }
 
-async fn try_inject(debug_port: u16, helper_port: u16) -> anyhow::Result<()> {
+async fn try_inject(
+    debug_port: u16,
+    helper_port: u16,
+    app_dir: Option<&Path>,
+) -> anyhow::Result<()> {
     let targets = crate::cdp::list_targets(debug_port).await?;
     let target = crate::cdp::pick_injectable_codex_page_target(&targets)?;
     let websocket_url = target
@@ -2430,7 +2467,8 @@ async fn try_inject(debug_port: u16, helper_port: u16) -> anyhow::Result<()> {
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("selected CDP target has no websocket URL"))?;
     let settings = SettingsStore::default().load().unwrap_or_default();
-    let script = crate::assets::injection_script_with_settings(helper_port, &settings);
+    let script =
+        crate::assets::injection_script_with_settings_and_app_dir(helper_port, &settings, app_dir);
     let ctx = crate::routes::BridgeContext::core(Arc::new(crate::routes::CoreRuntimeService::new(
         debug_port,
         StatusStore::default(),

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -992,7 +992,7 @@ fn injection_script_does_not_unlock_disabled_plugin_install_buttons() {
 fn injection_script_keeps_bundled_marketplace_name_for_default_filter() {
     let script = assets::injection_script(57321);
 
-    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"15\""));
+    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"16\""));
     assert!(!script.contains("function pluginMarketplaceAliasForName"));
     assert!(
         !script.contains("if (name === \"openai-bundled\") return \"codex-plus-openai-bundled\"")
@@ -1004,7 +1004,7 @@ fn injection_script_keeps_bundled_marketplace_name_for_default_filter() {
 fn injection_script_does_not_bypass_plugin_marketplace_search_filters() {
     let script = assets::injection_script(57321);
 
-    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"15\""));
+    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"16\""));
     assert!(script.contains("codexPluginFilterSourceCache = new WeakMap()"));
     assert!(script.contains("function codexPluginFilterCallbackSource(callback)"));
     assert!(script.contains("isCodexPluginBuildFlavorFilter"));
@@ -1019,7 +1019,7 @@ fn injection_script_does_not_bypass_plugin_marketplace_search_filters() {
 fn injection_script_expands_api_key_plugin_marketplace_requests() {
     let script = assets::injection_script(57321);
 
-    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"15\""));
+    assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"16\""));
     assert!(script.contains("installPluginMarketplaceRequestPatch"));
     assert!(script.contains("installPluginMarketplaceBridgePatch"));
     assert!(script.contains("installPluginBuildFlavorFilterPatch"));
@@ -1028,9 +1028,7 @@ fn injection_script_expands_api_key_plugin_marketplace_requests() {
     assert!(script.contains("isCodexPluginBuildFlavorFilter"));
     assert!(script.contains("!filtered.includes(plugin) : !callback(plugin)"));
     assert!(script.contains("isCodexPluginMarketplaceHiddenFilter"));
-    assert!(script.contains(
-        "!filtered.includes(marketplace) : !callback(marketplace)"
-    ));
+    assert!(script.contains("!filtered.includes(marketplace) : !callback(marketplace)"));
     assert!(script.contains("plugin_marketplace_hidden_filter_bypassed"));
     assert!(script.contains("method === \"list-plugins\""));
     assert!(script.contains("method === \"vscode://codex/list-plugins\""));
@@ -1116,6 +1114,13 @@ fn injection_script_recovers_plugin_search_from_remote_auth_errors() {
     assert_eq!(cases["buildFlavorMatchedAgain"], true);
     assert_eq!(cases["cachedFunctionToStringCalls"], 1);
     assert_eq!(cases["initialKinds"], json!(["local", "vertical"]));
+    assert_eq!(
+        cases["bundledPluginNames"],
+        json!(["browser", "sites", "future-tool"])
+    );
+    assert_eq!(cases["existingBundledDisabled"], true);
+    assert_eq!(cases["bundledSourceLeaked"], false);
+    assert_eq!(cases["addedAppBundledPlugins"], 2);
     assert_eq!(cases["latestBroadOmittedHasKinds"], false);
     assert_eq!(cases["latestBroadOmittedKinds"], serde_json::Value::Null);
     assert_eq!(cases["latestBroadNullHasKinds"], true);
@@ -1144,9 +1149,12 @@ fn injection_script_recovers_plugin_search_from_remote_auth_errors() {
     assert_eq!(cases["generalAfterFallbackCwds"], json!(["C:/workspace"]));
     assert_eq!(
         cases["localFallbackMarketplaceNames"],
-        json!(["fixture-local"])
+        json!(["fixture-local", "openai-bundled"])
     );
-    assert_eq!(cases["localFallbackPluginNames"], json!(["alpha"]));
+    assert_eq!(
+        cases["localFallbackPluginNames"],
+        json!(["alpha", "browser", "sites", "future-tool"])
+    );
     assert_eq!(cases["chatGptKinds"], json!(["created-by-me-remote"]));
     assert_eq!(cases["unrelatedErrorMatched"], false);
 }
@@ -1198,6 +1206,14 @@ window.__CODEX_PLUS_PLUGIN_MARKETPLACES__ = [{{
   displayName: "Fixture Local",
   path: "C:/fixture/marketplace.json",
   plugins: [{{ id: "alpha@fixture-local", name: "alpha", marketplaceName: "fixture-local" }}],
+}}, {{
+  name: "openai-bundled",
+  codexPlusSource: "app-bundled",
+  plugins: [
+    {{ id: "browser@openai-bundled", name: "browser", marketplaceName: "openai-bundled" }},
+    {{ id: "sites@openai-bundled", name: "sites", marketplaceName: "openai-bundled" }},
+    {{ id: "future-tool@openai-bundled", name: "future-tool", marketplaceName: "openai-bundled" }},
+  ],
 }}];
 const api = window.__codexPlusPluginMarketplaceTest;
 api.reset();
@@ -1220,6 +1236,14 @@ const buildFlavorMatched = api.isBuildFlavorFilter(buildFlavorFilter, officialPl
 const buildFlavorMatchedAgain = api.isBuildFlavorFilter(buildFlavorFilter, officialPlugins);
 const cachedFunctionToStringCalls = functionToStringCalls - ordinaryFunctionToStringCalls;
 Function.prototype.toString = nativeFunctionToString;
+const nativeBundledResult = {{
+  marketplaces: [{{
+    name: "openai-bundled",
+    plugins: [{{ id: "browser@openai-bundled", disabled: true }}],
+  }}],
+}};
+const bundledMerge = api.mergeLocal(nativeBundledResult);
+const recoveredBundled = nativeBundledResult.marketplaces[0];
 const initial = api.patchRequestParams("list-plugins", {{ cwds: ["C:/workspace"] }});
 api.setCodexAppVersion("26.803.41515");
 const latestBroadOmitted = api.patchRequestParams("list-plugins", {{ cwds: ["C:/workspace"] }});
@@ -1257,6 +1281,10 @@ const cases = {{
   buildFlavorMatchedAgain,
   cachedFunctionToStringCalls,
   initialKinds: initial.marketplaceKinds,
+  bundledPluginNames: recoveredBundled.plugins.map((plugin) => plugin.name),
+  existingBundledDisabled: recoveredBundled.plugins.find((plugin) => plugin.name === "browser")?.disabled,
+  bundledSourceLeaked: Object.prototype.hasOwnProperty.call(recoveredBundled, "codexPlusSource"),
+  addedAppBundledPlugins: bundledMerge.addedAppBundledPlugins,
   latestBroadOmittedHasKinds: Object.prototype.hasOwnProperty.call(latestBroadOmitted, "marketplaceKinds"),
   latestBroadOmittedKinds: latestBroadOmitted.marketplaceKinds ?? null,
   latestBroadNullHasKinds: Object.prototype.hasOwnProperty.call(latestBroadNull, "marketplaceKinds"),


### PR DESCRIPTION
## 中文

### 背景

旧 PR #1537 依赖固定的 Browser / Chrome / Computer Use 名单，并包含已经被当前上游移除的 Computer Use guard、provider switch 和配置维护链。新版 Codex App 直接在应用包内提供 `openai-bundled` marketplace；继续维护旧名单会遗漏后续新增插件，也可能让旧缓存遮蔽当前 App 的真实清单。

### 本 PR

- 从本次实际启动的 Codex App 目录读取包内 `openai-bundled/.agents/plugins/marketplace.json`。
- Windows、macOS 及常见 unpacked 资源布局均为只读探测；缺失、不可读或格式无效时 fail open，不影响原生流程。
- 将 App manifest 中的全部插件动态合并到普通 `plugin/list` 结果；未来新增插件无需修改 Codex++ 名单。
- 只补齐缺失插件与缺失元数据，不覆盖原生 `disabled`、`hidden`、`available` 或限制原因。
- 首次注入绑定实际解析的 App 目录；watchdog 重注入回退到保存路径/平台探测。
- 不写入 `[marketplaces.openai-bundled]`，不恢复 provider-switch guard、watchdog 配置维护或持久化 baseline。

本 PR 已取代 #1537 的维护方向；旧 PR 已关闭并保留为历史对照。

### 验证

- `cargo test -p codex-plus-core --lib -j 2`：227/227
- `cargo test -p codex-plus-core --test cdp_bridge -j 2`：109/109
- `cargo test -p codex-plus-core --test launcher -j 2`：79/79
- `cargo test -p codex-plus-core --test bridge_routes -j 2`：30/30
- App manifest / fallback 聚焦资产测试：6/6
- `cargo check -p codex-plus-launcher -j 2`
- `node --check assets/inject/renderer-inject.js`
- focused rustfmt checks for the changed core/test Rust files and `git diff --check`; the launcher entry file still has a pre-existing upstream rustfmt diff at `launcher_main`

### 真人验证

- Windows 本地安装了包含本 PR 同等逻辑的累计构建（累计提交 `1548c87`，保留其他尚未发布功能）。
- 用户已完成本地真人启动与插件 UI 验收，确认当前 App 的内置插件已全量显示并解锁。
- 该结果验证的是等价累计构建的 Windows 真实使用路径；聚焦 PR 分支二进制未单独安装，macOS 仍由 CI 覆盖。

## English

### Background

PR #1537 relied on a fixed Browser / Chrome / Computer Use allowlist and on Computer Use guard/provider-switch maintenance paths that current upstream has removed. Current Codex App packages the authoritative `openai-bundled` marketplace directly, so a fixed list can miss newly bundled plugins and let stale caches hide the App's current catalog.

### This PR

- Reads the packaged `openai-bundled/.agents/plugins/marketplace.json` from the exact Codex App directory used for launch.
- Probes Windows, macOS, and common unpacked resource layouts read-only; missing or invalid manifests fail open.
- Dynamically merges every packaged plugin into ordinary `plugin/list` results, so future additions require no Codex++ allowlist update.
- Fills only missing plugins and metadata. Native `disabled`, `hidden`, `available`, and restriction fields remain authoritative.
- Pins initial injection to the resolved App directory and lets watchdog reinjection fall back to the saved/platform-resolved App path.
- Does not write `[marketplaces.openai-bundled]` or restore provider-switch guards, config watchdogs, or persistent baselines.

This supersedes the maintenance direction of #1537. The older PR is now closed and retained only as historical context.

### Validation

- core lib: 227/227
- CDP bridge: 109/109
- launcher lifecycle: 79/79
- bridge routes: 30/30
- focused App-manifest/fallback asset tests: 6/6
- launcher cargo check
- renderer JavaScript syntax
- focused rustfmt checks for the changed core/test Rust files and diff checks; the launcher entry file still has a pre-existing upstream rustfmt diff at `launcher_main`

### Human validation

- A cumulative Windows build carrying the same PR behavior was installed locally at cumulative commit `1548c87` while preserving the other unpublished local features.
- The user completed a real local launch and plugin UI acceptance test, confirming that the current App's bundled plugins are all visible and unlocked.
- This validates the equivalent cumulative Windows path; the focused PR binary was not installed separately, while macOS remains covered by CI.

### CI

GitHub Actions run 32261490989 passed Windows artifacts, macOS x64, and macOS arm64.