### PR TITLE
Fix Windows CI test compatibility

### DIFF
--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -5986,7 +5986,7 @@ mod tests {
     }
 
     #[test]
-    fn active_official_sync_clears_custom_provider() {
+    fn active_official_sync_clears_custom_provider_selection() {
         let temp = tempfile::tempdir().unwrap();
         std::fs::write(
             temp.path().join("config.toml"),
@@ -6012,9 +6012,13 @@ mod tests {
         sync_active_relay_to_home(&settings, temp.path()).unwrap();
 
         let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+        let parsed = config.parse::<toml_edit::DocumentMut>().unwrap();
         let auth = std::fs::read_to_string(temp.path().join("auth.json")).unwrap();
-        assert!(!config.contains("model_provider"));
-        assert!(!config.contains("model_providers.custom"));
+        assert!(parsed.get("model_provider").is_none());
+        assert_eq!(
+            parsed["model_providers"]["custom"]["base_url"].as_str(),
+            Some("https://old.example/v1")
+        );
         assert!(!auth.contains("OPENAI_API_KEY"));
         assert!(auth.contains("auth_mode"));
     }

--- a/crates/codex-plus-core/src/plugin_marketplace.rs
+++ b/crates/codex-plus-core/src/plugin_marketplace.rs
@@ -873,19 +873,21 @@ mod tests {
         let home = temp.path();
         write_marketplace(home);
         write_remote_marketplace(home);
+        let plugins_source = home.join(".tmp").join("plugins").display().to_string();
+        let extended_plugins_source = windows_extended_path(&home.join(".tmp").join("plugins"));
         std::fs::write(
             home.join("config.toml"),
             format!(
                 r#"[marketplaces.openai-curated]
 source_type = "local"
-source = "{}"
+source = {}
 
 [marketplaces.openai-api-curated]
 source_type = "local"
-source = '{}'
+source = {}
 "#,
-                home.join(".tmp").join("plugins").display(),
-                format!(r"\\?\{}", home.join(".tmp").join("plugins").display())
+                toml_edit::value(plugins_source),
+                toml_edit::value(extended_plugins_source),
             ),
         )
         .unwrap();

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -1366,7 +1366,9 @@ fn injection_script_keeps_session_action_buttons_in_pr_style() {
 
     assert!(script.contains("actionButtonClass = \"codex-session-action-button\""));
     assert!(script.contains("background: transparent;"));
-    assert!(script.contains("background: #363839;"));
+    assert!(script.contains(
+        "background: var(--codex-session-action-hover-background, transparent);"
+    ));
     assert!(script.contains("cursor: default;"));
 }
 


### PR DESCRIPTION
## 背景与目标

修复当前 Windows CI 中三项与功能改动无关的测试兼容性和测试契约问题，保持生产逻辑和测试标准不变。

## 变更内容

- 更新注入脚本样式契约测试，使其检查当前使用的主题变量，而不是已经过期的固定颜色。
- 修复插件市场测试夹具对 Windows 本地路径的 TOML 构造方式，确保反斜杠按 TOML 规则正确转义。
- 更新 Manager 官方供应商同步测试：结构化检查顶层供应商选择已清除，同时验证新的迁移语义会保留不含认证字段的供应商定义。

## 影响范围

- 仅涉及测试契约和跨平台测试数据构造。
- 不修改生产功能、不修改 CI 配置、不降低断言覆盖范围。
- 解决 Windows 下完整 Rust 测试无法继续执行的问题。

## 验证

- `cargo test -p codex-plus-core --lib plugin_marketplace::tests::ensure_openai_curated_marketplace_config_removes_managed_reserved_entries -- --exact`
- `cargo test -p codex-plus-core --test cdp_bridge injection_script_keeps_session_action_buttons_in_pr_style -- --exact`
- `cargo test -p codex-plus-manager --lib commands::tests::active_official_sync_clears_custom_provider_selection -- --exact`
- `git diff --check`

三项定向测试均已通过。
