### PR TITLE
fix(dreamskin): skip invalid community catalog entries

### DIFF
--- a/crates/codex-plus-core/src/dream_skin_community.rs
+++ b/crates/codex-plus-core/src/dream_skin_community.rs
@@ -98,7 +98,7 @@ pub async fn fetch_community_catalog() -> anyhow::Result<DreamSkinCommunityCatal
     let client = community_http_client(Duration::from_secs(30))?;
     let mut items = Vec::new();
     let mut offset = 0usize;
-    let total = loop {
+    loop {
         let url = format!(
             "{COMMUNITY_API_ORIGIN}/v1/themes?limit={PAGE_SIZE}&offset={offset}&sort=recent"
         );
@@ -110,10 +110,10 @@ pub async fn fetch_community_catalog() -> anyhow::Result<DreamSkinCommunityCatal
         let count = page.items.len();
         items.extend(page.items);
         if count == 0 || items.len() >= page_total || items.len() >= CATALOG_LIMIT {
-            break page_total;
+            break;
         }
         offset = items.len();
-    };
+    }
     items.truncate(CATALOG_LIMIT);
     filter_invalid_catalog_items(&mut items)?;
     let total = items.len();

--- a/crates/codex-plus-core/src/dream_skin_community.rs
+++ b/crates/codex-plus-core/src/dream_skin_community.rs
@@ -115,7 +115,8 @@ pub async fn fetch_community_catalog() -> anyhow::Result<DreamSkinCommunityCatal
         offset = items.len();
     };
     items.truncate(CATALOG_LIMIT);
-    validate_catalog(&items)?;
+    filter_invalid_catalog_items(&mut items)?;
+    let total = items.len();
     Ok(DreamSkinCommunityCatalog {
         total,
         items,
@@ -258,13 +259,11 @@ fn pending_link_path() -> std::path::PathBuf {
     crate::paths::default_app_state_dir().join(PENDING_LINK_FILE)
 }
 
-fn validate_catalog(items: &[DreamSkinCommunityTheme]) -> anyhow::Result<()> {
+fn filter_invalid_catalog_items(items: &mut Vec<DreamSkinCommunityTheme>) -> anyhow::Result<()> {
     if items.len() > CATALOG_LIMIT {
         bail!("DreamSkin 社区主题数量超过限制");
     }
-    for item in items {
-        validate_community_theme(item)?;
-    }
+    items.retain(|item| validate_community_theme(item).is_ok());
     Ok(())
 }
 
@@ -367,8 +366,9 @@ fn read_cached_catalog(state_dir: &Path) -> anyhow::Result<DreamSkinCommunityCat
     {
         bail!("DreamSkin 社区缓存无效");
     }
-    let catalog: DreamSkinCommunityCatalog = serde_json::from_slice(&std::fs::read(path)?)?;
-    validate_catalog(&catalog.items)?;
+    let mut catalog: DreamSkinCommunityCatalog = serde_json::from_slice(&std::fs::read(path)?)?;
+    filter_invalid_catalog_items(&mut catalog.items)?;
+    catalog.total = catalog.items.len();
     Ok(catalog)
 }
 
@@ -432,7 +432,44 @@ async fn download_limited(
 
 #[cfg(test)]
 mod tests {
-    use super::version_id_from_link;
+    use super::{DreamSkinCommunityTheme, filter_invalid_catalog_items, version_id_from_link};
+
+    fn community_theme(id: &str, name: &str) -> DreamSkinCommunityTheme {
+        DreamSkinCommunityTheme {
+            apply_compatible: true,
+            author_display_name: "DreamSkin Author".to_string(),
+            author_user_id: String::new(),
+            display_meta: serde_json::Value::Null,
+            download_count: 0,
+            id: id.to_string(),
+            license: "MIT".to_string(),
+            name: name.to_string(),
+            package_bytes: 1024,
+            package_sha256: "a".repeat(64),
+            reviewed_at: String::new(),
+            slug: String::new(),
+            submitted_at: String::new(),
+            theme_id: "theme-id".to_string(),
+            version: "1.0.0".to_string(),
+            preview_url: String::new(),
+            installed: false,
+            installed_version: String::new(),
+            update_available: false,
+        }
+    }
+
+    #[test]
+    fn catalog_skips_invalid_theme_without_rejecting_valid_entries() {
+        let mut items = vec![
+            community_theme("ver_1234abcd", "Valid theme"),
+            community_theme("ver_5678efgh", "粉色\u{200b}鲸鱼"),
+        ];
+
+        filter_invalid_catalog_items(&mut items).unwrap();
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "ver_1234abcd");
+    }
 
     #[test]
     fn community_link_accepts_only_canonical_version_id() {


### PR DESCRIPTION
## 问题

Fixes #1947.

DreamSkin 社区目录当前会严格校验清单中的每一条主题元数据。只要其中一条展示字段包含不允许的字符，例如主题名称中的 `U+200B` 零宽空格，`validate_catalog` 就会使整个在线目录加载失败，并回退到本地缓存。

## 修复内容

* 在线社区目录中，单条主题元数据校验失败时仅跳过该条目，不再使整个目录加载失败。
* 读取本地社区缓存时采用相同处理，避免历史异常条目导致缓存无法使用。
* 过滤后重新计算目录中的 `total`。
* 保持单个主题安装路径的严格元数据校验不变，异常主题仍不能被安装。
* 添加回归测试，覆盖包含 `U+200B` 零宽空格的异常主题与正常主题同时存在的情况。

## 验证

新增单元测试：

`catalog_skips_invalid_theme_without_rejecting_valid_entries`

该测试确认异常主题会被过滤，同时合法主题仍正常保留。

本地完整 `cargo test` / `cargo clippy` 未运行，等待仓库 CI 验证。
