### PR TITLE
fix(provider-sync): prune archived and ineligible catalog rows

### DIFF
--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -274,6 +274,12 @@ struct CatalogRepairThread {
     thread_source: Option<String>,
 }
 
+#[derive(Debug)]
+struct CatalogRepairObservedThread {
+    thread: CatalogRepairThread,
+    eligible: bool,
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct CatalogRepairCounts {
     inserted_rows: usize,
@@ -295,12 +301,14 @@ impl CatalogRepairCounts {
 struct CatalogRepairPlan {
     threads: HashMap<String, CatalogRepairThread>,
     non_root_thread_ids: HashSet<String>,
+    ineligible_thread_ids: HashSet<String>,
     catalog_non_root_thread_ids: HashMap<PathBuf, HashSet<String>>,
 }
 
 impl CatalogRepairPlan {
     fn has_cleanup_candidates(&self) -> bool {
         !self.non_root_thread_ids.is_empty()
+            || !self.ineligible_thread_ids.is_empty()
             || self
                 .catalog_non_root_thread_ids
                 .values()
@@ -309,6 +317,7 @@ impl CatalogRepairPlan {
 
     fn cleanup_thread_ids_for_path(&self, path: &Path) -> HashSet<String> {
         let mut thread_ids = self.non_root_thread_ids.clone();
+        thread_ids.extend(self.ineligible_thread_ids.iter().cloned());
         if let Some(catalog_thread_ids) = self.catalog_non_root_thread_ids.get(path) {
             thread_ids.extend(catalog_thread_ids.iter().cloned());
         }
@@ -439,6 +448,7 @@ pub fn run_remote_control_session_catalog_recovery_for_thread_with_target(
     }
     let thread_ids = HashSet::from([thread_id.to_string()]);
     let recovery = run_remote_control_catalog_recovery_for_threads(
+        &home,
         &provider_sync_db_paths(&home),
         target_provider,
         &thread_ids,
@@ -559,6 +569,7 @@ pub fn run_remote_control_session_finalization_for_thread_with_target(
         }
         let thread_ids = HashSet::from([thread_id.to_string()]);
         let catalog_repairs = repair_missing_local_thread_catalog_rows_for_threads(
+            &home,
             &sqlite_paths,
             target_provider,
             &thread_ids,
@@ -598,6 +609,7 @@ pub fn run_remote_control_session_finalization_for_thread_with_target(
 }
 
 fn run_remote_control_catalog_recovery_for_threads(
+    home: &Path,
     sqlite_paths: &[PathBuf],
     target_provider: &str,
     requested_thread_ids: &HashSet<String>,
@@ -619,6 +631,7 @@ fn run_remote_control_catalog_recovery_for_threads(
     }
 
     let catalog_repairs = repair_missing_local_thread_catalog_rows_for_threads(
+        home,
         sqlite_paths,
         target_provider,
         &thread_ids,
@@ -759,7 +772,7 @@ pub fn run_provider_sync_with_target(
             &subagent_thread_ids,
         )?;
         let catalog_repair_count =
-            count_local_thread_catalog_repairs(&sqlite_paths, &target_provider)?;
+            count_local_thread_catalog_repairs(&home, &sqlite_paths, &target_provider)?;
         let global_state_update_count =
             count_global_state_updates(&home.join(".codex-global-state.json"))?;
         if rewrite_changes.is_empty()
@@ -794,7 +807,7 @@ pub fn run_provider_sync_with_target(
             )?;
             let mut sqlite_updates = sqlite_updates;
             let catalog_repairs =
-                repair_missing_local_thread_catalog_rows(&sqlite_paths, &target_provider)?;
+                repair_missing_local_thread_catalog_rows(&home, &sqlite_paths, &target_provider)?;
             sqlite_updates.catalog_insert_rows = catalog_repairs.inserted_rows;
             sqlite_updates.catalog_remove_rows = catalog_repairs.removed_rows;
             let updated_workspace_roots =
@@ -2958,10 +2971,11 @@ fn apply_remote_control_catalog_updates(
 }
 
 fn count_local_thread_catalog_repairs(
+    home: &Path,
     paths: &[PathBuf],
     target_provider: &str,
 ) -> anyhow::Result<usize> {
-    let plan = collect_catalog_repair_plan(paths, target_provider, None)?;
+    let plan = collect_catalog_repair_plan(home, paths, target_provider, None)?;
     if plan.threads.is_empty() && !plan.has_cleanup_candidates() {
         return Ok(0);
     }
@@ -2993,18 +3007,21 @@ fn count_local_thread_catalog_repairs(
 }
 
 fn repair_missing_local_thread_catalog_rows(
+    home: &Path,
     paths: &[PathBuf],
     target_provider: &str,
 ) -> anyhow::Result<CatalogRepairCounts> {
-    repair_missing_local_thread_catalog_rows_filtered(paths, target_provider, None, true)
+    repair_missing_local_thread_catalog_rows_filtered(home, paths, target_provider, None, true)
 }
 
 fn repair_missing_local_thread_catalog_rows_for_threads(
+    home: &Path,
     paths: &[PathBuf],
     target_provider: &str,
     thread_ids: &HashSet<String>,
 ) -> anyhow::Result<CatalogRepairCounts> {
     repair_missing_local_thread_catalog_rows_filtered(
+        home,
         paths,
         target_provider,
         Some(thread_ids),
@@ -3013,12 +3030,13 @@ fn repair_missing_local_thread_catalog_rows_for_threads(
 }
 
 fn repair_missing_local_thread_catalog_rows_filtered(
+    home: &Path,
     paths: &[PathBuf],
     target_provider: &str,
     thread_ids: Option<&HashSet<String>>,
     update_full_sync_state: bool,
 ) -> anyhow::Result<CatalogRepairCounts> {
-    let plan = collect_catalog_repair_plan(paths, target_provider, thread_ids)?;
+    let plan = collect_catalog_repair_plan(home, paths, target_provider, thread_ids)?;
     if plan.threads.is_empty()
         && (!update_full_sync_state || !plan.has_cleanup_candidates())
     {
@@ -3105,6 +3123,7 @@ fn repair_missing_local_thread_catalog_rows_filtered(
 }
 
 fn collect_catalog_repair_plan(
+    home: &Path,
     paths: &[PathBuf],
     target_provider: &str,
     thread_ids: Option<&HashSet<String>>,
@@ -3112,7 +3131,7 @@ fn collect_catalog_repair_plan(
     let spawned_child_ids = collect_spawned_child_thread_ids(paths)?;
     let mut catalog_non_root_thread_ids =
         collect_catalog_marked_non_root_thread_ids(paths, &spawned_child_ids)?;
-    let mut threads = HashMap::new();
+    let mut observed_threads = HashMap::new();
     for path in paths {
         if !path.exists() {
             continue;
@@ -3134,53 +3153,95 @@ fn collect_catalog_repair_plan(
         let source_detail = text_expr(&columns, "rollout_path", "''");
         let git_branch = text_expr(&columns, "git_branch", "NULL");
         let thread_source = text_expr(&columns, "thread_source", "NULL");
+        let archived = text_expr(&columns, "archived", "0");
+        let has_user_event = text_expr(&columns, "has_user_event", "1");
+        let agent_role = text_expr(&columns, "agent_role", "''");
         let subagent_filter = subagent_filter(&db, "threads.id")?;
         let sql = format!(
-            "SELECT id, {display_title}, {source_created_at}, {source_updated_at}, {cwd}, {source_kind}, {source_detail}, {git_branch}, {thread_source} FROM threads WHERE COALESCE(id, '') <> ''{subagent_filter}"
+            "SELECT id, {display_title}, {source_created_at}, {source_updated_at}, {cwd}, {source_kind}, {source_detail}, {git_branch}, {thread_source}, {archived}, {has_user_event}, {agent_role} FROM threads WHERE COALESCE(id, '') <> ''{subagent_filter}"
         );
         let mut stmt = db.prepare(&sql)?;
         let rows = stmt.query_map([], |row| {
-            Ok(CatalogRepairThread {
-                id: row.get(0)?,
-                display_title: row.get::<_, String>(1).unwrap_or_default(),
-                source_created_at: row.get::<_, f64>(2).unwrap_or_default(),
-                source_updated_at: row.get::<_, f64>(3).unwrap_or_default(),
-                cwd: row.get::<_, String>(4).unwrap_or_default(),
-                source_kind: row
-                    .get::<_, String>(5)
-                    .unwrap_or_else(|_| "cli".to_string()),
-                source_detail: row.get::<_, String>(6).unwrap_or_default(),
-                model_provider: target_provider.to_string(),
-                git_branch: row.get::<_, Option<String>>(7).unwrap_or(None),
-                thread_source: row.get::<_, Option<String>>(8).unwrap_or(None),
-            })
+            Ok((
+                CatalogRepairThread {
+                    id: row.get(0)?,
+                    display_title: row.get::<_, String>(1).unwrap_or_default(),
+                    source_created_at: row.get::<_, f64>(2).unwrap_or_default(),
+                    source_updated_at: row.get::<_, f64>(3).unwrap_or_default(),
+                    cwd: row.get::<_, String>(4).unwrap_or_default(),
+                    source_kind: row
+                        .get::<_, String>(5)
+                        .unwrap_or_else(|_| "cli".to_string()),
+                    source_detail: row.get::<_, String>(6).unwrap_or_default(),
+                    model_provider: target_provider.to_string(),
+                    git_branch: row.get::<_, Option<String>>(7).unwrap_or(None),
+                    thread_source: row.get::<_, Option<String>>(8).unwrap_or(None),
+                },
+                row.get::<_, i64>(9).unwrap_or_default(),
+                row.get::<_, i64>(10).unwrap_or(1),
+                row.get::<_, String>(11).unwrap_or_default(),
+            ))
         })?;
         for item in rows {
-            let thread = item?;
-            let replace = threads
+            let (thread, archived, has_user_event, agent_role) = item?;
+            let marked_non_user = columns.contains("thread_source")
+                && thread.thread_source.as_deref().is_some_and(|value| {
+                    let value = value.trim();
+                    !value.is_empty() && !value.eq_ignore_ascii_case("user")
+                });
+            let non_root = is_catalog_non_root_agent(&thread, &spawned_child_ids);
+            let source_is_exec = thread.source_kind.trim().eq_ignore_ascii_case("exec");
+            let rollout_exists = catalog_rollout_path_exists(home, &thread.source_detail);
+            let eligible = archived == 0
+                && has_user_event == 1
+                && agent_role.trim().is_empty()
+                && !marked_non_user
+                && !source_is_exec
+                && !non_root
+                && rollout_exists;
+            let replace = observed_threads
                 .get(&thread.id)
-                .map(|current: &CatalogRepairThread| {
-                    thread.source_updated_at > current.source_updated_at
+                .map(|current: &CatalogRepairObservedThread| {
+                    // Copies can share a timestamp; an ineligible observation wins the tie so
+                    // an archived or agent-owned thread cannot be resurrected by a stale copy.
+                    thread.source_updated_at > current.thread.source_updated_at
+                        || (thread.source_updated_at == current.thread.source_updated_at
+                            && !eligible
+                            && current.eligible)
                 })
                 .unwrap_or(true);
             if replace {
-                threads.insert(thread.id.clone(), thread);
+                observed_threads.insert(
+                    thread.id.clone(),
+                    CatalogRepairObservedThread { thread, eligible },
+                );
             }
         }
     }
     if let Some(thread_ids) = thread_ids {
-        threads.retain(|thread_id, _| thread_ids.contains(thread_id));
+        observed_threads.retain(|thread_id, _| thread_ids.contains(thread_id));
     }
-    let explicit_user_thread_ids = threads
+    let explicit_user_thread_ids = observed_threads
         .values()
-        .filter(|thread| thread_source_is_user(thread.thread_source.as_deref()))
-        .map(|thread| thread.id.clone())
+        .filter(|observed| thread_source_is_user(observed.thread.thread_source.as_deref()))
+        .map(|observed| observed.thread.id.clone())
         .collect::<HashSet<_>>();
-    let non_root_thread_ids = threads
+    let non_root_thread_ids = observed_threads
         .values()
-        .filter(|thread| is_catalog_non_root_agent(thread, &spawned_child_ids))
-        .map(|thread| thread.id.clone())
+        .filter(|observed| is_catalog_non_root_agent(&observed.thread, &spawned_child_ids))
+        .map(|observed| observed.thread.id.clone())
         .collect::<HashSet<_>>();
+    let ineligible_thread_ids = observed_threads
+        .values()
+        .filter(|observed| !observed.eligible)
+        .map(|observed| observed.thread.id.clone())
+        .collect::<HashSet<_>>();
+    let threads = observed_threads
+        .into_iter()
+        .filter_map(|(thread_id, observed)| {
+            observed.eligible.then_some((thread_id, observed.thread))
+        })
+        .collect::<HashMap<_, _>>();
     // Catalog-only evidence stays path-scoped so one stale database cannot remove another's row.
     for catalog_thread_ids in catalog_non_root_thread_ids.values_mut() {
         catalog_thread_ids.retain(|thread_id| {
@@ -3191,12 +3252,25 @@ fn collect_catalog_repair_plan(
         });
     }
     catalog_non_root_thread_ids.retain(|_, thread_ids| !thread_ids.is_empty());
-    threads.retain(|thread_id, _| !non_root_thread_ids.contains(thread_id));
     Ok(CatalogRepairPlan {
         threads,
         non_root_thread_ids,
+        ineligible_thread_ids,
         catalog_non_root_thread_ids,
     })
+}
+
+fn catalog_rollout_path_exists(home: &Path, rollout_path: &str) -> bool {
+    let rollout_path = rollout_path.trim();
+    if rollout_path.is_empty() {
+        return true;
+    }
+    let rollout_path = Path::new(rollout_path);
+    if rollout_path.is_absolute() {
+        rollout_path.is_file()
+    } else {
+        home.join(rollout_path).is_file()
+    }
 }
 
 fn collect_spawned_child_thread_ids(paths: &[PathBuf]) -> anyhow::Result<HashSet<String>> {

--- a/crates/codex-plus-data/tests/provider_sync.rs
+++ b/crates/codex-plus-data/tests/provider_sync.rs
@@ -56,6 +56,70 @@ fn write_rollout(path: &Path, provider: &str, thread_id: &str, cwd: &str) {
     fs::write(path, format!("{first}\n{event}\n")).unwrap();
 }
 
+fn write_catalog_rollout(path: &Path) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, "").unwrap();
+}
+
+fn catalog_eligibility_thread_snapshot(path: &Path) -> Vec<serde_json::Value> {
+    let db = Connection::open(path).unwrap();
+    db.prepare(
+        "SELECT id, model_provider, archived, has_user_event, cwd, title, rollout_path, source,
+                created_at_ms, updated_at_ms, thread_source, git_branch, agent_role
+         FROM threads ORDER BY id",
+    )
+    .unwrap()
+    .query_map([], |row| {
+        Ok(json!({
+            "id": row.get::<_, String>(0)?,
+            "model_provider": row.get::<_, String>(1)?,
+            "archived": row.get::<_, i64>(2)?,
+            "has_user_event": row.get::<_, i64>(3)?,
+            "cwd": row.get::<_, String>(4)?,
+            "title": row.get::<_, String>(5)?,
+            "rollout_path": row.get::<_, String>(6)?,
+            "source": row.get::<_, String>(7)?,
+            "created_at_ms": row.get::<_, i64>(8)?,
+            "updated_at_ms": row.get::<_, i64>(9)?,
+            "thread_source": row.get::<_, Option<String>>(10)?,
+            "git_branch": row.get::<_, Option<String>>(11)?,
+            "agent_role": row.get::<_, String>(12)?,
+        }))
+    })
+    .unwrap()
+    .collect::<rusqlite::Result<Vec<_>>>()
+    .unwrap()
+}
+
+fn rollout_files_snapshot(path: &Path) -> Vec<(String, Vec<u8>, SystemTime)> {
+    let mut snapshot = fs::read_dir(path)
+        .unwrap()
+        .map(|entry| {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            (
+                entry.file_name().to_string_lossy().to_string(),
+                fs::read(&path).unwrap(),
+                fs::metadata(path).unwrap().modified().unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+    snapshot.sort_by(|left, right| left.0.cmp(&right.0));
+    snapshot
+}
+
+fn catalog_rows_snapshot(path: &Path) -> Vec<(String, String)> {
+    let db = Connection::open(path).unwrap();
+    db.prepare(
+        "SELECT host_id, thread_id FROM local_thread_catalog ORDER BY host_id, thread_id",
+    )
+    .unwrap()
+    .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))
+    .unwrap()
+    .collect::<rusqlite::Result<Vec<_>>>()
+    .unwrap()
+}
+
 fn write_subagent_rollout(path: &Path, provider: &str, thread_id: &str, cwd: &str) {
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     let first = json!({
@@ -822,12 +886,14 @@ fn provider_sync_repairs_missing_local_thread_catalog_rows_from_threads() {
         [],
     )
     .unwrap();
+    let rollout_path = home.join("sessions/rollout-thread-1.jsonl");
+    write_catalog_rollout(&rollout_path);
     db.execute(
         "INSERT INTO threads VALUES (
             'thread-1', 'old-provider', 0, 1, 'C:/workspace', 'Thread One',
-            'C:/rollout.jsonl', 'cli', 100000, 200000, 'user', 'main'
+            ?1, 'cli', 100000, 200000, 'user', 'main'
         )",
-        [],
+        [rollout_path.to_string_lossy().to_string()],
     )
     .unwrap();
     drop(db);
@@ -864,7 +930,7 @@ fn provider_sync_repairs_missing_local_thread_catalog_rows_from_threads() {
     assert_eq!(row.2, 200.0);
     assert_eq!(row.3, "C:/workspace");
     assert_eq!(row.4, "cli");
-    assert_eq!(row.5, "C:/rollout.jsonl");
+    assert_eq!(row.5, rollout_path.to_string_lossy());
     assert_eq!(row.6, "apigather");
     assert_eq!(row.7, "main");
     assert_eq!(row.8, "user");
@@ -1012,6 +1078,7 @@ fn provider_sync_catalogs_user_threads_but_skips_subagents() {
         [],
     )
     .unwrap();
+    let rollout_dir = home.join("sessions/catalog-eligibility");
     for (id, source, thread_source, updated_at) in [
         ("user-one", "vscode", "user", 200000_i64),
         (
@@ -1034,22 +1101,32 @@ fn provider_sync_catalogs_user_threads_but_skips_subagents() {
             215000_i64,
         ),
     ] {
+        let rollout_path = rollout_dir.join(format!("{id}.jsonl"));
+        write_catalog_rollout(&rollout_path);
         db.execute(
             "INSERT INTO threads VALUES (
                 ?1, 'apigather', 0, 1, 'C:/workspace', 'Same title',
                 ?2, ?3, 100000, ?4, ?5, 'main'
             )",
-            rusqlite::params![id, format!("C:/{id}.jsonl"), source, updated_at, thread_source],
+            rusqlite::params![
+                id,
+                rollout_path.to_string_lossy().to_string(),
+                source,
+                updated_at,
+                thread_source
+            ],
         )
         .unwrap();
     }
+    let null_source_rollout = rollout_dir.join("null-source-child.jsonl");
+    write_catalog_rollout(&null_source_rollout);
     db.execute(
         "INSERT INTO threads VALUES (
             'null-source-child', 'apigather', 0, 1, 'C:/workspace', 'Same title',
-            'C:/null-source-child.jsonl', '{\"sub_agent\":{\"other\":\"guardian\"}}',
+            ?1, '{\"sub_agent\":{\"other\":\"guardian\"}}',
             100000, 217000, NULL, 'main'
         )",
-        [],
+        [null_source_rollout.to_string_lossy().to_string()],
     )
     .unwrap();
     drop(db);
@@ -1082,12 +1159,19 @@ fn provider_sync_catalogs_user_threads_but_skips_subagents() {
         ("internal-child", "internal_memory_consolidation", 237000_i64),
         ("edge-child", "cli", 240000_i64),
     ] {
+        let rollout_path = rollout_dir.join(format!("{id}.jsonl"));
+        write_catalog_rollout(&rollout_path);
         db.execute(
             "INSERT INTO threads VALUES (
                 ?1, 'apigather', 0, 1, 'C:/workspace', 'Same title',
                 ?2, ?3, 100000, ?4, 'main'
             )",
-            rusqlite::params![id, format!("C:/{id}.jsonl"), source, updated_at],
+            rusqlite::params![
+                id,
+                rollout_path.to_string_lossy().to_string(),
+                source,
+                updated_at
+            ],
         )
         .unwrap();
     }
@@ -1164,13 +1248,20 @@ fn provider_sync_prunes_existing_local_subagent_catalog_rows() {
         [],
     )
     .unwrap();
+    let rollout_dir = home.join("sessions/catalog-pruning");
     for (id, thread_source) in [("root", "user"), ("child", "subagent")] {
+        let rollout_path = rollout_dir.join(format!("{id}.jsonl"));
+        write_catalog_rollout(&rollout_path);
         db.execute(
             "INSERT INTO threads VALUES (
                 ?1, 'apigather', 0, 1, 'C:/workspace', ?1,
                 ?2, 'vscode', 100000, 200000, ?3, 'main'
             )",
-            rusqlite::params![id, format!("C:/{id}.jsonl"), thread_source],
+            rusqlite::params![
+                id,
+                rollout_path.to_string_lossy().to_string(),
+                thread_source
+            ],
         )
         .unwrap();
     }
@@ -1315,6 +1406,212 @@ fn provider_sync_prunes_existing_local_subagent_catalog_rows() {
     assert_eq!(second.sqlite_catalog_rows_removed, 0);
     assert_eq!(second.sqlite_rows_updated, 0);
     assert!(second.backup_dir.is_none());
+}
+
+#[test]
+fn provider_sync_prunes_archived_and_ineligible_catalog_rows() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    let sqlite_dir = home.join("sqlite");
+    fs::create_dir_all(&sqlite_dir).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+
+    let rollout_dir = home.join("sessions");
+    let state_db = home.join("state_5.sqlite");
+    let db = Connection::open(&state_db).unwrap();
+    db.execute(
+        "CREATE TABLE threads (
+            id TEXT PRIMARY KEY, model_provider TEXT, archived INTEGER, has_user_event INTEGER,
+            cwd TEXT, title TEXT, rollout_path TEXT, source TEXT, created_at_ms INTEGER,
+            updated_at_ms INTEGER, thread_source TEXT, git_branch TEXT, agent_role TEXT
+        )",
+        [],
+    )
+    .unwrap();
+    for (id, archived, has_user_event, source, thread_source, agent_role, updated_at) in [
+        ("active", 0, 1, "vscode", "user", "", 300000_i64),
+        ("archived", 1, 1, "vscode", "user", "", 310000_i64),
+        ("no-user-event", 0, 0, "vscode", "user", "", 320000_i64),
+        ("role-owned", 0, 1, "vscode", "user", "reviewer", 330000_i64),
+        ("exec", 0, 1, "exec", "user", "", 340000_i64),
+        ("subagent", 0, 1, "subagent", "subagent", "", 350000_i64),
+        (
+            "guardian",
+            0,
+            1,
+            r#"{"subagent":{"other":"guardian"}}"#,
+            "user",
+            "",
+            355000_i64,
+        ),
+    ] {
+        let rollout_path = rollout_dir.join(format!("{id}.jsonl"));
+        write_catalog_rollout(&rollout_path);
+        db.execute(
+            "INSERT INTO threads VALUES (
+                ?1, 'apigather', ?2, ?3, 'C:/workspace', ?1, ?4, ?5,
+                100000, ?6, ?7, 'main', ?8
+            )",
+            rusqlite::params![
+                id,
+                archived,
+                has_user_event,
+                rollout_path.to_string_lossy().to_string(),
+                source,
+                updated_at,
+                thread_source,
+                agent_role
+            ],
+        )
+        .unwrap();
+    }
+    let archived_rollout = rollout_dir.join("archived.jsonl");
+    fs::write(&archived_rollout, "archived rollout sentinel\n").unwrap();
+
+    let relative_rollout = Path::new("sessions").join("relative-rollout.jsonl");
+    write_catalog_rollout(&home.join(&relative_rollout));
+    db.execute(
+        "INSERT INTO threads VALUES (
+            'relative-rollout', 'apigather', 0, 1, 'C:/workspace', 'relative-rollout',
+            ?1, 'vscode', 100000, 357000, 'user', 'main', ''
+        )",
+        [relative_rollout.to_string_lossy().to_string()],
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO threads VALUES (
+            'empty-rollout', 'apigather', 0, 1, 'C:/workspace', 'empty-rollout',
+            '', 'vscode', 100000, 358000, 'user', 'main', ''
+        )",
+        [],
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO threads VALUES (
+            'missing-rollout', 'apigather', 0, 1, 'C:/workspace', 'missing-rollout',
+            'sessions/missing-rollout.jsonl', 'vscode', 100000, 360000, 'user', 'main', ''
+        )",
+        [],
+    )
+    .unwrap();
+    drop(db);
+    let threads_before = catalog_eligibility_thread_snapshot(&state_db);
+
+    // An equally recent active copy must not override the archived canonical state.
+    let stale_rollout = rollout_dir.join("archived-stale.jsonl");
+    write_catalog_rollout(&stale_rollout);
+    let stale_db = sqlite_dir.join("state_5.sqlite");
+    let db = Connection::open(&stale_db).unwrap();
+    db.execute(
+        "CREATE TABLE threads (
+            id TEXT PRIMARY KEY, model_provider TEXT, archived INTEGER, has_user_event INTEGER,
+            cwd TEXT, title TEXT, rollout_path TEXT, source TEXT, created_at_ms INTEGER,
+            updated_at_ms INTEGER, thread_source TEXT, git_branch TEXT, agent_role TEXT
+        )",
+        [],
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO threads VALUES (
+            'archived', 'apigather', 0, 1, 'C:/workspace', 'archived', ?1,
+            'vscode', 100000, 310000, 'user', 'main', ''
+        )",
+        [stale_rollout.to_string_lossy().to_string()],
+    )
+    .unwrap();
+    drop(db);
+
+    let catalog_db = sqlite_dir.join("codex-dev.db");
+    create_local_thread_catalog_db(
+        &catalog_db,
+        &[
+            ("active", "apigather"),
+            ("archived", "apigather"),
+            ("no-user-event", "apigather"),
+            ("role-owned", "apigather"),
+            ("exec", "apigather"),
+            ("subagent", "apigather"),
+            ("guardian", "apigather"),
+            ("relative-rollout", "apigather"),
+            ("empty-rollout", "apigather"),
+            ("missing-rollout", "apigather"),
+            ("orphan", "apigather"),
+        ],
+    );
+    let db = Connection::open(&catalog_db).unwrap();
+    db.execute(
+        "INSERT INTO local_thread_catalog_hosts VALUES ('remote', 'remote')",
+        [],
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO local_thread_catalog (
+            host_id, thread_id, display_title, source_created_at, source_updated_at, cwd,
+            source_kind, source_detail, model_provider, git_branch, observation_sequence,
+            missing_candidate, thread_source
+        ) VALUES (
+            'remote', 'archived', 'archived', 100, 100, 'C:/workspace', 'cli', '',
+            'apigather', NULL, 1, 0, 'user'
+        )",
+        [],
+    )
+    .unwrap();
+    drop(db);
+    let rollout_files_before = rollout_files_snapshot(&rollout_dir);
+
+    let result = run_provider_sync(Some(&home));
+
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert_eq!(result.sqlite_catalog_rows_inserted, 0);
+    assert_eq!(result.sqlite_catalog_rows_removed, 7);
+    assert_eq!(
+        catalog_rows_snapshot(&catalog_db),
+        vec![
+            ("local".to_string(), "active".to_string()),
+            ("local".to_string(), "empty-rollout".to_string()),
+            ("local".to_string(), "orphan".to_string()),
+            ("local".to_string(), "relative-rollout".to_string()),
+            ("remote".to_string(), "archived".to_string()),
+        ]
+    );
+    assert_eq!(
+        catalog_eligibility_thread_snapshot(&state_db),
+        threads_before
+    );
+    assert_eq!(rollout_files_snapshot(&rollout_dir), rollout_files_before);
+
+    let stale = Connection::open(&stale_db).unwrap();
+    let stale_archived_state = stale
+        .query_row(
+            "SELECT archived, updated_at_ms FROM threads WHERE id = 'archived'",
+            [],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+        )
+        .unwrap();
+    assert_eq!(stale_archived_state, (0, 310000));
+    drop(stale);
+
+    let second = run_provider_sync(Some(&home));
+    assert_eq!(second.status, ProviderSyncStatus::Synced);
+    assert_eq!(second.sqlite_catalog_rows_inserted, 0);
+    assert_eq!(second.sqlite_catalog_rows_removed, 0);
+    assert_eq!(second.sqlite_rows_updated, 0);
+    assert!(second.backup_dir.is_none());
+    assert_eq!(
+        catalog_eligibility_thread_snapshot(&state_db),
+        threads_before
+    );
+    assert_eq!(rollout_files_snapshot(&rollout_dir), rollout_files_before);
+    assert_eq!(
+        catalog_rows_snapshot(&catalog_db),
+        vec![
+            ("local".to_string(), "active".to_string()),
+            ("local".to_string(), "empty-rollout".to_string()),
+            ("local".to_string(), "orphan".to_string()),
+            ("local".to_string(), "relative-rollout".to_string()),
+            ("remote".to_string(), "archived".to_string()),
+        ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## English

### Summary

- Rebased the existing PR onto upstream `main` commit `0182a58e28e7251112a16f0072f1e3b05c2d7e0e` (August 25, 2026).
- Restored catalog eligibility checks for archived threads, threads without user events, agent-owned/`exec` threads, non-root/subagent threads, and non-empty rollout paths whose files no longer exist.
- Preserved the latest Guardian/structured-subagent detection and provider-sync lock recovery behavior from `main`.
- When duplicate databases contain the same timestamp, an ineligible observation wins the tie so a stale active copy cannot resurrect an archived/internal thread.
- Relative rollout paths are resolved under `CODEX_HOME`, not the process working directory.

### Data boundary

Cleanup is limited to derived rows in the current host's `local_thread_catalog`. It does **not** delete or modify `threads`, rollout files, conversation history, remote-host catalog rows, or catalog-only orphan rows. Provider/session sync remains enabled.

### Validation

- `cargo test -p codex-plus-data`: run twice, **80/80 passed each run**.
- `cargo check -p codex-plus-data`: passed.
- `cargo check -p codex-plus-manager`: passed on both upstream baseline and this PR with separate target directories.
- Windows `cargo build --release`: passed.
- Frontend `npm test`: **106/106 passed**.
- Frontend `npm run check` and `npm run vite:build`: passed.
- The catalog regression test snapshots all relevant `threads` fields and every rollout file's contents/mtime before and after sync, then repeats sync to verify idempotency and no extra backup.
- Full workspace testing reaches the same existing Windows-only `plugin_marketplace` TOML path-escaping failure on both upstream `main` and this PR; the exact failing test was reproduced independently on both trees.
- Hosted Windows and macOS x64/arm64 checks are awaiting maintainer approval. No hosted result is claimed yet.

---

## 中文

### 修改概要

- 现有 PR 已 rebase 到 2026 年 8 月 25 日主仓 `main`：`0182a58e28e7251112a16f0072f1e3b05c2d7e0e`。
- 恢复目录资格检查，排除已归档、无用户事件、agent-owned、`exec`、非 root/子代理，以及非空 rollout 路径对应文件已不存在的记录。
- 保留最新主线中的 Guardian/结构化子代理判定和 provider sync 锁恢复逻辑。
- 多个数据库存在相同时间戳时，不合资格状态优先，避免旧 active 副本重新放出已归档或内部会话。
- 相对 rollout 路径按 `CODEX_HOME` 解析，不依赖进程工作目录。

### 数据边界

清理仅作用于当前本机 `local_thread_catalog` 中的派生记录；**不会**删除或修改 `threads`、rollout 文件、会话历史、远程主机目录记录或只有目录记录的 orphan。provider/session sync 保持启用。

### 验证结果

- `cargo test -p codex-plus-data`：连续运行两次，每次 **80/80 全部通过**。
- `cargo check -p codex-plus-data`：通过。
- `cargo check -p codex-plus-manager`：主线基线和本 PR 分别使用独立 target，均通过。
- Windows `cargo build --release`：通过。
- 前端 `npm test`：**106/106 通过**。
- 前端 `npm run check`、`npm run vite:build`：通过。
- 目录回归测试会在同步前后完整快照相关 `threads` 字段、全部 rollout 文件内容与 mtime，并再次同步验证幂等且不产生额外备份。
- 全量 workspace 测试在主线和本 PR 上都会触发同一个 Windows `plugin_marketplace` TOML 路径转义问题；已分别在两个代码树上独立复现该精确测试。
- 托管 Windows、macOS x64、macOS arm64 检查仍等待维护者批准，当前不宣称已有托管构建结果。