### PR TITLE
fix: harden OpenAI provider boundary handling

### DIFF
--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -3018,7 +3018,7 @@
     return nextParams;
   }
 
-  function codexRemoteSessionProviderNormalizationEnabled() {
+  function codexRemoteSessionProviderPatchEnabled() {
     if (!codexPlusBackendSettings.relayProfilesEnabled) return false;
     const profiles = Array.isArray(codexPlusBackendSettings.relayProfiles)
       ? codexPlusBackendSettings.relayProfiles
@@ -3027,15 +3027,22 @@
     const profile = profiles.find((item) => String(item?.id || "") === activeId);
     if (!profile) return false;
     const relayMode = String(profile.relayMode || "");
-    const targetProvider = codexRemoteSessionTargetProvider();
     return relayMode === "official"
-      && !!profile.officialMixApiKey
-      && targetProvider !== "openai";
+      && !!profile.officialMixApiKey;
+  }
+
+  function codexRemoteSessionProviderNormalizationEnabled() {
+    if (!codexRemoteSessionProviderPatchEnabled()) return false;
+    const sessionProvider = String(
+      codexPlusBackendSettings.activeRelaySessionProvider || "custom"
+    ).trim().toLowerCase();
+    return sessionProvider !== "openai";
   }
 
   function codexRemoteSessionTargetProvider() {
     return String(
-      codexModelCatalog?.codex_model_provider
+      codexPlusBackendSettings.activeRelayCodexProvider
+      || codexModelCatalog?.codex_model_provider
       || codexModelCatalog?.codexModelProvider
       || codexModelCatalog?.model_provider
       || codexModelCatalog?.modelProvider
@@ -3411,7 +3418,7 @@
     void patch();
   }
 
-  async function loadBackendSettings() {
+  async function loadBackendSettingsState() {
     const seq = codexPlusBackendSettingsSeq;
     try {
       const settings = await postJson("/settings/get", {});
@@ -3423,15 +3430,19 @@
       }
       codexPlusBackendSettings = { ...codexPlusBackendSettings, ...settings };
       codexPlusBackendSettingsLoaded = true;
-      if (codexRemoteSessionProviderNormalizationEnabled()) {
-        void loadCodexModelCatalog();
-      }
-      refreshCodexPlusBackendToggles();
       return true;
     } catch (_) {
-      refreshCodexPlusBackendToggles();
       return false;
     }
+  }
+
+  async function loadBackendSettings() {
+    const loaded = await loadBackendSettingsState();
+    if (loaded && codexRemoteSessionProviderNormalizationEnabled()) {
+      void loadCodexModelCatalog();
+    }
+    refreshCodexPlusBackendToggles();
+    return loaded;
   }
 
   function loadBackendSettingsForStartup(attempt = 0) {
@@ -6041,6 +6052,8 @@
         codexPlusBackendSettings = { ...codexPlusBackendSettings, ...settings };
         codexPlusBackendSettingsLoaded = true;
       },
+      providerPatchEnabled: () => codexRemoteSessionProviderPatchEnabled(),
+      providerNormalizationEnabled: () => codexRemoteSessionProviderNormalizationEnabled(),
       setServiceTierState: (state = {}) => {
         codexServiceTierState = { ...codexServiceTierState, ...state };
       },
@@ -6469,12 +6482,19 @@
     client.__codexPlusModelOriginalSendRequest = originalSendRequest;
     client.sendRequest = async function codexPlusModelPatchedSendRequest(method, params, options) {
       const requestMethod = appServerModelRequestMethod(String(method || ""), params);
+      let providerRefreshFailed = false;
       if (codexRemoteSessionThreadStartMethod(requestMethod)
-          && codexRemoteSessionProviderNormalizationEnabled()
-          && !codexRemoteSessionTargetProvider()) {
-        await loadCodexModelCatalog();
+          && codexRemoteSessionProviderPatchEnabled()
+          && window.__codexSessionDeleteBridge) {
+        const settingsLoaded = await loadBackendSettingsState();
+        providerRefreshFailed = !settingsLoaded;
+        if (providerRefreshFailed) {
+          sendCodexPlusDiagnostic("remote_session_provider_refresh_failed", {});
+        }
       }
-      const nextParams = applyCodexRemoteSessionProviderOverride(requestMethod, params);
+      const nextParams = providerRefreshFailed
+        ? params
+        : applyCodexRemoteSessionProviderOverride(requestMethod, params);
       const result = await originalSendRequest(method, nextParams, options);
       if (!codexPlusModelUnlockEnabled()) return result;
       if (!codexPlusModelNames().length) await loadCodexModelCatalog();
@@ -6491,7 +6511,7 @@
   let appServerModelRequestPatchRetryTimer = 0;
 
   function scheduleAppServerModelRequestPatchRetry() {
-    if (!codexRemoteSessionProviderNormalizationEnabled()) return;
+    if (!codexRemoteSessionProviderPatchEnabled()) return;
     if (appServerModelRequestPatchRetryTimer) return;
     appServerModelRequestPatchRetryTimer = window.setTimeout(() => {
       appServerModelRequestPatchRetryTimer = 0;
@@ -6513,7 +6533,7 @@
     if (appServerModelRequestPatchMissCount === 1) {
       sendCodexPlusDiagnostic(event, detail);
     }
-    if (codexRemoteSessionProviderNormalizationEnabled()) {
+    if (codexRemoteSessionProviderPatchEnabled()) {
       scheduleAppServerModelRequestPatchRetry();
       return;
     }
@@ -6578,7 +6598,7 @@
 
   function ensureCodexModelWhitelistInstalls() {
     if (codexPlusModelUnlockEnabled()
-        || (codexPlusBackendSettingsLoaded && codexRemoteSessionProviderNormalizationEnabled())) {
+        || (codexPlusBackendSettingsLoaded && codexRemoteSessionProviderPatchEnabled())) {
       installAppServerModelRequestPatch();
     }
     if (!codexPlusModelUnlockEnabled()) return;

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use serde::Serialize;
 use serde_json::{Value, json};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use toml_edit::{DocumentMut, Item, Table, TableLike};
@@ -206,6 +206,7 @@ pub fn relay_config_status_from_home(home: &Path) -> RelayConfigStatus {
     let config_path = home.join("config.toml");
     let contents = std::fs::read_to_string(&config_path).unwrap_or_default();
     let auth_contents = std::fs::read_to_string(home.join("auth.json")).unwrap_or_default();
+    let has_auth_api_key = codex_auth_api_key(&auth_contents).is_some();
     let root_provider = root_key_string(&contents, "model_provider");
     let provider = root_provider.as_ref().and_then(|provider| {
         let active = table_values(&contents, &format!("model_providers.{provider}"));
@@ -213,13 +214,21 @@ pub fn relay_config_status_from_home(home: &Path) -> RelayConfigStatus {
             return active;
         }
 
+        if active
+            .as_ref()
+            .is_some_and(|values| provider_values_are_configured(values, has_auth_api_key))
+        {
+            return active;
+        }
+
+        let uses_managed_openai_identity = root_key_string(&contents, OPENAI_BASE_URL_KEY)
+            .is_some_and(|value| value.trim() == managed_openai_base_url());
+        if !uses_managed_openai_identity {
+            return active;
+        }
+
         table_values(&contents, &format!("model_providers.{RELAY_PROVIDER}"))
-            .filter(|values| {
-                values
-                    .get("base_url")
-                    .map(|value| !unquote_toml_string(value).trim().is_empty())
-                    .unwrap_or(false)
-            })
+            .filter(|values| provider_values_are_configured(values, has_auth_api_key))
             .or(active)
     });
     let requires_openai_auth = provider
@@ -240,12 +249,25 @@ pub fn relay_config_status_from_home(home: &Path) -> RelayConfigStatus {
         .unwrap_or(false);
     RelayConfigStatus {
         configured: root_provider.is_some()
-            && (has_bearer_token || codex_auth_api_key(&auth_contents).is_some())
+            && (has_bearer_token || has_auth_api_key)
             && has_base_url,
         requires_openai_auth,
         has_bearer_token,
         config_path: config_path.to_string_lossy().to_string(),
     }
+}
+
+fn provider_values_are_configured(
+    values: &HashMap<String, String>,
+    has_auth_api_key: bool,
+) -> bool {
+    let has_base_url = values
+        .get("base_url")
+        .is_some_and(|value| !unquote_toml_string(value).trim().is_empty());
+    let has_bearer_token = values
+        .get("experimental_bearer_token")
+        .is_some_and(|value| !unquote_toml_string(value).trim().is_empty());
+    has_base_url && (has_bearer_token || has_auth_api_key)
 }
 
 pub fn responses_proxy_configured_in_home(home: &Path) -> bool {

--- a/crates/codex-plus-core/src/routes.rs
+++ b/crates/codex-plus-core/src/routes.rs
@@ -584,16 +584,28 @@ impl BridgeDataService for UnavailableDataService {
     ) -> anyhow::Result<Option<SessionRef>> {
         Ok(None)
     }
-
 }
 
 fn settings_payload_value(
     settings: BackendSettings,
     codex_app_version: String,
 ) -> anyhow::Result<Value> {
+    let active_relay_session_provider = settings.active_relay_session_provider();
+    let active_relay_codex_provider = crate::model_catalog::codex_model_provider_for_relay_profile(
+        &crate::relay_config::default_codex_home_dir(),
+        &settings.active_relay_profile(),
+    );
     let mut value = serde_json::to_value(settings)?;
     if let Some(object) = value.as_object_mut() {
         object.remove("codexAppStepwiseApiKey");
+        object.insert(
+            "activeRelaySessionProvider".to_string(),
+            Value::String(active_relay_session_provider.as_str().to_string()),
+        );
+        object.insert(
+            "activeRelayCodexProvider".to_string(),
+            Value::String(active_relay_codex_provider),
+        );
         object.insert(
             "codexAppVersion".to_string(),
             Value::String(codex_app_version),

--- a/crates/codex-plus-core/tests/bridge_routes.rs
+++ b/crates/codex-plus-core/tests/bridge_routes.rs
@@ -169,9 +169,52 @@ async fn settings_get_includes_runtime_codex_app_version() {
     let result = handle_bridge_request(ctx, "/settings/get", json!({})).await;
 
     assert_eq!(result["codexAppVersion"], json!("26.601.21317"));
+    assert_eq!(result["activeRelaySessionProvider"], json!("custom"));
     assert_eq!(result["codexAppPluginMarketplaceUnlock"], json!(true));
     assert_eq!(result.get("codexAppForcePluginInstall"), None);
     assert_eq!(result["codexAppThreadIdBadge"], json!(false));
+}
+
+#[tokio::test]
+async fn settings_get_exposes_active_openai_session_provider() {
+    let settings = BackendSettings {
+        relay_profiles: vec![codex_plus_core::settings::RelayProfile {
+            config_contents: "model_provider = \"openai\"\n".to_string(),
+            ..codex_plus_core::settings::RelayProfile::default()
+        }],
+        ..BackendSettings::default()
+    };
+    let ctx = BridgeContext::new(
+        Arc::new(FakeSettings::with_settings(settings)),
+        Arc::new(FakeRuntime::default()),
+        Arc::new(FakeData::default()),
+    );
+
+    let result = handle_bridge_request(ctx, "/settings/get", json!({})).await;
+
+    assert_eq!(result["activeRelaySessionProvider"], json!("openai"));
+    assert_eq!(result["activeRelayCodexProvider"], json!("openai"));
+}
+
+#[tokio::test]
+async fn settings_get_preserves_arbitrary_custom_provider_id() {
+    let settings = BackendSettings {
+        relay_profiles: vec![codex_plus_core::settings::RelayProfile {
+            config_contents: "model_provider = \"ccswitch\"\n".to_string(),
+            ..codex_plus_core::settings::RelayProfile::default()
+        }],
+        ..BackendSettings::default()
+    };
+    let ctx = BridgeContext::new(
+        Arc::new(FakeSettings::with_settings(settings)),
+        Arc::new(FakeRuntime::default()),
+        Arc::new(FakeData::default()),
+    );
+
+    let result = handle_bridge_request(ctx, "/settings/get", json!({})).await;
+
+    assert_eq!(result["activeRelaySessionProvider"], json!("custom"));
+    assert_eq!(result["activeRelayCodexProvider"], json!("ccswitch"));
 }
 
 #[tokio::test]
@@ -1414,7 +1457,6 @@ impl BridgeDataService for FakeData {
             title,
         }))
     }
-
 }
 
 #[derive(Clone)]

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -1690,6 +1690,17 @@ fn injection_script_exposes_fast_service_tier_control() {
 }
 
 #[test]
+fn injection_script_keeps_remote_provider_patch_installed_for_openai_identity() {
+    let script = assets::injection_script(57321);
+
+    assert!(
+        script
+            .contains("codexPlusBackendSettingsLoaded && codexRemoteSessionProviderPatchEnabled()")
+    );
+    assert!(script.contains("if (!codexRemoteSessionProviderPatchEnabled()) return;"));
+}
+
+#[test]
 fn injection_script_prompts_for_markdown_export_path_when_supported() {
     let script = assets::injection_script(57321);
 
@@ -1832,7 +1843,7 @@ fn injection_script_applies_fast_service_tier_contract() {
     assert_eq!(cases["legacyStateApi"], true);
     assert_eq!(cases["currentStateApi"], true);
     assert_eq!(cases["appServerParamsUnchanged"], true);
-    assert_eq!(cases["appServerSentCount"], 2);
+    assert_eq!(cases["appServerSentCount"], 5);
     assert_eq!(
         cases["providerFromMissing"]["modelProvider"],
         "vendor_alpha"
@@ -1877,6 +1888,11 @@ fn injection_script_applies_fast_service_tier_contract() {
     assert_eq!(cases["remoteRecoveryRetryAttempts"], json!([0, 1]));
     assert_eq!(cases["openAiSessionProviderUnchanged"], true);
     assert_eq!(cases["openAiRecoveryUnscheduled"], true);
+    assert_eq!(cases["openAiPatchRemainsInstalled"], true);
+    assert_eq!(cases["openAiNormalizationDisabled"], true);
+    assert_eq!(cases["refreshedCustomProviderOverride"], "refreshed_vendor");
+    assert_eq!(cases["refreshedOpenAiProvider"], "openai");
+    assert_eq!(cases["failedRefreshProviderUnchanged"], "openai");
     assert_eq!(cases["missingActiveProviderUnchanged"], true);
     assert_eq!(cases["missingActiveRecoveryUnscheduled"], true);
     assert_eq!(cases["pureApiProviderUnchanged"], true);
@@ -2162,6 +2178,8 @@ const appServerParamsUnchanged = appServerCalls[0]?.params === nativeAppServerPa
 api.setBackendSettings({{
   relayProfilesEnabled: true,
   activeRelayId: "custom-relay",
+  activeRelaySessionProvider: "custom",
+  activeRelayCodexProvider: "vendor_alpha",
   relayProfiles: [{{ id: "custom-relay", relayMode: "official", officialMixApiKey: true }}],
 }});
 api.setModelCatalog({{
@@ -2287,13 +2305,15 @@ const remoteRecoveryRetryAttempts = remoteRecoveryRetryCalls.map((call) => call.
 api.setBackendSettings({{
   relayProfilesEnabled: true,
   activeRelayId: "openai-relay",
+  activeRelaySessionProvider: "openai",
+  activeRelayCodexProvider: "openai",
   relayProfiles: [{{ id: "openai-relay", relayMode: "official", officialMixApiKey: true }}],
 }});
 api.setModelCatalog({{
   status: "ok",
   model: "gpt-5.6-sol",
   default_model: "gpt-5.6-sol",
-  codex_model_provider: "openai",
+  codex_model_provider: "stale_custom_provider",
   models: ["gpt-5.6-sol"],
 }});
 const openAiSessionParams = {{ cwd: "C:/mobile", modelProvider: "openai" }};
@@ -2302,6 +2322,95 @@ const openAiRecoveryUnscheduled = api.observeRemoteSessionNotification({{
   method: "thread/started",
   params: {{ thread: {{ id: "thread-mobile-openai" }} }},
 }}) === false;
+const openAiPatchRemainsInstalled = api.providerPatchEnabled();
+const openAiNormalizationDisabled = !api.providerNormalizationEnabled();
+api.setBackendSettings({{
+  relayProfilesEnabled: true,
+  activeRelayId: "stale-openai-relay",
+  activeRelaySessionProvider: "openai",
+  activeRelayCodexProvider: "openai",
+  relayProfiles: [{{ id: "stale-openai-relay", relayMode: "official", officialMixApiKey: true }}],
+}});
+api.setModelCatalog({{
+  status: "ok",
+  model: "gpt-5.6-sol",
+  default_model: "gpt-5.6-sol",
+  codex_model_provider: "openai",
+  models: ["gpt-5.6-sol"],
+}});
+window.__codexSessionDeleteBridge = async (path) => {{
+  if (path === "/settings/get") return {{
+    launchMode: "patch",
+    enhancementsEnabled: true,
+    providerSyncEnabled: true,
+    relayProfilesEnabled: true,
+    activeRelayId: "refreshed-custom-relay",
+    activeRelaySessionProvider: "custom",
+    activeRelayCodexProvider: "refreshed_vendor",
+    relayProfiles: [{{ id: "refreshed-custom-relay", relayMode: "official", officialMixApiKey: true }}],
+  }};
+  if (path === "/codex-model-catalog") return {{
+    status: "ok",
+    model: "gpt-5.6-sol",
+    default_model: "gpt-5.6-sol",
+    codex_model_provider: "refreshed_vendor",
+    models: ["gpt-5.6-sol"],
+  }};
+  return {{ status: "failed" }};
+}};
+await appServerClient.sendRequest("thread/start", {{ cwd: "C:/mobile", modelProvider: "openai" }}, {{ signal: "provider-switch" }});
+const refreshedCustomProviderOverride = appServerCalls.at(-1)?.params?.modelProvider || "";
+api.setBackendSettings({{
+  relayProfilesEnabled: true,
+  activeRelayId: "stale-custom-relay",
+  activeRelaySessionProvider: "custom",
+  activeRelayCodexProvider: "stale_custom_provider",
+  relayProfiles: [{{ id: "stale-custom-relay", relayMode: "official", officialMixApiKey: true }}],
+}});
+api.setModelCatalog({{
+  status: "ok",
+  model: "gpt-5.6-sol",
+  default_model: "gpt-5.6-sol",
+  codex_model_provider: "stale_custom_provider",
+  models: ["gpt-5.6-sol"],
+}});
+window.__codexSessionDeleteBridge = async (path) => {{
+  if (path === "/settings/get") return {{
+    launchMode: "patch",
+    enhancementsEnabled: true,
+    providerSyncEnabled: true,
+    relayProfilesEnabled: true,
+    activeRelayId: "refreshed-openai-relay",
+    activeRelaySessionProvider: "openai",
+    activeRelayCodexProvider: "openai",
+    relayProfiles: [{{ id: "refreshed-openai-relay", relayMode: "official", officialMixApiKey: true }}],
+  }};
+  if (path === "/codex-model-catalog") return {{
+    status: "ok",
+    model: "gpt-5.6-sol",
+    default_model: "gpt-5.6-sol",
+    codex_model_provider: "stale_custom_provider",
+    models: ["gpt-5.6-sol"],
+  }};
+  return {{ status: "failed" }};
+}};
+await appServerClient.sendRequest("thread/start", {{ cwd: "C:/mobile", modelProvider: "openai" }}, {{ signal: "openai-switch" }});
+const refreshedOpenAiProvider = appServerCalls.at(-1)?.params?.modelProvider || "";
+delete window.__codexSessionDeleteBridge;
+api.setBackendSettings({{
+  relayProfilesEnabled: true,
+  activeRelayId: "stale-custom-relay",
+  activeRelaySessionProvider: "custom",
+  activeRelayCodexProvider: "stale_custom_provider",
+  relayProfiles: [{{ id: "stale-custom-relay", relayMode: "official", officialMixApiKey: true }}],
+}});
+window.__codexSessionDeleteBridge = async (path) => {{
+  if (path === "/settings/get") throw new Error("settings unavailable");
+  return {{ status: "failed" }};
+}};
+await appServerClient.sendRequest("thread/start", {{ cwd: "C:/mobile", modelProvider: "openai" }}, {{ signal: "provider-refresh-failed" }});
+const failedRefreshProviderUnchanged = appServerCalls.at(-1)?.params?.modelProvider || "";
+delete window.__codexSessionDeleteBridge;
 api.setBackendSettings({{
   relayProfilesEnabled: true,
   activeRelayId: "missing",
@@ -2382,6 +2491,11 @@ process.stdout.write(JSON.stringify({{
   remoteRecoveryRetryAttempts,
   openAiSessionProviderUnchanged,
   openAiRecoveryUnscheduled,
+  openAiPatchRemainsInstalled,
+  openAiNormalizationDisabled,
+  refreshedCustomProviderOverride,
+  refreshedOpenAiProvider,
+  failedRefreshProviderUnchanged,
   missingActiveProviderUnchanged,
   missingActiveRecoveryUnscheduled,
   pureApiProviderUnchanged,

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -307,6 +307,153 @@ experimental_bearer_token = "sk-test-redacted"
 }
 
 #[test]
+fn reports_complete_openai_provider_before_incomplete_custom_transport() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("config.toml"),
+        r#"model_provider = "openai"
+openai_base_url = "http://127.0.0.1:57321/v1"
+
+[model_providers.openai]
+name = "openai"
+wire_api = "responses"
+requires_openai_auth = false
+base_url = "https://openai.example.test/v1"
+experimental_bearer_token = "sk-openai"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://stale-relay.example.test/v1"
+"#,
+    )
+    .unwrap();
+
+    let status = relay_config_status_from_home(temp.path());
+
+    assert!(status.configured);
+    assert!(!status.requires_openai_auth);
+    assert!(status.has_bearer_token);
+}
+
+#[test]
+fn reports_complete_openai_provider_before_complete_custom_transport() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("config.toml"),
+        r#"model_provider = "openai"
+openai_base_url = "http://127.0.0.1:57321/v1"
+
+[model_providers.openai]
+name = "openai"
+wire_api = "responses"
+requires_openai_auth = false
+base_url = "https://openai.example.test/v1"
+experimental_bearer_token = "sk-openai"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example.test/v1"
+experimental_bearer_token = "sk-custom"
+"#,
+    )
+    .unwrap();
+
+    let status = relay_config_status_from_home(temp.path());
+
+    assert!(status.configured);
+    assert!(!status.requires_openai_auth);
+    assert!(status.has_bearer_token);
+}
+
+#[test]
+fn does_not_use_custom_transport_without_managed_openai_identity() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("config.toml"),
+        r#"model_provider = "openai"
+openai_base_url = "https://user-openai.example.test/v1"
+
+[model_providers.openai]
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://stale-relay.example.test/v1"
+experimental_bearer_token = "sk-stale"
+"#,
+    )
+    .unwrap();
+
+    let status = relay_config_status_from_home(temp.path());
+
+    assert!(!status.configured);
+    assert!(!status.requires_openai_auth);
+    assert!(!status.has_bearer_token);
+}
+
+#[test]
+fn managed_openai_identity_requires_custom_transport_credentials() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("config.toml"),
+        r#"model_provider = "openai"
+openai_base_url = "http://127.0.0.1:57321/v1"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example.test/v1"
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        temp.path().join("auth.json"),
+        r#"{"auth_mode":"chatgpt","tokens":{"access_token":"oauth-token"}}"#,
+    )
+    .unwrap();
+
+    let status = relay_config_status_from_home(temp.path());
+
+    assert!(!status.configured);
+    assert!(!status.requires_openai_auth);
+    assert!(!status.has_bearer_token);
+}
+
+#[test]
+fn managed_openai_identity_accepts_auth_api_key_for_custom_transport() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("config.toml"),
+        r#"model_provider = "openai"
+openai_base_url = "http://127.0.0.1:57321/v1"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+base_url = "https://relay.example.test/v1"
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        temp.path().join("auth.json"),
+        r#"{"OPENAI_API_KEY":"sk-pure-api"}"#,
+    )
+    .unwrap();
+
+    let status = relay_config_status_from_home(temp.path());
+
+    assert!(status.configured);
+    assert!(!status.requires_openai_auth);
+    assert!(!status.has_bearer_token);
+}
+
+#[test]
 fn reports_pure_api_configured_from_auth_api_key_without_bearer_token() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::write(
@@ -411,7 +558,11 @@ fn openai_session_provider_rejects_chat_completions() {
     )
     .unwrap_err();
 
-    assert!(error.to_string().contains("OpenAI 会话身份仅支持 Responses API"));
+    assert!(
+        error
+            .to_string()
+            .contains("OpenAI 会话身份仅支持 Responses API")
+    );
     assert!(!temp.path().join("config.toml").exists());
 }
 
@@ -3879,7 +4030,10 @@ requires_openai_auth = true
     let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
     let parsed: toml::Value = toml::from_str(&config).unwrap();
     assert_eq!(parsed["features"]["code_mode_only"].as_bool(), Some(true));
-    assert_eq!(parsed["features"]["code_mode"]["enabled"].as_bool(), Some(true));
+    assert_eq!(
+        parsed["features"]["code_mode"]["enabled"].as_bool(),
+        Some(true)
+    );
 
     let catalog: serde_json::Value = serde_json::from_str(
         &std::fs::read_to_string(


### PR DESCRIPTION
## Scope

Follow-up to merged PR #1891.

This PR hardens the OpenAI session-identity boundary without changing the OpenAI identity model introduced by #1891.

- Prefer a complete active `[model_providers.openai]` table over stale or incomplete `[model_providers.custom]` data.
- Use `custom` as a transport fallback only when Codex++'s managed `openai_base_url` marker is present and the transport has usable credentials.
- Include the active session identity and effective Codex provider in the same `/settings/get` response.
- Refresh that settings state before eligible thread-start requests.
- Keep the provider patch installed while the active session identity is OpenAI, so a later switch to a custom identity can take effect without requiring the renderer to be reinjected first.
- If settings refresh fails, preserve the caller's original provider instead of rewriting it with stale cached state.

## Regression Coverage

- OpenAI/custom credential and precedence matrix, including OAuth-only auth and an unmanaged `openai_base_url`.
- Settings route coverage for OpenAI and arbitrary provider IDs such as `ccswitch`.
- Renderer coverage for provider switches, stale model catalogs, startup with OpenAI identity, and settings-refresh failure.
- Full local suites passed:
  - `cargo test -p codex-plus-core --test relay_config`
  - `cargo test -p codex-plus-core --test bridge_routes`
  - `cargo test -p codex-plus-core --test cdp_bridge`
  - `cargo test -p codex-plus-core --test model_catalog`

## Out Of Scope

This PR does not change:

- Codex Desktop's native `thread/archive` RPC.
- Historical session restoration or provider-sync repair.
- Codex++'s session deletion path.

Those behaviors require separate investigation and regression coverage.
