### PR TITLE
Extract floating-panel Stepwise feature modules

### DIFF
--- a/assets/inject/floating-panel/stepwise/generation.js
+++ b/assets/inject/floating-panel/stepwise/generation.js
@@ -1,0 +1,370 @@
+/* Stepwise generation: request lifecycle, cache, composer, and prompt submission. */
+
+  function bridgeRequestKey(userText, assistantText) {
+    return hashText(`${state.activeContext.sessionId}\n${shortText(userText, 2400)}\n\n--- assistant ---\n\n${shortText(assistantText, 5200)}`);
+  }
+
+  // Bridge requests are deduplicated by answer identity and guarded against late responses from older turns.
+  function requestBridgeStepwise(key, userText, assistantText, requestMode = stepwiseGenerationMode(), options = {}) {
+    if (!stepwiseEnabled() || !key || state.bridgePendingHash === key || state.bridgeCache.has(key)) return;
+
+    const normalizedMode = normalizeGenerationMode(requestMode);
+    if (normalizedMode === "manual" && options.userInitiated !== true) return;
+    pushDiagnostic("bridge:generate-request", {
+      userTextLength: userText.length,
+      assistantTextLength: assistantText.length,
+      mode: normalizedMode,
+    });
+    const requestContext = contextSnapshot();
+    const requestEpoch = state.stepwiseEpoch;
+    const requestId = ++state.bridgeRequestSequence;
+    const requestAssistantMessageId = requestContext.assistantMessageId;
+    const requestOwned = () => state.bridgePendingHash === key
+      && state.bridgePendingRequestId === requestId
+      && state.bridgePendingMode === normalizedMode;
+    const requestCurrent = () => stepwiseEnabled()
+      && stepwiseGenerationMode() === normalizedMode
+      && requestEpoch === state.stepwiseEpoch
+      && contextMatches(requestContext)
+      && state.activeContext.assistantMessageId === requestAssistantMessageId
+      && state.bridgeActiveKey === key
+      && !chatBusy();
+    state.bridgePendingHash = key;
+    state.bridgePendingRequestId = requestId;
+    state.bridgePendingMode = normalizedMode;
+    state.bridgeStatus = "pending";
+    state.bridgeError = "";
+    state.promptContext = requestContext;
+    renderFloat();
+
+    bridgeCall(
+      "/stepwise/generate",
+      {
+        request: {
+        lastUserMessage: userText,
+        lastAssistantMessage: assistantText,
+        threadTitle: document.title || "",
+        pageUrl: location.href,
+      },
+      }
+    )
+      .then((payload) => {
+        if (!requestOwned() || !requestCurrent()) return;
+        const prompts = payload?.disabled || payload?.error ? [] : payloadPrompts(payload);
+        pushDiagnostic("bridge:generate-result", {
+          status: payload?.status || "",
+          disabled: Boolean(payload?.disabled),
+          error: normalizeText(payload?.error || ""),
+          rawItemCount: payloadItems(payload).length,
+          promptCount: prompts.length,
+          payloadKeys: payload && typeof payload === "object" ? Object.keys(payload).slice(0, 12) : [],
+        });
+        const bridgeStatus = payload?.disabled ? "disabled" : payload?.error ? "failed" : "ok";
+        state.bridgeCache.set(key, {
+          status: bridgeStatus,
+          disabled: Boolean(payload?.disabled),
+          error: normalizeText(payload?.error || ""),
+          prompts,
+        });
+        state.bridgeStatus = bridgeStatus;
+        state.bridgeError = normalizeText(payload?.error || "");
+        state.promptContext = requestContext;
+        if (bridgeStatus === "ok") triggerCompletionBeam(prompts.length);
+      })
+      .catch((error) => {
+        if (!requestOwned() || !requestCurrent()) return;
+        pushDiagnostic("bridge:generate-failed", { error: error.message });
+        state.bridgeCache.set(key, {
+          status: "failed",
+          disabled: true,
+          error: error.message,
+          prompts: [],
+        });
+        state.bridgeStatus = "failed";
+        state.bridgeError = error.message;
+      })
+      .finally(() => {
+        if (!requestOwned()) return;
+        state.bridgePendingHash = "";
+        state.bridgePendingRequestId = 0;
+        state.bridgePendingMode = stepwiseGenerationMode();
+        if (state.bridgeStatus === "pending") {
+          state.bridgeStatus = "idle";
+          state.bridgeError = "";
+          state.promptContext = null;
+        }
+        scheduleScan(0);
+      });
+  }
+
+  function forceRefreshStepwise() {
+    if (!isCurrentRuntime() || !stepwiseEnabled()) return;
+    if (state.bridgeStatus === "pending") {
+      setScanStatus("manual-refresh-pending", {});
+      return;
+    }
+    if (chatBusy()) {
+      if (!state.prompts.length) state.bridgeError = "回答生成中，结束后再刷新";
+      setScanStatus("manual-refresh-busy", {});
+      renderFloat();
+      return;
+    }
+
+    const message = findLatestAssistantMessage();
+    if (!message) {
+      state.bridgeError = "未找到可用于生成的回答";
+      state.prompts = [];
+      state.promptContext = null;
+      state.promptPreviewIndex = 0;
+      setScanStatus("manual-refresh-no-assistant", {});
+      renderFloat();
+      return;
+    }
+
+    const nextAssistantMessageId = assistantMessageId(message);
+    if (state.activeContext.assistantMessageId !== nextAssistantMessageId) {
+      state.activeContext.assistantMessageId = nextAssistantMessageId;
+    }
+
+    const stepwisePayload = extractStepwisePayload(message);
+    hideStepwisePayload(message.node);
+    const assistantText = shortText(stepwisePayload.textWithoutPayload || message.text);
+    const userText = findPreviousUserText(message);
+    const bridgeKey = bridgeRequestKey(userText, assistantText);
+    const generationMode = stepwiseGenerationMode();
+    state.bridgeActiveKey = bridgeKey;
+    state.stepwiseEpoch += 1;
+    state.bridgePendingHash = "";
+    state.bridgePendingRequestId = 0;
+    state.bridgePendingMode = generationMode;
+    if (bridgeKey) state.bridgeCache.delete(bridgeKey);
+
+    state.lastAssistantHash = hashText(assistantText);
+    state.lastAssistantAt = 0;
+    state.currentHash = `${state.lastAssistantHash}:manual-refresh`;
+    state.prompts = [];
+    state.promptContext = contextSnapshot();
+    state.promptPreviewIndex = 0;
+    state.bridgeError = "";
+    setScanStatus("manual-refresh", { hash: state.lastAssistantHash, textLength: assistantText.length });
+    requestBridgeStepwise(bridgeKey, userText, assistantText, generationMode, { userInitiated: true });
+    renderFloat();
+  }
+
+  function clearPromptsForNewAssistant(hash) {
+    state.stepwiseEpoch += 1;
+    state.bridgeActiveKey = "";
+    state.bridgePendingHash = "";
+    state.bridgePendingRequestId = 0;
+    state.bridgePendingMode = stepwiseGenerationMode();
+    state.bridgeStatus = state.bridgePendingMode === "manual" ? "manual-ready" : "idle";
+    state.currentHash = `${hash}:pending`;
+    state.prompts = [];
+    state.promptContext = contextSnapshot();
+    state.promptPreviewIndex = 0;
+    state.bridgeError = "";
+    renderFloat();
+  }
+
+  function composerRootForContext(snapshot = state.promptContext) {
+    if (snapshot?.paneKey) return rootForContext(snapshot.paneKey, snapshot.sessionId);
+    return chatRoot();
+  }
+
+  function composerTargetForContext(snapshot = state.promptContext) {
+    const root = composerRootForContext(snapshot);
+    if (!root) return null;
+    return mainComposerCandidate(composerCandidates(root), root);
+  }
+
+  function setNativeValue(element, value) {
+    const prototype = Object.getPrototypeOf(element);
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, "value");
+    if (descriptor && typeof descriptor.set === "function") descriptor.set.call(element, value);
+    else element.value = value;
+  }
+
+  function composerText(target) {
+    if (target instanceof HTMLTextAreaElement || target instanceof HTMLInputElement) return normalizeText(target.value);
+    return normalizeText(target?.innerText || target?.textContent || "");
+  }
+
+  function pressEnter(target) {
+    target.focus();
+    const base = {
+      key: "Enter",
+      code: "Enter",
+      keyCode: 13,
+      which: 13,
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    };
+    const down = target.dispatchEvent(new KeyboardEvent("keydown", base));
+    target.dispatchEvent(new KeyboardEvent("keypress", base));
+    target.dispatchEvent(new KeyboardEvent("keyup", base));
+    pushDiagnostic("submit:enter-fallback", { defaultAllowed: down });
+    return true;
+  }
+
+  function submitComposer(target, allowFallback = false) {
+    if (!(target instanceof HTMLElement)) return false;
+    if (composerBusy(target)) {
+      pushDiagnostic("submit:blocked-local-stop", { attemptFallback: allowFallback });
+      return false;
+    }
+
+    const button = nearbySubmitButton(target);
+    if (button) {
+      pushDiagnostic("submit:button-click", {
+        label: buttonLabel(button),
+        disabled: disabledButton(button),
+        rect: rectSummary(button),
+        className: String(button.className || "").slice(0, 160),
+        composerTextLength: composerText(target).length,
+        iconPath: iconPathData(button).slice(0, 160),
+      });
+      button.click();
+      return true;
+    }
+
+    const pendingButton = nearbySubmitButton(target, { includeDisabled: true });
+    if (pendingButton && disabledButton(pendingButton)) {
+      pushDiagnostic("submit:button-disabled", {
+        label: buttonLabel(pendingButton),
+        rect: rectSummary(pendingButton),
+        className: String(pendingButton.className || "").slice(0, 160),
+        composerTextLength: composerText(target).length,
+        iconPath: iconPathData(pendingButton).slice(0, 160),
+      });
+      return false;
+    }
+
+    const form = target.closest("form");
+    if (form && allowFallback) {
+      pushDiagnostic("submit:form-fallback", { rect: rectSummary(form) });
+      try {
+        form.requestSubmit();
+      } catch {
+        pushDiagnostic("submit:form-fallback-failed", {});
+        return false;
+      }
+      return true;
+    }
+
+    if (allowFallback) return pressEnter(target);
+    pushDiagnostic("submit:no-button-yet", { allowFallback });
+    return false;
+  }
+
+  function submitComposerWhenReady(target, expectedText = "", attempt = 0) {
+    let currentTarget = target;
+    if (!(currentTarget instanceof HTMLElement)) return false;
+    if (!document.contains(currentTarget)) {
+      currentTarget = composerTargetForContext(state.promptContext || state.activeContext);
+      pushDiagnostic("submit:target-detached", {
+        attempt,
+        rebound: Boolean(currentTarget),
+        paneKey: state.promptContext?.paneKey || state.activeContext.paneKey,
+        sessionId: state.promptContext?.sessionId || state.activeContext.sessionId,
+      });
+      if (!currentTarget) {
+        if (attempt >= SUBMIT_RETRY_LIMIT) return false;
+        window.setTimeout(() => submitComposerWhenReady(target, expectedText, attempt + 1), SUBMIT_RETRY_DELAY_MS);
+        return false;
+      }
+    }
+    if (normalizeText(expectedText) && composerText(currentTarget) !== normalizeText(expectedText)) {
+      pushDiagnostic("submit:composer-changed", {
+        attempt,
+        expectedLength: normalizeText(expectedText).length,
+        actualLength: composerText(currentTarget).length,
+      });
+      return false;
+    }
+    if (composerBusy(currentTarget)) {
+      if (attempt === 0 || attempt % 10 === 0 || attempt >= SUBMIT_RETRY_LIMIT) {
+        pushDiagnostic("submit:blocked-local-stop", {
+          attempt,
+          retrying: attempt < SUBMIT_RETRY_LIMIT,
+          targetRect: rectSummary(currentTarget),
+        });
+      }
+      if (attempt >= SUBMIT_RETRY_LIMIT) {
+        pushDiagnostic("submit:blocked-local-stop-timeout", { attempt, targetRect: rectSummary(currentTarget) });
+        return false;
+      }
+      window.setTimeout(() => submitComposerWhenReady(currentTarget, expectedText, attempt + 1), SUBMIT_RETRY_DELAY_MS);
+      return false;
+    }
+    if (submitComposer(currentTarget, attempt >= SUBMIT_RETRY_LIMIT)) return true;
+    if (attempt >= SUBMIT_RETRY_LIMIT) return false;
+    window.setTimeout(() => submitComposerWhenReady(currentTarget, expectedText, attempt + 1), SUBMIT_RETRY_DELAY_MS);
+    return false;
+  }
+
+  function setEditableText(target, prompt) {
+    target.focus();
+    const selection = window.getSelection?.();
+    const range = document.createRange();
+    range.selectNodeContents(target);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    let inserted = false;
+    try {
+      inserted = document.execCommand?.("insertText", false, prompt) === true;
+    } catch {
+      inserted = false;
+    }
+    if (!inserted) target.textContent = prompt;
+  }
+
+  function fillComposer(prompt, submit = false) {
+    const context = state.promptContext || state.activeContext;
+    const targetRoot = composerRootForContext(context);
+    const candidates = targetRoot ? composerCandidates(targetRoot) : [];
+    const target = targetRoot
+      ? mainComposerCandidate(candidates, targetRoot)
+      : null;
+    pushDiagnostic("fill:start", {
+      submit,
+      candidateCount: candidates.length,
+      paneKey: context?.paneKey || "",
+      sessionId: context?.sessionId || "",
+      targetTag: target?.tagName || "",
+      targetRole: target?.getAttribute?.("role") || "",
+      targetClass: String(target?.className || "").slice(0, 120),
+      targetRect: rectSummary(target),
+      chatRootRect: rectSummary(targetRoot),
+      promptLength: normalizeText(prompt).length,
+    });
+    if (!target) {
+      pushDiagnostic("fill:no-main-composer", { candidateCount: candidates.length });
+      window.prompt("Copy Stepwise prompt", prompt);
+      return false;
+    }
+
+    target.focus();
+    if (target instanceof HTMLTextAreaElement || target instanceof HTMLInputElement) {
+      setNativeValue(target, prompt);
+      target.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: prompt }));
+      target.dispatchEvent(new Event("change", { bubbles: true }));
+      pushDiagnostic("fill:text-control", { valueLength: normalizeText(target.value).length });
+      if (submit) submitComposerWhenReady(target, prompt);
+      return true;
+    }
+
+    if (target.isContentEditable || target.getAttribute("role") === "textbox") {
+      setEditableText(target, prompt);
+      target.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: prompt }));
+      pushDiagnostic("fill:editable", { valueLength: normalizeText(target.textContent).length });
+      if (submit) window.setTimeout(() => submitComposerWhenReady(target, prompt), EDITABLE_SUBMIT_DELAY_MS);
+      return true;
+    }
+
+    window.prompt("Copy Stepwise prompt", prompt);
+    return false;
+  }
+
+  // Scanning observes the pinned conversation, settles streamed answers, and schedules only necessary work.

--- a/assets/inject/floating-panel/stepwise/suggestions.js
+++ b/assets/inject/floating-panel/stepwise/suggestions.js
@@ -1,0 +1,222 @@
+/* Stepwise suggestions: payload parsing, normalization, labels, and deduplication. */
+
+  function hideStepwisePayload(root) {
+    if (!(root instanceof Element)) return;
+
+    const blocks = Array.from(root.querySelectorAll("pre, code")).filter((node) => {
+      if (!(node instanceof Element)) return false;
+      return /"codex_stepwise"\s*:\s*true/.test(node.textContent || "");
+    });
+
+    for (const block of blocks) {
+      const container = block.closest("[class*='_codeBlock_'], pre") || block;
+      container.setAttribute(PAYLOAD_ATTR, "true");
+    }
+  }
+
+  function clearStepwisePayloadMarks() {
+    document.querySelectorAll(`[${PAYLOAD_ATTR}]`).forEach((node) => {
+      node.removeAttribute(PAYLOAD_ATTR);
+    });
+  }
+
+  function uniquePrompts(items) {
+    const seen = new Set();
+    const result = [];
+    const maxItems = configuredMaxPromptItems();
+    for (const item of Array.isArray(items) ? items : []) {
+      const prompt = normalizeText(typeof item === "string" ? item : item.prompt);
+      const dedupeKey = prompt.replace(/\s+/g, " ");
+      if (!prompt || seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      result.push({
+        label: leadingPromptText(typeof item === "string" ? labelForPrompt(prompt) : item.label || labelForPrompt(prompt), 36),
+        summary: leadingPromptText(
+          typeof item === "string" ? summaryForPrompt(prompt) : item.summary || summaryForPrompt(prompt),
+          MAX_PROMPT_SUMMARY_LENGTH,
+        ),
+        prompt,
+      });
+      if (result.length >= maxItems) break;
+    }
+    return result;
+  }
+
+  function normalizePromptState(items = state.prompts) {
+    const normalized = uniquePrompts(items);
+    state.prompts = normalized;
+    state.promptPreviewIndex = normalized.length
+      ? clamp(Number(state.promptPreviewIndex) || 0, 0, normalized.length - 1)
+      : 0;
+    return normalized;
+  }
+
+  function leadingPromptText(value, limit) {
+    const characters = Array.from(normalizeText(value).replace(/\s+/g, " "));
+    if (characters.length <= limit) return characters.join("");
+    return `${characters.slice(0, Math.max(0, limit - 1)).join("").trimEnd()}…`;
+  }
+
+  function summaryForPrompt(prompt) {
+    return leadingPromptText(prompt, MAX_PROMPT_SUMMARY_LENGTH);
+  }
+
+  function labelForPrompt(prompt) {
+    const text = normalizeText(prompt);
+    const rules = [
+      [/diff|风险分级|改动.*总结/i, "查看 diff"],
+      [/commit|提交/i, "整理 commit"],
+      [/截图验证|遮挡|浮球|面板/i, "验证界面"],
+      [/设置|配置|Bridge|API/i, "检查配置"],
+      [/Codex\+\+|用户脚本|reload|生效/i, "检查脚本"],
+      [/只读验证|确认.*生效|验证步骤/i, "验证生效"],
+      [/错误|失败|最小复现|排查/i, "继续排查"],
+      [/P0|P1|P2|执行顺序/i, "分级排序"],
+      [/维护成本|长期稳定性|审查/i, "重新审查"],
+      [/文件路径|当前状态|继续追踪/i, "列出路径"],
+      [/下一步|改哪些文件/i, "继续下一步"],
+      [/遗漏的风险|回滚方式/i, "风险回滚"],
+    ];
+
+    for (const [pattern, label] of rules) {
+      if (pattern.test(text)) return label;
+    }
+
+    return text
+      .replace(/^(帮我|请|把|给我|继续|检查|执行一次|基于刚才的)/, "")
+      .replace(/[，。,.].*$/, "")
+      .trim()
+      .slice(0, 10) || "继续";
+  }
+
+  // Stepwise payload parsing accepts the backend's strict JSON contract and legacy embedded payload shapes.
+  function parseStepwiseJson(text) {
+    const blocks = Array.from(text.matchAll(/```(?:json)?\s*([\s\S]*?)```/gi))
+      .map((match) => match[1])
+      .filter((block) => /"codex_stepwise"\s*:\s*true/.test(block));
+
+    for (const block of blocks.reverse()) {
+      const parsed = parsePayloadCandidate(block);
+      if (parsed) return parsed;
+    }
+    return parsePayloadCandidate(extractJsonObject(text));
+  }
+
+  function parsePayloadCandidate(value) {
+    const text = normalizeText(value)
+      .replace(/^```(?:json)?/i, "")
+      .replace(/```$/i, "")
+      .replace(/^json\s+/i, "")
+      .trim();
+
+    if (!/"codex_stepwise"\s*:\s*true/.test(text)) return null;
+
+    try {
+      const parsed = JSON.parse(text);
+      return parsed && parsed.codex_stepwise === true ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function extractJsonObject(text) {
+    const source = String(text || "");
+    const marker = source.search(/"codex_stepwise"\s*:\s*true/);
+    if (marker < 0) return "";
+
+    const start = source.lastIndexOf("{", marker);
+    if (start < 0) return "";
+
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+
+    for (let index = start; index < source.length; index += 1) {
+      const char = source[index];
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (char === "\"") {
+        inString = !inString;
+        continue;
+      }
+      if (inString) continue;
+      if (char === "{") depth += 1;
+      if (char === "}") depth -= 1;
+      if (depth === 0) return source.slice(start, index + 1);
+    }
+
+    return "";
+  }
+
+  function stripStepwisePayloadText(text) {
+    const withoutFence = String(text || "").replace(/```(?:json)?\s*[\s\S]*?"codex_stepwise"\s*:\s*true[\s\S]*?```/gi, "");
+    const payloadObject = extractJsonObject(withoutFence);
+    return normalizeText(payloadObject ? withoutFence.replace(payloadObject, "") : withoutFence);
+  }
+
+  function payloadFromDom(root) {
+    if (!(root instanceof Element)) return null;
+    const blocks = Array.from(root.querySelectorAll("pre, code"))
+      .filter((node) => /"codex_stepwise"\s*:\s*true/.test(node.textContent || ""));
+
+    for (const block of blocks.reverse()) {
+      const parsed = parsePayloadCandidate(block.textContent || "");
+      if (parsed) return parsed;
+    }
+
+    return null;
+  }
+
+  function payloadItems(payload) {
+    if (!payload) return [];
+    if (Array.isArray(payload)) return payload;
+    for (const key of ["items", "suggestions", "next_steps", "nextSteps", "actions", "prompts"]) {
+      if (Array.isArray(payload[key])) return payload[key];
+    }
+    return [];
+  }
+
+  function payloadPrompts(payload) {
+    const rawItems = payloadItems(payload);
+    if (!rawItems.length) return [];
+    const items = rawItems
+      .slice(0, configuredMaxPromptItems())
+      .map((item) => {
+        const prompt = normalizeText(
+          typeof item === "string"
+            ? item
+            : item?.prompt || item?.text || item?.action || item?.content || item?.message || "",
+        );
+        const label = leadingPromptText(
+          typeof item === "string" ? "" : item?.label || item?.title || item?.name || "",
+          36,
+        );
+        const summary = leadingPromptText(
+          typeof item === "string" ? "" : item?.summary || item?.preview || item?.description || "",
+          MAX_PROMPT_SUMMARY_LENGTH,
+        );
+        return prompt ? {
+          label: label || labelForPrompt(prompt),
+          summary: summary || summaryForPrompt(prompt),
+          prompt,
+        } : null;
+      })
+      .filter(Boolean);
+    return uniquePrompts(items);
+  }
+
+  function extractStepwisePayload(message) {
+    const text = elementText(message.node);
+    const payload = payloadFromDom(message.node) || parseStepwiseJson(text);
+    return {
+      payload,
+      prompts: payloadPrompts(payload),
+      textWithoutPayload: stripStepwisePayloadText(text),
+    };
+  }

--- a/crates/codex-plus-core/tests/floating_panel_stepwise.rs
+++ b/crates/codex-plus-core/tests/floating_panel_stepwise.rs
@@ -1,0 +1,29 @@
+#[test]
+fn stepwise_fragments_expose_the_expected_contract() {
+    let suggestions = include_str!("../../../assets/inject/floating-panel/stepwise/suggestions.js")
+        .replace("\r\n", "\n");
+    let generation = include_str!("../../../assets/inject/floating-panel/stepwise/generation.js")
+        .replace("\r\n", "\n");
+
+    assert!(suggestions.starts_with("/* Stepwise suggestions:"));
+    assert!(suggestions.contains("function uniquePrompts"));
+    assert!(suggestions.contains("function parseStepwiseJson"));
+    assert!(suggestions.contains("function extractStepwisePayload"));
+    assert!(generation.starts_with("/* Stepwise generation:"));
+    assert!(generation.contains("function requestBridgeStepwise"));
+    assert!(generation.contains("function forceRefreshStepwise"));
+    assert!(generation.contains("function fillComposer"));
+    assert!(generation.contains("bridgeCall(\n      \"/stepwise/generate\""));
+    assert!(generation.contains("requestEpoch === state.stepwiseEpoch"));
+    assert!(generation.contains("contextMatches(requestContext)"));
+    assert!(generation.contains("if (!isCurrentRuntime() || !stepwiseEnabled()) return;"));
+    assert!(generation.contains("state.activeContext.assistantMessageId"));
+
+    for source in [suggestions.as_str(), generation.as_str()] {
+        assert!(!source.contains("import "));
+        assert!(!source.contains("export "));
+        assert!(!source.contains("fetch("));
+        assert!(!source.contains("new WebSocket"));
+        assert!(!source.contains("outline"));
+    }
+}


### PR DESCRIPTION
## 背景与目标

Stepwise 的页面侧职责包括建议 payload 解析、标签和摘要生成、去重、请求并发控制、过期结果保护，以及将用户选择填入当前会话的 Composer。此前这些职责仍位于单一注入核心中，容易与共享回答上下文、面板交互和 Answer Outline 混在一起审查。

本 PR 将 Stepwise 专属逻辑归位到 `assets/inject/floating-panel/stepwise/`，明确“共享运行能力”和“建议功能”的边界。它只增加 Stepwise 功能源码片段及源码契约测试，不新增模型协议实现，也不改变当前生产注入组合。

## 变更内容

### `suggestions.js`

- 识别并隐藏回答中的 Stepwise payload。
- 解析严格 JSON 与兼容的嵌入 payload。
- 统一建议标签、摘要、数量限制和去重规则。
- 将后端返回结果规范化为面板使用的 Prompt 状态。

### `generation.js`

- 根据当前会话和回答内容生成稳定请求键。
- 通过现有页面 Bridge 调用 `/stepwise/generate`。
- 管理自动/手动生成、请求序号、缓存、并发和 stale result。
- 使用回答身份、功能 epoch 和上下文快照拒绝旧结果。
- 将选中建议填入当前会话 Composer，并支持现有提交行为。

### 源码契约测试

- 验证建议解析、请求生命周期、手动刷新和 Composer 提交入口。
- 验证 Stepwise 仅通过既有 `bridgeCall()` 调用后端路由。
- 禁止直接 `fetch()`、WebSocket、浏览器运行时 import/export 和 Outline 逻辑进入本模块。
- 测试在读取片段时规范化 CRLF/LF，兼容 Windows checkout。

## 行为边界

- 不修改 `crates/codex-plus-core/src/assets.rs`，当前生产 bundle 和页面行为保持不变。
- 不修改 `stepwise.rs` 的 Chat Completions、Responses 或 Anthropic Messages 协议适配。
- 不新增第二条模型请求链；页面侧仍调用现有 `/stepwise/generate` 路由。
- 不包含 Answer Outline 解析、标题导航、视觉样式、面板布局或 Manager 设置。
- 不新增浏览器运行时模块加载、目录扫描或网络资源。

## 验证

- `cargo test -p codex-plus-core --test floating_panel_stepwise --test cdp_bridge`：`114` 项通过。
- `cargo test -p codex-plus-core --test bridge_routes`：`32` 项通过。
- `cargo check -p codex-plus-core`：通过。
- Stepwise 两个片段组合后的 `node --check`：通过。
- 两个 Stepwise 文件与完整目标树 T（commit `2258044`）逐字节一致，SHA-256 已核对。
- `git diff --check`：通过。
- 最新验证基线为 `upstream/main` commit `7385664`。

## 提交说明

- `d188060`：Stepwise 建议处理和生成提交源码。
- `434e4d5`：Stepwise 源码契约测试。

两个提交分别对应功能源码与测试覆盖，便于独立审查和回退。
