### PR TITLE
fix(proxy): preserve ctc_ IDs for custom tool calls

### DIFF
--- a/crates/codex-plus-core/src/protocol_proxy.rs
+++ b/crates/codex-plus-core/src/protocol_proxy.rs
@@ -923,6 +923,9 @@ async fn upstream_request_parts(
         RelayProtocol::Responses => request_json,
         RelayProtocol::ChatCompletions => responses_to_chat_completions(request_json)?,
     };
+    if relay.protocol == RelayProtocol::Responses {
+        normalize_responses_custom_tool_call_ids(&mut body);
+    }
 
     // Image handling (per-model): send-as-is / strip / VLM analysis
     let model = body
@@ -1602,7 +1605,17 @@ impl ChatSseState {
                 state.arguments.push_str(&args_delta);
             }
 
-            if !state.added && (!state.call_id.is_empty() || !state.name.is_empty()) {
+            // Custom tool output items must use the `ctc_` ID namespace. Some
+            // Chat Completions providers send the call ID before the function
+            // name, so wait for the name when the request includes custom tools
+            // instead of emitting a provisional `function_call` with an `fc_`
+            // ID that cannot later be replayed as a `custom_tool_call`.
+            let waiting_for_custom_tool_name =
+                self.tool_context.has_custom_tools && state.name.is_empty();
+            if !state.added
+                && (!state.call_id.is_empty() || !state.name.is_empty())
+                && !waiting_for_custom_tool_name
+            {
                 should_add = true;
                 pending_arguments = state.arguments.clone();
             } else if state.added {
@@ -1622,7 +1635,7 @@ impl ChatSseState {
                 state.name = "unknown_tool".to_string();
             }
             state.output_index = Some(assigned);
-            state.item_id = format!("fc_{}", state.call_id);
+            state.item_id = tool_call_item_id(&state.call_id, &state.name, &self.tool_context);
             let added_item = tool_call_added_item(state, assigned, &self.tool_context);
             push_sse(output, "response.output_item.added", added_item);
             if !pending_arguments.is_empty() {
@@ -1805,7 +1818,7 @@ impl ChatSseState {
                     state.name = "unknown_tool".to_string();
                 }
                 state.output_index = Some(assigned);
-                state.item_id = format!("fc_{}", state.call_id);
+                state.item_id = tool_call_item_id(&state.call_id, &state.name, &self.tool_context);
                 let added_item = tool_call_added_item(state, assigned, &self.tool_context);
                 push_sse(output, "response.output_item.added", added_item);
             }
@@ -2044,6 +2057,38 @@ fn upstream_error_parts(
 
 fn truncate_error_preview(input: &str) -> String {
     input.chars().take(ERROR_BODY_PREVIEW_LIMIT).collect()
+}
+
+fn normalize_responses_custom_tool_call_ids(body: &mut Value) {
+    let Some(input) = body.get_mut("input") else {
+        return;
+    };
+    match input {
+        Value::Array(items) => {
+            for item in items {
+                normalize_custom_tool_call_item_id(item);
+            }
+        }
+        Value::Object(_) => normalize_custom_tool_call_item_id(input),
+        _ => {}
+    }
+}
+
+fn normalize_custom_tool_call_item_id(item: &mut Value) {
+    if item.get("type").and_then(Value::as_str) != Some("custom_tool_call") {
+        return;
+    }
+    let Some(id) = item.get("id").and_then(Value::as_str) else {
+        return;
+    };
+    if id.starts_with("ctc_") {
+        return;
+    }
+    let suffix = id
+        .strip_prefix("fc_")
+        .or_else(|| id.strip_prefix("item_"))
+        .unwrap_or(id);
+    item["id"] = json!(format!("ctc_{suffix}"));
 }
 
 fn append_responses_input(input: &Value, messages: &mut Vec<Value>) {
@@ -3249,7 +3294,7 @@ fn tool_call_added_item(
             "type": "response.output_item.added",
             "output_index": output_index,
             "item": {
-                "id": format!("ctc_{}", state.call_id),
+                "id": tool_call_item_id(&state.call_id, &state.name, tool_context),
                 "type": "custom_tool_call",
                 "status": "in_progress",
                 "call_id": state.call_id,
@@ -3312,7 +3357,7 @@ fn push_tool_call_done_sse(
             "response.custom_tool_call_input.delta",
             json!({
                 "type": "response.custom_tool_call_input.delta",
-                "item_id": format!("ctc_{}", state.call_id),
+                "item_id": tool_call_item_id(&state.call_id, &state.name, tool_context),
                 "call_id": state.call_id,
                 "output_index": output_index,
                 "delta": reconstruct_custom_tool_call_input_with_context(
@@ -3348,7 +3393,7 @@ fn response_tool_call_item(
 ) -> Value {
     if tool_context.is_custom_tool_proxy(name) {
         return json!({
-            "id": format!("ctc_{call_id}"),
+            "id": tool_call_item_id(call_id, name, tool_context),
             "type": "custom_tool_call",
             "status": "completed",
             "call_id": call_id,
@@ -3369,6 +3414,15 @@ fn response_tool_call_item(
         item["namespace"] = json!(namespace);
     }
     item
+}
+
+fn tool_call_item_id(call_id: &str, name: &str, tool_context: &CodexToolContext) -> String {
+    let prefix = if tool_context.is_custom_tool_proxy(name) {
+        "ctc_"
+    } else {
+        "fc_"
+    };
+    format!("{prefix}{call_id}")
 }
 
 fn split_leading_think_block(text: &str) -> Option<(String, String)> {

--- a/crates/codex-plus-core/tests/protocol_proxy.rs
+++ b/crates/codex-plus-core/tests/protocol_proxy.rs
@@ -1439,9 +1439,36 @@ data: [DONE]
         1
     );
     assert!(converted.contains("\"type\":\"custom_tool_call\""));
+    assert!(converted.contains("\"id\":\"ctc_call_custom\""));
+    assert!(converted.contains("\"item_id\":\"ctc_call_custom\""));
+    assert!(!converted.contains("\"id\":\"fc_call_custom\""));
+    assert!(!converted.contains("\"item_id\":\"fc_call_custom\""));
     assert!(converted.contains("\"name\":\"exec\""));
     assert!(converted.contains("\"input\":\"ls -la\""));
     assert!(converted.contains("data: [DONE]"));
+}
+
+#[test]
+fn chat_sse_waits_for_custom_tool_name_before_assigning_item_id() {
+    let converted = chat_sse_to_responses_sse_with_request(
+        r#"data: {"id":"chatcmpl_custom_split","model":"gpt-5.4","choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_custom_split","type":"function"}]}}]}
+
+data: {"id":"chatcmpl_custom_split","model":"gpt-5.4","choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"exec","arguments":"{\"input\":\"pwd\"}"}}]},"finish_reason":"tool_calls"}]}
+
+data: [DONE]
+
+"#,
+        &json!({
+            "model": "gpt-5.4",
+            "tools": [{ "type": "custom", "name": "exec" }]
+        }),
+    );
+
+    assert!(converted.contains("\"type\":\"custom_tool_call\""));
+    assert!(converted.contains("\"id\":\"ctc_call_custom_split\""));
+    assert!(converted.contains("\"item_id\":\"ctc_call_custom_split\""));
+    assert!(!converted.contains("fc_call_custom_split"));
+    assert!(converted.contains("\"input\":\"pwd\""));
 }
 
 #[test]
@@ -1708,6 +1735,44 @@ async fn model_route_can_rewrite_only_the_target_model_name() {
     let mut expected = request;
     expected["model"] = json!("provider-luna-v2");
     assert_eq!(upstream_body, expected);
+}
+
+#[tokio::test]
+async fn responses_proxy_normalizes_legacy_custom_tool_item_ids_only() {
+    let target = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .unwrap();
+    let target_addr = target.local_addr().unwrap();
+    let target_server = tokio::spawn(capture_json_request_once(target));
+    let request = json!({
+        "model": "gpt-5.6-luna",
+        "input": [
+            {
+                "type": "custom_tool_call",
+                "id": "fc_legacy_custom_item",
+                "call_id": "call_legacy_custom",
+                "name": "exec",
+                "input": "pwd"
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "content": "continue"
+            }
+        ],
+        "stream": false
+    });
+    let settings = model_route_settings("gpt-5.6-luna", "", format!("http://{target_addr}/v1"));
+
+    let result = open_responses_proxy_request_with_settings(&request.to_string(), settings)
+        .await
+        .unwrap();
+    assert_eq!(result.status_code, 200);
+    let (_, upstream_body) = target_server.await.unwrap();
+
+    assert_eq!(upstream_body["input"][0]["id"], "ctc_legacy_custom_item");
+    assert_eq!(upstream_body["input"][0]["call_id"], "call_legacy_custom");
+    assert_eq!(upstream_body["input"][1]["type"], "message");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes the `fc_...` versus `ctc_...` custom tool call ID mismatch tracked in upstream issue #1929.

Changes:
- Keep custom tool output item IDs in the `ctc_` namespace in Chat Completions → Responses streaming conversion.
- Delay provisional tool item creation until the custom tool name is known.
- Normalize only legacy `custom_tool_call` history item IDs in Responses requests; preserve `call_id` and unrelated IDs.
- Add regression coverage for streaming and replayed history.

Validation: `cargo test -p codex-plus-core --test protocol_proxy` (61 passed).