### PR TITLE
fix(macos): resolve issue #1990 and stale helper runtime

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -192,7 +192,6 @@ fn should_recover_stale_launcher(debug_port: u16) -> bool {
 
 async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<()> {
     let hooks = LauncherHooks::default();
-    let helper_port = hooks.select_helper_port(options.helper_port);
     let settings = hooks.load_settings().await?;
     let app_dir = hooks.resolve_app_dir(options.app_dir.as_deref(), &settings)?;
     let has_pending_recovery = hooks.has_pending_remote_control_session_recoveries();
@@ -218,9 +217,6 @@ async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<
             &settings.codex_extra_args,
         )
         .await;
-    if settings.enhancements_enabled {
-        hooks.start_helper(helper_port).await?;
-    }
     let process_ids = codex_plus_core::watcher::find_codex_processes();
     #[cfg(windows)]
     let activated = process_ids
@@ -229,31 +225,18 @@ async fn activate_existing_codex_app(options: &LaunchOptions) -> anyhow::Result<
         .any(codex_plus_core::windows_activate_process_window);
     #[cfg(not(windows))]
     let activated = false;
-    let injection_ready = if settings.enhancements_enabled {
-        hooks
-            .ensure_injection(options.debug_port, helper_port, &app_dir)
-            .await
-    } else {
-        false
-    };
-    if injection_ready {
-        hooks
-            .start_bridge_watchdog(options.debug_port, helper_port)
-            .await?;
-        hooks.write_status("running").await;
-    } else if settings.enhancements_enabled {
-        hooks.write_status("running_degraded").await;
-    }
+    let helper_available = !settings.enhancements_enabled
+        || codex_plus_core::ports::can_connect_loopback_port(options.helper_port);
     let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
         "launcher.activate_existing_codex",
         json!({
             "app_dir": app_dir.to_string_lossy(),
             "debug_port": options.debug_port,
-            "helper_port": helper_port,
+            "helper_port": options.helper_port,
             "requested_helper_port": options.helper_port,
             "process_ids": process_ids,
             "activated": activated,
-            "injection_ready": injection_ready,
+            "helper_available": helper_available,
             "launch_ok": launch_result.is_ok(),
             "launch_error": launch_result.as_ref().err().map(|error| error.to_string())
         }),
@@ -1147,6 +1130,24 @@ mod tests {
         assert!(
             body[recovery..launch].contains("hooks.run_remote_control_session_recovery().await?")
         );
+    }
+
+    #[test]
+    fn existing_launcher_path_reuses_the_primary_launcher_runtime() {
+        let source = include_str!("main.rs");
+        let start = source
+            .find("async fn activate_existing_codex_app")
+            .expect("existing launcher activation function");
+        let end = source[start..]
+            .find("fn should_finalize_pending_remote_control_recovery")
+            .map(|offset| start + offset)
+            .expect("next function after existing launcher activation");
+        let body = &source[start..end];
+
+        assert!(!body.contains("hooks.start_helper"));
+        assert!(!body.contains("hooks.ensure_injection"));
+        assert!(!body.contains("hooks.start_bridge_watchdog"));
+        assert!(body.contains("can_connect_loopback_port(options.helper_port)"));
     }
 
     #[test]

--- a/apps/codex-plus-manager/src/renderer-inject.test.ts
+++ b/apps/codex-plus-manager/src/renderer-inject.test.ts
@@ -206,6 +206,17 @@ describe("renderer injection header compatibility", () => {
     assert.match(appended[0].textContent ?? "", /#codex-plus-sidebar-nav/);
   });
 
+  it("does not override the host document root typography or foreground", async () => {
+    const renderer = await readFile(new URL("../../../assets/inject/renderer-inject.js", import.meta.url), "utf8");
+    const appended = installRendererStyle(renderer);
+    const css = appended[0].textContent ?? "";
+    const rootRule = css.match(/:root\s*\{([^}]*)\}/)?.[1] ?? "";
+
+    assert.doesNotMatch(rootRule, /(?:^|;)\s*font(?:-family)?\s*:/);
+    assert.doesNotMatch(rootRule, /(?:^|;)\s*color\s*:/);
+    assert.match(css, /:where\([^)]*codex-plus-modal-overlay[^)]*\)\s*\{[^}]*font-family:\s*inherit;/s);
+  });
+
   it("hides only the official usage alert and restores it without changing upstream styles", async () => {
     const renderer = await readFile(new URL("../../../assets/inject/renderer-inject.js", import.meta.url), "utf8");
     const wrapper = new FakeElement({ className: "w-full", styleDisplay: "grid" });

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -1213,7 +1213,7 @@
       .codex-plus-ad-link { display: inline-flex; align-items: center; justify-content: center; border-radius: 9px; background: #2563eb; color: #ffffff; font-size: 13px; font-weight: 650; text-decoration: none; padding: 8px 12px; }
       .codex-plus-ad-empty { border: 1px dashed rgba(255,255,255,.16); border-radius: 12px; color: #9ca3af; font-size: 13px; padding: 12px; text-align: center; }
       /* Keep injected surfaces on Codex's own semantic palette in both themes. */
-      :root, :where(.${moreMenuClass}, .${actionTooltipClass}, .${zedRemoteToastClass}, .codex-delete-toast, .codex-delete-confirm-overlay, .codex-plus-modal-overlay, .${codexPlusPageClass}) {
+      :root {
         --codex-plus-bg-primary: var(--color-token-bg-primary, var(--token-bg-primary, #fff));
         --codex-plus-bg-secondary: var(--color-token-bg-secondary, var(--token-bg-secondary, #f7f7f7));
         --codex-plus-bg-elevated: var(--color-token-dropdown-background, var(--color-token-bg-elevated-secondary, var(--codex-plus-bg-primary)));
@@ -1229,6 +1229,8 @@
         --codex-plus-danger-bg: var(--color-background-danger-soft, rgba(220,38,38,.1));
         --codex-plus-success: var(--color-text-success, #15803d);
         --codex-plus-warning: var(--color-text-warning, #a16207);
+      }
+      :where(.${moreMenuClass}, .${actionTooltipClass}, .${zedRemoteToastClass}, .codex-delete-toast, .codex-delete-confirm-overlay, .codex-plus-modal-overlay, .${codexPlusPageClass}) {
         color: var(--codex-plus-text);
         font-family: inherit;
       }

--- a/crates/codex-plus-core/src/install/mod.rs
+++ b/crates/codex-plus-core/src/install/mod.rs
@@ -10,6 +10,7 @@ pub mod windows;
 pub const SILENT_NAME: &str = "Codex++";
 pub const MANAGER_NAME: &str = "Codex++ 管理工具";
 pub const SILENT_BINARY: &str = "codex-plus-plus";
+pub const MACOS_SILENT_EXECUTABLE: &str = "CodexPlusPlus";
 pub const MANAGER_BINARY: &str = "codex-plus-plus-manager";
 pub const SILENT_BUNDLE_ID: &str = "com.bigpizzav3.codexplusplus";
 pub const MANAGER_BUNDLE_ID: &str = "com.bigpizzav3.codexplusplus.manager";

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -312,6 +312,14 @@ where
     }
 }
 
+fn helper_bind_retry_timeout_ms(protocol_proxy_enabled: bool, is_macos: bool) -> u64 {
+    if protocol_proxy_enabled || is_macos {
+        HELPER_BIND_RETRY_TIMEOUT_MS
+    } else {
+        0
+    }
+}
+
 pub async fn launch_and_inject_with_hooks<H>(
     options: LaunchOptions,
     hooks: H,
@@ -390,12 +398,9 @@ where
             helper_port = crate::protocol_proxy::DEFAULT_PROTOCOL_PROXY_PORT;
         }
         if settings.enhancements_enabled || protocol_proxy_enabled {
-            // 只有被固定成协议代理端口时才需要等：普通 helper 端口上面已经挑过空闲的了。
-            let bind_retry_timeout_ms = if protocol_proxy_enabled {
-                HELPER_BIND_RETRY_TIMEOUT_MS
-            } else {
-                0
-            };
+            // macOS 重启时旧 launcher 的 socket 释放可能稍晚于进程退出。
+            let bind_retry_timeout_ms =
+                helper_bind_retry_timeout_ms(protocol_proxy_enabled, cfg!(target_os = "macos"));
             start_helper_waiting_for_busy_port(
                 || hooks.start_helper(helper_port),
                 bind_retry_timeout_ms,
@@ -3103,6 +3108,19 @@ mod tests {
         assert!(should_probe_launcher_cdp(true, false));
         assert!(!should_probe_launcher_cdp(true, true));
         assert!(!should_probe_launcher_cdp(false, false));
+    }
+
+    #[test]
+    fn helper_bind_retry_covers_fixed_proxy_ports_and_macos_restarts() {
+        assert_eq!(
+            helper_bind_retry_timeout_ms(true, false),
+            HELPER_BIND_RETRY_TIMEOUT_MS
+        );
+        assert_eq!(
+            helper_bind_retry_timeout_ms(false, true),
+            HELPER_BIND_RETRY_TIMEOUT_MS
+        );
+        assert_eq!(helper_bind_retry_timeout_ms(false, false), 0);
     }
 
     #[tokio::test]

--- a/crates/codex-plus-core/src/watcher.rs
+++ b/crates/codex-plus-core/src/watcher.rs
@@ -153,6 +153,13 @@ pub fn process_ids_still_running(
         .collect()
 }
 
+pub fn macos_launcher_process_names() -> [&'static str; 2] {
+    [
+        crate::install::SILENT_BINARY,
+        crate::install::MACOS_SILENT_EXECUTABLE,
+    ]
+}
+
 #[cfg(windows)]
 pub fn process_id_is_running(process_id: u32) -> Option<bool> {
     if process_id == 0 {
@@ -515,18 +522,28 @@ fn terminate_macos_process(process_id: u32) -> std::io::Result<()> {
 
 #[cfg(target_os = "macos")]
 fn find_launcher_processes() -> Vec<u32> {
-    std::process::Command::new("pgrep")
-        .args(["-x", crate::install::SILENT_BINARY])
-        .output()
-        .ok()
+    let current_process_id = std::process::id();
+    let mut process_ids = macos_launcher_process_names()
         .into_iter()
-        .flat_map(|output| {
-            String::from_utf8_lossy(&output.stdout)
-                .lines()
-                .filter_map(|value| value.trim().parse::<u32>().ok())
+        .flat_map(|process_name| {
+            std::process::Command::new("pgrep")
+                .args(["-x", process_name])
+                .output()
+                .ok()
+                .into_iter()
+                .flat_map(|output| {
+                    String::from_utf8_lossy(&output.stdout)
+                        .lines()
+                        .filter_map(|value| value.trim().parse::<u32>().ok())
+                        .collect::<Vec<_>>()
+                })
                 .collect::<Vec<_>>()
         })
-        .collect()
+        .filter(|process_id| *process_id != current_process_id)
+        .collect::<Vec<_>>();
+    process_ids.sort_unstable();
+    process_ids.dedup();
+    process_ids
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/codex-plus-core/tests/watcher.rs
+++ b/crates/codex-plus-core/tests/watcher.rs
@@ -1,8 +1,8 @@
 use codex_plus_core::watcher::{
     build_spawn_launcher_command, build_watcher_install_plan, cdp_listening, codex_process_ids,
     disable_watcher_at, enable_watcher_at, filter_killable_launcher_processes,
-    process_id_is_running, process_ids_still_running, should_recover_stale_launcher,
-    watcher_disabled_flag,
+    macos_launcher_process_names, process_id_is_running, process_ids_still_running,
+    should_recover_stale_launcher, watcher_disabled_flag,
 };
 
 #[cfg(windows)]
@@ -125,6 +125,14 @@ fn launcher_process_filter_protects_current_process_ancestry() {
     ];
 
     assert_eq!(filter_killable_launcher_processes(processes, 30), vec![40]);
+}
+
+#[test]
+fn macos_launcher_process_names_cover_development_and_packaged_binaries() {
+    assert_eq!(
+        macos_launcher_process_names(),
+        ["codex-plus-plus", "CodexPlusPlus"]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Fix issue #1990, where restoring the original Codex appearance causes the font to fall back to 宋体.
- Keep Codex root typography and foreground styles untouched when applying Codex++ skin styles.
- Make macOS launcher cleanup recognize both development and packaged executable names, while preserving the current process.
- Prevent a duplicate launcher from binding a second helper runtime on port 57321.
- Retry macOS helper binding briefly during restart races.

## Validation
- Rust core, watcher, launcher, and CDP bridge tests passed.
- Frontend tests, TypeScript check, and Vite production build passed.
- arm64 macOS DMG built and verified locally.

Fixes #1990