### PR TITLE
feat: support per-model auto-compact thresholds

### DIFF
--- a/apps/codex-plus-manager/src/auto-compact.ts
+++ b/apps/codex-plus-manager/src/auto-compact.ts
@@ -1,0 +1,18 @@
+export const DEFAULT_AUTO_COMPACT_PERCENT = "90%";
+
+/** 校验用户输入的自动压缩比例；空值表示沿用 Codex 默认行为。 */
+export function isValidAutoCompactPercent(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return true;
+  if (!/^\d+(?:\.\d{1,6})?%?$/.test(trimmed)) return false;
+  const numeric = Number(trimmed.replace(/%$/, ""));
+  return Number.isFinite(numeric) && numeric > 0 && numeric <= 100;
+}
+
+/** 将合法比例统一为带百分号的文本；非法值原样返回，便于界面显示错误。 */
+export function normalizeAutoCompactPercent(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  if (!isValidAutoCompactPercent(trimmed)) return trimmed;
+  return `${trimmed.replace(/%$/, "").trim()}%`;
+}

--- a/apps/codex-plus-manager/src/model-windows.test.ts
+++ b/apps/codex-plus-manager/src/model-windows.test.ts
@@ -108,6 +108,21 @@ describe("model-windows helpers", () => {
     );
   });
 
+  it("modelWindowRowsFromProfile 忽略损坏 map 中的非字符串值", () => {
+    assert.deepStrictEqual(
+      modelWindowRowsFromProfile(
+        "a\nb",
+        '{"a":1048576,"b":"512K"}',
+        '{"a":true,"b":"strip"}',
+        '{"a":90,"b":"80%"}',
+      ),
+      [
+        { model: "a", window: "", autoCompact: "", imageHandling: "send-as-is" },
+        { model: "b", window: "512K", autoCompact: "80%", imageHandling: "strip" },
+      ],
+    );
+  });
+
   it("serializeModelWindowRows 从行控件生成 modelList、modelWindows 和 modelVlm", () => {
     assert.deepStrictEqual(
       serializeModelWindowRows([

--- a/apps/codex-plus-manager/src/model-windows.test.ts
+++ b/apps/codex-plus-manager/src/model-windows.test.ts
@@ -123,6 +123,16 @@ describe("model-windows helpers", () => {
     );
   });
 
+  it("modelWindowRowsFromProfile 不因 null map 崩溃", () => {
+    assert.deepStrictEqual(
+      modelWindowRowsFromProfile("a\nb", "null", "{}", "null"),
+      [
+        { model: "a", window: "", autoCompact: "", imageHandling: "send-as-is" },
+        { model: "b", window: "", autoCompact: "", imageHandling: "send-as-is" },
+      ],
+    );
+  });
+
   it("serializeModelWindowRows 从行控件生成 modelList、modelWindows 和 modelVlm", () => {
     assert.deepStrictEqual(
       serializeModelWindowRows([

--- a/apps/codex-plus-manager/src/model-windows.test.ts
+++ b/apps/codex-plus-manager/src/model-windows.test.ts
@@ -31,6 +31,7 @@ const _profileTypeCheck: RelayProfile = {
   autoCompactLimit: "",
   modelList: "",
   modelWindows: "",
+  modelAutoCompact: "",
   modelVlm: "",
   vlmApiKey: "",
   vlmModel: "",
@@ -89,9 +90,9 @@ describe("model-windows helpers", () => {
     assert.deepStrictEqual(
       modelWindowRowsFromProfile("a\nb\nc", '{"a":"1M","c":"200K"}'),
       [
-        { model: "a", window: "1M", imageHandling: "send-as-is" },
-        { model: "b", window: "", imageHandling: "send-as-is" },
-        { model: "c", window: "200K", imageHandling: "send-as-is" },
+        { model: "a", window: "1M", autoCompact: "", imageHandling: "send-as-is" },
+        { model: "b", window: "", autoCompact: "", imageHandling: "send-as-is" },
+        { model: "c", window: "200K", autoCompact: "", imageHandling: "send-as-is" },
       ],
     );
   });
@@ -100,9 +101,9 @@ describe("model-windows helpers", () => {
     assert.deepStrictEqual(
       modelWindowRowsFromProfile("a\nb\nc", '{}', '{"a":"vlm","b":"strip"}'),
       [
-        { model: "a", window: "", imageHandling: "vlm" },
-        { model: "b", window: "", imageHandling: "strip" },
-        { model: "c", window: "", imageHandling: "send-as-is" },
+        { model: "a", window: "", autoCompact: "", imageHandling: "vlm" },
+        { model: "b", window: "", autoCompact: "", imageHandling: "strip" },
+        { model: "c", window: "", autoCompact: "", imageHandling: "send-as-is" },
       ],
     );
   });
@@ -110,14 +111,15 @@ describe("model-windows helpers", () => {
   it("serializeModelWindowRows 从行控件生成 modelList、modelWindows 和 modelVlm", () => {
     assert.deepStrictEqual(
       serializeModelWindowRows([
-        { model: "a", window: "1M", imageHandling: "vlm" },
-        { model: "", window: "400K", imageHandling: "send-as-is" },
-        { model: "b", window: "", imageHandling: "send-as-is" },
+        { model: "a", window: "1M", autoCompact: "", imageHandling: "vlm" },
+        { model: "", window: "400K", autoCompact: "", imageHandling: "send-as-is" },
+        { model: "b", window: "", autoCompact: "", imageHandling: "send-as-is" },
       ]),
       {
         modelList: "a\nb",
         modelWindows: '{"a":"1M"}',
         modelVlm: '{"a":"vlm"}',
+        modelAutoCompact: "{}",
       },
     );
   });
@@ -126,18 +128,18 @@ describe("model-windows helpers", () => {
     assert.deepStrictEqual(
       mergeModelWindowRows(
         [
-          { model: "deepseek-v4-flash", window: "1M", imageHandling: "vlm" },
-          { model: "  ", window: "", imageHandling: "send-as-is" },
+          { model: "deepseek-v4-flash", window: "1M", autoCompact: "90%", imageHandling: "vlm" },
+          { model: "  ", window: "", autoCompact: "", imageHandling: "send-as-is" },
         ],
         [
-          { model: "deepseek-v4-flash", window: "", imageHandling: "send-as-is" },
-          { model: "deepseek-v4-pro", window: "", imageHandling: "vlm" },
-          { model: " deepseek-v4-pro ", window: "200K", imageHandling: "send-as-is" },
+          { model: "deepseek-v4-flash", window: "", autoCompact: "", imageHandling: "send-as-is" },
+          { model: "deepseek-v4-pro", window: "", autoCompact: "", imageHandling: "vlm" },
+          { model: " deepseek-v4-pro ", window: "200K", autoCompact: "", imageHandling: "send-as-is" },
         ],
       ),
       [
-        { model: "deepseek-v4-flash", window: "1M", imageHandling: "vlm" },
-        { model: "deepseek-v4-pro", window: "", imageHandling: "vlm" },
+        { model: "deepseek-v4-flash", window: "1M", autoCompact: "90%", imageHandling: "vlm" },
+        { model: "deepseek-v4-pro", window: "", autoCompact: "", imageHandling: "vlm" },
       ],
     );
   });

--- a/apps/codex-plus-manager/src/model-windows.ts
+++ b/apps/codex-plus-manager/src/model-windows.ts
@@ -42,6 +42,11 @@ export type ModelWindowRowsValidationIssue = {
   model: string;
 };
 
+function asStringMap(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value as Record<string, string>;
+}
+
 export function isValidModelWindow(value: string): boolean {
   const trimmed = value.trim();
   if (!trimmed) return true;
@@ -101,13 +106,13 @@ export function modelWindowRowsFromProfile(
 ): ModelWindowRow[] {
   let map: Record<string, string> = {};
   try {
-    map = JSON.parse(modelWindows || "{}") as Record<string, string>;
+    map = asStringMap(JSON.parse(modelWindows || "{}"));
   } catch {
     map = {};
   }
   let autoCompactMap: Record<string, string> = {};
   try {
-    autoCompactMap = JSON.parse(modelAutoCompact || "{}") as Record<string, string>;
+    autoCompactMap = asStringMap(JSON.parse(modelAutoCompact || "{}"));
   } catch {
     autoCompactMap = {};
   }

--- a/apps/codex-plus-manager/src/model-windows.ts
+++ b/apps/codex-plus-manager/src/model-windows.ts
@@ -132,8 +132,10 @@ export function modelWindowRowsFromProfile(
     .filter(Boolean)
     .map((model) => ({
       model,
-      window: map[model] ?? "",
-      autoCompact: normalizeAutoCompactPercent(autoCompactMap[model] ?? ""),
+      window: typeof map[model] === "string" ? map[model] : "",
+      autoCompact: normalizeAutoCompactPercent(
+        typeof autoCompactMap[model] === "string" ? autoCompactMap[model] : "",
+      ),
       imageHandling: vlmMap[model] ?? "send-as-is",
     }));
   return rows.length ? rows : [{ model: "", window: "", autoCompact: "", imageHandling: "send-as-is" }];

--- a/apps/codex-plus-manager/src/model-windows.ts
+++ b/apps/codex-plus-manager/src/model-windows.ts
@@ -1,3 +1,5 @@
+import { isValidAutoCompactPercent, normalizeAutoCompactPercent } from "./auto-compact.ts";
+
 /// 把 model_windows JSON map 按 model_list 行顺序转成文本（每行一个窗口，空行表示默认）。
 export function modelWindowsMapToText(modelList: string, modelWindows: string): string {
   try {
@@ -30,8 +32,44 @@ export type ImageHandling = "" | "send-as-is" | "strip" | "vlm";
 export type ModelWindowRow = {
   model: string;
   window: string;
+  /// 自动压缩百分比；空字符串表示沿用 Codex 默认行为。
+  autoCompact: string;
   imageHandling: ImageHandling;
 };
+
+export type ModelWindowRowsValidationIssue = {
+  code: "duplicateModel" | "invalidWindow" | "invalidAutoCompact";
+  model: string;
+};
+
+export function isValidModelWindow(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return true;
+  const match = trimmed.match(/^(\d+)([KkMm])?$/);
+  if (!match) return false;
+  const multiplier = match[2]?.toLowerCase() === "m"
+    ? 1_000_000n
+    : match[2]
+      ? 1_000n
+      : 1n;
+  const tokens = BigInt(match[1]) * multiplier;
+  return tokens > 0n && tokens <= 18_446_744_073_709_551_615n;
+}
+
+export function modelWindowRowsValidationError(rows: ModelWindowRow[]): ModelWindowRowsValidationIssue | null {
+  const seen = new Set<string>();
+  for (const row of rows) {
+    const model = row.model.trim();
+    if (!model) continue;
+    if (seen.has(model)) return { code: "duplicateModel", model };
+    seen.add(model);
+    if (!isValidModelWindow(row.window)) return { code: "invalidWindow", model };
+    if (!isValidAutoCompactPercent(row.autoCompact ?? "")) {
+      return { code: "invalidAutoCompact", model };
+    }
+  }
+  return null;
+}
 
 export function mergeModelWindowRows(
   currentRows: ModelWindowRow[],
@@ -43,19 +81,35 @@ export function mergeModelWindowRows(
     const model = row.model.trim();
     if (!model || seen.has(model)) return;
     seen.add(model);
-    rows.push({ model, window: row.window.trim(), imageHandling: row.imageHandling ?? "send-as-is" });
+    rows.push({
+      model,
+      window: row.window.trim(),
+      autoCompact: normalizeAutoCompactPercent(row.autoCompact ?? ""),
+      imageHandling: row.imageHandling ?? "send-as-is",
+    });
   };
   currentRows.forEach(append);
   incomingRows.forEach(append);
-  return rows.length ? rows : [{ model: "", window: "", imageHandling: "send-as-is" }];
+  return rows.length ? rows : [{ model: "", window: "", autoCompact: "", imageHandling: "send-as-is" }];
 }
 
-export function modelWindowRowsFromProfile(modelList: string, modelWindows: string, modelVlm?: string): ModelWindowRow[] {
+export function modelWindowRowsFromProfile(
+  modelList: string,
+  modelWindows: string,
+  modelVlm?: string,
+  modelAutoCompact?: string,
+): ModelWindowRow[] {
   let map: Record<string, string> = {};
   try {
     map = JSON.parse(modelWindows || "{}") as Record<string, string>;
   } catch {
     map = {};
+  }
+  let autoCompactMap: Record<string, string> = {};
+  try {
+    autoCompactMap = JSON.parse(modelAutoCompact || "{}") as Record<string, string>;
+  } catch {
+    autoCompactMap = {};
   }
   // 解析 modelVlm JSON：`{"model": "vlm"/"strip"}`
   let vlmMap: Record<string, ImageHandling> = {};
@@ -76,14 +130,25 @@ export function modelWindowRowsFromProfile(modelList: string, modelWindows: stri
     .split("\n")
     .map((model) => model.trim())
     .filter(Boolean)
-    .map((model) => ({ model, window: map[model] ?? "", imageHandling: vlmMap[model] ?? "send-as-is" }));
-  return rows.length ? rows : [{ model: "", window: "", imageHandling: "send-as-is" }];
+    .map((model) => ({
+      model,
+      window: map[model] ?? "",
+      autoCompact: normalizeAutoCompactPercent(autoCompactMap[model] ?? ""),
+      imageHandling: vlmMap[model] ?? "send-as-is",
+    }));
+  return rows.length ? rows : [{ model: "", window: "", autoCompact: "", imageHandling: "send-as-is" }];
 }
 
-export function serializeModelWindowRows(rows: ModelWindowRow[]): { modelList: string; modelWindows: string; modelVlm: string } {
+export function serializeModelWindowRows(rows: ModelWindowRow[]): {
+  modelList: string;
+  modelWindows: string;
+  modelVlm: string;
+  modelAutoCompact: string;
+} {
   const modelList: string[] = [];
   const modelWindows: Record<string, string> = {};
   const modelVlm: Record<string, string> = {};
+  const modelAutoCompact: Record<string, string> = {};
   mergeModelWindowRows(rows, []).forEach((row) => {
     const model = row.model.trim();
     if (!model) return;
@@ -96,11 +161,16 @@ export function serializeModelWindowRows(rows: ModelWindowRow[]): { modelList: s
     if (row.imageHandling === "vlm" || row.imageHandling === "strip") {
       modelVlm[model] = row.imageHandling;
     }
+    const autoCompact = row.autoCompact?.trim() ?? "";
+    if (autoCompact) {
+      modelAutoCompact[model] = autoCompact;
+    }
   });
   return {
     modelList: modelList.join("\n"),
     modelWindows: JSON.stringify(modelWindows),
     modelVlm: JSON.stringify(modelVlm),
+    modelAutoCompact: JSON.stringify(modelAutoCompact),
   };
 }
 

--- a/apps/codex-plus-manager/src/styles.css
+++ b/apps/codex-plus-manager/src/styles.css
@@ -4945,7 +4945,7 @@ input[type="range"]:disabled {
 
 .relay-model-row {
   display: grid;
-  grid-template-columns: minmax(220px, 1.6fr) minmax(130px, 0.7fr) minmax(180px, 1fr) 40px;
+  grid-template-columns: minmax(220px, 1.6fr) minmax(130px, 0.7fr) minmax(110px, 0.6fr) minmax(180px, 1fr) 40px;
   align-items: center;
   gap: 8px;
   min-height: var(--relay-control-height);

--- a/crates/codex-plus-core/examples/generate_model_catalog.rs
+++ b/crates/codex-plus-core/examples/generate_model_catalog.rs
@@ -6,11 +6,12 @@
 use codex_plus_core::model_suffix::{
     build_model_catalog_json, collect_catalog_entries, migrate_model_list_with_suffixes,
 };
+use std::collections::HashMap;
 
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
     let raw_list = args.join("\n");
     let (model_list, model_windows) = migrate_model_list_with_suffixes(&raw_list);
-    let entries = collect_catalog_entries(&model_list, &model_windows, "");
+    let entries = collect_catalog_entries(&model_list, &model_windows, &HashMap::new(), "");
     print!("{}", build_model_catalog_json(&entries, None));
 }

--- a/crates/codex-plus-core/src/ccs_import.rs
+++ b/crates/codex-plus-core/src/ccs_import.rs
@@ -160,6 +160,7 @@ pub fn relay_profile_from_ccs(
         model_insert_mode: Default::default(),
         model_list: String::new(),
         model_windows: String::new(),
+        model_auto_compact: String::new(),
         model_vlm: String::new(),
         vlm_api_key: String::new(),
         vlm_model: String::new(),

--- a/crates/codex-plus-core/src/model_suffix.rs
+++ b/crates/codex-plus-core/src/model_suffix.rs
@@ -3,7 +3,7 @@
 //! 后缀语法：`deepseek-v4-pro[1M]` 表示 slug=deepseek-v4-pro、context_window=1000000。
 //! 单位 K/k=1000、M/m=1000000；纯数字也接受。后缀在生成 catalog 时剥离。
 
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -12,6 +12,9 @@ pub struct ModelCatalogEntry {
     pub display_name: String,
     /// 来自后缀的窗口值；None 表示该条目无后缀（回落顶层默认）。
     pub suffix_window: Option<u64>,
+    /// 显式自动压缩百分比，以百万分之一百分比为单位（90% = 90_000_000）。
+    /// None 表示不覆盖 Codex 默认的自动压缩行为。
+    pub auto_compact_percent: Option<u32>,
 }
 
 /// 解析单个模型条目的后缀，返回 (slug, 可选窗口)。
@@ -69,8 +72,36 @@ pub(crate) fn parse_window_token(token: &str) -> Option<u64> {
         .trim()
         .parse::<u64>()
         .ok()
-        .map(|value| value * multiplier)
+        .and_then(|value| value.checked_mul(multiplier))
         .filter(|value| *value > 0)
+}
+
+/// 解析自动压缩百分比 token，如 "90"、"84.329412%"。
+/// 返回百万分之一百分比，供 Rust 与前端使用同一套精度和舍入规则。
+pub(crate) fn parse_compact_percent(token: &str) -> Option<u32> {
+    let token = token.trim();
+    let token = token.strip_suffix('%').unwrap_or(token).trim();
+    if token.ends_with('%') {
+        return None;
+    }
+    let (whole, fraction) = token.split_once('.').unwrap_or((token, ""));
+    if fraction.len() > 6 || whole.is_empty() || !whole.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    if !fraction.is_empty() && !fraction.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    let whole = whole.parse::<u32>().ok()?;
+    let mut fraction_value = if fraction.is_empty() {
+        0
+    } else {
+        fraction.parse::<u32>().ok()?
+    };
+    for _ in fraction.len()..6 {
+        fraction_value = fraction_value.checked_mul(10)?;
+    }
+    let scaled = whole.checked_mul(1_000_000)?.checked_add(fraction_value)?;
+    (scaled > 0 && scaled <= 100_000_000).then_some(scaled)
 }
 
 /// 收集 profile 的全部模型条目（当前 model + model_list），去重并从 `model_windows` map 读取窗口。
@@ -82,6 +113,7 @@ pub(crate) fn parse_window_token(token: &str) -> Option<u64> {
 pub fn collect_catalog_entries(
     model_list: &str,
     model_windows: &HashMap<String, String>,
+    model_auto_compact: &HashMap<String, String>,
     current_model: &str,
 ) -> Vec<ModelCatalogEntry> {
     // 先解析 model_list，保留顺序并去重；后缀已从 model_list 剥离，窗口来自 model_windows map。
@@ -102,10 +134,14 @@ pub fn collect_catalog_entries(
         let suffix_window = model_windows
             .get(&slug)
             .and_then(|token| parse_window_token(token));
+        let auto_compact_percent = model_auto_compact
+            .get(&slug)
+            .and_then(|token| parse_compact_percent(token));
         list_entries.push(ModelCatalogEntry {
             display_name: slug.clone(),
             slug,
             suffix_window,
+            auto_compact_percent,
         });
     }
 
@@ -118,10 +154,14 @@ pub fn collect_catalog_entries(
             let suffix_window = model_windows
                 .get(&slug)
                 .and_then(|token| parse_window_token(token));
+            let auto_compact_percent = model_auto_compact
+                .get(&slug)
+                .and_then(|token| parse_compact_percent(token));
             entries.push(ModelCatalogEntry {
                 display_name: slug.clone(),
                 slug: slug.clone(),
                 suffix_window,
+                auto_compact_percent,
             });
             // 从 list_entries 中移除同 slug 条目，避免重复。
             list_entries.retain(|entry| entry.slug != slug);
@@ -204,7 +244,7 @@ pub fn model_ui_metadata(slug: &str) -> Option<Value> {
 /// 再覆盖 slug / display_name / description / context_window / max_context_window /
 /// effective_context_window_percent / priority / auto_compact_token_limit 等字段。
 /// 无后缀条目用 fallback_window；fallback 也无时回落 272000（codex 默认）。
-/// auto_compact_token_limit 留 null：codex 内置模型即 null（按比例算，调研第六节）。
+/// auto_compact_token_limit 仅在条目带显式百分比时写入；否则留 null，保持 Codex 默认行为。
 pub fn build_model_catalog_json(
     entries: &[ModelCatalogEntry],
     fallback_window: Option<u64>,
@@ -262,7 +302,14 @@ pub(crate) fn build_model_catalog_json_with_capabilities(
             if !deepseek_metadata {
                 model["effective_context_window_percent"] = json!(100);
             }
-            model["auto_compact_token_limit"] = Value::Null;
+            if let Some(compact_percent) = entry.auto_compact_percent {
+                let compact_limit = ((context_window as u128 * compact_percent as u128
+                    + 50_000_000)
+                    / 100_000_000) as u64;
+                model["auto_compact_token_limit"] = json!(compact_limit.max(1));
+            } else {
+                model["auto_compact_token_limit"] = Value::Null;
+            }
             model["priority"] = json!(1000 + index);
             model["visibility"] = json!("list");
             if !deepseek_metadata {

--- a/crates/codex-plus-core/src/provider_import.rs
+++ b/crates/codex-plus-core/src/provider_import.rs
@@ -201,6 +201,7 @@ fn relay_profile_from_request(
         model_insert_mode: Default::default(),
         model_list: String::new(),
         model_windows: String::new(),
+        model_auto_compact: String::new(),
         model_vlm: String::new(),
         vlm_api_key: String::new(),
         vlm_model: String::new(),

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -1075,24 +1075,15 @@ pub fn delete_context_entry_from_common_config(
     Ok(normalize_optional_toml(doc))
 }
 
-<<<<<<< ours
 /// 剥掉通用配置里供应商各自持有的键，丢掉历史遗留的 `[skills.<id>]` 死表，
 /// 再丢掉标记为 `enabled = false` 的上下文条目，得到本次切换真正要合并进
 /// config.toml 的那份通用配置。
-=======
-/// 剥掉通用配置里供应商各自持有的键，再丢掉标记为 `enabled = false` 的上下文条目，
-/// 得到本次切换真正要合并进 config.toml 的那份通用配置。
->>>>>>> theirs
 ///
 /// 条目启停以条目自身的 `enabled` 为唯一依据——旧版还存在一份「按供应商勾选」的
 /// selection，两套机制重叠，空的 selection 会把 live config 里的 MCP 全清空，已移除。
 pub fn prepare_common_config_for_apply(common_config: &str) -> anyhow::Result<String> {
-<<<<<<< ours
     let sanitized_common =
         strip_legacy_skill_tables(&sanitize_common_config_contents(common_config));
-=======
-    let sanitized_common = sanitize_common_config_contents(common_config);
->>>>>>> theirs
     let mut filtered = parse_toml_document(&sanitized_common)?;
     remove_disabled_context_tables(filtered.as_table_mut());
     Ok(normalize_optional_toml(filtered))

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -1075,15 +1075,24 @@ pub fn delete_context_entry_from_common_config(
     Ok(normalize_optional_toml(doc))
 }
 
+<<<<<<< ours
 /// 剥掉通用配置里供应商各自持有的键，丢掉历史遗留的 `[skills.<id>]` 死表，
 /// 再丢掉标记为 `enabled = false` 的上下文条目，得到本次切换真正要合并进
 /// config.toml 的那份通用配置。
+=======
+/// 剥掉通用配置里供应商各自持有的键，再丢掉标记为 `enabled = false` 的上下文条目，
+/// 得到本次切换真正要合并进 config.toml 的那份通用配置。
+>>>>>>> theirs
 ///
 /// 条目启停以条目自身的 `enabled` 为唯一依据——旧版还存在一份「按供应商勾选」的
 /// selection，两套机制重叠，空的 selection 会把 live config 里的 MCP 全清空，已移除。
 pub fn prepare_common_config_for_apply(common_config: &str) -> anyhow::Result<String> {
+<<<<<<< ours
     let sanitized_common =
         strip_legacy_skill_tables(&sanitize_common_config_contents(common_config));
+=======
+    let sanitized_common = sanitize_common_config_contents(common_config);
+>>>>>>> theirs
     let mut filtered = parse_toml_document(&sanitized_common)?;
     remove_disabled_context_tables(filtered.as_table_mut());
     Ok(normalize_optional_toml(filtered))

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -1953,6 +1953,16 @@ fn apply_model_catalog_to_config(
             || crate::model_suffix::requires_bundled_metadata_catalog(&entry.slug)
             || (official_deepseek_responses && entry.slug.starts_with("deepseek-v4-"))
     }) {
+        // Clear a stale catalog pointer previously generated for this profile when
+        // the user removes all per-model overrides. External catalogs are returned
+        // earlier and remain untouched.
+        if root_key_string(&config_text, "model_catalog_json").as_deref()
+            == Some(catalog_relative.as_str())
+        {
+            let mut doc = parse_toml_document(&config_text)?;
+            doc.remove("model_catalog_json");
+            return Ok(normalize_optional_toml(doc));
+        }
         return Ok(config_text);
     }
     let catalog_path = home.join(&catalog_relative);
@@ -1989,9 +1999,9 @@ fn parse_model_string_map(
     object
         .iter()
         .map(|(key, value)| {
-            let value = value.as_str().ok_or_else(|| {
-                anyhow::anyhow!("{field_name} 的模型 {key} 值必须是字符串")
-            })?;
+            let value = value
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("{field_name} 的模型 {key} 值必须是字符串"))?;
             Ok((key.clone(), value.to_string()))
         })
         .collect()
@@ -2006,9 +2016,7 @@ fn validate_model_windows(model_windows: &HashMap<String, String>) -> anyhow::Re
     Ok(())
 }
 
-fn validate_model_auto_compact(
-    model_auto_compact: &HashMap<String, String>,
-) -> anyhow::Result<()> {
+fn validate_model_auto_compact(model_auto_compact: &HashMap<String, String>) -> anyhow::Result<()> {
     for (slug, value) in model_auto_compact {
         if crate::model_suffix::parse_compact_percent(value).is_none() {
             anyhow::bail!("model_auto_compact 的模型 {slug} 百分比无效：{value}");

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -1863,6 +1863,27 @@ fn apply_model_catalog_to_config(
         sanitize_catalog_filename(&profile.id)
     );
     let mut config_text = config_text.to_string();
+    let mut model_windows = parse_model_string_map(&profile.model_windows, "model_windows")?;
+    validate_model_windows(&model_windows)?;
+    let model_list = if profile.model_list.contains('[') {
+        let (clean_list, migrated_windows) =
+            crate::model_suffix::migrate_model_list_with_suffixes(&profile.model_list);
+        for (slug, window) in migrated_windows {
+            model_windows.entry(slug).or_insert(window);
+        }
+        clean_list
+    } else {
+        profile.model_list.clone()
+    };
+    let model_auto_compact =
+        parse_model_string_map(&profile.model_auto_compact, "model_auto_compact")?;
+    validate_model_auto_compact(&model_auto_compact)?;
+    let entries = crate::model_suffix::collect_catalog_entries(
+        &model_list,
+        &model_windows,
+        &model_auto_compact,
+        &profile.model,
+    );
     let custom_responses = custom_responses_provider(&config_text);
     // Catalog capabilities must follow the effective config, not stale profile URLs.
     let official_deepseek_responses =
@@ -1928,6 +1949,7 @@ fn apply_model_catalog_to_config(
     // Known bundled metadata entries need a catalog even without a user-supplied window.
     if !entries.iter().any(|entry| {
         entry.suffix_window.is_some()
+            || entry.auto_compact_percent.is_some()
             || crate::model_suffix::requires_bundled_metadata_catalog(&entry.slug)
             || (official_deepseek_responses && entry.slug.starts_with("deepseek-v4-"))
     }) {
@@ -1950,6 +1972,49 @@ fn apply_model_catalog_to_config(
     let mut doc = parse_toml_document(&config_text)?;
     doc["model_catalog_json"] = toml_edit::value(catalog_relative);
     Ok(normalize_optional_toml(doc))
+}
+
+fn parse_model_string_map(
+    value: &str,
+    field_name: &str,
+) -> anyhow::Result<HashMap<String, String>> {
+    if value.trim().is_empty() {
+        return Ok(HashMap::new());
+    }
+    let parsed: Value = serde_json::from_str(value)
+        .map_err(|error| anyhow::anyhow!("{field_name} JSON 解析失败：{error}"))?;
+    let object = parsed
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("{field_name} 必须是 JSON 对象"))?;
+    object
+        .iter()
+        .map(|(key, value)| {
+            let value = value.as_str().ok_or_else(|| {
+                anyhow::anyhow!("{field_name} 的模型 {key} 值必须是字符串")
+            })?;
+            Ok((key.clone(), value.to_string()))
+        })
+        .collect()
+}
+
+fn validate_model_windows(model_windows: &HashMap<String, String>) -> anyhow::Result<()> {
+    for (slug, value) in model_windows {
+        if crate::model_suffix::parse_window_token(value).is_none() {
+            anyhow::bail!("model_windows 的模型 {slug} 窗口值无效：{value}");
+        }
+    }
+    Ok(())
+}
+
+fn validate_model_auto_compact(
+    model_auto_compact: &HashMap<String, String>,
+) -> anyhow::Result<()> {
+    for (slug, value) in model_auto_compact {
+        if crate::model_suffix::parse_compact_percent(value).is_none() {
+            anyhow::bail!("model_auto_compact 的模型 {slug} 百分比无效：{value}");
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn uses_official_deepseek_responses(profile: &RelayProfile) -> bool {
@@ -2852,12 +2917,21 @@ pub fn normalize_relay_profile_for_storage(profile: &mut RelayProfile) -> anyhow
             }
         })
         .collect();
-    if profile.model_windows.trim().is_empty() && profile.model_list.contains('[') {
-        let (clean_list, windows) =
+    if profile.model_list.contains('[') {
+        let (clean_list, migrated_windows) =
             crate::model_suffix::migrate_model_list_with_suffixes(&profile.model_list);
+        let mut windows = parse_model_string_map(&profile.model_windows, "model_windows")?;
+        for (slug, window) in migrated_windows {
+            windows.entry(slug).or_insert(window);
+        }
         profile.model_list = clean_list;
-        profile.model_windows = serde_json::to_string(&windows).unwrap_or_default();
+        profile.model_windows = serde_json::to_string(&windows)?;
     }
+    let model_windows = parse_model_string_map(&profile.model_windows, "model_windows")?;
+    validate_model_windows(&model_windows)?;
+    let model_auto_compact =
+        parse_model_string_map(&profile.model_auto_compact, "model_auto_compact")?;
+    validate_model_auto_compact(&model_auto_compact)?;
     if profile.relay_mode == crate::settings::RelayMode::Official && !profile.official_mix_api_key {
         let has_api_config = !profile.base_url.trim().is_empty()
             || !profile.api_key.trim().is_empty()

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -1888,17 +1888,6 @@ fn apply_model_catalog_to_config(
     // Catalog capabilities must follow the effective config, not stale profile URLs.
     let official_deepseek_responses =
         uses_official_deepseek_responses_for_config(profile, &config_text);
-    let (model_list, model_windows): (String, std::collections::HashMap<String, String>) =
-        if profile.model_windows.trim().is_empty() && profile.model_list.contains('[') {
-            crate::model_suffix::migrate_model_list_with_suffixes(&profile.model_list)
-        } else {
-            (
-                profile.model_list.clone(),
-                serde_json::from_str(&profile.model_windows).unwrap_or_default(),
-            )
-        };
-    let entries =
-        crate::model_suffix::collect_catalog_entries(&model_list, &model_windows, &profile.model);
     let fallback = parse_optional_positive_u64(&profile.context_window, "上下文大小")?;
     // 用户已手写 model_catalog_json 指针时保留，不覆盖（保 preserves_user_model_catalog_json 测试）
     // 仅当现有指针指向本 profile 自己生成的 catalog 时才重新生成。

--- a/crates/codex-plus-core/src/settings.rs
+++ b/crates/codex-plus-core/src/settings.rs
@@ -66,6 +66,14 @@ pub struct RelayProfile {
         skip_serializing_if = "String::is_empty"
     )]
     pub model_windows: String,
+    /// 每模型自动压缩百分比（JSON map: slug -> 百分比字符串，如 "90" 或 "90%"）。
+    /// 为空时保持 Codex 原有的默认自动压缩行为，不向 catalog 写入覆盖值。
+    #[serde(
+        rename = "modelAutoCompact",
+        default,
+        skip_serializing_if = "String::is_empty"
+    )]
+    pub model_auto_compact: String,
     #[serde(rename = "modelVlm", default, skip_serializing_if = "String::is_empty")]
     pub model_vlm: String,
     #[serde(
@@ -182,6 +190,7 @@ impl Default for RelayProfile {
             model_insert_mode: RelayModelInsertMode::Patch,
             model_list: String::new(),
             model_windows: String::new(),
+            model_auto_compact: String::new(),
             model_vlm: String::new(),
             vlm_api_key: String::new(),
             vlm_model: String::new(),
@@ -649,6 +658,7 @@ impl BackendSettings {
                 model_insert_mode: RelayModelInsertMode::Patch,
                 model_list: String::new(),
                 model_windows: String::new(),
+                model_auto_compact: String::new(),
                 model_vlm: String::new(),
                 vlm_api_key: String::new(),
                 vlm_model: String::new(),
@@ -701,6 +711,7 @@ impl BackendSettings {
             model_insert_mode: RelayModelInsertMode::Patch,
             model_list: String::new(),
             model_windows: String::new(),
+            model_auto_compact: String::new(),
             model_vlm: String::new(),
             vlm_api_key: String::new(),
             vlm_model: String::new(),
@@ -1929,6 +1940,7 @@ mod tests {
         assert!(profile.auto_compact_limit.is_empty());
         assert_eq!(profile.model_insert_mode, RelayModelInsertMode::Patch);
         assert!(profile.model_list.is_empty());
+        assert!(profile.model_auto_compact.is_empty());
         assert!(profile.model_routes.is_empty());
         assert!(!profile.has_model_routes());
     }
@@ -1946,6 +1958,24 @@ mod tests {
         };
 
         assert!(settings.active_relay_uses_protocol_proxy());
+    }
+
+    #[test]
+    fn relay_profile_model_auto_compact_is_opt_in_and_round_trips() {
+        let profile = RelayProfile::default();
+        let serialized = serde_json::to_value(&profile).unwrap();
+        assert!(serialized.get("modelAutoCompact").is_none());
+
+        let profile: RelayProfile = serde_json::from_value(serde_json::json!({
+            "id": "relay",
+            "name": "Relay",
+            "modelAutoCompact": "{\"gpt-5.6-sol\":\"84.329412%\"}"
+        }))
+        .unwrap();
+        assert_eq!(
+            profile.model_auto_compact,
+            r#"{"gpt-5.6-sol":"84.329412%"}"#
+        );
     }
 
     #[test]

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -1576,6 +1576,7 @@ async fn launch_starts_helper_when_chat_protocol_proxy_is_enabled() {
             model_insert_mode: codex_plus_core::settings::RelayModelInsertMode::default(),
             model_list: String::new(),
             model_windows: String::new(),
+            model_auto_compact: String::new(),
             model_vlm: String::new(),
             vlm_api_key: String::new(),
             vlm_model: String::new(),

--- a/crates/codex-plus-core/tests/model_suffix.rs
+++ b/crates/codex-plus-core/tests/model_suffix.rs
@@ -57,7 +57,12 @@ fn collect_entries_includes_current_model_and_strips_suffix() {
     let mut windows = HashMap::new();
     windows.insert("deepseek-v4-pro".to_string(), "1M".to_string());
     let entries =
-        collect_catalog_entries("deepseek-v4-pro\nqwen3-coder", &windows, "deepseek-v4-pro");
+        collect_catalog_entries(
+            "deepseek-v4-pro\nqwen3-coder",
+            &windows,
+            &HashMap::new(),
+            "deepseek-v4-pro",
+        );
     // 当前 model 与列表去重后共 2 条
     assert_eq!(entries.len(), 2);
     assert_eq!(entries[0].slug, "deepseek-v4-pro");
@@ -69,7 +74,12 @@ fn collect_entries_includes_current_model_and_strips_suffix() {
 #[test]
 fn collect_entries_deduplicates() {
     let entries =
-        collect_catalog_entries("qwen3-coder\nqwen3-coder", &HashMap::new(), "qwen3-coder");
+        collect_catalog_entries(
+            "qwen3-coder\nqwen3-coder",
+            &HashMap::new(),
+            &HashMap::new(),
+            "qwen3-coder",
+        );
     assert_eq!(entries.len(), 1);
 }
 
@@ -78,7 +88,12 @@ fn build_catalog_json_writes_context_window_and_strips_suffix() {
     let mut windows = HashMap::new();
     windows.insert("deepseek-v4-pro".to_string(), "1M".to_string());
     windows.insert("claude-sonnet-4".to_string(), "200K".to_string());
-    let entries = collect_catalog_entries("deepseek-v4-pro\nclaude-sonnet-4", &windows, "");
+    let entries = collect_catalog_entries(
+        "deepseek-v4-pro\nclaude-sonnet-4",
+        &windows,
+        &HashMap::new(),
+        "",
+    );
     let catalog = build_model_catalog_json(&entries, None);
     assert!(catalog.contains(r#""slug": "deepseek-v4-pro""#));
     assert!(catalog.contains(r#""context_window": 1000000"#));
@@ -94,7 +109,7 @@ fn build_catalog_json_writes_context_window_and_strips_suffix() {
 
 #[test]
 fn build_catalog_json_uses_fallback_for_no_suffix_entries() {
-    let entries = collect_catalog_entries("qwen3-coder", &HashMap::new(), "");
+    let entries = collect_catalog_entries("qwen3-coder", &HashMap::new(), &HashMap::new(), "");
     let catalog = build_model_catalog_json(&entries, Some(272_000));
     assert!(catalog.contains(r#""slug": "qwen3-coder""#));
     assert!(catalog.contains(r#""context_window": 272000"#));
@@ -104,6 +119,7 @@ fn build_catalog_json_uses_fallback_for_no_suffix_entries() {
 fn build_catalog_json_uses_runtime_compatible_gpt56_metadata() {
     let entries = collect_catalog_entries(
         "gpt-5.6-sol\ngpt-5.6-terra\ngpt-5.6-luna",
+        &HashMap::new(),
         &HashMap::new(),
         "gpt-5.6-sol",
     );
@@ -149,7 +165,12 @@ fn build_catalog_json_uses_runtime_compatible_gpt56_metadata() {
 
 #[test]
 fn build_catalog_json_preserves_template_responses_lite_behavior() {
-    let entries = collect_catalog_entries("official-model", &HashMap::new(), "official-model");
+    let entries = collect_catalog_entries(
+        "official-model",
+        &HashMap::new(),
+        &HashMap::new(),
+        "official-model",
+    );
     let template = serde_json::json!({
         "slug": "official-template",
         "supports_search_tool": true,
@@ -183,7 +204,12 @@ fn collect_entries_adopts_suffix_for_current_model_from_list() {
     let mut windows = HashMap::new();
     windows.insert("deepseek-v4-pro".to_string(), "1M".to_string());
     let entries =
-        collect_catalog_entries("qwen3-coder\ndeepseek-v4-pro", &windows, "deepseek-v4-pro");
+        collect_catalog_entries(
+            "qwen3-coder\ndeepseek-v4-pro",
+            &windows,
+            &HashMap::new(),
+            "deepseek-v4-pro",
+        );
     assert_eq!(entries.len(), 2);
     assert_eq!(entries[0].slug, "deepseek-v4-pro");
     assert_eq!(entries[0].suffix_window, Some(1_000_000));
@@ -197,6 +223,7 @@ fn collect_entries_prefers_later_suffix_for_duplicate_slug() {
     let entries = collect_catalog_entries(
         "deepseek/deepseek-v4-flash\ndeepseek/deepseek-v4-flash",
         &windows,
+        &HashMap::new(),
         "",
     );
     assert_eq!(entries.len(), 1);
@@ -212,6 +239,7 @@ fn collect_entries_prefers_later_suffix_when_reversed() {
     let entries = collect_catalog_entries(
         "deepseek/deepseek-v4-flash\ndeepseek/deepseek-v4-flash",
         &windows,
+        &HashMap::new(),
         "",
     );
     assert_eq!(entries.len(), 1);
@@ -234,4 +262,74 @@ fn migrate_model_list_with_suffixes_splits_slug_and_window() {
     );
     assert_eq!(windows.get("deepseek-v4-pro"), None);
     assert_eq!(windows.get("nvidia/...:free"), Some(&"200000".to_string()));
+}
+
+#[test]
+fn build_catalog_json_writes_explicit_auto_compact_percent_only() {
+    let mut windows = HashMap::new();
+    windows.insert("deepseek-v4-pro".to_string(), "1M".to_string());
+    let mut compacts = HashMap::new();
+    compacts.insert("deepseek-v4-pro".to_string(), "80".to_string());
+    let entries = collect_catalog_entries("deepseek-v4-pro", &windows, &compacts, "");
+    let catalog: serde_json::Value =
+        serde_json::from_str(&build_model_catalog_json(&entries, None)).unwrap();
+    assert_eq!(catalog["models"][0]["context_window"], 1_000_000);
+    assert_eq!(catalog["models"][0]["auto_compact_token_limit"], 800_000);
+
+    let default_entries = collect_catalog_entries(
+        "default-model",
+        &HashMap::new(),
+        &HashMap::new(),
+        "",
+    );
+    let default_catalog: serde_json::Value =
+        serde_json::from_str(&build_model_catalog_json(&default_entries, Some(200_000))).unwrap();
+    assert_eq!(default_catalog["models"][0]["auto_compact_token_limit"], serde_json::Value::Null);
+}
+
+#[test]
+fn build_catalog_json_accepts_decimal_percent_and_rounds_half_up() {
+    let mut windows = HashMap::new();
+    windows.insert("gpt-5.6-sol".to_string(), "272000".to_string());
+    let mut compacts = HashMap::new();
+    compacts.insert("gpt-5.6-sol".to_string(), "84.329412%".to_string());
+    let entries = collect_catalog_entries("gpt-5.6-sol", &windows, &compacts, "");
+    let catalog: serde_json::Value =
+        serde_json::from_str(&build_model_catalog_json(&entries, None)).unwrap();
+    assert_eq!(catalog["models"][0]["auto_compact_token_limit"], 229_376);
+
+    let mut tiny_windows = HashMap::new();
+    tiny_windows.insert("rounding-model".to_string(), "3".to_string());
+    let mut tiny_compacts = HashMap::new();
+    tiny_compacts.insert("rounding-model".to_string(), "50%".to_string());
+    let tiny_entries = collect_catalog_entries("rounding-model", &tiny_windows, &tiny_compacts, "");
+    let tiny_catalog: serde_json::Value =
+        serde_json::from_str(&build_model_catalog_json(&tiny_entries, None)).unwrap();
+    assert_eq!(tiny_catalog["models"][0]["auto_compact_token_limit"], 2);
+}
+
+#[test]
+fn build_catalog_json_recalculates_threshold_when_window_changes() {
+    let mut compacts = HashMap::new();
+    compacts.insert("gpt-5.6-sol".to_string(), "84.329412%".to_string());
+    let mut original_windows = HashMap::new();
+    original_windows.insert("gpt-5.6-sol".to_string(), "272000".to_string());
+    let original = collect_catalog_entries("gpt-5.6-sol", &original_windows, &compacts, "");
+    let mut changed_windows = HashMap::new();
+    changed_windows.insert("gpt-5.6-sol".to_string(), "800000".to_string());
+    let changed = collect_catalog_entries("gpt-5.6-sol", &changed_windows, &compacts, "");
+    assert_eq!(changed[0].auto_compact_percent, original[0].auto_compact_percent);
+    let catalog: serde_json::Value =
+        serde_json::from_str(&build_model_catalog_json(&changed, None)).unwrap();
+    assert_eq!(catalog["models"][0]["auto_compact_token_limit"], 674_635);
+}
+
+#[test]
+fn build_catalog_json_ignores_invalid_percent_and_relay_validation_rejects_it() {
+    let mut windows = HashMap::new();
+    windows.insert("model".to_string(), "1M".to_string());
+    let mut compacts = HashMap::new();
+    compacts.insert("model".to_string(), "90%%".to_string());
+    let entries = collect_catalog_entries("model", &windows, &compacts, "");
+    assert_eq!(entries[0].auto_compact_percent, None);
 }

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -4221,6 +4221,44 @@ experimental_bearer_token = "sk-new"
 }
 
 #[test]
+fn apply_relay_profile_removes_stale_catalog_after_clearing_model_overrides() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut profile = RelayProfile {
+        id: "relay-clear-catalog".to_string(),
+        name: "Relay".to_string(),
+        model: "qwen3-coder".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model = "qwen3-coder"
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example/v1"
+experimental_bearer_token = "sk-new"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        model_insert_mode: Default::default(),
+        model_list: "qwen3-coder".to_string(),
+        model_windows: r#"{"qwen3-coder":"1M"}"#.to_string(),
+        model_auto_compact: r#"{"qwen3-coder":"80%"}"#.to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+    let generated_config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(generated_config.contains("model-catalogs/relay-clear-catalog.json"));
+
+    profile.model_windows.clear();
+    profile.model_auto_compact.clear();
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+    let cleared_config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(!cleared_config.contains("model_catalog_json"));
+}
+
+#[test]
 fn apply_relay_profile_generates_compatible_gpt56_catalog_without_suffix() {
     let temp = tempfile::tempdir().unwrap();
     let profile = RelayProfile {

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -4259,6 +4259,67 @@ experimental_bearer_token = "sk-new"
 }
 
 #[test]
+fn apply_relay_profile_switches_catalog_and_falls_back_to_profile_limits() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile_a = RelayProfile {
+        id: "relay-switch-a".to_string(),
+        relay_mode: RelayMode::PureApi,
+        model: "deepseek-v4-pro".to_string(),
+        model_list: "deepseek-v4-pro".to_string(),
+        model_windows: r#"{"deepseek-v4-pro":"1M"}"#.to_string(),
+        model_auto_compact: r#"{"deepseek-v4-pro":"80%"}"#.to_string(),
+        config_contents: r#"model = "deepseek-v4-pro"
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay-a.example/v1"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-a"}"#.to_string(),
+        ..RelayProfile::default()
+    };
+    apply_relay_profile_to_home_with_switch_rules(temp.path(), &profile_a, "").unwrap();
+    let generated = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(generated.contains("model_catalog_json = \"model-catalogs/relay-switch-a.json\""));
+    let catalog: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(temp.path().join("model-catalogs/relay-switch-a.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(catalog["models"][0]["auto_compact_token_limit"], 800_000);
+
+    let profile_b = RelayProfile {
+        id: "relay-switch-b".to_string(),
+        relay_mode: RelayMode::PureApi,
+        model: "qwen3-coder".to_string(),
+        context_window: "200000".to_string(),
+        auto_compact_limit: "160000".to_string(),
+        config_contents: r#"model = "qwen3-coder"
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay-b.example/v1"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-b"}"#.to_string(),
+        ..RelayProfile::default()
+    };
+    apply_relay_profile_to_home_with_switch_rules(temp.path(), &profile_b, "").unwrap();
+    let fallback = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(!fallback.contains("model_catalog_json"));
+    assert!(fallback.contains("model_context_window = 200000"));
+    assert!(fallback.contains("model_auto_compact_token_limit = 160000"));
+    let auth: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(temp.path().join("auth.json")).unwrap()).unwrap();
+    assert_eq!(auth["OPENAI_API_KEY"], "sk-b");
+}
+
+#[test]
 fn apply_relay_profile_generates_compatible_gpt56_catalog_without_suffix() {
     let temp = tempfile::tempdir().unwrap();
     let profile = RelayProfile {


### PR DESCRIPTION
## Summary

This is the clean PR1 follow-up to closed #1837, rebuilt from the latest upstream/main. It keeps the scope limited to per-model context windows and automatic compaction thresholds.

## Changes

- add opt-in modelAutoCompact profile field
- validate integer and decimal percentages from 0 to 100
- calculate per-model auto_compact_token_limit from catalog context windows
- extend the manager model editor with per-model auto-compact values
- preserve legacy profile behavior when the field is absent or empty
- remove stale self-generated catalog pointers after all per-model overrides are cleared
- tolerate malformed historical model maps in the editor

## Scope

This PR intentionally does not include model metadata import, protected metadata fields, or external catalog conflict handling. Those belong to the follow-up PR2.

## Validation

- npm test: 71 passed
- npm run check
- cargo test -p codex-plus-core: all passed
- relay_config integration tests: 133 passed
- npm run vite:build
- git diff --check

Related: #1837 (closed split request)