### PR TITLE
feat(stepwise): add adaptive floating panel materials

### DIFF
--- a/assets/inject/floating-panel-visual-inject.js
+++ b/assets/inject/floating-panel-visual-inject.js
@@ -1,0 +1,151 @@
+(() => {
+  "use strict";
+
+  const API_KEY = "__codexFloatingPanelVisual";
+  const PANEL_KEY = "__codexFloatingPanel";
+  const ROOT_ATTR = "data-codex-floating-panel-root";
+  const STYLE_ID = "codex-floating-panel-visual-style";
+  const FILTER_ID = "codex-floating-panel-noise-filter";
+  const MATERIALS = ["frosted", "clear", "liquid", "crystal", "matte"];
+  const instanceId = `visual-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  let observer = null;
+  let themeObserver = null;
+  let destroyed = false;
+
+  function root() {
+    return document.querySelector(`[${ROOT_ATTR}="true"]`);
+  }
+
+  function hostTypography() {
+    const candidate = document.querySelector("[data-codex-intelligence-trigger], textarea, [contenteditable='true'], body");
+    if (!candidate) return null;
+    const style = getComputedStyle(candidate);
+    return {
+      family: style.fontFamily || "-apple-system, system-ui, sans-serif",
+      size: style.fontSize || "13px",
+      weight: style.fontWeight || "400",
+    };
+  }
+
+  function installFilters() {
+    if (document.getElementById(FILTER_ID)) return;
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.id = FILTER_ID;
+    svg.setAttribute("aria-hidden", "true");
+    svg.setAttribute("width", "0");
+    svg.setAttribute("height", "0");
+    svg.style.position = "absolute";
+    svg.innerHTML = `<defs>
+      <filter id="cfp-noise-filter" x="-10%" y="-10%" width="120%" height="120%">
+        <feTurbulence type="fractalNoise" baseFrequency=".8" numOctaves="2" seed="17" result="noise" />
+        <feColorMatrix in="noise" type="saturate" values="0" result="mono" />
+        <feComponentTransfer in="mono"><feFuncA type="table" tableValues="0 .12" /></feComponentTransfer>
+      </filter>
+    </defs>`;
+    document.body?.appendChild(svg);
+  }
+
+  function installStyle() {
+    if (document.getElementById(STYLE_ID)) return;
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = `
+      [${ROOT_ATTR}="true"] {
+        --cfp-font-family: -apple-system, system-ui, "Segoe UI", sans-serif;
+        --cfp-font-size: 13px;
+        --cfp-font-weight: 400;
+        --cfp-material-tint: transparent;
+        --cfp-material-opacity: .92;
+        --cfp-material-blur: 24px;
+        --cfp-material-saturation: 1.08;
+        --cfp-material-noise: 0;
+        --cfp-elevation: 0 10px 28px rgb(0 0 0 / 12%);
+        font-family: var(--cfp-font-family);
+        font-size: var(--cfp-font-size);
+        font-weight: var(--cfp-font-weight);
+      }
+      [${ROOT_ATTR}="true"] .cfp-capsule,
+      [${ROOT_ATTR}="true"] .cfp-panel {
+        background-color: color-mix(in srgb, var(--cfp-bg) calc(var(--cfp-material-opacity) * 100%), transparent);
+        background-image: linear-gradient(135deg, var(--cfp-material-tint), transparent 62%);
+        box-shadow: var(--cfp-elevation);
+        -webkit-backdrop-filter: blur(var(--cfp-material-blur)) saturate(var(--cfp-material-saturation));
+        backdrop-filter: blur(var(--cfp-material-blur)) saturate(var(--cfp-material-saturation));
+      }
+      [${ROOT_ATTR}="true"] .cfp-panel::before,
+      [${ROOT_ATTR}="true"] .cfp-capsule::before {
+        background: rgba(255,255,255,var(--cfp-material-noise));
+        content: "";
+        inset: 0;
+        opacity: .55;
+        pointer-events: none;
+        position: absolute;
+        filter: url(#cfp-noise-filter);
+      }
+      [${ROOT_ATTR}="true"] .cfp-panel { isolation: isolate; }
+      [${ROOT_ATTR}="true"] .cfp-capsule { isolation: isolate; overflow: hidden; }
+      [${ROOT_ATTR}="true"] .cfp-panel > *,
+      [${ROOT_ATTR}="true"] .cfp-capsule > * { position: relative; z-index: 1; }
+      [${ROOT_ATTR}="true"][data-material="frosted"] { --cfp-material-tint: rgba(255,255,255,.18); --cfp-material-opacity: .88; --cfp-material-blur: 20px; --cfp-material-noise: .06; }
+      [${ROOT_ATTR}="true"][data-material="clear"] { --cfp-material-tint: rgba(255,255,255,.08); --cfp-material-opacity: .34; --cfp-material-blur: 10px; --cfp-material-saturation: 1.2; --cfp-material-noise: .04; }
+      [${ROOT_ATTR}="true"][data-material="liquid"] { --cfp-material-tint: rgba(111,169,255,.2); --cfp-material-opacity: .54; --cfp-material-blur: 16px; --cfp-material-saturation: 1.25; --cfp-material-noise: .09; }
+      [${ROOT_ATTR}="true"][data-material="crystal"] { --cfp-material-tint: rgba(206,229,255,.24); --cfp-material-opacity: .62; --cfp-material-blur: 12px; --cfp-material-saturation: 1.3; --cfp-material-noise: .08; }
+      [${ROOT_ATTR}="true"][data-material="matte"] { --cfp-material-tint: rgba(80,87,101,.12); --cfp-material-opacity: .82; --cfp-material-blur: 4px; --cfp-material-saturation: .92; --cfp-material-noise: .025; }
+      [${ROOT_ATTR}="true"][data-theme="dark"] { --cfp-elevation: 0 12px 32px rgb(0 0 0 / 38%); }
+      [${ROOT_ATTR}="true"] .cfp-capsule[data-pending="true"] .cfp-glyph,
+      [${ROOT_ATTR}="true"] .cfp-capsule[data-pending="true"] .cfp-capsule-label {
+        background: linear-gradient(90deg, currentColor 35%, var(--cfp-accent) 50%, currentColor 65%);
+        background-clip: text;
+        background-size: 220% 100%;
+        color: transparent;
+        -webkit-background-clip: text;
+        animation: cfp-shimmer 1.5s linear infinite;
+      }
+      @keyframes cfp-shimmer { from { background-position: 180% 0; } to { background-position: -20% 0; } }
+      @media (prefers-reduced-motion: reduce) {
+        [${ROOT_ATTR}="true"] .cfp-capsule[data-pending="true"] .cfp-glyph,
+        [${ROOT_ATTR}="true"] .cfp-capsule[data-pending="true"] .cfp-capsule-label { animation: none; color: var(--cfp-muted); }
+      }
+    `;
+    document.documentElement.appendChild(style);
+  }
+
+  function apply() {
+    if (destroyed) return;
+    const panelRoot = root();
+    if (!panelRoot) return;
+    const typography = hostTypography();
+    if (typography) {
+      panelRoot.style.setProperty("--cfp-font-family", typography.family);
+      panelRoot.style.setProperty("--cfp-font-size", typography.size);
+      panelRoot.style.setProperty("--cfp-font-weight", typography.weight);
+    }
+    const pending = panelRoot.querySelector(".cfp-capsule-label")?.textContent?.includes("正在");
+    panelRoot.querySelector(".cfp-capsule")?.setAttribute("data-pending", String(Boolean(pending)));
+    panelRoot.dataset.visualLayer = "true";
+  }
+
+  function destroy() {
+    destroyed = true;
+    observer?.disconnect();
+    themeObserver?.disconnect();
+    document.getElementById(STYLE_ID)?.remove();
+    document.getElementById(FILTER_ID)?.remove();
+    if (window[API_KEY]?.instanceId === instanceId) delete window[API_KEY];
+  }
+
+  function start() {
+    if (destroyed) return;
+    installFilters();
+    installStyle();
+    apply();
+    observer = new MutationObserver(apply);
+    observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+    themeObserver = new MutationObserver(apply);
+    themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ["class", "style"] });
+  }
+
+  window[API_KEY] = { version: "1.0.0", instanceId, destroy, apply };
+  if (document.body) start();
+  else document.addEventListener("DOMContentLoaded", start, { once: true });
+})();

--- a/crates/codex-plus-core/src/assets.rs
+++ b/crates/codex-plus-core/src/assets.rs
@@ -46,6 +46,8 @@ const DREAM_SKIN_DEFAULT_IMAGE: &[u8] =
     include_bytes!("../../../assets/inject/upstream/dream-skin/macos/portal-hero.png");
 const PET_REAL_MOUSE_SCRIPT: &str = include_str!("../../../assets/inject/pet-real-mouse-inject.js");
 const STEPWISE_SCRIPT: &str = include_str!("../../../assets/inject/stepwise-inject.js");
+const FLOATING_PANEL_VISUAL_SCRIPT: &str =
+    include_str!("../../../assets/inject/floating-panel-visual-inject.js");
 pub const DIAGNOSTIC_BUILD_ID: &str = "diag-20260518-1";
 const DREAM_SKIN_RENDERER_REVISION: &str = "20-modern-main-surface";
 
@@ -270,6 +272,10 @@ pub fn stepwise_script() -> &'static str {
     STEPWISE_SCRIPT
 }
 
+pub fn floating_panel_visual_script() -> &'static str {
+    FLOATING_PANEL_VISUAL_SCRIPT
+}
+
 pub fn pet_real_mouse_script() -> &'static str {
     PET_REAL_MOUSE_SCRIPT
 }
@@ -405,9 +411,13 @@ pub fn injection_script_with_settings(helper_port: u16, settings: &BackendSettin
     let fast_startup = fast_startup_config(settings);
     let hide_official_usage_alert = hide_official_usage_alert_config(settings);
     let stepwise_runtime = if settings.codex_app_stepwise_enabled {
-        stepwise_script()
+        format!(
+            "{}\n{}",
+            stepwise_script(),
+            floating_panel_visual_script()
+        )
     } else {
-        ""
+        String::new()
     };
     format!(
         "window.__CODEX_SESSION_DELETE_HELPER__ = {};\nwindow.__CODEX_PLUS_VERSION__ = {};\nwindow.__CODEX_PLUS_BUILD__ = {};\nwindow.__CODEX_PLUS_IMAGE_OVERLAY__ = {};\nwindow.__CODEX_PLUS_PLUGIN_MARKETPLACES__ = {};\nwindow.__CODEX_PLUS_EXTERNAL_DREAM_SKIN_RUNTIME__ = true;\nwindow.__CODEX_PLUS_DREAM_SKIN_PLATFORM__ = {};\nwindow.__CODEX_PLUS_DREAM_SKIN_REVISION__ = {};\nwindow.__CODEX_PLUS_DREAM_SKIN_ART__ = {};\nwindow.__CODEX_PLUS_DREAM_SKIN_ART_SIGNATURE__ = {};\nwindow.__CODEX_PLUS_DREAM_SKIN_THEME__ = {};\nwindow.__CODEX_PLUS_PASTE_FIX__ = {};\nwindow.__CODEX_PLUS_FORCE_CHINESE_LOCALE__ = {};\nwindow.__CODEX_PLUS_FAST_STARTUP__ = {};\nwindow.__CODEX_PLUS_HIDE_OFFICIAL_USAGE_ALERT__ = {};\n{}\n{}\n{}",

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -90,6 +90,21 @@ fn injection_script_includes_stepwise_runtime_when_enabled() {
 }
 
 #[test]
+fn injection_script_includes_visual_layer_only_with_stepwise() {
+    let disabled = assets::injection_script_with_settings(57321, &BackendSettings::default());
+    assert!(!disabled.contains("__codexFloatingPanelVisual"));
+
+    let enabled = BackendSettings {
+        codex_app_stepwise_enabled: true,
+        ..Default::default()
+    };
+    let script = assets::injection_script_with_settings(57321, &enabled);
+    assert!(script.contains("__codexFloatingPanelVisual"));
+    assert!(script.contains("cfp-noise-filter"));
+    assert!(script.contains("prefers-reduced-motion"));
+}
+
+#[test]
 fn pet_real_mouse_settings_are_gated_to_windows_in_injected_ui() {
     let script = assets::injection_script(57321);
 


### PR DESCRIPTION
## 变更概述

为悬浮面板增加独立的宿主自适应视觉层，提供五种材质选择和克制的状态动效。

## 范围

- 新增 `floating-panel-visual-inject.js`，不改变面板 DOM、数据流或请求逻辑。
- 提供磨砂、通透、液态、冰晶、哑光五种材质变量。
- 根据 Codex 宿主实时字体采样同步字体族、字号和字重。
- 使用低对比噪点、高光和背景模糊表达材质，避免对内容层整体应用扭曲滤镜造成文字模糊。
- 对生成中状态增加轻微文字流光，并支持 `prefers-reduced-motion`。
- 没有悬浮面板宿主时不产生可见 UI。

## 独立性

不修改面板结构、Stepwise 请求层、Answer Outline 数据层或 Manager 设置。

## 验证

- `node --check assets/inject/floating-panel-visual-inject.js`
- `cargo test -p codex-plus-core --test cdp_bridge`
- 结果：111/111 通过。
