### PR TITLE
feat(skills): support shared ~/.agents/skills root

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Telegram 频道：<https://t.me/CodexPlusPlus>
 | --- | --- |
 | 供应商配置 | 官方登录、官方登录混入 API、纯 API、聚合供应商；Responses / Chat Completions；模型测试、模型列表、Provider Doctor、cc-switch 与链接导入 |
 | 模型与上下文 | 每模型上下文窗口、自动压缩阈值、`model_catalog_json`、通用配置，以及按供应商选择 MCP、Skill 和 Plugin |
+| Skill 管理 | 优先复用 `~/.agents/skills` 作为跨 Agent 共享根；原有共享 Skill 只启停不覆盖，Codex++ 安装的 Skill 可更新和归档 |
 | 会话管理 | 扫描本地会话、批量删除、Markdown 导出、Token 用量历史、Provider metadata 同步与备份 |
 | Codex 增强 | 插件市场与模型白名单、会话操作、粘贴修复、中文界面、快速启动、会话宽度与滚动恢复、服务层级控制、Goals、Stepwise、图片覆盖层 |
 | 开发工作流 | 项目移动、Upstream worktree、线程 ID、Zed Remote 项目识别与打开 |
@@ -213,6 +214,7 @@ Codex++ 通过 GitHub Release 发布安装包。Windows 会生成 NSIS 安装程
 - Codex 配置：`~/.codex/config.toml`
 - Codex 登录状态：`~/.codex/auth.json`
 - Codex 本地数据库：优先读取 `~/.codex/sqlite/*.db`，旧版回退到 `~/.codex/state_5.sqlite`
+- 共享 Skill：`~/.agents/skills`（目录存在时由 Codex++ 优先复用）
 - Codex++ 状态与日志：`~/.codex-session-delete/`
 - Provider 同步备份：`~/.codex/backups_state/provider-sync`
 

--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -492,6 +492,7 @@ pub struct SkillsPayload {
     pub repo_errors: Vec<String>,
     pub skills_dir: String,
     pub codex_skills_dir: String,
+    pub shared_source: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -3520,6 +3521,7 @@ fn skills_payload(
         repo_errors,
         skills_dir: manager.source_dir().to_string_lossy().to_string(),
         codex_skills_dir: manager.linked_dir().to_string_lossy().to_string(),
+        shared_source: manager.shared_source(),
     }
 }
 
@@ -3528,12 +3530,16 @@ fn current_skills_payload(manager: &codex_plus_core::skills::SkillsManager) -> S
 }
 
 fn default_skills_manager() -> codex_plus_core::skills::SkillsManager {
-    codex_plus_core::skills::SkillsManager::new(
-        codex_plus_core::paths::default_skills_source_dir(),
-        codex_plus_core::paths::default_skill_backups_dir(),
-        codex_plus_core::paths::default_skills_state_path(),
-        codex_plus_core::codex_home::default_codex_home_dir(),
-    )
+    let source = codex_plus_core::paths::default_skills_source_dir();
+    let shared = codex_plus_core::paths::default_shared_skills_source_dir();
+    let backups = codex_plus_core::paths::default_skill_backups_dir();
+    let state = codex_plus_core::paths::default_skills_state_path();
+    let home = codex_plus_core::codex_home::default_codex_home_dir();
+    if source == shared {
+        codex_plus_core::skills::SkillsManager::new_shared(source, backups, state, home)
+    } else {
+        codex_plus_core::skills::SkillsManager::new(source, backups, state, home)
+    }
 }
 
 /// 上一次成功拉取的远端清单，按仓库 key 存。

--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -333,8 +333,8 @@ type AggregateRelayProfile = {
   members: AggregateRelayMember[];
 };
 
-/// codex 的 config.toml 上下文表。skill 不在这里——它是 `$CODEX_HOME/skills/`
-/// 下的目录约定，`[skills.<id>]` codex 根本不读，由 Skills 面板单独管。
+/// codex 的 config.toml 上下文表。Skill 内容来自目录，单项启停由
+/// `[[skills.config]]` 管理，不与 MCP / Plugin 的通用配置混在一起。
 type ContextKind = "mcp" | "plugin";
 
 type CodexContextEntry = {
@@ -870,6 +870,7 @@ type SkillEntry = {
   repoPath: string;
   installed: boolean;
   enabled: boolean;
+  managed: boolean;
   bundled: boolean;
   contentHash: string;
   remoteHash: string;
@@ -890,6 +891,7 @@ type SkillsResult = CommandResult<{
   repoErrors: string[];
   skillsDir: string;
   codexSkillsDir: string;
+  sharedSource: boolean;
 }>;
 
 /** 仓库源的稳定标识，必须和 Rust 侧 `SkillRepo::key()` 生成的一致。 */
@@ -1364,9 +1366,12 @@ export function App() {
   const setSkillEnabled = (id: string, enabled: boolean) =>
     runSkillAction(id, "set_skill_enabled", { id, enabled });
 
-  const uninstallSkill = async (id: string) => {
-    if (!window.confirm(tf("卸载 Skill「{0}」？源目录会先备份，可以再恢复回来。", [id]))) return;
-    await runSkillAction(id, "uninstall_skill", { id });
+  const uninstallSkill = async (entry: SkillEntry, sharedSource: boolean) => {
+    const prompt = sharedSource
+      ? tf("归档共享 Skill「{0}」？源目录会移入备份，这会影响所有使用共享根的 Agent。", [entry.id])
+      : tf("卸载 Skill「{0}」？源目录会先备份，可以再恢复回来。", [entry.id]);
+    if (!window.confirm(prompt)) return;
+    await runSkillAction(entry.id, "uninstall_skill", { id: entry.id });
   };
 
   const restoreSkillBackup = (backupId: string) =>
@@ -3808,7 +3813,7 @@ type Actions = {
   installSkill: (repoKey: string, id: string) => Promise<void>;
   updateSkill: (repoKey: string, id: string) => Promise<void>;
   setSkillEnabled: (id: string, enabled: boolean) => Promise<void>;
-  uninstallSkill: (id: string) => Promise<void>;
+  uninstallSkill: (entry: SkillEntry, sharedSource: boolean) => Promise<void>;
   restoreSkillBackup: (backupId: string) => Promise<void>;
   deleteSkillBackup: (backupId: string) => Promise<void>;
   upsertSkillRepo: (repo: SkillRepo) => Promise<SkillsResult | null>;
@@ -6373,8 +6378,8 @@ type SkillFilter = "all" | "installed" | "available";
 /**
  * Skills 面板。
  *
- * codex 的 skill 是文件系统约定（`$CODEX_HOME/skills/<id>/SKILL.md`），不是配置项，
- * 所以这里管的是目录：从 GitHub 仓库源装到我们的 SSOT，再软链进 codex home。
+ * 共享根模式直接管理 `~/.agents/skills`，启停写入 Codex 官方 `[[skills.config]]`。
+ * 原有共享 Skill 只允许启停；只有 Codex++ 自己安装的条目才允许归档。
  */
 function SkillsScreen({ skills, actions }: { skills: SkillsResult | null; actions: Actions }) {
   const entries = skills?.skills ?? [];
@@ -6414,7 +6419,9 @@ function SkillsScreen({ skills, actions }: { skills: SkillsResult | null; action
       <Panel>
         <CardHead
           title={t("Skills 技能")}
-          detail={t("从 GitHub 仓库安装 Skill 到 Codex。启用后软链到 ~/.codex/skills/，下次对话即可用。")}
+          detail={skills?.sharedSource
+            ? t("管理跨 Agent 共享 Skill；启停使用 Codex 官方配置，原有共享源不会被覆盖。")
+            : t("从 GitHub 仓库安装 Skill 到 Codex。启用后软链到 ~/.codex/skills/，下次对话即可用。")}
         />
         <CardContent>
           <div className="metric-list">
@@ -6445,7 +6452,9 @@ function SkillsScreen({ skills, actions }: { skills: SkillsResult | null; action
           </Toolbar>
           {skills ? (
             <div className="relay-context-summary">
-              {tf("源目录 {0}；启用后软链到 {1}", [skills.skillsDir, skills.codexSkillsDir])}
+              {skills.sharedSource
+                ? tf("共享源目录 {0}；Codex 兼容入口 {1}", [skills.skillsDir, skills.codexSkillsDir])
+                : tf("源目录 {0}；启用后软链到 {1}", [skills.skillsDir, skills.codexSkillsDir])}
             </div>
           ) : null}
           {repoErrors.length ? (
@@ -6494,7 +6503,7 @@ function SkillsScreen({ skills, actions }: { skills: SkillsResult | null; action
           {visible.length ? (
             <div className="script-market-grid">
               {visible.map((entry) => (
-                <SkillCard actions={actions} entry={entry} key={entry.id} />
+                <SkillCard actions={actions} entry={entry} key={entry.id} sharedSource={skills?.sharedSource ?? false} />
               ))}
             </div>
           ) : (
@@ -6508,10 +6517,12 @@ function SkillsScreen({ skills, actions }: { skills: SkillsResult | null; action
   );
 }
 
-function SkillCard({ entry, actions }: { entry: SkillEntry; actions: Actions }) {
+function SkillCard({ entry, actions, sharedSource }: { entry: SkillEntry; actions: Actions; sharedSource: boolean }) {
   const busy = actions.skillBusyId === entry.id;
   const tags = [
     entry.bundled ? t("内置") : null,
+    sharedSource && entry.installed && !entry.managed && !entry.bundled ? t("共享") : null,
+    entry.managed && !entry.bundled ? t("Codex++ 托管") : null,
     entry.installed && !entry.bundled ? (entry.enabled ? t("已启用") : t("已停用")) : null,
     entry.updateAvailable ? t("有新版本") : null,
   ].filter((tag): tag is string => tag !== null);
@@ -6553,10 +6564,12 @@ function SkillCard({ entry, actions }: { entry: SkillEntry; actions: Actions }) 
                 {t("更新")}
               </Button>
             ) : null}
-            <Button disabled={busy} onClick={() => void actions.uninstallSkill(entry.id)} size="sm" variant="ghost">
-              <Trash2 className="h-4 w-4" />
-              {t("卸载")}
-            </Button>
+            {entry.managed ? (
+              <Button disabled={busy} onClick={() => void actions.uninstallSkill(entry, sharedSource)} size="sm" variant="ghost">
+                <Trash2 className="h-4 w-4" />
+                {sharedSource ? t("归档") : t("卸载")}
+              </Button>
+            ) : null}
           </>
         ) : (
           <Button disabled={busy || !entry.repoKey} onClick={() => void actions.installSkill(entry.repoKey, entry.id)} size="sm">

--- a/apps/codex-plus-manager/src/i18n-en.ts
+++ b/apps/codex-plus-manager/src/i18n-en.ts
@@ -1135,10 +1135,18 @@ export const EN_TEMPLATE: Record<string, string> = {
   "备份（{0}）": "Backups ({0})",
   "当前显示 {0} / {1}": "Showing {0} of {1}",
   "源目录 {0}；启用后软链到 {1}": "Source directory {0}; enabled skills are symlinked into {1}",
+  "共享源目录 {0}；Codex 兼容入口 {1}": "Shared source {0}; Codex compatibility entrypoint {1}",
   "以下仓库拉取失败，显示的是上次的结果：{0}":
     "These repositories failed to load, so the previous results are shown: {0}",
   "卸载 Skill「{0}」？源目录会先备份，可以再恢复回来。":
     "Uninstall the skill \"{0}\"? The source directory is backed up first and can be restored.",
+  "归档共享 Skill「{0}」？源目录会移入备份，这会影响所有使用共享根的 Agent。":
+    "Archive the shared skill \"{0}\"? Its source directory will move to backup and all agents using the shared root will be affected.",
+  "管理跨 Agent 共享 Skill；启停使用 Codex 官方配置，原有共享源不会被覆盖。":
+    "Manage skills shared across agents. Enablement uses Codex's official configuration and existing shared sources are protected from overwrite.",
+  "共享": "Shared",
+  "Codex++ 托管": "Managed by Codex++",
+  "归档": "Archive",
   "删除备份「{0}」？此操作不可撤销。": "Delete the backup \"{0}\"? This cannot be undone.",
   "删除仓库源「{0}」？已装的 Skill 不受影响，只是不再更新。":
     "Delete the repository \"{0}\"? Installed skills are unaffected — they just stop receiving updates.",

--- a/crates/codex-plus-core/src/paths.rs
+++ b/crates/codex-plus-core/src/paths.rs
@@ -11,6 +11,7 @@ const PENDING_REMOTE_CONTROL_RECOVERY_FILE: &str = "pending-remote-control-recov
 const SKILLS_STATE_FILE: &str = "skills.json";
 const SKILLS_DIR: &str = "skills";
 const SKILL_BACKUPS_DIR: &str = "skill-backups";
+const SHARED_AGENT_DIR: &str = ".agents";
 
 pub fn default_app_state_dir() -> PathBuf {
     if let Some(home_dir) = directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf()) {
@@ -47,10 +48,24 @@ pub fn default_pending_remote_control_recovery_path() -> PathBuf {
     default_app_state_dir().join(PENDING_REMOTE_CONTROL_RECOVERY_FILE)
 }
 
-/// Skills 的「单一事实来源」目录。已安装的 skill 目录都放这里，
-/// 启用时再软链到 `$CODEX_HOME/skills/<id>`，停用只删链接、源目录留着。
+/// 跨 Agent 共用的 Skills 单一事实来源。
+pub fn default_shared_skills_source_dir() -> PathBuf {
+    if let Some(home_dir) = directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf()) {
+        return home_dir.join(SHARED_AGENT_DIR).join(SKILLS_DIR);
+    }
+
+    PathBuf::from(SHARED_AGENT_DIR).join(SKILLS_DIR)
+}
+
+/// Skills 的「单一事实来源」目录。已有共享根时优先复用；没有时保持
+/// Codex++ 原有的私有目录，避免改变首次安装行为。
 pub fn default_skills_source_dir() -> PathBuf {
-    default_app_state_dir().join(SKILLS_DIR)
+    let shared = default_shared_skills_source_dir();
+    if shared.is_dir() {
+        shared
+    } else {
+        default_app_state_dir().join(SKILLS_DIR)
+    }
 }
 
 pub fn default_skills_state_path() -> PathBuf {

--- a/crates/codex-plus-core/src/skills.rs
+++ b/crates/codex-plus-core/src/skills.rs
@@ -1,9 +1,7 @@
 //! Codex Skills 管理。
 //!
-//! codex 的 skill 是文件系统约定，不是配置项：它扫描 `$CODEX_HOME/skills/<id>/SKILL.md`，
-//! 从 YAML frontmatter 读 `name` / `description`，然后把清单注入 `<skills_instructions>`。
-//! `config.toml` 里的 `[skills]` 是一个三字段结构体（bundled / include_instructions /
-//! max_context_tokens），写 `[skills.<id>]` 会被 serde 当未知字段静默丢弃，什么都不会发生。
+//! Codex 会从用户级 `~/.agents/skills` 和 `$CODEX_HOME/skills` 发现 skill，并支持
+//! 通过 `[[skills.config]]` 的 `path` / `enabled` 精确控制单个 skill。
 //!
 //! 所以这里采用「SSOT + 软链」模型（与 cc-switch 一致）：
 //!
@@ -24,6 +22,7 @@ use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
+use toml_edit::{ArrayOfTables, DocumentMut, Item, Table, value};
 
 const SKILL_MANIFEST_FILE: &str = "SKILL.md";
 const BUNDLED_SKILLS_DIR: &str = ".system";
@@ -158,6 +157,8 @@ pub struct SkillEntry {
     pub repo_path: String,
     pub installed: bool,
     pub enabled: bool,
+    /// 是否由 Codex++ 安装并记录；共享根里原有的 skill 只读管理，不允许覆盖或归档。
+    pub managed: bool,
     /// codex 自带的 `.system` skill，只读展示，不能安装/卸载。
     pub bundled: bool,
     pub content_hash: String,
@@ -180,6 +181,7 @@ pub struct SkillsManager {
     backups_dir: PathBuf,
     state_path: PathBuf,
     codex_home: PathBuf,
+    shared_source: bool,
     state_lock: Arc<Mutex<()>>,
 }
 
@@ -195,12 +197,28 @@ impl SkillsManager {
             backups_dir: backups_dir.into(),
             state_path: state_path.into(),
             codex_home: codex_home.into(),
+            shared_source: false,
             state_lock: Arc::new(Mutex::new(())),
         }
     }
 
+    pub fn new_shared(
+        source_dir: impl Into<PathBuf>,
+        backups_dir: impl Into<PathBuf>,
+        state_path: impl Into<PathBuf>,
+        codex_home: impl Into<PathBuf>,
+    ) -> Self {
+        let mut manager = Self::new(source_dir, backups_dir, state_path, codex_home);
+        manager.shared_source = true;
+        manager
+    }
+
     pub fn source_dir(&self) -> &Path {
         &self.source_dir
+    }
+
+    pub fn shared_source(&self) -> bool {
+        self.shared_source
     }
 
     /// codex 扫描的 skill 目录。启用一个 skill 就是往这里放一个指向源目录的软链。
@@ -256,11 +274,16 @@ impl SkillsManager {
     /// 把远端清单和本地状态合并成一份列表。`remote` 传空就是纯本地视图。
     pub fn merge_entries(&self, remote: &[RemoteSkill]) -> Vec<SkillEntry> {
         let state = self.load_state();
-        let linked = self.linked_dir();
         let mut entries: BTreeMap<String, SkillEntry> = BTreeMap::new();
 
         for skill in remote {
-            let installed = state.installed.get(&skill.id);
+            let managed = state.installed.get(&skill.id);
+            let installed = managed.is_some()
+                || self
+                    .source_dir
+                    .join(&skill.id)
+                    .join(SKILL_MANIFEST_FILE)
+                    .is_file();
             entries.insert(
                 skill.id.clone(),
                 SkillEntry {
@@ -269,14 +292,15 @@ impl SkillsManager {
                     description: skill.description.clone(),
                     repo_key: skill.repo_key.clone(),
                     repo_path: skill.repo_path.clone(),
-                    installed: installed.is_some(),
-                    enabled: is_linked(&linked.join(&skill.id)),
+                    installed,
+                    enabled: installed && self.skill_enabled(&skill.id),
+                    managed: managed.is_some(),
                     bundled: false,
-                    content_hash: installed
+                    content_hash: managed
                         .map(|item| item.content_hash.clone())
                         .unwrap_or_default(),
                     remote_hash: skill.content_hash.clone(),
-                    update_available: installed
+                    update_available: managed
                         .map(|item| {
                             !item.content_hash.is_empty()
                                 && !skill.content_hash.is_empty()
@@ -300,7 +324,8 @@ impl SkillsManager {
                 repo_key: installed.repo_key.clone(),
                 repo_path: String::new(),
                 installed: true,
-                enabled: is_linked(&linked.join(id)),
+                enabled: self.skill_enabled(id),
+                managed: true,
                 bundled: false,
                 content_hash: installed.content_hash.clone(),
                 remote_hash: String::new(),
@@ -308,11 +333,74 @@ impl SkillsManager {
             });
         }
 
+        // 共享根里原本就有的 skill 也要显示。它们不是 Codex++ 安装的，
+        // 所以可以启停，但不能被市场安装覆盖或从这里归档。
+        for skill in self.list_source_skills(&state) {
+            entries
+                .entry(skill.id.clone())
+                .and_modify(|entry| {
+                    entry.installed = true;
+                    entry.enabled = skill.enabled;
+                    entry.managed = skill.managed;
+                    if entry.name.is_empty() {
+                        entry.name = skill.name.clone();
+                    }
+                    if entry.description.is_empty() {
+                        entry.description = skill.description.clone();
+                    }
+                })
+                .or_insert(skill);
+        }
+
         for skill in self.list_bundled_skills() {
             entries.entry(skill.id.clone()).or_insert(skill);
         }
 
         entries.into_values().collect()
+    }
+
+    fn list_source_skills(&self, state: &SkillsState) -> Vec<SkillEntry> {
+        let Ok(dir) = std::fs::read_dir(&self.source_dir) else {
+            return Vec::new();
+        };
+        let mut skills = Vec::new();
+        for entry in dir.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let Some(id) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if id.starts_with('.') {
+                continue;
+            }
+            let manifest = path.join(SKILL_MANIFEST_FILE);
+            if !manifest.is_file() {
+                continue;
+            }
+            let managed = state.installed.get(id);
+            let (name, description) = read_skill_manifest(&manifest, id);
+            skills.push(SkillEntry {
+                id: id.to_string(),
+                name,
+                description,
+                repo_key: managed
+                    .map(|item| item.repo_key.clone())
+                    .unwrap_or_default(),
+                repo_path: String::new(),
+                installed: true,
+                enabled: self.skill_enabled(id),
+                managed: managed.is_some(),
+                bundled: false,
+                content_hash: managed
+                    .map(|item| item.content_hash.clone())
+                    .unwrap_or_default(),
+                remote_hash: String::new(),
+                update_available: false,
+            });
+        }
+        skills
     }
 
     /// codex 随包附带的 `.system` skill，只列出来让用户知道有这些，不参与安装。
@@ -343,6 +431,7 @@ impl SkillsManager {
                 repo_path: String::new(),
                 installed: true,
                 enabled: true,
+                managed: false,
                 bundled: true,
                 content_hash: String::new(),
                 remote_hash: String::new(),
@@ -371,22 +460,35 @@ impl SkillsManager {
         result?;
 
         let destination = self.source_dir.join(&skill.id);
-        if destination.exists() {
-            // 更新场景：先撤掉旧的，再把暂存目录顶上去。
-            std::fs::remove_dir_all(&destination)
-                .with_context(|| format!("移除旧 skill 目录失败：{}", destination.display()))?;
+        let managed = self.load_state().installed.contains_key(&skill.id);
+        if destination.exists() && !managed {
+            let _ = std::fs::remove_dir_all(&staging);
+            anyhow::bail!(
+                "共享 Skill 已存在且不由 Codex++ 管理，拒绝覆盖：{}",
+                destination.display()
+            );
         }
         if let Some(parent) = destination.parent() {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("创建目录失败：{}", parent.display()))?;
         }
-        std::fs::rename(&staging, &destination).with_context(|| {
-            format!(
+        let previous_backup = if destination.exists() {
+            Some(self.archive_source_dir(&skill.id)?)
+        } else {
+            None
+        };
+        if let Err(error) = std::fs::rename(&staging, &destination) {
+            if let Some(backup) = previous_backup
+                && let Err(restore_error) = std::fs::rename(&backup, &destination)
+            {
+                anyhow::bail!("移动新 Skill 失败：{error}；回滚旧版本也失败：{restore_error}");
+            }
+            return Err(anyhow::Error::from(error).context(format!(
                 "移动 skill 到 {} 失败（暂存目录 {}）",
                 destination.display(),
                 staging.display()
-            )
-        })?;
+            )));
+        }
 
         let _guard = self.state_lock.lock().unwrap();
         let mut state = self.load_state_unlocked();
@@ -408,16 +510,42 @@ impl SkillsManager {
         Ok(self.load_state())
     }
 
-    /// 启用 = 在 `$CODEX_HOME/skills/` 下建一个指向源目录的软链；停用 = 删掉它。
+    fn skill_enabled(&self, id: &str) -> bool {
+        if self.shared_source {
+            let manifest = self.source_dir.join(id).join(SKILL_MANIFEST_FILE);
+            return skill_enabled_from_config(&self.codex_home.join("config.toml"), &manifest)
+                .unwrap_or(true);
+        }
+        is_linked(&self.linked_dir().join(id))
+    }
+
+    /// 共享根模式使用 Codex 官方 `[[skills.config]]` 控制启停，同时只清理
+    /// 确认指向共享源的旧联接。私有模式保持原来的软链行为。
     pub fn set_enabled(&self, id: &str, enabled: bool) -> anyhow::Result<()> {
         validate_skill_id(id)?;
         let source = self.source_dir.join(id);
         let link = self.linked_dir().join(id);
+        if !source.join(SKILL_MANIFEST_FILE).is_file() {
+            anyhow::bail!("skill 源目录不存在或缺少 SKILL.md：{}", source.display());
+        }
+        if self.shared_source {
+            set_skill_enabled_in_config(
+                &self.codex_home.join("config.toml"),
+                &source.join(SKILL_MANIFEST_FILE),
+                enabled,
+            )?;
+            if !enabled {
+                if paths_resolve_to_same(&link, &source) {
+                    remove_link(&link)?;
+                }
+                return Ok(());
+            }
+            // 用户级 `.agents/skills` 会被 Codex 直接发现，不再额外制造一份复制
+            // 回退。已有的兼容联接可以保留，停用时会安全移除。
+            return Ok(());
+        }
         if !enabled {
             return remove_link(&link);
-        }
-        if !source.is_dir() {
-            anyhow::bail!("skill 源目录不存在：{}", source.display());
         }
         std::fs::create_dir_all(self.linked_dir())
             .with_context(|| format!("创建 {} 失败", self.linked_dir().display()))?;
@@ -428,22 +556,15 @@ impl SkillsManager {
     /// 卸载：删软链，源目录整体移进备份目录。不做自动轮转删除。
     pub fn uninstall(&self, id: &str) -> anyhow::Result<SkillsState> {
         validate_skill_id(id)?;
-        remove_link(&self.linked_dir().join(id))?;
+        let current = self.load_state();
+        if self.shared_source && !current.installed.contains_key(id) {
+            anyhow::bail!("这是共享根中原有的 Skill，只能停用，不能由 Codex++ 归档");
+        }
+        self.set_enabled(id, false)?;
 
         let source = self.source_dir.join(id);
         if source.is_dir() {
-            std::fs::create_dir_all(&self.backups_dir)
-                .with_context(|| format!("创建备份目录失败：{}", self.backups_dir.display()))?;
-            let backup = self
-                .backups_dir
-                .join(format!("{id}-{}", current_unix_timestamp_string()));
-            std::fs::rename(&source, &backup).with_context(|| {
-                format!(
-                    "备份 skill 到 {} 失败（源 {}）",
-                    backup.display(),
-                    source.display()
-                )
-            })?;
+            self.archive_source_dir(id)?;
         }
 
         let _guard = self.state_lock.lock().unwrap();
@@ -451,6 +572,28 @@ impl SkillsManager {
         state.installed.remove(id);
         self.save_state_unlocked(&state)?;
         Ok(state)
+    }
+
+    fn archive_source_dir(&self, id: &str) -> anyhow::Result<PathBuf> {
+        let source = self.source_dir.join(id);
+        std::fs::create_dir_all(&self.backups_dir)
+            .with_context(|| format!("创建备份目录失败：{}", self.backups_dir.display()))?;
+        let mut timestamp = current_unix_timestamp_string()
+            .parse::<u64>()
+            .unwrap_or_default();
+        let mut backup = self.backups_dir.join(format!("{id}-{timestamp}"));
+        while backup.exists() {
+            timestamp = timestamp.saturating_add(1);
+            backup = self.backups_dir.join(format!("{id}-{timestamp}"));
+        }
+        std::fs::rename(&source, &backup).with_context(|| {
+            format!(
+                "备份 skill 到 {} 失败（源 {}）",
+                backup.display(),
+                source.display()
+            )
+        })?;
+        Ok(backup)
     }
 
     pub fn list_backups(&self) -> Vec<SkillBackup> {
@@ -958,6 +1101,104 @@ pub async fn download_repo_zip(repo: &SkillRepo) -> anyhow::Result<Vec<u8>> {
     Ok(bytes.to_vec())
 }
 
+fn skill_enabled_from_config(config_path: &Path, manifest: &Path) -> anyhow::Result<bool> {
+    let Ok(contents) = std::fs::read_to_string(config_path) else {
+        return Ok(true);
+    };
+    let doc = contents
+        .parse::<DocumentMut>()
+        .with_context(|| format!("解析 {} 失败", config_path.display()))?;
+    let Some(configs) = doc
+        .get("skills")
+        .and_then(Item::as_table)
+        .and_then(|skills| skills.get("config"))
+        .and_then(Item::as_array_of_tables)
+    else {
+        return Ok(true);
+    };
+    let tables: Vec<&Table> = configs.iter().collect();
+    for table in tables.into_iter().rev() {
+        let Some(path) = table.get("path").and_then(Item::as_str) else {
+            continue;
+        };
+        if path_keys_match(Path::new(path), manifest) {
+            return Ok(table.get("enabled").and_then(Item::as_bool).unwrap_or(true));
+        }
+    }
+    Ok(true)
+}
+
+fn set_skill_enabled_in_config(
+    config_path: &Path,
+    manifest: &Path,
+    enabled: bool,
+) -> anyhow::Result<()> {
+    let contents = std::fs::read_to_string(config_path).unwrap_or_default();
+    let mut doc = if contents.trim().is_empty() {
+        DocumentMut::new()
+    } else {
+        contents
+            .parse::<DocumentMut>()
+            .with_context(|| format!("解析 {} 失败", config_path.display()))?
+    };
+    if doc.get("skills").is_none() {
+        doc["skills"] = Item::Table(Table::new());
+    }
+    let skills = doc
+        .get_mut("skills")
+        .and_then(Item::as_table_mut)
+        .context("config.toml 中的 skills 不是表")?;
+    if skills.get("config").is_none() {
+        skills["config"] = Item::ArrayOfTables(ArrayOfTables::new());
+    }
+    let configs = skills
+        .get_mut("config")
+        .and_then(Item::as_array_of_tables_mut)
+        .context("config.toml 中的 skills.config 不是表数组")?;
+    let remove: Vec<usize> = configs
+        .iter()
+        .enumerate()
+        .filter_map(|(index, table)| {
+            table
+                .get("path")
+                .and_then(Item::as_str)
+                .filter(|path| path_keys_match(Path::new(path), manifest))
+                .map(|_| index)
+        })
+        .collect();
+    for index in remove.into_iter().rev() {
+        configs.remove(index);
+    }
+    let mut entry = Table::new();
+    entry["path"] = value(manifest.to_string_lossy().to_string());
+    entry["enabled"] = value(enabled);
+    configs.push(entry);
+
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("创建目录失败：{}", parent.display()))?;
+    }
+    crate::settings::atomic_write(config_path, doc.to_string().as_bytes())
+}
+
+fn path_keys_match(left: &Path, right: &Path) -> bool {
+    normalized_path_key(left) == normalized_path_key(right)
+}
+
+fn normalized_path_key(path: &Path) -> String {
+    let resolved = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let key = resolved.to_string_lossy().replace('\\', "/");
+    if cfg!(windows) {
+        key.to_ascii_lowercase()
+    } else {
+        key
+    }
+}
+
+fn paths_resolve_to_same(left: &Path, right: &Path) -> bool {
+    left.exists() && right.exists() && path_keys_match(left, right)
+}
+
 /// 软链优先，失败回退复制。Windows 上建目录软链要开发者模式或管理员权限，
 /// 拿不到就退化成复制——功能一样，只是更新时要重装。
 fn link_or_copy(source: &Path, link: &Path) -> anyhow::Result<()> {
@@ -1072,6 +1313,15 @@ mod tests {
     fn manager(temp: &tempfile::TempDir) -> SkillsManager {
         SkillsManager::new(
             temp.path().join("skills"),
+            temp.path().join("skill-backups"),
+            temp.path().join("skills.json"),
+            temp.path().join("codex-home"),
+        )
+    }
+
+    fn shared_manager(temp: &tempfile::TempDir) -> SkillsManager {
+        SkillsManager::new_shared(
+            temp.path().join(".agents").join("skills"),
             temp.path().join("skill-backups"),
             temp.path().join("skills.json"),
             temp.path().join("codex-home"),
@@ -1279,6 +1529,95 @@ mod tests {
                 .join("SKILL.md")
                 .is_file()
         );
+    }
+
+    #[test]
+    fn shared_source_lists_unmanaged_skills_and_uses_official_toggle_config() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = shared_manager(&temp);
+        let skill = manager.source_dir().join("alpha");
+        std::fs::create_dir_all(&skill).unwrap();
+        std::fs::write(
+            skill.join(SKILL_MANIFEST_FILE),
+            "---\nname: alpha\ndescription: shared demo\n---\n",
+        )
+        .unwrap();
+
+        let initial = manager.merge_entries(&[]);
+        let alpha = initial.iter().find(|entry| entry.id == "alpha").unwrap();
+        assert!(alpha.installed);
+        assert!(alpha.enabled);
+        assert!(!alpha.managed);
+
+        manager.set_enabled("alpha", false).unwrap();
+        let config_path = temp.path().join("codex-home").join("config.toml");
+        let config = std::fs::read_to_string(&config_path).unwrap();
+        assert!(config.contains("[[skills.config]]"));
+        assert!(config.contains("enabled = false"));
+        assert!(
+            !manager
+                .merge_entries(&[])
+                .iter()
+                .find(|entry| entry.id == "alpha")
+                .unwrap()
+                .enabled
+        );
+
+        manager.set_enabled("alpha", true).unwrap();
+        let config = std::fs::read_to_string(&config_path).unwrap();
+        assert_eq!(config.matches("[[skills.config]]").count(), 1);
+        assert!(config.contains("enabled = true"));
+        assert!(manager.uninstall("alpha").is_err());
+        assert!(skill.join(SKILL_MANIFEST_FILE).is_file());
+    }
+
+    #[test]
+    fn shared_source_refuses_to_overwrite_an_unmanaged_skill() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = shared_manager(&temp);
+        let skill = manager.source_dir().join("alpha");
+        std::fs::create_dir_all(&skill).unwrap();
+        std::fs::write(skill.join(SKILL_MANIFEST_FILE), "original\n").unwrap();
+
+        let error = manager
+            .install_from_zip(
+                &sample_skill("alpha", "alpha", "hash-1"),
+                &repo_zip(&[("kit-main/alpha/SKILL.md", "replacement\n")]),
+            )
+            .unwrap_err();
+
+        assert!(error.to_string().contains("拒绝覆盖"));
+        assert_eq!(
+            std::fs::read_to_string(skill.join(SKILL_MANIFEST_FILE)).unwrap(),
+            "original\n"
+        );
+    }
+
+    #[test]
+    fn shared_source_can_archive_only_codex_plus_managed_skills() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = shared_manager(&temp);
+        manager
+            .install_from_zip(
+                &sample_skill("alpha", "alpha", "hash-1"),
+                &repo_zip(&[("kit-main/alpha/SKILL.md", "---\nname: alpha\n---\n")]),
+            )
+            .unwrap();
+
+        let entry = manager
+            .merge_entries(&[])
+            .into_iter()
+            .find(|entry| entry.id == "alpha")
+            .unwrap();
+        assert!(entry.managed);
+        assert!(entry.enabled);
+
+        manager.uninstall("alpha").unwrap();
+        assert!(!manager.source_dir().join("alpha").exists());
+        assert_eq!(manager.list_backups().len(), 1);
+        let config =
+            std::fs::read_to_string(temp.path().join("codex-home").join("config.toml")).unwrap();
+        assert!(config.contains("enabled = false"));
     }
 
     /// 停用 → 重新启用 → 再停用，反复切换不该残留或报错。


### PR DESCRIPTION
## Summary

- prefer the shared `~/.agents/skills` root when it already exists while retaining the legacy Codex++ source as a fallback
- inventory shared Skills independently of Codex++ state and distinguish shared entries from Codex++-managed entries in the UI
- allow enable/disable for existing shared Skills without overwriting or archiving them
- write official `[[skills.config]]` entries for shared-mode toggles
- archive managed versions before replacement and roll back failed updates
- document the shared-root behavior and data location

## Verification

- `cargo test -p codex-plus-core --lib` (303 passed)
- Skill-focused Rust tests (22 passed)
- manager Rust tests (63 passed)
- Windows integration tests (22 passed)
- frontend tests (118 passed)
- `npm run check`
- `npm run vite:build`
- `cargo clippy -p codex-plus-core -p codex-plus-manager --all-targets`
- `git diff --check`
- Rust formatting check for modified files

Related to #1190.