### PR TITLE
Extract floating-panel Answer Outline modules

### DIFF
--- a/assets/inject/floating-panel/outline/feature.js
+++ b/assets/inject/floating-panel/outline/feature.js
@@ -1,0 +1,79 @@
+/* Answer Outline lifecycle: current-answer binding, refresh, and invalidation. */
+
+  function outlineBuild(message, sourceHash) {
+    if (!message?.node) {
+      outlineClearMarks();
+      return { items: [], fingerprint: sourceHash || "", message: null };
+    }
+    const textLength = message.text.length;
+    const raw = outlineCollectHeadingElements(outlineMarkdownRoot(message.node));
+    const items = outlineNormalizeDisplayLevels(outlineDedupeItems(raw));
+    const structuredEnough = items.length >= Math.max(MIN_OUTLINE_ITEMS, 3) && textLength >= 160;
+    outlineClearMarks();
+    if (textLength < MIN_OUTLINE_TEXT_LEN && !structuredEnough || items.length < MIN_OUTLINE_ITEMS) {
+      return { items: [], fingerprint: `${sourceHash}|empty`, message: message.node };
+    }
+    outlineMarkItems(items);
+    return {
+      items,
+      fingerprint: `${sourceHash}|${hashText(items.map((item) => `${item.level}:${item.text}`).join("|"))}`,
+      message: message.node,
+    };
+  }
+
+  function invalidateOutline(message = null, sourceHash = "") {
+    outlineClearMarks();
+    state.outlineItems = [];
+    state.outlineStatus = chatBusy() ? "pending" : "idle";
+    state.outlineError = "";
+    state.outlineFingerprint = "";
+    state.outlineSourceHash = "";
+    state.outlineMessage = message?.node || null;
+    if (state.activeTab === "outline" && state.panel) renderFloat({ preserveMorph: true });
+  }
+
+  // Outline refresh is keyed to the pinned latest answer, so passive scrolling cannot switch context.
+  async function refreshOutline(options = {}) {
+    if (!isCurrentRuntime() || !outlineEnabled()) return;
+    if (state.outlineRefreshPromise) return state.outlineRefreshPromise;
+    const requestContext = contextSnapshot();
+    const requestEpoch = state.outlineEpoch;
+    const requestCurrent = () => outlineEnabled()
+      && requestEpoch === state.outlineEpoch
+      && contextMatches(requestContext);
+    state.outlineStatus = "pending";
+    state.outlineError = "";
+    if (state.activeTab === "outline") renderFloat({ preserveMorph: true });
+
+    const task = Promise.resolve().then(() => {
+      if (!requestCurrent()) return;
+      const message = options.message || findLatestAssistantMessage();
+      const sourceHash = options.assistantHash || hashText(message?.text || "");
+      if (chatBusy()) {
+        state.outlineError = "回答尚未完成，完成后再试";
+        state.outlineStatus = "pending";
+        scheduleScan(STREAM_IDLE_MS);
+        return;
+      }
+      const result = outlineBuild(message, sourceHash);
+      if (!requestCurrent()) return;
+      state.outlineItems = result.items;
+      state.outlineFingerprint = result.fingerprint;
+      state.outlineSourceHash = sourceHash;
+      state.outlineMessage = result.message;
+      state.outlineStatus = result.items.length ? "ready" : "empty";
+      state.outlineError = "";
+    }).catch((error) => {
+      if (!requestCurrent()) return;
+      outlineClearMarks();
+      state.outlineItems = [];
+      state.outlineStatus = "error";
+      state.outlineError = error?.message || "大纲暂不可用";
+    }).finally(() => {
+      if (!requestCurrent()) return;
+      if (state.outlineRefreshPromise === task) state.outlineRefreshPromise = null;
+      if (state.activeTab === "outline") renderFloat({ preserveMorph: true });
+    });
+    state.outlineRefreshPromise = task;
+    return task;
+  }

--- a/assets/inject/floating-panel/outline/navigation.js
+++ b/assets/inject/floating-panel/outline/navigation.js
@@ -1,0 +1,226 @@
+/* Answer Outline navigation: bounded, direction-aware scrolling and anchors. */
+
+  function outlineFindScrollContainer(fromElement) {
+    let node = fromElement instanceof Element ? fromElement.parentElement : null;
+    while (node && node !== document.documentElement) {
+      const style = window.getComputedStyle(node);
+      const overflowY = style.overflowY || style.overflow;
+      if (/(auto|scroll|overlay)/.test(overflowY) && node.scrollHeight > node.clientHeight + 4) return node;
+      node = node.parentElement;
+    }
+    return document.scrollingElement || document.documentElement;
+  }
+
+  function outlineIsDocumentScroller(container) {
+    return container === document.scrollingElement
+      || container === document.documentElement
+      || container === document.body;
+  }
+
+  // Codex thread scrollers may use column-reverse, where valid scrollTop values are negative.
+  function outlineScrollBounds(container) {
+    const maxDistance = Math.max(0, container.scrollHeight - container.clientHeight);
+    const style = window.getComputedStyle(container);
+    const reversed = !outlineIsDocumentScroller(container)
+      && (style.flexDirection === "column-reverse" || container.scrollTop < -1);
+    return reversed
+      ? { min: -maxDistance, max: 0 }
+      : { min: 0, max: maxDistance };
+  }
+
+  function outlineScrollViewportTop(container) {
+    const safeTop = Math.max(0, contentSafeBounds().top - PANEL_SAFE_MARGIN);
+    if (outlineIsDocumentScroller(container)) return safeTop;
+    return Math.max(safeTop, container.getBoundingClientRect().top);
+  }
+
+  function outlineScrollScale(container) {
+    const layoutHeight = container.clientHeight;
+    const visualHeight = container.getBoundingClientRect().height;
+    if (!(layoutHeight > 0) || !(visualHeight > 0)) return 1;
+    const scale = visualHeight / layoutHeight;
+    return Number.isFinite(scale) && scale > 0.01 ? scale : 1;
+  }
+
+  function outlineTargetScrollTop(element, container) {
+    const bounds = outlineScrollBounds(container);
+    const elementTop = element.getBoundingClientRect().top;
+    const targetViewportTop = outlineScrollViewportTop(container) + OUTLINE_TARGET_TOP_OFFSET;
+    const delta = elementTop - targetViewportTop;
+    const deltaInScrollSpace = delta / outlineScrollScale(container);
+    return clamp(container.scrollTop + deltaInScrollSpace, bounds.min, bounds.max);
+  }
+
+  function outlineScheduleScrollSettle(element, container) {
+    state.outlineScrollCleanup?.();
+    let settleTimer = 0;
+    let recheckTimer = 0;
+    let finished = false;
+    const cleanup = () => {
+      if (settleTimer) window.clearTimeout(settleTimer);
+      if (recheckTimer) window.clearTimeout(recheckTimer);
+      settleTimer = 0;
+      recheckTimer = 0;
+      container.removeEventListener("scrollend", settle);
+      container.removeEventListener("wheel", cancel);
+      container.removeEventListener("pointerdown", cancel);
+      if (state.outlineScrollCleanup === cancel) state.outlineScrollCleanup = null;
+    };
+    const cancel = () => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+    };
+    const correct = () => {
+      if (!isCurrentRuntime() || !element.isConnected || !container.isConnected) return false;
+      const targetTop = outlineTargetScrollTop(element, container);
+      if (Math.abs(container.scrollTop - targetTop) > 1) container.scrollTop = targetTop;
+      return true;
+    };
+    const finish = () => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+    };
+    const settle = () => {
+      if (finished) return;
+      container.removeEventListener("scrollend", settle);
+      if (settleTimer) window.clearTimeout(settleTimer);
+      settleTimer = 0;
+      if (!correct()) {
+        finish();
+        return;
+      }
+      recheckTimer = window.setTimeout(() => {
+        recheckTimer = 0;
+        correct();
+        finish();
+      }, OUTLINE_SCROLL_RECHECK_MS);
+    };
+    state.outlineScrollCleanup = cancel;
+    container.addEventListener("scrollend", settle, { once: true });
+    container.addEventListener("wheel", cancel, { once: true, passive: true });
+    container.addEventListener("pointerdown", cancel, { once: true, passive: true });
+    settleTimer = window.setTimeout(settle, OUTLINE_SCROLL_SETTLE_MS);
+  }
+
+  function outlineScrollToElement(element) {
+    const container = outlineFindScrollContainer(element);
+    if (!(container instanceof Element)) return false;
+    // Use one bounded destination instead of chaining scrollIntoView with a corrective scroll.
+    const targetTop = outlineTargetScrollTop(element, container);
+    if (!Number.isFinite(targetTop)) return false;
+    if (Math.abs(container.scrollTop - targetTop) < 0.5) {
+      state.outlineScrollCleanup?.();
+      return true;
+    }
+    outlineScheduleScrollSettle(element, container);
+    try {
+      container.scrollTo({ top: targetTop, behavior: "smooth" });
+    } catch {
+      state.outlineScrollCleanup?.();
+      container.scrollTop = targetTop;
+    }
+    return true;
+  }
+
+  function outlineScrollToEnd(fromElement) {
+    const container = outlineFindScrollContainer(fromElement);
+    if (!(container instanceof Element)) return false;
+    state.outlineScrollCleanup?.();
+    const targetTop = outlineScrollBounds(container).max;
+    if (Math.abs(container.scrollTop - targetTop) < 0.5) return true;
+    try {
+      container.scrollTo({ top: targetTop, behavior: "smooth" });
+    } catch {
+      container.scrollTop = targetTop;
+    }
+    return true;
+  }
+
+  function outlineResolveElement(id) {
+    const item = state.outlineItems.find((entry) => entry.id === id) || null;
+    if (item?.el?.isConnected) return item.el;
+    const marked = Array.from(document.querySelectorAll(`[${MARK_ATTR}]`))
+      .find((node) => node.getAttribute(MARK_ATTR) === String(id));
+    if (marked instanceof Element) {
+      if (item) item.el = marked;
+      return marked;
+    }
+    const latest = state.outlineMessage?.isConnected ? { node: state.outlineMessage } : findLatestAssistantMessage();
+    const root = outlineMarkdownRoot(latest?.node);
+    if (!root || !item?.text) return null;
+    const kind = item.kind === "semantic" ? "semantic" : "pseudo";
+    const selector = kind === "semantic" ? OUTLINE_SEMANTIC_HEADING_SELECTOR : OUTLINE_PSEUDO_HEADING_SELECTOR;
+    const candidates = root.querySelectorAll(selector);
+    for (const node of candidates) {
+      if (kind === "pseudo" && node.closest(OUTLINE_SEMANTIC_HEADING_SELECTOR)) continue;
+      const candidate = outlineHeadingCandidate(node, kind);
+      if (!candidate || !outlineTitlesEquivalent(candidate.text, item.text)) continue;
+      node.setAttribute(MARK_ATTR, id);
+      item.el = node;
+      return node;
+    }
+    return null;
+  }
+
+  function outlineFlash(element) {
+    if (!(element instanceof Element)) return;
+    element.classList.add(HIGHLIGHT_CLASS);
+    if (state.flashTimer) window.clearTimeout(state.flashTimer);
+    state.flashTimer = window.setTimeout(() => {
+      element.classList.remove(HIGHLIGHT_CLASS);
+      state.flashTimer = 0;
+    }, FLASH_MS);
+  }
+
+  function outlineSetActiveTarget({ id = "", anchor = "" } = {}) {
+    state.panel?.querySelectorAll("[data-outline-id],[data-outline-anchor]").forEach((button) => {
+      const isActive = id
+        ? button.dataset.outlineId === id
+        : anchor && button.dataset.outlineAnchor === anchor;
+      button.dataset.active = isActive ? "true" : "false";
+      if (isActive) button.setAttribute("aria-current", "location");
+      else button.removeAttribute("aria-current");
+    });
+  }
+
+  function outlineJumpTo(id) {
+    const element = outlineResolveElement(id);
+    if (!(element instanceof Element)) return false;
+    outlineSetActiveTarget({ id });
+    outlineScrollToElement(element);
+    outlineFlash(element);
+    return true;
+  }
+
+  function outlineCurrentMessageElement() {
+    if (state.outlineMessage?.isConnected) return state.outlineMessage;
+    const latest = findLatestAssistantMessage();
+    return latest?.node instanceof Element ? latest.node : null;
+  }
+
+  function outlineTurnStartElement(message) {
+    const turn = message?.closest?.(CONVERSATION_TURN_SELECTOR)
+      || (state.latestTurnAnchor?.turnNode?.isConnected ? state.latestTurnAnchor.turnNode : null);
+    if (!(turn instanceof Element)) return message;
+    return labeledMessageContainer(turn, "user") || turn;
+  }
+
+  function outlineJumpToAnchor(anchor) {
+    const message = outlineCurrentMessageElement();
+    if (!(message instanceof Element)) return false;
+    if (anchor === "start") {
+      const startElement = outlineTurnStartElement(message);
+      if (!(startElement instanceof Element)) return false;
+      outlineSetActiveTarget({ anchor });
+      outlineScrollToElement(startElement);
+      outlineFlash(startElement);
+      return true;
+    }
+    if (anchor === "end") {
+      outlineSetActiveTarget({ anchor });
+      return outlineScrollToEnd(message);
+    }
+    return false;
+  }

--- a/assets/inject/floating-panel/outline/parser.js
+++ b/assets/inject/floating-panel/outline/parser.js
@@ -1,0 +1,305 @@
+/* Answer Outline parser: heading candidates, levels, deduplication, and marks. */
+
+  // Outline extraction is deliberately conservative: only visible, structured headings become targets.
+  function outlineVisible(node) {
+    if (!(node instanceof Element)) return false;
+    const rect = node.getBoundingClientRect();
+    return Boolean(rect.width > 8 && rect.height > 8);
+  }
+
+  function outlineMarkdownRoot(messageNode) {
+    if (!(messageNode instanceof Element)) return null;
+    const preferred = messageNode.querySelector(
+      [
+        "[class*='markdownContent']",
+        "[class*='markdown-content']",
+        ".markdown",
+        ".prose",
+        "article",
+      ].join(",")
+    );
+    if (preferred && !preferred.closest(`[${ROOT_ATTR}="true"]`)) return preferred;
+    return messageNode;
+  }
+
+  function outlineProtectedSurface(node) {
+    if (!(node instanceof Element)) return true;
+    return Boolean(node.closest([
+      `[${ROOT_ATTR}="true"]`,
+      "[contenteditable='true']",
+      "textarea",
+      "input",
+      "form",
+      ".ProseMirror",
+    ].join(",")));
+  }
+
+  function outlineInCodeLike(node) {
+    if (!(node instanceof Element)) return true;
+    return Boolean(node.closest("pre, code, kbd, samp, [data-code-block], .cm-editor, .monaco-editor"));
+  }
+
+  function outlineInTableLike(node) {
+    if (!(node instanceof Element)) return true;
+    return Boolean(node.closest(OUTLINE_TABLE_SELECTOR));
+  }
+
+  function outlineHeadingLevelFromTag(tag) {
+    const match = /^h([1-6])$/i.exec(tag || "");
+    return match ? Number(match[1]) : 0;
+  }
+
+  function outlineIsMarkerOnlyTitle(text) {
+    const value = normalizeText(text);
+    if (!value) return true;
+    if (/^[一二三四五六七八九十百零]+[、.．)]?$/.test(value)) return true;
+    if (/^\d{1,2}[\.、．)]?$/.test(value)) return true;
+    if (/^[（(]\d{1,2}[）)]$/.test(value)) return true;
+    return /^#{1,6}$/.test(value);
+  }
+
+  function outlineIsNoiseTitle(text) {
+    if (!text || outlineIsMarkerOnlyTitle(text)) return true;
+    if (text.length < MIN_OUTLINE_TITLE_LEN || text.length > MAX_OUTLINE_TITLE_LEN) return true;
+    if (text.length <= 4 && !/[0-9一二三四五六七八九十#：:]/.test(text) && !outlineHasChapterHeading(text)) return true;
+    if (/^https?:\/\//i.test(text)) return true;
+    if (/^[\w./~-]+\.(js|ts|json|md|py|sh|log|png|jpg)$/i.test(text)) return true;
+    if (/^\$ |^>`|^```/.test(text)) return true;
+    if (/^(复制|copy|edit|编辑|share|分享|continue|继续|retry|重试|项|实现|位置|范围|标题|跳转|折叠|刷新)$/i.test(text)) return true;
+    if (/^[\d\s:./-]+$/.test(text)) return true;
+    if (/^\/Users\/|^~\/|^\.\/|^\/Volumes\//.test(text)) return true;
+    return /^(OK|PASS|FAIL|true|false|null)$/i.test(text);
+  }
+
+  function outlineHasChapterHeading(text) {
+    const value = normalizeText(text);
+    if (!value) return false;
+    if (/^(摘要|简介|概述|概览|前言|背景|目标|现状|问题(?:分析)?|原因(?:分析)?|分析|方案|解决方案|步骤|实施步骤|实现|验证|验证结果|测试|测试结果|结果|结论|最终结论|总结|建议|后续建议|注意(?:事项)?|说明|补充说明|附录|下一步)(?:\s*[：:—-]\s*\S.*)?$/.test(value)) {
+      return value.length <= 24;
+    }
+    return /^(abstract|introduction|overview|background|goals?|problems?|causes?|analysis|solutions?|steps?|implementation|verification|tests?|results?|conclusions?|summary|recommendations?|notes?|appendix|next steps?)(?:\s*[:：—-]\s*\S.*)?$/i.test(value)
+      && value.length <= 32;
+  }
+
+  function outlineLooksStructuredHeading(text) {
+    const value = normalizeText(text);
+    if (!value || outlineIsMarkerOnlyTitle(value)) return false;
+    if (/^#{1,6}\s+\S/.test(value)) return true;
+    if (/^第[一二三四五六七八九十百零\d]+[章节部分步]/.test(value)) return true;
+    if (/^[一二三四五六七八九十]+[、.．]\s*\S{2,}/.test(value)) return true;
+    if (/^（?[0-9]{1,2}）\s*\S{2,}/.test(value) || /^\([0-9]{1,2}\)\s*\S{2,}/.test(value)) return true;
+    if (/^\d{1,2}[\.、．\)]\s*\S{2,}/.test(value)) return true;
+    return outlineHasChapterHeading(value);
+  }
+
+  function outlineScorePseudoHeading(text, levelHint) {
+    let score = levelHint ? 20 : 0;
+    if (!outlineLooksStructuredHeading(text) && !levelHint) return 0;
+    if (/^#{1,6}\s+\S/.test(text)) score += 50;
+    if (/^第[一二三四五六七八九十百零\d]+[章节部分步]/.test(text)) score += 30;
+    if (/^[一二三四五六七八九十]+[、.．]\s*\S{2,}/.test(text)) score += 28;
+    if (/^（?[0-9]{1,2}）\s*\S{2,}/.test(text) || /^\([0-9]{1,2}\)\s*\S{2,}/.test(text)) score += 24;
+    if (/^\d{1,2}[\.、．\)]\s*\S{2,}/.test(text)) score += 26;
+    if (/[：:]$/.test(text) && text.length <= 18 && text.length >= 4) score += 8;
+    if (outlineHasChapterHeading(text)) score += 24;
+    if (text.length >= 4 && text.length <= 20) score += 6;
+    if (text.length >= 28) score -= 8;
+    if (/[。！？]$/.test(text)) score -= 12;
+    if (text.split(" ").length > 12) score -= 10;
+    return score;
+  }
+
+  function outlineStripHeadingMarkers(text) {
+    const stripped = normalizeText(text)
+      .replace(/^#{1,6}\s+/, "")
+      .replace(/^([（(]?\d{1,2}[）)]|[一二三四五六七八九十]{1,3}|\d{1,2})[\.、．\)]\s*/, "");
+    return stripped && !outlineIsMarkerOnlyTitle(stripped) ? stripped : normalizeText(text);
+  }
+
+  function outlineDisplayHeadingTitle(text) {
+    const value = normalizeText(text).replace(/^#{1,6}\s+/, "");
+    return value.length <= MAX_OUTLINE_TITLE_LEN ? value : `${value.slice(0, MAX_OUTLINE_TITLE_LEN - 1)}…`;
+  }
+
+  function outlineTitlesEquivalent(left, right) {
+    const a = normalizeText(left);
+    const b = normalizeText(right);
+    return Boolean(a && b && (a === b || outlineStripHeadingMarkers(a) === outlineStripHeadingMarkers(b)
+      || outlineDisplayHeadingTitle(a) === outlineDisplayHeadingTitle(b)));
+  }
+
+  function outlineOwnsOwnLine(node, text) {
+    if (!(node instanceof Element)) return false;
+    const parent = node.parentElement;
+    if (!parent) return true;
+    const parentText = normalizeText(parent.innerText || parent.textContent || "");
+    if (!parentText || parentText === text) return true;
+    return parentText.startsWith(text) && parentText.length <= text.length + 4;
+  }
+
+  function outlineHeadingNumbering(text) {
+    const value = normalizeText(text);
+    const patterns = [
+      [/^([一二三四五六七八九十]+[、.．])\s*(\S.*)$/, "han"],
+      [/^(第[一二三四五六七八九十百零\d]+[章节部分步])\s*(\S.*)$/, "chapter"],
+      [/^((?:（[0-9]{1,2}）|\([0-9]{1,2}\)))\s*(\S.*)$/, "arabic-parenthesized"],
+    ];
+    for (const [pattern, key] of patterns) {
+      const match = value.match(pattern);
+      if (match) return { prefix: match[1], title: match[2], pattern: key };
+    }
+    const arabic = value.match(/^(\d{1,2}(?:(?:[\.、．\)]\d{1,2})+)?[\.、．\)]?)\s+(\S.*)$/);
+    if (!arabic) return { prefix: "", title: value, pattern: "" };
+    const segments = arabic[1].match(/\d{1,2}/g)?.length || 1;
+    const separators = arabic[1].match(/[\.、．\)]/g)?.join("") || ".";
+    return {
+      prefix: arabic[1],
+      title: arabic[2],
+      pattern: `arabic:${separators}:${segments}`,
+    };
+  }
+
+  function outlineHeadingCandidate(node, kind) {
+    if (!(node instanceof Element) || !outlineVisible(node) || outlineProtectedSurface(node) || outlineInCodeLike(node)) return null;
+    if (node.closest(`[${ROOT_ATTR}="true"]`)) return null;
+
+    const text = normalizeText(node.innerText || node.textContent || "");
+    if (!text || text.length > MAX_OUTLINE_TITLE_LEN + 8) return null;
+    const displayText = outlineDisplayHeadingTitle(text);
+    if (outlineIsNoiseTitle(displayText) || outlineIsMarkerOnlyTitle(displayText)) return null;
+    const numbering = outlineHeadingNumbering(displayText);
+
+    if (kind === "semantic") {
+      const tagLevel = outlineHeadingLevelFromTag(node.tagName);
+      const ariaLevel = Number(node.getAttribute("aria-level") || 0);
+      return {
+        el: node,
+        text: displayText,
+        level: clamp(tagLevel || ariaLevel || 2, 1, 6),
+        numberingPattern: numbering.pattern,
+        numberPrefix: numbering.prefix,
+        labelText: numbering.title,
+        kind,
+      };
+    }
+
+    if (outlineInTableLike(node)) return null;
+    const childCount = node.children?.length || 0;
+    if (childCount > 3 || node.querySelector("p,div,li,h1,h2,h3,h4,h5,h6,table,pre")) return null;
+
+    if (node.matches("strong,b")) {
+      if (!outlineOwnsOwnLine(node, text)) return null;
+      const score = outlineScorePseudoHeading(text, 1) + 8;
+      if (score < OUTLINE_PSEUDO_MIN_SCORE) return null;
+      return {
+        el: node,
+        text: displayText,
+        level: 3,
+        numberingPattern: numbering.pattern,
+        numberPrefix: numbering.prefix,
+        labelText: numbering.title,
+        kind,
+      };
+    }
+
+    const rect = node.getBoundingClientRect();
+    if (rect.height > 84 || !outlineLooksStructuredHeading(text)) return null;
+    const score = outlineScorePseudoHeading(text, 0);
+    if (score < OUTLINE_PSEUDO_MIN_SCORE) return null;
+    return {
+      el: node,
+      text: displayText,
+      level: numbering.pattern ? 2 : text.length <= 12 ? 2 : 3,
+      numberingPattern: numbering.pattern,
+      numberPrefix: numbering.prefix,
+      labelText: numbering.title,
+      kind,
+    };
+  }
+
+  function outlineCollectSemanticHeadings(root) {
+    if (!(root instanceof Element)) return [];
+    const result = [];
+    const nodes = root.querySelectorAll(OUTLINE_SEMANTIC_HEADING_SELECTOR);
+    for (const node of nodes) {
+      const item = outlineHeadingCandidate(node, "semantic");
+      if (item) result.push(item);
+    }
+    return result;
+  }
+
+  function outlineCollectPseudoHeadings(root) {
+    if (!(root instanceof Element)) return [];
+    const result = [];
+    const nodes = root.querySelectorAll(OUTLINE_PSEUDO_HEADING_SELECTOR);
+    for (const node of nodes) {
+      if (node.closest(OUTLINE_SEMANTIC_HEADING_SELECTOR)) continue;
+      const item = outlineHeadingCandidate(node, "pseudo");
+      if (item) result.push(item);
+    }
+    return result;
+  }
+
+  function outlineSortInDocumentOrder(items) {
+    return items.slice().sort((left, right) => {
+      if (left.el === right.el) return 0;
+      const position = left.el.compareDocumentPosition(right.el);
+      if (position & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
+      if (position & Node.DOCUMENT_POSITION_PRECEDING) return 1;
+      return 0;
+    });
+  }
+
+  function outlineCollectHeadingElements(root) {
+    const semanticItems = outlineCollectSemanticHeadings(root);
+    if (semanticItems.length >= MIN_OUTLINE_ITEMS) return outlineSortInDocumentOrder(semanticItems);
+    return outlineSortInDocumentOrder([...semanticItems, ...outlineCollectPseudoHeadings(root)]);
+  }
+
+  function outlineDedupeItems(items) {
+    const seen = new Set();
+    const result = [];
+    for (const item of items) {
+      const key = `${item.level}|${item.text}`;
+      if (seen.has(key)) continue;
+      const previous = result.at(-1);
+      if (previous && (previous.text === item.text || previous.el.contains(item.el) || item.el.contains(previous.el))) {
+        continue;
+      }
+      seen.add(key);
+      result.push(item);
+      if (result.length >= MAX_OUTLINE_ITEMS) break;
+    }
+    return result;
+  }
+
+  function outlineNormalizeDisplayLevels(items) {
+    if (!items.length) return items;
+    const minimumLevel = Math.min(...items.map((item) => item.level));
+    const numberedLevels = new Map();
+    items.forEach((item) => {
+      const baseLevel = item.level - minimumLevel;
+      if (!item.numberingPattern) {
+        item.displayLevel = baseLevel;
+        return;
+      }
+      if (!numberedLevels.has(item.numberingPattern)) numberedLevels.set(item.numberingPattern, baseLevel);
+      item.displayLevel = numberedLevels.get(item.numberingPattern);
+    });
+    return items;
+  }
+
+  function outlineMarkItems(items) {
+    items.forEach((item, index) => {
+      const id = `stepwise-outline-${hashText(`${index}:${item.text}`)}-${index + 1}`;
+      item.id = id;
+      item.el.setAttribute(MARK_ATTR, id);
+    });
+    return items;
+  }
+
+  function outlineClearMarks(root = document) {
+    if (!root?.querySelectorAll) return;
+    root.querySelectorAll(`[${MARK_ATTR}]`).forEach((node) => node.removeAttribute(MARK_ATTR));
+    root.querySelectorAll(`.${HIGHLIGHT_CLASS}`).forEach((node) => node.classList.remove(HIGHLIGHT_CLASS));
+  }

--- a/assets/inject/floating-panel/outline/view.js
+++ b/assets/inject/floating-panel/outline/view.js
@@ -1,0 +1,90 @@
+/* Answer Outline view: markup, events, and panel content scroll state. */
+
+  function alignOutlineNestedText() {
+    const rows = Array.from(state.panel?.querySelectorAll?.(".csw-outline-row[data-outline-id]") || []);
+    const numberedAncestors = [];
+    rows.forEach((row) => {
+      const level = Math.max(0, Number(row.dataset.level) || 0);
+      while (numberedAncestors.length && numberedAncestors.at(-1).level >= level) numberedAncestors.pop();
+
+      const ancestor = numberedAncestors.at(-1);
+      if (row.dataset.numbered === "true") {
+        row.style.removeProperty("--csw-outline-hanging-indent");
+        const prefix = row.querySelector(".csw-outline-prefix");
+        numberedAncestors.push({
+          level,
+          width: Math.max(
+            0,
+            (prefix?.getBoundingClientRect().width || 0) + 8 - OUTLINE_INDENT_STEP,
+          ),
+        });
+        return;
+      }
+
+      row.style.setProperty(
+        "--csw-outline-hanging-indent",
+        ancestor ? `${ancestor.width}px` : "0px",
+      );
+    });
+  }
+
+  function outlineHtml() {
+    if (state.outlineStatus === "pending") {
+      return `<div class="csw-progress" aria-label="正在整理大纲">
+        <span class="csw-progress-ring" aria-hidden="true"></span>
+        <span class="csw-progress-copy">
+          <span class="csw-progress-title">正在整理大纲</span>
+        </span>
+      </div>`;
+    }
+    if (state.outlineStatus === "error") {
+      return `<div class="csw-empty" data-kind="outline">
+        <div class="csw-empty-title">${escapeHtml(outlineErrorTitle())}</div>
+      </div>`;
+    }
+    if (!state.outlineItems.length) {
+      return `<div class="csw-empty" data-kind="outline">
+        <div class="csw-empty-title">暂无大纲</div>
+      </div>`;
+    }
+    return `<div class="csw-outline-view">
+      <div class="csw-outline-list" role="list">${state.outlineItems.map((item) => {
+      const displayLevel = item.displayLevel ?? 0;
+      const numberPrefix = item.numberPrefix || "";
+      const labelText = item.labelText || item.text;
+      return `
+        <button class="csw-outline-row" type="button" role="listitem" data-outline-id="${escapeAttr(item.id)}" data-level="${displayLevel}" data-numbered="${numberPrefix ? "true" : "false"}" aria-label="${escapeAttr(item.text)}" style="--csw-outline-indent:${Math.min(3, Math.max(0, displayLevel)) * OUTLINE_INDENT_STEP}px">
+          <span class="csw-outline-heading-marker" aria-hidden="true"></span>
+          <span class="csw-outline-prefix" aria-hidden="true">${escapeHtml(numberPrefix)}</span>
+          <span class="csw-outline-label">${escapeHtml(labelText)}</span>
+        </button>
+      `;
+      }).join("")}
+      </div>
+      <div class="csw-outline-toolbar" role="toolbar" aria-label="本轮导航">
+        <button class="csw-outline-nav-button" type="button" data-outline-anchor="start" title="本轮开头" aria-label="定位到本轮开头">${iconSvg("turn-start")}</button>
+        <button class="csw-outline-nav-button" type="button" data-outline-anchor="end" title="本轮结尾" aria-label="定位到本轮结尾">${iconSvg("turn-end")}</button>
+      </div>
+    </div>`;
+  }
+
+  function attachOutlineEvents() {
+    state.panel.querySelectorAll("[data-outline-id]").forEach((button) => {
+      button.addEventListener("click", () => {
+        if (!outlineJumpTo(button.dataset.outlineId)) {
+          state.outlineStatus = "error";
+          state.outlineError = "找不到对应的小节，刷新后再试。";
+          renderFloat({ preserveMorph: true });
+        }
+      });
+    });
+    state.panel.querySelectorAll("[data-outline-anchor]").forEach((button) => {
+      button.addEventListener("click", () => {
+        if (!outlineJumpToAnchor(button.dataset.outlineAnchor)) {
+          state.outlineStatus = "error";
+          state.outlineError = "找不到当前回答位置，刷新后再试。";
+          renderFloat({ preserveMorph: true });
+        }
+      });
+    });
+  }

--- a/crates/codex-plus-core/tests/floating_panel_outline.rs
+++ b/crates/codex-plus-core/tests/floating_panel_outline.rs
@@ -1,0 +1,35 @@
+#[test]
+fn outline_fragments_expose_the_expected_contract() {
+    let parser = include_str!("../../../assets/inject/floating-panel/outline/parser.js")
+        .replace("\r\n", "\n");
+    let navigation = include_str!("../../../assets/inject/floating-panel/outline/navigation.js")
+        .replace("\r\n", "\n");
+    let feature = include_str!("../../../assets/inject/floating-panel/outline/feature.js")
+        .replace("\r\n", "\n");
+    let view = include_str!("../../../assets/inject/floating-panel/outline/view.js")
+        .replace("\r\n", "\n");
+
+    assert!(parser.starts_with("/* Answer Outline parser:"));
+    assert!(parser.contains("function outlineCollectHeadingElements"));
+    assert!(parser.contains("function outlineDedupeItems"));
+    assert!(parser.contains("function outlineNormalizeDisplayLevels"));
+    assert!(navigation.starts_with("/* Answer Outline navigation:"));
+    assert!(navigation.contains("function outlineJumpTo"));
+    assert!(navigation.contains("function outlineJumpToAnchor"));
+    assert!(feature.starts_with("/* Answer Outline lifecycle:"));
+    assert!(feature.contains("function refreshOutline"));
+    assert!(feature.contains("contextMatches(requestContext)"));
+    assert!(feature.contains("if (!isCurrentRuntime() || !outlineEnabled()) return;"));
+    assert!(view.starts_with("/* Answer Outline view:"));
+    assert!(view.contains("function outlineHtml"));
+    assert!(view.contains("function attachOutlineEvents"));
+
+    for source in [parser.as_str(), navigation.as_str(), feature.as_str(), view.as_str()] {
+        assert!(!source.contains("import "));
+        assert!(!source.contains("export "));
+        assert!(!source.contains("fetch("));
+        assert!(!source.contains("new WebSocket"));
+        assert!(!source.contains("new MutationObserver"));
+        assert!(!source.contains("/stepwise/generate"));
+    }
+}


### PR DESCRIPTION
## 背景与目标

Answer Outline 负责从当前助手回答中识别标题结构，并提供层级展示、当前回答绑定和页面跳转。此前这些逻辑与 Stepwise 建议、面板交互和共享扫描核心混在同一个注入文件中，标题规则或滚动行为的修改会扩大审查范围。

本 PR 将 Answer Outline 专属逻辑归位到 `assets/inject/floating-panel/outline/`，明确标题解析、层级处理、导航和视图展示的职责边界。它只增加 Outline 源码片段及源码契约测试，不新增第二套回答扫描或网络请求路径，也不改变当前生产注入组合。

## 变更内容

### `parser.js`

- 识别语义标题和结构化伪标题。
- 排除代码块、表格、噪声标题和悬浮窗自有 DOM。
- 清理标题标记、识别序列号并保留多级层级。
- 对标题候选进行文档顺序排序、去重和显示层级归一化。
- 为当前回答标题写入稳定 DOM 标记，并提供清理入口。

### `navigation.js`

- 定位页面滚动容器并计算安全滚动边界。
- 提供标题、当前回答、段首和段尾的跳转。
- 使用方向感知滚动和边界钳制，避免跳转超出可视区域。
- 管理跳转后的稳定检查、目标高亮和旧滚动清理。

### `feature.js`

- 将 Outline 刷新绑定到共享的当前回答快照。
- 在回答仍生成时保持 pending 状态。
- 使用 Outline epoch 和上下文匹配拒绝过期刷新结果。
- 在关闭、错误、空结果和成功状态之间清理并更新 Outline 状态。

### `view.js`

- 生成 Outline 列表、空状态、加载状态和错误状态视图。
- 保留多级标题缩进与序列号文字对齐策略。
- 绑定标题跳转、段首/段尾跳转及目标状态同步。

### 源码契约测试

- 验证解析、层级归一化、去重、刷新、跳转和视图入口。
- 验证 Outline 复用共享上下文，不创建第二个回答扫描器。
- 禁止直接 `fetch()`、WebSocket、`MutationObserver`、浏览器运行时 import/export 和 `/stepwise/generate`。
- 测试读取片段时规范化 CRLF/LF，兼容 Windows checkout。

## 行为边界

- 不修改 `crates/codex-plus-core/src/assets.rs`，当前生产 bundle 和页面行为保持不变。
- 不包含 Stepwise 建议生成、缓存、模型请求或 API Key 处理。
- 不包含视觉样式、面板布局、拖动缩放或 Manager 设置。
- 不新增 Rust DOM 解析器、第二套上下文识别或第二套 CDP Bridge。
- 不新增浏览器运行时模块加载、目录扫描或网络资源。

## 验证

- `cargo test -p codex-plus-core --test floating_panel_outline --test cdp_bridge --test bridge_routes`：`146` 项通过。
- `cargo check -p codex-plus-core`：通过。
- Outline 四个片段组合后的 `node --check`：通过。
- 四个 Outline 文件与完整目标树 T（commit `2258044`）逐字节一致，SHA-256 已核对。
- `git diff --check`：通过。
- 最新验证基线为 `upstream/main` commit `7385664`。

## 提交说明

- `2fa24dd`：Answer Outline 解析、导航、生命周期和视图源码。
- `773c620`：Answer Outline 源码契约测试。

两个提交分别对应功能源码与测试覆盖，便于独立审查和回退。
