### PR TITLE
feat(manager): enable DeepSeek V4 Pro

### DIFF
--- a/apps/codex-plus-manager/src/presets.test.ts
+++ b/apps/codex-plus-manager/src/presets.test.ts
@@ -9,5 +9,5 @@ test("DeepSeek preset uses the official Responses integration", () => {
   assert.equal(preset.baseUrl, "https://api.deepseek.com/");
   assert.equal(preset.protocol, "responses");
   assert.equal(preset.model, "deepseek-v4-flash");
-  assert.deepEqual(preset.modelList, ["deepseek-v4-flash"]);
+  assert.deepEqual(preset.modelList, ["deepseek-v4-flash", "deepseek-v4-pro"]);
 });

--- a/apps/codex-plus-manager/src/presets.ts
+++ b/apps/codex-plus-manager/src/presets.ts
@@ -53,7 +53,7 @@ export const PRESETS: ProviderPreset[] = [
     baseUrl: "https://api.deepseek.com/",
     protocol: "responses",
     model: "deepseek-v4-flash",
-    modelList: ["deepseek-v4-flash"],
+    modelList: ["deepseek-v4-flash", "deepseek-v4-pro"],
   },
   {
     id: "zhipu-glm",

--- a/assets/deepseek-model-metadata.json
+++ b/assets/deepseek-model-metadata.json
@@ -75,7 +75,7 @@
       "shell_type": "shell_command",
       "visibility": "list",
       "minimal_client_version": "0.144.0",
-      "supported_in_api": false,
+      "supported_in_api": true,
       "priority": 2
     }
   ]

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -3918,7 +3918,7 @@ experimental_bearer_token = "sk-deepseek"
         .iter()
         .find(|model| model["slug"] == "deepseek-v4-pro")
         .unwrap();
-    assert_eq!(pro["supported_in_api"], false);
+    assert_eq!(pro["supported_in_api"], true);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Enable DeepSeek V4 Pro in the official provider preset.

## Changes

- Add `deepseek-v4-pro` to the DeepSeek Responses model list.
- Mark the bundled Pro metadata as `supported_in_api: true`.
- Update the preset regression test.

This reuses the existing DeepSeek Responses compatibility path; no new protocol handling is introduced.

## Validation

- `npm test` in `apps/codex-plus-manager`: 69 passed.
- `cargo test -p codex-plus-core --test model_catalog --locked`: 9 passed.
- `git diff --check`: passed.
- `npm run check` is blocked by the repository's existing TypeScript 7 incompatibility with `tsconfig.json` (`baseUrl` has been removed), unrelated to this change.
