### PR TITLE
fix(proxy): always emit output_tokens_details.reasoning_tokens in usage / 始终在 usage 中补全 reasoning_tokens 字段

### DIFF
--- a/crates/codex-plus-core/src/protocol_proxy.rs
+++ b/crates/codex-plus-core/src/protocol_proxy.rs
@@ -3493,7 +3493,14 @@ fn extract_reasoning_summary_text(value: &Value) -> Option<String> {
 }
 
 fn default_responses_usage() -> Value {
-    json!({ "input_tokens": 0, "output_tokens": 0, "total_tokens": 0 })
+    // Codex 把 output_tokens_details.reasoning_tokens 当必填解析,
+    // 兜底 usage 也必须带齐该结构。
+    json!({
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "output_tokens_details": { "reasoning_tokens": 0 }
+    })
 }
 
 fn chat_usage_to_responses_usage(usage: Option<&Value>) -> Value {
@@ -3597,7 +3604,19 @@ fn chat_usage_to_responses_usage(usage: Option<&Value>) -> Value {
         result["input_tokens_details"] = json!({ "cached_tokens": cached_tokens });
     }
     if let Some(details) = usage.get("completion_tokens_details") {
-        result["output_tokens_details"] = details.clone();
+        // Codex parses output_tokens_details.reasoning_tokens as a required field;
+        // upstreams (e.g. Kimi) omit the key when a response had no reasoning,
+        // which makes the Responses client fail with "missing field
+        // `reasoning_tokens`" and abort the whole turn. Default it to 0.
+        let mut details = details.clone();
+        if details.is_object() && details.get("reasoning_tokens").is_none() {
+            details["reasoning_tokens"] = json!(0);
+        }
+        result["output_tokens_details"] = details;
+    } else {
+        // 上游连 completion_tokens_details 都没给时同样补全, 避免
+        // Codex 解析 response.completed 时缺字段断流。
+        result["output_tokens_details"] = json!({ "reasoning_tokens": 0 });
     }
     if let Some(cache_read) = usage.get("cache_read_input_tokens") {
         result["cache_read_input_tokens"] = cache_read.clone();

--- a/crates/codex-plus-core/tests/protocol_proxy.rs
+++ b/crates/codex-plus-core/tests/protocol_proxy.rs
@@ -966,6 +966,74 @@ fn chat_completion_response_maps_reasoning_tool_calls_and_usage_details() {
 }
 
 #[test]
+fn chat_completion_response_defaults_missing_reasoning_tokens_to_zero() {
+    // Kimi 等上游在一次响应无 reasoning 时会省略 completion_tokens_details
+    // 里的 reasoning_tokens; Codex 将该字段当必填解析, 缺省会报
+    // "missing field `reasoning_tokens`" 并把整轮判为断流。
+    let converted = chat_completion_to_response(json!({
+        "id": "chatcmpl_no_reasoning",
+        "created": 123,
+        "model": "k3-256k",
+        "choices": [{
+            "finish_reason": "stop",
+            "message": { "role": "assistant", "content": "done" }
+        }],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "completion_tokens_details": {}
+        }
+    }))
+    .unwrap();
+    assert_eq!(
+        converted["usage"]["output_tokens_details"]["reasoning_tokens"],
+        0
+    );
+}
+
+#[test]
+fn chat_sse_defaults_missing_reasoning_tokens_to_zero() {
+    let sse = chat_sse_to_responses_sse(
+        r#"data: {"id":"chatcmpl_kimi","created":123,"model":"k3-256k","choices":[{"delta":{"content":"Done"},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":6,"total_tokens":10,"completion_tokens_details":{}}}
+
+data: [DONE]
+
+"#,
+    );
+    assert!(sse.contains("event: response.completed"));
+    assert!(sse.contains("\"reasoning_tokens\":0"));
+}
+
+#[test]
+fn chat_sse_without_usage_details_still_emits_reasoning_tokens() {
+    // 上游连 completion_tokens_details 都没有时也要补上, Codex 才能解析。
+    let sse = chat_sse_to_responses_sse(
+        r#"data: {"id":"chatcmpl_plain","created":123,"model":"k3-256k","choices":[{"delta":{"content":"Done"},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":6,"total_tokens":10}}
+
+data: [DONE]
+
+"#,
+    );
+    assert!(sse.contains("event: response.completed"));
+    assert!(sse.contains("\"output_tokens_details\":{\"reasoning_tokens\":0}"));
+}
+
+#[test]
+fn chat_sse_without_any_usage_still_emits_reasoning_tokens() {
+    // 上游全程未发 usage chunk → default usage 兜底同样带齐结构。
+    let sse = chat_sse_to_responses_sse(
+        r#"data: {"id":"chatcmpl_nousg","created":123,"model":"k3-256k","choices":[{"delta":{"content":"Done"},"finish_reason":"stop"}]}
+
+data: [DONE]
+
+"#,
+    );
+    assert!(sse.contains("event: response.completed"));
+    assert!(sse.contains("\"reasoning_tokens\":0"));
+}
+
+#[test]
 fn chat_completion_response_extracts_reasoning_details_like_ccswitch() {
     let converted = chat_completion_to_response(json!({
         "id": "chatcmpl_reasoning_details",


### PR DESCRIPTION
## 中文

### 问题

Codex（Responses API 客户端）在解析 `response.completed` 时，`usage.output_tokens_details.reasoning_tokens` 是必填字段。部分上游（如 Kimi For Coding）在响应未使用推理 token 时会省略该字段。中转层此前原样透传 details 对象，导致 Codex 报 `missing field 'reasoning_tokens'`，并把整个回合按 `stream disconnected before completion` 中止——尽管全部内容其实已经流式返回完毕。

### 改动

在所有可能产生缺失该字段的 `response.completed` 的路径上补 `reasoning_tokens = 0`：

- 上游返回了 `completion_tokens_details` 但缺少 `reasoning_tokens` key
- 上游完全未返回 `completion_tokens_details`
- 上游从未发送 usage chunk（`default_responses_usage` 兜底路径）

由此中转层产出的每个 `response.completed` 都能被 Codex 正常解析，回合不再被误中止。

### 测试

新增 4 个测试覆盖上述路径（unary 与 SSE 转换两侧）：

- `chat_completion_response_defaults_missing_reasoning_tokens_to_zero`
- `chat_sse_defaults_missing_reasoning_tokens_to_zero`
- `chat_sse_without_usage_details_still_emits_reasoning_tokens`
- `chat_sse_without_any_usage_still_emits_reasoning_tokens`

本地 `cargo test -p codex-plus-core` 全部通过。

---

## English

### Problem

Codex (a Responses API client) parses `response.completed` with `usage.output_tokens_details.reasoning_tokens` as a required field. Some upstreams (e.g. Kimi For Coding) omit the key when a response used no reasoning tokens. The relay passed the details object through verbatim, so Codex failed with `missing field 'reasoning_tokens'` and aborted the whole turn as `stream disconnected before completion` — even though all content had already streamed.

### Change

Emit `reasoning_tokens = 0` on every path that can produce a `response.completed` without it:

- the upstream sends `completion_tokens_details` without the `reasoning_tokens` key
- the upstream sends no `completion_tokens_details` at all
- the upstream never sends a usage chunk (the `default_responses_usage` fallback)

Every `response.completed` the relay produces is now parseable by Codex, so turns are no longer aborted spuriously.

### Tests

Four new tests cover the paths above, on both the unary and the SSE conversion sides:

- `chat_completion_response_defaults_missing_reasoning_tokens_to_zero`
- `chat_sse_defaults_missing_reasoning_tokens_to_zero`
- `chat_sse_without_usage_details_still_emits_reasoning_tokens`
- `chat_sse_without_any_usage_still_emits_reasoning_tokens`

`cargo test -p codex-plus-core` passes locally.
