### PR TITLE
feat(manager): add independent Stepwise and outline settings

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -859,27 +859,46 @@ impl BridgeRuntimeService for LauncherRuntimeService {
         }))
     }
 
-    async fn open_manager(&self) -> anyhow::Result<Value> {
-        let target = codex_plus_core::install::spawn_companion(
-            codex_plus_core::install::MANAGER_BINARY,
-            std::iter::empty::<&str>(),
-        )
-        .map_err(|error| anyhow::anyhow!("启动管理工具失败：{error}"))?;
+    async fn open_manager(&self, payload: Value) -> anyhow::Result<Value> {
+        let navigation =
+            codex_plus_core::manager_navigation::save_pending_manager_navigation_from_payload(
+                &payload,
+            )?;
+        let target = codex_plus_core::install::open_or_activate_manager()
+            .map_err(|error| anyhow::anyhow!("启动管理工具失败：{error}"))
+            .map_err(|error| {
+                codex_plus_core::manager_navigation::rollback_pending_manager_navigation_after_launch_failure(
+                    navigation.as_ref(),
+                    error,
+                )
+            })?;
         Ok(json!({
             "status": "ok",
-            "path": target
+            "path": target,
+            "navigation": navigation
         }))
     }
 
-    async fn open_transient_manager(&self) -> anyhow::Result<Value> {
+    async fn open_transient_manager(&self, payload: Value) -> anyhow::Result<Value> {
+        let navigation =
+            codex_plus_core::manager_navigation::save_pending_manager_navigation_from_payload(
+                &payload,
+            )?;
         let target = codex_plus_core::install::spawn_companion(
             codex_plus_core::install::MANAGER_BINARY,
             ["--transient"],
         )
-        .map_err(|error| anyhow::anyhow!("启动管理工具失败：{error}"))?;
+        .map_err(|error| anyhow::anyhow!("启动管理工具失败：{error}"))
+        .map_err(|error| {
+            codex_plus_core::manager_navigation::rollback_pending_manager_navigation_after_launch_failure(
+                navigation.as_ref(),
+                error,
+            )
+        })?;
         Ok(json!({
             "status": "ok",
-            "path": target
+            "path": target,
+            "navigation": navigation
         }))
     }
 

--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -493,6 +493,13 @@ pub fn startup_options() -> CommandResult<StartupPayload> {
     )
 }
 
+#[tauri::command]
+pub fn consume_pending_manager_navigation(
+) -> Result<Option<codex_plus_core::manager_navigation::ManagerNavigationIntent>, String> {
+    codex_plus_core::manager_navigation::consume_pending_manager_navigation()
+        .map_err(|error| error.to_string())
+}
+
 pub fn startup_should_show_update() -> bool {
     should_show_update(
         std::env::args(),

--- a/apps/codex-plus-manager/src-tauri/src/lib.rs
+++ b/apps/codex-plus-manager/src-tauri/src/lib.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
-use tauri::{Manager, WindowEvent};
+use tauri::{Emitter, Manager, WindowEvent};
 
 const TRAY_ID: &str = "codex_plus_tray";
 
@@ -14,6 +14,7 @@ const TRAY_MENU_SHOW: &str = "tray_show_main";
 const TRAY_MENU_DREAM_SKIN_APPLY: &str = "tray_apply_dream_skin";
 const TRAY_MENU_QUIT: &str = "tray_quit_app";
 const DREAM_SKIN_DEBUG_PORT: u16 = 9229;
+const MANAGER_NAVIGATION_EVENT: &str = "manager-navigation-requested";
 
 pub fn run() {
     install_panic_logger();
@@ -65,6 +66,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             commands::backend_version,
             commands::startup_options,
+            commands::consume_pending_manager_navigation,
             commands::load_overview,
             commands::launch_codex_plus,
             commands::restart_codex_plus,
@@ -271,12 +273,16 @@ fn register_main_window_events<R: tauri::Runtime>(
     let minimized_window = event_window.clone();
     let close_event_window = event_window.clone();
     let close_event_app = event_window.app_handle().clone();
+    let focus_event_window = event_window.clone();
 
     event_window.on_window_event(move |event| match event {
         WindowEvent::Resized(_) => {
             if matches!(minimized_window.is_minimized(), Ok(true)) {
                 let _ = minimized_window.hide();
             }
+        }
+        WindowEvent::Focused(true) => {
+            let _ = focus_event_window.emit(MANAGER_NAVIGATION_EVENT, ());
         }
         WindowEvent::CloseRequested { api, .. } => {
             if APP_EXITING.load(Ordering::SeqCst) {

--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -227,7 +227,9 @@ type BackendSettings = {
   codexAppServiceTierControls: boolean;
   codexAppPetRealMouseLook: boolean;
   codexAppStepwiseEnabled: boolean;
+  codexAppAnswerOutlineEnabled: boolean;
   codexAppStepwiseDirectSend: boolean;
+  codexAppStepwiseGenerationMode: StepwiseGenerationMode;
   codexAppStepwiseBaseUrl: string;
   codexAppStepwiseApiKey: string;
   codexAppStepwiseApiKeyEnv: string;
@@ -350,6 +352,7 @@ type CodexContextEntries = {
 };
 
 type RelayProtocol = "responses" | "chatCompletions";
+type StepwiseGenerationMode = "auto" | "manual";
 type RelayMode = "official" | "mixedApi" | "pureApi" | "aggregate";
 type RelaySessionProvider = "custom" | "openai";
 const CHAT_UPSTREAM_BASE_URL_KEY = "codex_plus_chat_base_url";
@@ -827,8 +830,16 @@ type StartupResult = CommandResult<{
   showUpdate: boolean;
 }>;
 
+type ManagerNavigationIntent = {
+  page: "settings";
+  section?: "stepwise";
+};
+
 type Route = "overview" | "relay" | "relayEnvironment" | "sessions" | "context" | "weixin" | "enhance" | "dreamSkin" | "zedRemote" | "userScripts" | "recommendations" | "maintenance" | "about" | "settings";
 type Theme = "dark" | "light";
+
+const MANAGER_NAVIGATION_EVENT = "manager-navigation-requested";
+const SETTINGS_STEPWISE_SECTION_ID = "settings-stepwise";
 
 const routes: Array<{ id: Route; label: string; icon: LucideIcon; badge?: string }> = [
   { id: "overview", label: t("概览"), icon: LayoutDashboard },
@@ -892,7 +903,9 @@ const defaultSettings: BackendSettings = {
   codexAppServiceTierControls: false,
   codexAppPetRealMouseLook: false,
   codexAppStepwiseEnabled: false,
+  codexAppAnswerOutlineEnabled: false,
   codexAppStepwiseDirectSend: false,
+  codexAppStepwiseGenerationMode: "auto",
   codexAppStepwiseBaseUrl: "",
   codexAppStepwiseApiKey: "",
   codexAppStepwiseApiKeyEnv: "CODEX_STEPWISE_API_KEY",
@@ -966,6 +979,7 @@ const defaultSettings: BackendSettings = {
 export function App() {
   const [theme, setTheme] = useState<Theme>(() => loadInitialTheme());
   const [route, setRoute] = useState<Route>(() => loadInitialRoute());
+  const [pendingSettingsSection, setPendingSettingsSection] = useState<ManagerNavigationIntent["section"] | null>(null);
   const [notice, setNotice] = useState<{ title: string; message: string; status?: Status } | null>(null);
   const [confirmDialog, setConfirmDialog] = useState<{
     title: string;
@@ -2700,6 +2714,22 @@ export function App() {
     await call<void>("manager_hide_to_tray");
   };
 
+  const consumePendingManagerNavigation = async (): Promise<boolean> => {
+    try {
+      const navigation = await invoke<ManagerNavigationIntent | null>("consume_pending_manager_navigation");
+      if (!navigation) return false;
+      if (navigation.page === "settings") {
+        setPendingSettingsSection(navigation.section ?? null);
+        setRoute("settings");
+        await refreshSettings(true);
+        return true;
+      }
+    } catch (error) {
+      logDiagnostic("manager.navigation_failed", { error: stringifyError(error) });
+    }
+    return false;
+  };
+
   const showResultNotice = (
     title: string,
     result: Pick<CommandResult<unknown>, "message" | "status">,
@@ -2712,14 +2742,15 @@ export function App() {
   useEffect(() => {
     void (async () => {
       const startup = await run(() => call<StartupResult>("startup_options"));
-      if (startup?.showUpdate) {
+      const handledNavigation = await consumePendingManagerNavigation();
+      if (!handledNavigation && startup?.showUpdate) {
         setRoute("about");
         void checkUpdate(false);
       } else {
         void checkUpdate(true);
       }
       await refreshOverview(true);
-      await refreshSettings(true);
+      if (!handledNavigation) await refreshSettings(true);
       await refreshRelay(true);
       await refreshEnvConflicts(true);
       await refreshProviderSyncTargets(true);
@@ -2728,6 +2759,39 @@ export function App() {
       await refreshRemotePluginMarketplace(true);
     })();
   }, []);
+
+  useEffect(() => {
+    let disposed = false;
+    let stopListening: (() => void) | undefined;
+    void listen(MANAGER_NAVIGATION_EVENT, () => {
+      if (!disposed) void consumePendingManagerNavigation();
+    }).then((unlisten) => {
+      if (disposed) unlisten();
+      else stopListening = unlisten;
+    });
+    return () => {
+      disposed = true;
+      stopListening?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (route !== "settings" || pendingSettingsSection !== "stepwise") return;
+    let secondFrame = 0;
+    const firstFrame = window.requestAnimationFrame(() => {
+      secondFrame = window.requestAnimationFrame(() => {
+        document.getElementById(SETTINGS_STEPWISE_SECTION_ID)?.scrollIntoView({
+          behavior: "smooth",
+          block: "start",
+        });
+        setPendingSettingsSection(null);
+      });
+    });
+    return () => {
+      window.cancelAnimationFrame(firstFrame);
+      if (secondFrame) window.cancelAnimationFrame(secondFrame);
+    };
+  }, [pendingSettingsSection, route]);
 
   useEffect(() => {
     if (getLanguage() === "en") {
@@ -4405,9 +4469,9 @@ function EnhanceScreen({
               <FeatureToggle title={t("对话居中宽度")} detail={t("把主对话和输入框限制到固定最大宽度，适合大屏阅读。")} checked={form.codexAppConversationView} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppConversationView", value)} />
               <FeatureToggle title={t("切换对话保留位置")} detail={t("切换 thread 时恢复上一次浏览位置。")} checked={form.codexAppThreadScrollRestore} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppThreadScrollRestore", value)} />
             </FeatureGroup>
-            <FeatureGroup title="Stepwise" detail={t("基于当前对话生成下一步建议，使用独立 API 配置。")}>
-              <FeatureToggle title="Stepwise" detail={t("在 Codex 页面显示可拖动的后续建议浮层；建议由单独配置的 Stepwise API 生成。启停后需重启 Codex++ 生效。")} checked={form.codexAppStepwiseEnabled} disabled={!masterEnabled} onChange={(value) => setEnhanceFlag("codexAppStepwiseEnabled", value)} />
-              <FeatureToggle title={t("Stepwise 直接发送")} detail={t("点击建议后自动发送；关闭时只填入输入框。")} checked={form.codexAppStepwiseDirectSend} disabled={!masterEnabled || !form.codexAppStepwiseEnabled} onChange={(value) => setEnhanceFlag("codexAppStepwiseDirectSend", value)} />
+            <FeatureGroup title={t("悬浮球")} detail={t("控制下一步建议与回答大纲。")}>
+              <FeatureToggle title="Stepwise" detail={t("根据当前回答生成下一步建议。")} checked={form.codexAppStepwiseEnabled} disabled={!masterEnabled} onChange={(value) => setPersistedEnhanceFlag("codexAppStepwiseEnabled", value)} />
+              <FeatureToggle title={t("回答大纲")} detail={t("整理当前回答的结构。")} checked={form.codexAppAnswerOutlineEnabled} disabled={!masterEnabled} onChange={(value) => setPersistedEnhanceFlag("codexAppAnswerOutlineEnabled", value)} />
             </FeatureGroup>
             <FeatureGroup title={t("界面与启动")} detail={t("控制语言、启动速度和 Codex 原生界面调整。")}>
               {isWindowsPlatform ? <FeatureToggle title={t("桌宠跟随真实鼠标")} detail={t("仅支持 V2 桌宠；不会修改宠物文件。将 V2 的 Computer Use 光标朝向动作映射到真实鼠标，V1 开启后安全不生效；拖拽、原生悬停或 Computer Use 活跃时自动让步。")} checked={form.codexAppPetRealMouseLook} disabled={!masterEnabled} onChange={(value) => setPersistedEnhanceFlag("codexAppPetRealMouseLook", value)} /> : null}
@@ -6204,7 +6268,7 @@ function SettingsScreen({
               placeholder={t("例如 gpt-5.4-mini")}
             />
           </Field>
-          <div className="settings-block stepwise-settings-block">
+          <div className="settings-block stepwise-settings-block" id={SETTINGS_STEPWISE_SECTION_ID}>
             <div className="section-title">Stepwise</div>
             <div className="stepwise-settings-section">{t("连接")}</div>
             <div className="form-row">
@@ -6223,6 +6287,16 @@ function SettingsScreen({
                 />
               </Field>
             </div>
+            <Field label={t("生成模式")}>
+              <AppSelect
+                value={form.codexAppStepwiseGenerationMode}
+                onChange={(value) => onFormChange({ ...form, codexAppStepwiseGenerationMode: value as StepwiseGenerationMode })}
+                options={[
+                  { value: "auto", label: t("自动生成") },
+                  { value: "manual", label: t("手动刷新") },
+                ]}
+              />
+            </Field>
             <Field label="API Key">
               <Input
                 type="password"
@@ -9300,6 +9374,8 @@ function normalizeSettings(settings: BackendSettings): BackendSettings {
     codexAppDreamSkinPaused: settings.codexAppDreamSkinPaused === true,
     codexAppDreamSkinThemeConfig: normalizeDreamSkinTheme(settings.codexAppDreamSkinThemeConfig),
     codexAppDreamSkinImagePath: (settings.codexAppDreamSkinImagePath || "").trim(),
+    codexAppAnswerOutlineEnabled: settings.codexAppAnswerOutlineEnabled === true,
+    codexAppStepwiseGenerationMode: normalizeStepwiseGenerationMode(settings.codexAppStepwiseGenerationMode),
     codexAppStepwiseMaxItems: clampNumber(settings.codexAppStepwiseMaxItems ?? 6, 0, 6),
     codexAppStepwiseMaxInputChars: clampNumber(settings.codexAppStepwiseMaxInputChars || 6000, 1000, 24000),
     codexAppStepwiseMaxOutputTokens: clampNumber(settings.codexAppStepwiseMaxOutputTokens || 500, 100, 4000),
@@ -9318,6 +9394,10 @@ function backendSettingsEqual(left: BackendSettings, right: BackendSettings): bo
 function clampNumber(value: number, min: number, max: number): number {
   if (!Number.isFinite(value)) return min;
   return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+function normalizeStepwiseGenerationMode(value: StepwiseGenerationMode | undefined): StepwiseGenerationMode {
+  return value === "manual" ? "manual" : "auto";
 }
 
 function parsePort(value: string, fallback: number): number {

--- a/apps/codex-plus-manager/src/renderer-inject.test.ts
+++ b/apps/codex-plus-manager/src/renderer-inject.test.ts
@@ -197,6 +197,22 @@ describe("renderer injection header compatibility", () => {
     assert.match(renderer, /codexPlusIsNodeTestHarness/);
   });
 
+  it("keeps the floating-panel feature flags opt-in", async () => {
+    const renderer = await readFile(new URL("../../../assets/inject/renderer-inject.js", import.meta.url), "utf8");
+
+    assert.match(renderer, /stepwise: false, answerOutline: false/);
+    assert.match(renderer, /answerOutline: "codexAppAnswerOutlineEnabled"/);
+    assert.match(renderer, /data-codex-plus-setting="answerOutline"/);
+  });
+
+  it("syncs the outline toggle through the existing Stepwise panel bridge", async () => {
+    const renderer = await readFile(new URL("../../../assets/inject/renderer-inject.js", import.meta.url), "utf8");
+
+    assert.match(renderer, /answerOutlineEnabled = codexPlusSettings\(\)\.answerOutline/);
+    assert.match(renderer, /answerOutlineEnabled: !!answerOutlineEnabled/);
+    assert.match(renderer, /key === "answerOutline"/);
+  });
+
   it("initializes renderer styles without unresolved template identifiers", async () => {
     const renderer = await readFile(new URL("../../../assets/inject/renderer-inject.js", import.meta.url), "utf8");
 

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -1257,7 +1257,7 @@
   }
 
   function defaultCodexPlusSettings() {
-    return { pluginMarketplaceUnlock: true, modelWhitelistUnlock: true, sessionDelete: true, markdownExport: true, pasteFix: false, threadIdBadge: false, conversationView: false, conversationViewMaxWidth: conversationViewDefaultWidth, threadScrollRestore: true, zedRemoteOpen: true, upstreamWorktreeCreate: true, nativeMenuPlacement: true, serviceTierControls: false, petRealMouseLook: false, stepwise: false, dreamSkinEnabled: false, dreamSkinPaused: false, dreamSkinThemeConfig: window.__CODEX_PLUS_DREAM_SKIN_THEME__ || {}, dreamSkinImagePath: "" };
+    return { pluginMarketplaceUnlock: true, modelWhitelistUnlock: true, sessionDelete: true, markdownExport: true, pasteFix: false, threadIdBadge: false, conversationView: false, conversationViewMaxWidth: conversationViewDefaultWidth, threadScrollRestore: true, zedRemoteOpen: true, upstreamWorktreeCreate: true, nativeMenuPlacement: true, serviceTierControls: false, petRealMouseLook: false, stepwise: false, answerOutline: false, dreamSkinEnabled: false, dreamSkinPaused: false, dreamSkinThemeConfig: window.__CODEX_PLUS_DREAM_SKIN_THEME__ || {}, dreamSkinImagePath: "" };
   }
 
   const codexPlusBackendSettingMap = {
@@ -1274,6 +1274,7 @@
     serviceTierControls: "codexAppServiceTierControls",
     petRealMouseLook: "codexAppPetRealMouseLook",
     stepwise: "codexAppStepwiseEnabled",
+    answerOutline: "codexAppAnswerOutlineEnabled",
     pasteFix: "codexAppPasteFix",
     dreamSkinEnabled: "codexAppDreamSkinEnabled",
     dreamSkinPaused: "codexAppDreamSkinPaused",
@@ -1312,6 +1313,7 @@
         serviceTierControls: false,
         petRealMouseLook: false,
         stepwise: false,
+        answerOutline: false,
         dreamSkinEnabled: false,
         dreamSkinPaused: false,
         dreamSkinThemeConfig: window.__CODEX_PLUS_DREAM_SKIN_THEME__ || {},
@@ -2078,9 +2080,10 @@
     const backendKey = codexPlusBackendSettingMap[key];
     if (backendKey) {
       if (key === "stepwise") syncStepwisePanel(value);
+      if (key === "answerOutline") syncStepwisePanel(undefined, value);
       void setBackendSetting(backendKey, value).then(() => {
-        if (key === "stepwise") {
-          Promise.resolve(window.__codexStepwisePanel?.loadSettings?.()).then(() => syncStepwisePanel(value));
+        if (key === "stepwise" || key === "answerOutline") {
+          Promise.resolve(window.__codexStepwisePanel?.loadSettings?.()).then(() => syncStepwisePanel());
         }
       }).catch(() => {
         void loadBackendSettings();
@@ -2119,9 +2122,15 @@
     scan();
   }
 
-  function syncStepwisePanel(enabled = codexPlusSettings().stepwise) {
+  function syncStepwisePanel(
+    enabled = codexPlusSettings().stepwise,
+    answerOutlineEnabled = codexPlusSettings().answerOutline
+  ) {
     try {
-      window.__codexStepwisePanel?.syncSettings?.({ enabled: !!enabled });
+      window.__codexStepwisePanel?.syncSettings?.({
+        enabled: !!enabled,
+        answerOutlineEnabled: !!answerOutlineEnabled,
+      });
     } catch (error) {
       sendCodexPlusDiagnostic("stepwise_sync_failed", {
         errorName: error?.name || "",
@@ -3868,6 +3877,10 @@
             <div class="codex-plus-row">
               <div><div class="codex-plus-row-title">Stepwise</div><div class="codex-plus-row-description">在当前 Codex 页面显示可拖动的下一步建议浮层，可在设置页配置模型和直接发送。启停后需重启 Codex++ 生效。</div></div>
               <button type="button" class="codex-plus-toggle" data-codex-plus-setting="stepwise"><span></span></button>
+            </div>
+            <div class="codex-plus-row">
+              <div><div class="codex-plus-row-title">回答大纲</div><div class="codex-plus-row-description">整理当前回答的结构。</div></div>
+              <button type="button" class="codex-plus-toggle" data-codex-plus-setting="answerOutline"><span></span></button>
             </div>
             <div class="codex-plus-row" data-codex-service-tier-controls="true">
               <div><div class="codex-plus-row-title">服务模式</div><div class="codex-plus-row-description">继承优先读取 Codex 应用内设置，其次读取 config.toml 的 service_tier；全局模式覆盖全部 thread；自定义允许按 thread 覆盖。</div></div>

--- a/crates/codex-plus-core/src/install/mod.rs
+++ b/crates/codex-plus-core/src/install/mod.rs
@@ -293,6 +293,24 @@ where
     Ok(path.to_string_lossy().to_string())
 }
 
+pub fn open_or_activate_manager() -> anyhow::Result<String> {
+    #[cfg(target_os = "macos")]
+    {
+        let exe = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("."));
+        if let Some(bundle_id) = macos_companion_bundle_identifier_from_exe(&exe, MANAGER_BINARY) {
+            let activated = Command::new("/usr/bin/open")
+                .args(["-b", bundle_id])
+                .status()
+                .is_ok_and(|status| status.success());
+            if activated {
+                return Ok(format!("bundle:{bundle_id}"));
+            }
+        }
+    }
+
+    spawn_companion(MANAGER_BINARY, std::iter::empty::<&str>())
+}
+
 pub fn macos_companion_bundle_identifier_from_exe(
     exe: &Path,
     binary: &str,

--- a/crates/codex-plus-core/src/lib.rs
+++ b/crates/codex-plus-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod env_conflicts;
 pub mod http_client;
 pub mod install;
 pub mod launcher;
+pub mod manager_navigation;
 pub mod model_catalog;
 pub mod model_suffix;
 pub mod models;

--- a/crates/codex-plus-core/src/manager_navigation.rs
+++ b/crates/codex-plus-core/src/manager_navigation.rs
@@ -1,0 +1,156 @@
+use anyhow::Context;
+use serde_json::Value;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagerNavigationIntent {
+    pub page: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub section: Option<String>,
+}
+
+pub fn save_pending_manager_navigation_from_payload(
+    payload: &Value,
+) -> anyhow::Result<Option<ManagerNavigationIntent>> {
+    if payload.as_object().is_some_and(|object| object.is_empty()) {
+        return Ok(None);
+    }
+    let navigation: ManagerNavigationIntent =
+        serde_json::from_value(payload.clone()).context("管理工具导航参数无效")?;
+    validate(&navigation)?;
+    save_pending_manager_navigation(&navigation)?;
+    Ok(Some(navigation))
+}
+
+pub fn save_pending_manager_navigation(navigation: &ManagerNavigationIntent) -> anyhow::Result<()> {
+    save_pending_manager_navigation_at(
+        &crate::paths::default_pending_manager_navigation_path(),
+        navigation,
+    )
+}
+
+pub fn consume_pending_manager_navigation() -> anyhow::Result<Option<ManagerNavigationIntent>> {
+    consume_pending_manager_navigation_at(&crate::paths::default_pending_manager_navigation_path())
+}
+
+pub fn rollback_pending_manager_navigation_after_launch_failure(
+    navigation: Option<&ManagerNavigationIntent>,
+    launch_error: anyhow::Error,
+) -> anyhow::Error {
+    let Some(navigation) = navigation else {
+        return launch_error;
+    };
+    match remove_pending_manager_navigation_if_matches(navigation) {
+        Ok(_) => launch_error,
+        Err(error) => launch_error.context(format!("清理未完成的管理工具导航失败：{error}")),
+    }
+}
+
+pub fn save_pending_manager_navigation_at(
+    path: &Path,
+    navigation: &ManagerNavigationIntent,
+) -> anyhow::Result<()> {
+    validate(navigation)?;
+    let contents = format!("{}\n", serde_json::to_string_pretty(navigation)?);
+    crate::settings::atomic_write(path, contents.as_bytes())
+        .with_context(|| format!("保存管理工具导航失败：{}", path.display()))
+}
+
+pub fn consume_pending_manager_navigation_at(
+    path: &Path,
+) -> anyhow::Result<Option<ManagerNavigationIntent>> {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).with_context(|| format!("读取管理工具导航失败：{}", path.display())),
+    };
+    let navigation = serde_json::from_str(&contents).context("管理工具导航内容无效")?;
+    validate(&navigation)?;
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error).with_context(|| format!("清理管理工具导航失败：{}", path.display())),
+    }
+    Ok(Some(navigation))
+}
+
+fn remove_pending_manager_navigation_if_matches(
+    navigation: &ManagerNavigationIntent,
+) -> anyhow::Result<bool> {
+    let path = crate::paths::default_pending_manager_navigation_path();
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error).with_context(|| format!("读取管理工具导航失败：{}", path.display())),
+    };
+    let pending: ManagerNavigationIntent =
+        serde_json::from_str(&contents).context("管理工具导航内容无效")?;
+    if pending != *navigation {
+        return Ok(false);
+    }
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error).context("清理管理工具导航失败"),
+    }
+}
+
+fn validate(navigation: &ManagerNavigationIntent) -> anyhow::Result<()> {
+    match (navigation.page.as_str(), navigation.section.as_deref()) {
+        ("settings", None | Some("stepwise")) => Ok(()),
+        _ => anyhow::bail!(
+            "不支持的管理工具导航：{}/{}",
+            navigation.page,
+            navigation.section.as_deref().unwrap_or("")
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn saves_and_consumes_navigation_once() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("pending-manager-navigation.json");
+        let navigation = ManagerNavigationIntent {
+            page: "settings".to_string(),
+            section: Some("stepwise".to_string()),
+        };
+
+        save_pending_manager_navigation_at(&path, &navigation).unwrap();
+        assert_eq!(consume_pending_manager_navigation_at(&path).unwrap(), Some(navigation));
+        assert_eq!(consume_pending_manager_navigation_at(&path).unwrap(), None);
+    }
+
+    #[test]
+    fn rejects_unknown_navigation_targets() {
+        let error = save_pending_manager_navigation_from_payload(&serde_json::json!({
+            "page": "settings",
+            "section": "unknown"
+        }))
+        .unwrap_err();
+        assert!(error.to_string().contains("不支持的管理工具导航"));
+    }
+
+    #[test]
+    fn launch_cleanup_does_not_remove_replacement_navigation() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("pending-manager-navigation.json");
+        let failed = ManagerNavigationIntent {
+            page: "settings".to_string(),
+            section: Some("stepwise".to_string()),
+        };
+        let replacement = ManagerNavigationIntent {
+            page: "settings".to_string(),
+            section: None,
+        };
+
+        save_pending_manager_navigation_at(&path, &failed).unwrap();
+        save_pending_manager_navigation_at(&path, &replacement).unwrap();
+        let loaded = consume_pending_manager_navigation_at(&path).unwrap();
+        assert_eq!(loaded, Some(replacement));
+    }
+}

--- a/crates/codex-plus-core/src/paths.rs
+++ b/crates/codex-plus-core/src/paths.rs
@@ -7,6 +7,7 @@ const LATEST_STATUS_FILE: &str = "latest-status.json";
 const DIAGNOSTIC_LOG_FILE: &str = "codex-plus.log";
 const PENDING_PROVIDER_IMPORT_FILE: &str = "pending-provider-import.json";
 const PENDING_REMOTE_CONTROL_RECOVERY_FILE: &str = "pending-remote-control-recovery.json";
+const PENDING_MANAGER_NAVIGATION_FILE: &str = "pending-manager-navigation.json";
 
 pub fn default_app_state_dir() -> PathBuf {
     if let Some(home_dir) = directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf()) {
@@ -37,6 +38,10 @@ pub fn default_pending_provider_import_path() -> PathBuf {
 
 pub fn default_pending_remote_control_recovery_path() -> PathBuf {
     default_app_state_dir().join(PENDING_REMOTE_CONTROL_RECOVERY_FILE)
+}
+
+pub fn default_pending_manager_navigation_path() -> PathBuf {
+    default_app_state_dir().join(PENDING_MANAGER_NAVIGATION_FILE)
 }
 
 fn settings_path_for_tests() -> Option<PathBuf> {
@@ -106,5 +111,11 @@ mod tests {
         let path = default_pending_remote_control_recovery_path();
 
         assert!(path.ends_with(".codex-session-delete/pending-remote-control-recovery.json"));
+    }
+
+    #[test]
+    fn default_pending_manager_navigation_path_uses_app_state_directory() {
+        let path = default_pending_manager_navigation_path();
+        assert!(path.ends_with(".codex-session-delete/pending-manager-navigation.json"));
     }
 }

--- a/crates/codex-plus-core/src/routes.rs
+++ b/crates/codex-plus-core/src/routes.rs
@@ -83,9 +83,9 @@ pub trait BridgeRuntimeService: Send + Sync {
     async fn delete_user_script(&self, key: String) -> anyhow::Result<Value>;
     async fn reload_user_scripts(&self) -> anyhow::Result<Value>;
     async fn open_devtools(&self) -> anyhow::Result<Value>;
-    async fn open_manager(&self) -> anyhow::Result<Value>;
-    async fn open_transient_manager(&self) -> anyhow::Result<Value> {
-        self.open_manager().await
+    async fn open_manager(&self, payload: Value) -> anyhow::Result<Value>;
+    async fn open_transient_manager(&self, payload: Value) -> anyhow::Result<Value> {
+        self.open_manager(payload).await
     }
     async fn backend_status(&self) -> anyhow::Result<Value>;
     async fn codex_model_catalog(&self) -> anyhow::Result<Value>;
@@ -182,8 +182,8 @@ pub async fn handle_bridge_request(
         }
         "/user-scripts/reload" => ctx.runtime.reload_user_scripts().await,
         "/devtools/open" => ctx.runtime.open_devtools().await,
-        "/manager/open" => ctx.runtime.open_manager().await,
-        "/manager/open-transient" => ctx.runtime.open_transient_manager().await,
+        "/manager/open" => ctx.runtime.open_manager(payload.clone()).await,
+        "/manager/open-transient" => ctx.runtime.open_transient_manager(payload.clone()).await,
         "/backend/status" => backend_status_value(
             ctx.runtime.backend_status().await,
             ctx.settings.get_settings().await,
@@ -459,23 +459,41 @@ impl BridgeRuntimeService for CoreRuntimeService {
         }))
     }
 
-    async fn open_manager(&self) -> anyhow::Result<Value> {
-        let target = crate::install::spawn_companion(
-            crate::install::MANAGER_BINARY,
-            std::iter::empty::<&str>(),
+    async fn open_manager(&self, payload: Value) -> anyhow::Result<Value> {
+        let navigation = crate::manager_navigation::save_pending_manager_navigation_from_payload(
+            &payload,
         )?;
+        let target = crate::install::open_or_activate_manager().map_err(|error| {
+            crate::manager_navigation::rollback_pending_manager_navigation_after_launch_failure(
+                navigation.as_ref(),
+                error,
+            )
+        })?;
         Ok(json!({
             "status": "ok",
-            "path": target
+            "path": target,
+            "navigation": navigation
         }))
     }
 
-    async fn open_transient_manager(&self) -> anyhow::Result<Value> {
-        let target =
-            crate::install::spawn_companion(crate::install::MANAGER_BINARY, ["--transient"])?;
+    async fn open_transient_manager(&self, payload: Value) -> anyhow::Result<Value> {
+        let navigation = crate::manager_navigation::save_pending_manager_navigation_from_payload(
+            &payload,
+        )?;
+        let target = crate::install::spawn_companion(
+            crate::install::MANAGER_BINARY,
+            ["--transient"],
+        )
+        .map_err(|error| {
+            crate::manager_navigation::rollback_pending_manager_navigation_after_launch_failure(
+                navigation.as_ref(),
+                error,
+            )
+        })?;
         Ok(json!({
             "status": "ok",
-            "path": target
+            "path": target,
+            "navigation": navigation
         }))
     }
 

--- a/crates/codex-plus-core/src/settings.rs
+++ b/crates/codex-plus-core/src/settings.rs
@@ -431,6 +431,14 @@ pub struct BackendSettings {
     pub codex_app_pet_real_mouse_look: bool,
     #[serde(rename = "codexAppStepwiseEnabled", default)]
     pub codex_app_stepwise_enabled: bool,
+    #[serde(
+        rename = "codexAppStepwiseGenerationMode",
+        default = "default_stepwise_generation_mode",
+        deserialize_with = "deserialize_stepwise_generation_mode"
+    )]
+    pub codex_app_stepwise_generation_mode: String,
+    #[serde(rename = "codexAppAnswerOutlineEnabled", default)]
+    pub codex_app_answer_outline_enabled: bool,
     #[serde(rename = "codexAppStepwiseDirectSend", default)]
     pub codex_app_stepwise_direct_send: bool,
     #[serde(rename = "codexAppStepwiseBaseUrl", default)]
@@ -586,6 +594,8 @@ impl Default for BackendSettings {
             codex_app_service_tier_controls: false,
             codex_app_pet_real_mouse_look: false,
             codex_app_stepwise_enabled: false,
+            codex_app_stepwise_generation_mode: default_stepwise_generation_mode(),
+            codex_app_answer_outline_enabled: false,
             codex_app_stepwise_direct_send: false,
             codex_app_stepwise_base_url: String::new(),
             codex_app_stepwise_api_key: String::new(),
@@ -803,6 +813,17 @@ pub fn normalize_stepwise_protocol(value: &str) -> String {
     }
 }
 
+pub fn default_stepwise_generation_mode() -> String {
+    "auto".to_string()
+}
+
+pub fn normalize_stepwise_generation_mode(value: &str) -> String {
+    match value.trim() {
+        "manual" => "manual".to_string(),
+        _ => default_stepwise_generation_mode(),
+    }
+}
+
 pub fn default_stepwise_max_items() -> u8 {
     6
 }
@@ -1006,6 +1027,15 @@ where
     Ok(Option::<String>::deserialize(deserializer)?
         .map(|value| normalize_stepwise_protocol(&value))
         .unwrap_or_else(default_stepwise_protocol))
+}
+
+fn deserialize_stepwise_generation_mode<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<String>::deserialize(deserializer)?
+        .map(|value| normalize_stepwise_generation_mode(&value))
+        .unwrap_or_else(default_stepwise_generation_mode))
 }
 
 fn deserialize_image_overlay_opacity<'de, D>(deserializer: D) -> Result<u8, D::Error>
@@ -1223,6 +1253,16 @@ fn merge_known_setting_fields(target: &mut Map<String, Value>, source: &Map<Stri
     merge_bool_setting(target, source, "codexAppServiceTierControls");
     merge_bool_setting(target, source, "codexAppPetRealMouseLook");
     merge_bool_setting(target, source, "codexAppStepwiseEnabled");
+    if let Some(value) = source
+        .get("codexAppStepwiseGenerationMode")
+        .and_then(Value::as_str)
+    {
+        target.insert(
+            "codexAppStepwiseGenerationMode".to_string(),
+            Value::String(normalize_stepwise_generation_mode(value)),
+        );
+    }
+    merge_bool_setting(target, source, "codexAppAnswerOutlineEnabled");
     merge_bool_setting(target, source, "codexAppStepwiseDirectSend");
     if let Some(value) = source
         .get("codexAppStepwiseBaseUrl")
@@ -1604,6 +1644,8 @@ fn normalize_settings_config_sections(mut settings: BackendSettings) -> BackendS
         };
     settings.codex_app_stepwise_protocol =
         normalize_stepwise_protocol(&settings.codex_app_stepwise_protocol);
+    settings.codex_app_stepwise_generation_mode =
+        normalize_stepwise_generation_mode(&settings.codex_app_stepwise_generation_mode);
     settings.codex_app_stepwise_model = settings.codex_app_stepwise_model.trim().to_string();
     settings.weixin_connect_base_url = settings
         .weixin_connect_base_url
@@ -1808,6 +1850,8 @@ mod tests {
         assert!(settings.relay_common_config_contents.is_empty());
         assert_eq!(settings.relay_test_model, default_relay_test_model());
         assert!(!settings.codex_app_stepwise_enabled);
+        assert_eq!(settings.codex_app_stepwise_generation_mode, "auto");
+        assert!(!settings.codex_app_answer_outline_enabled);
         assert!(!settings.codex_app_stepwise_direct_send);
         assert!(settings.codex_app_stepwise_base_url.is_empty());
         assert!(settings.codex_app_stepwise_api_key.is_empty());
@@ -1853,6 +1897,34 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(invalid.codex_app_stepwise_protocol, "chat_completions");
+    }
+
+    #[test]
+    fn settings_deserialize_defaults_stepwise_ui_settings() {
+        let defaults: BackendSettings = serde_json::from_str("{}").unwrap();
+        assert_eq!(defaults.codex_app_stepwise_generation_mode, "auto");
+        assert!(!defaults.codex_app_answer_outline_enabled);
+
+        let explicitly_enabled: BackendSettings = serde_json::from_value(json!({
+            "codexAppAnswerOutlineEnabled": true
+        }))
+        .unwrap();
+        assert!(explicitly_enabled.codex_app_answer_outline_enabled);
+    }
+
+    #[test]
+    fn settings_deserialize_normalizes_stepwise_generation_mode() {
+        let manual: BackendSettings = serde_json::from_value(json!({
+            "codexAppStepwiseGenerationMode": " manual "
+        }))
+        .unwrap();
+        assert_eq!(manual.codex_app_stepwise_generation_mode, "manual");
+
+        let invalid: BackendSettings = serde_json::from_value(json!({
+            "codexAppStepwiseGenerationMode": "unsupported"
+        }))
+        .unwrap();
+        assert_eq!(invalid.codex_app_stepwise_generation_mode, "auto");
     }
 
 

--- a/crates/codex-plus-core/src/stepwise.rs
+++ b/crates/codex-plus-core/src/stepwise.rs
@@ -66,6 +66,8 @@ pub struct StepwiseItem {
 #[serde(rename_all = "camelCase")]
 pub struct StepwisePublicSettings {
     pub enabled: bool,
+    pub answer_outline_enabled: bool,
+    pub generation_mode: String,
     pub direct_send: bool,
     pub base_url_configured: bool,
     pub api_key_configured: bool,
@@ -82,6 +84,8 @@ pub struct StepwisePublicSettings {
 pub fn public_settings(settings: &BackendSettings) -> StepwisePublicSettings {
     StepwisePublicSettings {
         enabled: settings.codex_app_stepwise_enabled,
+        answer_outline_enabled: settings.codex_app_answer_outline_enabled,
+        generation_mode: settings.codex_app_stepwise_generation_mode.clone(),
         direct_send: settings.codex_app_stepwise_direct_send,
         base_url_configured: !settings.codex_app_stepwise_base_url.trim().is_empty(),
         api_key_configured: !stepwise_api_key(settings).is_empty(),
@@ -107,6 +111,19 @@ pub fn settings_with_payload(mut settings: BackendSettings, payload: &Value) -> 
         .and_then(Value::as_bool)
     {
         settings.codex_app_stepwise_enabled = value;
+    }
+    if let Some(value) = raw_settings
+        .get("codexAppAnswerOutlineEnabled")
+        .and_then(Value::as_bool)
+    {
+        settings.codex_app_answer_outline_enabled = value;
+    }
+    if let Some(value) = raw_settings
+        .get("codexAppStepwiseGenerationMode")
+        .and_then(Value::as_str)
+    {
+        settings.codex_app_stepwise_generation_mode =
+            crate::settings::normalize_stepwise_generation_mode(value);
     }
     if let Some(value) = raw_settings
         .get("codexAppStepwiseDirectSend")
@@ -829,6 +846,8 @@ mod tests {
             &json!({
                 "settings": {
                     "codexAppStepwiseEnabled": true,
+                    "codexAppAnswerOutlineEnabled": true,
+                    "codexAppStepwiseGenerationMode": " manual ",
                     "codexAppStepwiseDirectSend": true,
                     "codexAppStepwiseBaseUrl": "https://api.example.test/v1/",
                     "codexAppStepwiseApiKey": " sk-test ",
@@ -844,6 +863,8 @@ mod tests {
         );
 
         assert!(settings.codex_app_stepwise_enabled);
+        assert!(settings.codex_app_answer_outline_enabled);
+        assert_eq!(settings.codex_app_stepwise_generation_mode, "manual");
         assert!(settings.codex_app_stepwise_direct_send);
         assert_eq!(
             settings.codex_app_stepwise_base_url,

--- a/crates/codex-plus-core/tests/bridge_routes.rs
+++ b/crates/codex-plus-core/tests/bridge_routes.rs
@@ -362,6 +362,14 @@ async fn stepwise_routes_use_settings_service() {
 
     let public_settings = handle_bridge_request(ctx.clone(), "/stepwise/settings", json!({})).await;
     assert_eq!(public_settings["settings"]["enabled"], json!(false));
+    assert_eq!(
+        public_settings["settings"]["answerOutlineEnabled"],
+        json!(false)
+    );
+    assert_eq!(
+        public_settings["settings"]["generationMode"],
+        json!("auto")
+    );
     assert_eq!(public_settings["settings"]["directSend"], json!(true));
     assert_eq!(
         public_settings["settings"]["model"],
@@ -460,15 +468,29 @@ async fn runtime_routes_keep_user_script_inventory_shape() {
 
 #[tokio::test]
 async fn runtime_status_devtools_repair_and_ads_routes_are_dispatched() {
-    let ctx = test_context();
+    let runtime = Arc::new(FakeRuntime::default());
+    let ctx = BridgeContext::new(
+        Arc::new(FakeSettings::default()),
+        runtime.clone(),
+        Arc::new(FakeData::default()),
+    );
 
     assert_eq!(
         handle_bridge_request(ctx.clone(), "/devtools/open", json!({})).await,
         json!({"status": "ok", "opened": true})
     );
     assert_eq!(
-        handle_bridge_request(ctx.clone(), "/manager/open", json!({})).await,
+        handle_bridge_request(
+            ctx.clone(),
+            "/manager/open",
+            json!({"page": "settings", "section": "stepwise"}),
+        )
+        .await,
         json!({"status": "ok", "opened": "manager"})
+    );
+    assert_eq!(
+        *runtime.manager_payload.lock().unwrap(),
+        json!({"page": "settings", "section": "stepwise"})
     );
     assert_eq!(
         handle_bridge_request(ctx.clone(), "/manager/open-transient", json!({})).await,
@@ -1204,6 +1226,7 @@ impl BridgeSettingsService for FakeSettings {
 struct FakeRuntime {
     enabled: Mutex<bool>,
     script_enabled: Mutex<bool>,
+    manager_payload: Mutex<Value>,
 }
 
 impl Default for FakeRuntime {
@@ -1211,6 +1234,7 @@ impl Default for FakeRuntime {
         Self {
             enabled: Mutex::new(true),
             script_enabled: Mutex::new(true),
+            manager_payload: Mutex::new(json!({})),
         }
     }
 }
@@ -1246,11 +1270,13 @@ impl BridgeRuntimeService for FakeRuntime {
         Ok(json!({"status": "ok", "opened": true}))
     }
 
-    async fn open_manager(&self) -> anyhow::Result<Value> {
+    async fn open_manager(&self, payload: Value) -> anyhow::Result<Value> {
+        *self.manager_payload.lock().unwrap() = payload;
         Ok(json!({"status": "ok", "opened": "manager"}))
     }
 
-    async fn open_transient_manager(&self) -> anyhow::Result<Value> {
+    async fn open_transient_manager(&self, payload: Value) -> anyhow::Result<Value> {
+        *self.manager_payload.lock().unwrap() = payload;
         Ok(json!({"status": "ok", "opened": "manager-transient"}))
     }
 


### PR DESCRIPTION
## 变更概述

为悬浮球相关功能补充独立的 Manager 设置契约与设置入口导航，使 Stepwise 和回答大纲可以分别控制。

## 变更范围

- 新增回答大纲开关和 Stepwise 生成模式设置，默认保持关闭和兼容回退。
- 将设置加入 BackendSettings、Bridge、renderer 同步和 Manager 表单。
- 支持从悬浮窗设置入口直接定位到 Manager 的 Stepwise 设置区块。
- 处理一次性导航意图的消费、重复焦点和启动失败清理。
- 同步调整相关设置区块的排版与分组，改善长期存在的 Manager 页面布局问题。
- 不包含回答大纲解析、悬浮面板结构或视觉主题实现。

## 验证

- `cargo test -p codex-plus-core --test bridge_routes`：32/32 通过
- Manager 前端测试未在本地执行：当前 checkout 未安装 `node_modules`，未擅自安装依赖；CI 将执行完整前端测试。

该 PR 仅负责设置契约、状态同步和 Manager 导航，可独立审查、测试和回退。
