### PR TITLE
feat(proxy): forward reasoning effort for Kimi For Coding models / 为 Kimi For Coding 模型转发 reasoning_effort

### DIFF
--- a/crates/codex-plus-core/src/protocol_proxy.rs
+++ b/crates/codex-plus-core/src/protocol_proxy.rs
@@ -4117,6 +4117,13 @@ fn apply_chat_reasoning_options(result: &mut Value, body: &Value, model: &str) {
         {
             result["reasoning_effort"] = json!(mapped);
         }
+        // Kimi For Coding (K3 / K2.7 Code): 官方接受 reasoning_effort 三档
+        // low/high/max (默认 high), 且服务端会把 medium→high、xhigh→max。
+        // 仅限 for-coding 模型 ID, 避免给 glm/mimo/kimi-k2 等其它
+        // Thinking 方言上游误发该字段。
+        ChatReasoningStyle::Thinking if is_kimi_coding_model(model) => {
+            result["reasoning_effort"] = json!(mapped);
+        }
         _ => {}
     }
 }
@@ -4145,6 +4152,7 @@ fn infer_chat_reasoning_style(model: &str) -> ChatReasoningStyle {
     }
     if model.contains("kimi")
         || model.contains("moonshot")
+        || model.starts_with("k3")
         || model.contains("glm")
         || model.contains("zhipu")
         || model.contains("z.ai")
@@ -4187,6 +4195,14 @@ fn map_chat_reasoning_effort(effort: &str, style: ChatReasoningStyle) -> Option<
             "minimal" => Some("minimal"),
             _ => None,
         },
+        // Kimi For Coding 官方映射: minimal/low→low, medium/high→high,
+        // xhigh/max→max。注意不能直接透传 "minimal", 服务端不认会 400。
+        ChatReasoningStyle::Thinking => match effort.as_str() {
+            "minimal" | "low" => Some("low"),
+            "medium" | "high" => Some("high"),
+            "xhigh" | "max" => Some("max"),
+            _ => None,
+        },
         _ => match effort.as_str() {
             "minimal" => Some("minimal"),
             "low" => Some("low"),
@@ -4197,6 +4213,14 @@ fn map_chat_reasoning_effort(effort: &str, style: ChatReasoningStyle) -> Option<
             _ => None,
         },
     }
+}
+
+/// Kimi For Coding 专属模型 ID(k3 / k3-256k / kimi-for-coding[-highspeed])。
+/// 只有这些上游接受 `reasoning_effort` 三档; kimi-k2-thinking 等旧模型
+/// 仍只发 thinking 开关。
+fn is_kimi_coding_model(model: &str) -> bool {
+    let model = model.to_ascii_lowercase();
+    model.starts_with("k3") || model.contains("for-coding")
 }
 
 fn supports_reasoning_effort(model: &str) -> bool {

--- a/crates/codex-plus-core/tests/protocol_proxy.rs
+++ b/crates/codex-plus-core/tests/protocol_proxy.rs
@@ -255,6 +255,47 @@ fn responses_request_applies_ccswitch_reasoning_dialects() {
 }
 
 #[test]
+fn responses_request_maps_kimi_coding_reasoning_effort_per_official_spec() {
+    // 官方映射 (kimi.com/code/docs): K3 接受 reasoning_effort low/high/max,
+    // Codex 档位 minimal/low→low, medium/high→high, xhigh/max→max。
+    for (effort, expected) in [
+        ("minimal", "low"),
+        ("low", "low"),
+        ("medium", "high"),
+        ("high", "high"),
+        ("xhigh", "max"),
+        ("max", "max"),
+    ] {
+        let converted = responses_to_chat_completions(json!({
+            "model": "k3-256k",
+            "reasoning": { "effort": effort },
+            "input": "hi"
+        }))
+        .unwrap();
+        assert_eq!(converted["thinking"]["type"], "enabled", "{effort}");
+        assert_eq!(converted["reasoning_effort"], expected, "{effort}");
+    }
+
+    let k2_coding = responses_to_chat_completions(json!({
+        "model": "kimi-for-coding",
+        "reasoning": { "effort": "xhigh" },
+        "input": "hi"
+    }))
+    .unwrap();
+    assert_eq!(k2_coding["reasoning_effort"], "max");
+
+    // effort none → thinking disabled (官方: K3 关思考会被路由到 K2.6, 保持现状)
+    let off = responses_to_chat_completions(json!({
+        "model": "k3-256k",
+        "reasoning": { "effort": "none" },
+        "input": "hi"
+    }))
+    .unwrap();
+    assert_eq!(off["thinking"]["type"], "disabled");
+    assert!(off.get("reasoning_effort").is_none());
+}
+
+#[test]
 fn responses_request_maps_developer_role_to_system_for_chat_upstream() {
     let converted = responses_to_chat_completions(json!({
         "model": "deepseek-chat",


### PR DESCRIPTION
## 中文

### 背景

按 Kimi For Coding 官方文档（kimi.com/code/docs），K3 接受 `reasoning_effort` 取值 `low` / `high` / `max`（默认 `high`），并将客户端取值映射为：`minimal`/`low` → `low`，`medium`/`high` → `high`，`xhigh`/`max` → `max`；未知取值会被上游以 HTTP 400 拒绝。

现有两处缺口导致 Codex 中选择的推理档位被静默忽略：

- `infer_chat_reasoning_style` 不识别 `k3` / `k3-256k` 这类模型 ID（不含 `kimi` / `moonshot` 子串），请求落入 Default 方言，思考开关与推理档位都不会被转发，完全依赖服务端默认值
- Thinking 方言本身从不转发 `reasoning_effort`

### 改动

- `k3*` / `*-for-coding` 形式的模型 ID 现在归类为 Thinking 方言
- 仅对这类模型，把映射后的 `low` / `high` / `max` 作为 `reasoning_effort` 发送（`minimal` 折叠为 `low`，避免透传后被上游 400 拒绝）
- 旧版 `kimi-k2-thinking` 及其他 Thinking 方言上游（glm / mimo / ...）保持仅转发思考开关的行为，不受影响

### 测试

新增测试 `responses_request_maps_kimi_coding_reasoning_effort_per_official_spec`，覆盖：

- 全部 6 个 Codex 档位（`minimal`/`low`/`medium`/`high`/`xhigh`/`max`）到官方三档的映射
- `kimi-for-coding` 形式模型 ID 的识别
- `effort: none` 时关闭思考且不发送 `reasoning_effort`

本地 `cargo test -p codex-plus-core --test protocol_proxy` 全部通过。

---

## English

### Background

Per the official Kimi For Coding docs (kimi.com/code/docs), K3 accepts `reasoning_effort` values `low` / `high` / `max` (default `high`) and maps client values: `minimal`/`low` → `low`, `medium`/`high` → `high`, `xhigh`/`max` → `max`; unknown values are rejected with HTTP 400.

Two gaps made Codex's selected effort silently ineffective:

- `infer_chat_reasoning_style` did not recognize the `k3` / `k3-256k` model IDs (no `kimi` / `moonshot` substring), so requests fell into the Default dialect and neither the thinking switch nor the effort was forwarded — everything relied on server-side defaults
- The Thinking dialect never forwarded `reasoning_effort` at all

### Change

- `k3*` / `*-for-coding` model IDs are now classified as the Thinking dialect
- For those models only, the mapped `low` / `high` / `max` value is sent as `reasoning_effort` (`minimal` is folded to `low` instead of being passed through to a 400)
- Legacy `kimi-k2-thinking` and other Thinking-dialect upstreams (glm / mimo / ...) keep the thinking-switch-only behavior, unchanged

### Tests

New test `responses_request_maps_kimi_coding_reasoning_effort_per_official_spec` covers:

- the mapping of all six Codex effort levels (`minimal`/`low`/`medium`/`high`/`xhigh`/`max`) onto the official three
- recognition of `kimi-for-coding`-style model IDs
- `effort: none` disabling thinking and omitting `reasoning_effort`

`cargo test -p codex-plus-core --test protocol_proxy` passes locally.
