### PR TITLE
fix(inject): 解析纯 API 中继实际使用的 model_provider，不再一律视为 custom

### DIFF
--- a/apps/codex-plus-manager/src/renderer-inject.test.ts
+++ b/apps/codex-plus-manager/src/renderer-inject.test.ts
@@ -256,3 +256,76 @@ describe("renderer injection header compatibility", () => {
     }
   });
 });
+
+describe("relay pureApi provider resolution", () => {
+  function providerRuntime(
+    renderer: string,
+    backendSettings: Record<string, unknown>,
+    catalog: Record<string, unknown>,
+    profile: Record<string, unknown>,
+  ) {
+    const start = renderer.indexOf("function codexRelayConfigModelProvider(");
+    const codeStart = renderer.indexOf("function codexRemoteSessionTargetProvider(");
+    const end = renderer.indexOf("\n  function codexRemoteSessionProviderRequestMethod", codeStart);
+    assert.ok(start >= 0 && codeStart >= 0 && end > codeStart);
+    const source = renderer.slice(start, end);
+    const create = new Function(
+      "codexPlusBackendSettings",
+      "codexModelCatalog",
+      "codexRemoteSessionActiveProfile",
+      `${source}\nreturn { codexRelayConfigModelProvider, codexRemoteSessionTargetProvider };`,
+    ) as (
+      backend: Record<string, unknown>,
+      cat: Record<string, unknown>,
+      activeProfile: () => Record<string, unknown>,
+    ) => {
+      codexRelayConfigModelProvider: (configContents: string) => string;
+      codexRemoteSessionTargetProvider: () => string;
+    };
+    return create(backendSettings, catalog, () => profile);
+  }
+
+  it("resolves the real model_provider from a pureApi relay profile instead of hardcoding custom", async () => {
+    const renderer = await readFile(new URL("../../../assets/inject/renderer-inject.js", import.meta.url), "utf8");
+    const runtime = providerRuntime(
+      renderer,
+      {},
+      { codex_model_provider: "deepseek" },
+      { relayMode: "pureApi", configContents: 'model = "deepseek-v4-flash-vision-exp"\nmodel_provider = "deepseek"' },
+    );
+
+    assert.equal(runtime.codexRelayConfigModelProvider('model_provider = "deepseek"'), "deepseek");
+    assert.equal(runtime.codexRemoteSessionTargetProvider(), "deepseek");
+  });
+
+  it("still returns custom for pureApi relays that genuinely declare the custom provider", async () => {
+    const renderer = await readFile(new URL("../../../assets/inject/renderer-inject.js", import.meta.url), "utf8");
+    const runtime = providerRuntime(
+      renderer,
+      {},
+      { codex_model_provider: "custom" },
+      { relayMode: "pureApi", configContents: 'model_provider = "custom"\n[model_providers.custom]' },
+    );
+
+    assert.equal(runtime.codexRemoteSessionTargetProvider(), "custom");
+  });
+
+  it("falls back to custom when a pureApi relay declares no provider", async () => {
+    const renderer = await readFile(new URL("../../../assets/inject/renderer-inject.js", import.meta.url), "utf8");
+    const runtime = providerRuntime(renderer, {}, { codex_model_provider: "" }, { relayMode: "pureApi", configContents: "" });
+
+    assert.equal(runtime.codexRemoteSessionTargetProvider(), "custom");
+  });
+
+  it("prefers activeRelayCodexProvider when configured", async () => {
+    const renderer = await readFile(new URL("../../../assets/inject/renderer-inject.js", import.meta.url), "utf8");
+    const runtime = providerRuntime(
+      renderer,
+      { activeRelayCodexProvider: "deepseek" },
+      { codex_model_provider: "" },
+      { relayMode: "pureApi", configContents: "" },
+    );
+
+    assert.equal(runtime.codexRemoteSessionTargetProvider(), "deepseek");
+  });
+});

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -3256,12 +3256,29 @@
     return codexRemoteSessionProviderNormalizationEnabled();
   }
 
+  function codexRelayConfigModelProvider(configContents) {
+    const text = String(configContents || "");
+    const match = /(?:^|\n)\s*model_provider\s*=\s*["']([^"'\n]+)["']/m.exec(text);
+    return match ? String(match[1]).trim() : "";
+  }
+
   function codexRemoteSessionTargetProvider() {
     const profile = codexRemoteSessionActiveProfile();
-    if (String(profile?.relayMode || "") === "pureApi") return "custom";
-    return String(
+    const relayMode = String(profile?.relayMode || "");
+    // Resolve the provider the active relay actually writes into config.toml
+    // (e.g. a relay profile that uses `model_provider = "deepseek"` with a
+    // matching [model_providers.deepseek] block) instead of assuming every
+    // pureApi relay is literally the "custom" provider. Fall back to "custom"
+    // only when the profile carries no provider and none is configured, so
+    // existing pureApi relays that genuinely use `[model_providers.custom]`
+    // keep working.
+    const resolved =
       codexPlusBackendSettings.activeRelayCodexProvider
-      || codexModelCatalog?.codex_model_provider
+      || codexRelayConfigModelProvider(profile?.configContents || "");
+    if (resolved) return String(resolved).trim();
+    if (relayMode === "pureApi") return "custom";
+    return String(
+      codexModelCatalog?.codex_model_provider
       || codexModelCatalog?.codexModelProvider
       || codexModelCatalog?.model_provider
       || codexModelCatalog?.modelProvider


### PR DESCRIPTION
纯 API（pureApi）中继此前在 thread/start|resume 与 turn/start 时被硬编码为 注入 modelProvider="custom"。若该中继在 config.toml 中使用了具名供应方 （例如 model_provider="deepseek" + [model_providers.deepseek]），恢复会话就会 报 "Model provider `custom` not found"，因为该供应方块从未定义。

现改为从中继档案的 configContents 解析其真正写入 config.toml 的 model_provider， 回退顺序为 activeRelayCodexProvider > configContents 解析 > "custom"，使注入的 供应方与加载配置一致；对确实使用 [model_providers.custom] 的纯 API 中继保持原行为。

回归测试：
- apps/codex-plus-manager/src/renderer-inject.test.ts 新增 "relay pureApi provider resolution" 用例，覆盖具名供应方解析、custom 保留、无供应方回退 custom、 activeRelayCodexProvider 优先四种场景。
- 执行 node --test src/renderer-inject.test.ts，14 个用例全部通过。