### PR TITLE
fix(dream_skin): fix Windows-only compile error breaking Windows CI

### DIFF
--- a/crates/codex-plus-core/src/dream_skin.rs
+++ b/crates/codex-plus-core/src/dream_skin.rs
@@ -590,7 +590,7 @@ fn normalized_identity_string(path: &Path) -> String {
         .strip_prefix(r"\\?\UNC\")
         .map(|rest| format!(r"\\{rest}"))
         .or_else(|| raw.strip_prefix(r"\\?\").map(ToString::to_string))
-        .unwrap_or_else(|| raw.into_owned());
+        .unwrap_or_else(|| raw);
     normalized.to_lowercase()
 }
 


### PR DESCRIPTION
## Problem

`main`'s **Windows artifacts** CI has been failing since `7385664` (last green) with a compile error:

```
error[E0599]: no method named `into_owned` found for struct `std::string::String`
  --> crates/codex-plus-core/src/dream_skin.rs:593:32
```

The `#[cfg(windows)]` `normalized_identity_string` builds `raw` as an owned `String`
(`path.to_string_lossy().replace('/', "\\")`), then calls `raw.into_owned()` in the final
`unwrap_or_else`. `String` has no `into_owned()` (that's `Cow`/`Borrow`), so it fails to
compile — but only on Windows, since the function is `#[cfg(windows)]` (non-Windows builds
use a separate branch, so macOS/Linux CI stays green and the break is easy to miss).

This blocks the Windows job for **every** PR rebased onto current `main`.

## Fix

Return `raw` directly (it is already the owned `String`):

```rust
-        .unwrap_or_else(|| raw.into_owned());
+        .unwrap_or_else(|| raw);
```

The other `into_owned()` calls in the tree operate on `Cow` (`to_string_lossy().into_owned()`)
and are fine; only this `String` case is wrong.

## Verification

Since the function is `#[cfg(windows)]`, verified with a Windows cross-target type-check
(`rustc --target x86_64-pc-windows-msvc --emit=metadata` on the isolated function):

- original `|| raw.into_owned()` → reproduces `error[E0599]`;
- fixed `|| raw` → type-checks clean.

`cargo check -p codex-plus-core` on macOS stays green.
