### PR TITLE
fix(provider-sync): hide guardian threads

### DIFF
--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -1042,7 +1042,7 @@ fn collect_session_changes(
             .thread_id
             .as_ref()
             .is_some_and(|thread_id| explicit_user_thread_ids.contains(thread_id));
-        if !is_explicit_user && rollout_session_meta_marks_non_root_agent(&text) {
+        if rollout_session_meta_marks_non_root_agent(&text) {
             if let Some(thread_id) = &rewrite.thread_id {
                 collected.subagent_thread_ids.insert(thread_id.clone());
             }
@@ -2211,11 +2211,13 @@ fn sqlite_provider_sync_thread_kinds(
             })?;
             for row in rows {
                 let (thread_id, source, thread_source) = row?;
-                if thread_source_is_user(thread_source.as_deref()) {
-                    kinds.explicit_user_thread_ids.insert(thread_id);
-                } else if thread_source_marks_non_root(thread_source.as_deref())
-                    || source_marks_non_root_agent(&source)
+                if source_structured_marks_non_root_agent(&source)
+                    || thread_source_marks_non_root(thread_source.as_deref())
                 {
+                    kinds.subagent_thread_ids.insert(thread_id);
+                } else if thread_source_is_user(thread_source.as_deref()) {
+                    kinds.explicit_user_thread_ids.insert(thread_id);
+                } else if source_marks_non_root_agent(&source) {
                     kinds.subagent_thread_ids.insert(thread_id);
                 }
             }
@@ -2963,12 +2965,19 @@ fn collect_catalog_marked_non_root_thread_ids(
         })?;
         for row in rows {
             let (thread_id, source_kind, thread_source) = row?;
+            if source_structured_marks_non_root_agent(&source_kind)
+                || thread_source_marks_non_root(thread_source.as_deref())
+            {
+                thread_ids_by_path
+                    .entry(path.clone())
+                    .or_default()
+                    .insert(thread_id);
+                continue;
+            }
             if thread_source_is_user(thread_source.as_deref()) {
                 continue;
             }
-            if thread_source_marks_non_root(thread_source.as_deref())
-                || source_marks_non_root_agent(&source_kind)
-                || spawned_child_ids.contains(&thread_id)
+            if source_marks_non_root_agent(&source_kind) || spawned_child_ids.contains(&thread_id)
             {
                 thread_ids_by_path
                     .entry(path.clone())
@@ -2984,12 +2993,16 @@ fn is_catalog_non_root_agent(
     thread: &CatalogRepairThread,
     spawned_child_ids: &HashSet<String>,
 ) -> bool {
-    // The explicit user marker is authoritative over legacy source and spawn-edge fallbacks.
+    if source_structured_marks_non_root_agent(&thread.source_kind)
+        || thread_source_marks_non_root(thread.thread_source.as_deref())
+    {
+        return true;
+    }
+    // The explicit user marker is authoritative over legacy text and spawn-edge fallbacks.
     if thread_source_is_user(thread.thread_source.as_deref()) {
         return false;
     }
-    thread_source_marks_non_root(thread.thread_source.as_deref())
-        || source_marks_non_root_agent(&thread.source_kind)
+    source_marks_non_root_agent(&thread.source_kind)
         || spawned_child_ids.contains(&thread.id)
 }
 
@@ -3011,7 +3024,11 @@ fn source_marks_non_root_agent(source: &str) -> bool {
     if source_text_marks_non_root_agent(source) {
         return true;
     }
-    serde_json::from_str::<Value>(source)
+    source_structured_marks_non_root_agent(source)
+}
+
+fn source_structured_marks_non_root_agent(source: &str) -> bool {
+    serde_json::from_str::<Value>(source.trim())
         .is_ok_and(|source| source_value_marks_non_root_agent(&source))
 }
 

--- a/crates/codex-plus-data/tests/provider_sync.rs
+++ b/crates/codex-plus-data/tests/provider_sync.rs
@@ -521,6 +521,7 @@ fn provider_sync_preserves_marked_subagents_and_explicit_user_priority() {
     let rollout_child = home.join("sessions/2026/rollout-source-child.jsonl");
     let marked_rollout = home.join("sessions/2026/rollout-marked-child.jsonl");
     let explicit_user_rollout = home.join("sessions/2026/rollout-explicit-user.jsonl");
+    let guardian_user_rollout = home.join("sessions/2026/rollout-guardian-user.jsonl");
     write_rollout(
         &structured_rollout,
         "openai",
@@ -539,11 +540,17 @@ fn provider_sync_preserves_marked_subagents_and_explicit_user_priority() {
         "marked-child",
         "C:/marked-new",
     );
-    write_subagent_rollout(
+    write_rollout(
         &explicit_user_rollout,
         "openai",
         "explicit-user",
         "C:/user-new",
+    );
+    write_subagent_rollout(
+        &guardian_user_rollout,
+        "openai",
+        "guardian-user",
+        "C:/guardian-new",
     );
 
     let state = home.join("state_5.sqlite");
@@ -569,6 +576,12 @@ fn provider_sync_preserves_marked_subagents_and_explicit_user_priority() {
         (
             "explicit-user",
             "C:/user-old",
+            "subagent_review",
+            Some("user"),
+        ),
+        (
+            "guardian-user",
+            "C:/guardian-old",
             structured_source.as_str(),
             Some("user"),
         ),
@@ -600,6 +613,7 @@ fn provider_sync_preserves_marked_subagents_and_explicit_user_priority() {
         (&rollout_child, "openai"),
         (&marked_rollout, "openai"),
         (&explicit_user_rollout, "apigather"),
+        (&guardian_user_rollout, "openai"),
     ] {
         let first: serde_json::Value = serde_json::from_str(
             fs::read_to_string(path).unwrap().lines().next().unwrap(),
@@ -617,6 +631,7 @@ fn provider_sync_preserves_marked_subagents_and_explicit_user_priority() {
         ("rollout-child", ("openai", 0_i64, "C:/rollout-old")),
         ("marked-child", ("openai", 0_i64, "C:/marked-old")),
         ("explicit-user", ("apigather", 1_i64, "C:/user-new")),
+        ("guardian-user", ("openai", 0_i64, "C:/guardian-old")),
     ] {
         let actual: (String, i64, String) = db
             .query_row(
@@ -888,9 +903,15 @@ fn provider_sync_catalogs_user_threads_but_skips_subagents() {
         ("user-one", "vscode", "user", 200000_i64),
         (
             "explicit-user",
-            r#"{"sub_agent":{"other":"review"}}"#,
+            "subagent_review",
             "user",
             205000_i64,
+        ),
+        (
+            "guardian-user",
+            r#"{"subagent":{"other":"guardian"}}"#,
+            "user",
+            207000_i64,
         ),
         ("marked-child", "vscode", "subagent", 210000_i64),
         (


### PR DESCRIPTION
## Summary

Fix Guardian/subagent sessions being restored as user-visible threads when
`thread_source = "user"` conflicts with structured subagent metadata.

- Treat structured `source.subagent` metadata as authoritative.
- Keep `thread_source = "user"` priority for legacy text and spawn-edge hints.
- Skip subagent rollout rewrites even when stale SQLite marks them as user.
- Add regression coverage for conflicting Guardian metadata.

<img width="737" height="1375" alt="image" src="https://github.com/user-attachments/assets/7ab3482e-08b5-4f17-b388-01b6e415f459" />
