### PR TITLE
fix(data): make provider sync lifecycle locking recoverable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "codex-plus-core",
+ "fs2",
  "rusqlite",
  "serde",
  "serde_json",

--- a/crates/codex-plus-core/src/watcher.rs
+++ b/crates/codex-plus-core/src/watcher.rs
@@ -160,20 +160,157 @@ pub fn macos_launcher_process_names() -> [&'static str; 2] {
     ]
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProcessInstanceState {
+    NotRunning,
+    Running {
+        started_at_secs: Option<u64>,
+        birth_id: Option<String>,
+    },
+    Unknown,
+}
+
 #[cfg(windows)]
-pub fn process_id_is_running(process_id: u32) -> Option<bool> {
+pub fn inspect_process_instance(process_id: u32) -> ProcessInstanceState {
     if process_id == 0 {
-        return Some(false);
+        return ProcessInstanceState::NotRunning;
     }
     let processes = crate::windows_integration::enumerate_processes();
     if processes.is_empty() {
-        return None;
+        return ProcessInstanceState::Unknown;
     }
-    Some(
-        processes
-            .iter()
-            .any(|process| process.process_id == process_id),
+    if !processes
+        .iter()
+        .any(|process| process.process_id == process_id)
+    {
+        return ProcessInstanceState::NotRunning;
+    }
+    let birth_id = crate::windows_integration::process_birth_id(process_id);
+    ProcessInstanceState::Running {
+        started_at_secs: birth_id
+            .and_then(crate::windows_integration::process_started_at_secs_from_birth_id),
+        birth_id: birth_id.map(|birth_id| birth_id.to_string()),
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub fn inspect_process_instance(process_id: u32) -> ProcessInstanceState {
+    match process_id_is_running(process_id) {
+        Some(false) => ProcessInstanceState::NotRunning,
+        Some(true) => {
+            let (started_at_secs, birth_id) = unix_process_identity(process_id);
+            ProcessInstanceState::Running {
+                started_at_secs,
+                birth_id,
+            }
+        }
+        None => ProcessInstanceState::Unknown,
+    }
+}
+
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
+pub fn inspect_process_instance(process_id: u32) -> ProcessInstanceState {
+    if process_id == 0 {
+        ProcessInstanceState::NotRunning
+    } else {
+        ProcessInstanceState::Unknown
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn unix_process_identity(process_id: u32) -> (Option<u64>, Option<String>) {
+    let process_id_arg = process_id.to_string();
+    let output = std::process::Command::new("ps")
+        .args([
+            "-p",
+            process_id_arg.as_str(),
+            "-o",
+            "etime=",
+            "-o",
+            "lstart=",
+        ])
+        .env("LC_ALL", "C")
+        .output();
+    let Ok(output) = output else {
+        return (None, None);
+    };
+    if !output.status.success() {
+        return (None, None);
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let text = text.trim();
+    let Some(split_at) = text.find(char::is_whitespace) else {
+        return (None, None);
+    };
+    let elapsed = parse_ps_elapsed_seconds(&text[..split_at]);
+    let birth_id = text[split_at..].trim();
+    let started_at_secs = elapsed.and_then(|elapsed| {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .ok()
+            .map(|now| now.as_secs().saturating_sub(elapsed))
+    });
+    (
+        started_at_secs,
+        (!birth_id.is_empty()).then(|| birth_id.to_string()),
     )
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", test))]
+fn parse_ps_elapsed_seconds(value: &str) -> Option<u64> {
+    let (days, time) = if let Some((days, time)) = value.split_once('-') {
+        (days.parse().ok()?, time)
+    } else {
+        (0, value)
+    };
+    let parts = time
+        .split(':')
+        .map(str::parse::<u64>)
+        .collect::<Result<Vec<_>, _>>()
+        .ok()?;
+    let (hours, minutes, seconds) = match parts.as_slice() {
+        [minutes, seconds] => (0, *minutes, *seconds),
+        [hours, minutes, seconds] => (*hours, *minutes, *seconds),
+        _ => return None,
+    };
+    Some(days * 86_400 + hours * 3_600 + minutes * 60 + seconds)
+}
+
+#[cfg(test)]
+mod process_identity_tests {
+    use super::*;
+
+    #[test]
+    fn parses_ps_elapsed_time_formats() {
+        assert_eq!(parse_ps_elapsed_seconds("03:04"), Some(184));
+        assert_eq!(parse_ps_elapsed_seconds("02:03:04"), Some(7_384));
+        assert_eq!(parse_ps_elapsed_seconds("2-02:03:04"), Some(180_184));
+        assert_eq!(parse_ps_elapsed_seconds("invalid"), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn current_windows_process_has_a_stable_birth_identity() {
+        let ProcessInstanceState::Running {
+            started_at_secs,
+            birth_id,
+        } = inspect_process_instance(std::process::id())
+        else {
+            panic!("current process should be visible");
+        };
+
+        assert!(started_at_secs.is_some());
+        assert!(birth_id.is_some());
+    }
+}
+
+#[cfg(windows)]
+pub fn process_id_is_running(process_id: u32) -> Option<bool> {
+    match inspect_process_instance(process_id) {
+        ProcessInstanceState::NotRunning => Some(false),
+        ProcessInstanceState::Running { .. } => Some(true),
+        ProcessInstanceState::Unknown => None,
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/codex-plus-core/src/windows_integration.rs
+++ b/crates/codex-plus-core/src/windows_integration.rs
@@ -12,7 +12,9 @@ use std::sync::OnceLock;
 #[cfg(windows)]
 use anyhow::Context;
 #[cfg(windows)]
-use windows::Win32::Foundation::{BOOL, CloseHandle, HANDLE, HWND, LPARAM, MAX_PATH, WPARAM};
+use windows::Win32::Foundation::{
+    BOOL, CloseHandle, FILETIME, HANDLE, HWND, LPARAM, MAX_PATH, WPARAM,
+};
 #[cfg(windows)]
 use windows::Win32::System::Com::{
     CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED, CoCreateInstance, CoInitializeEx,
@@ -30,8 +32,8 @@ use windows::Win32::System::Registry::{
 };
 #[cfg(windows)]
 use windows::Win32::System::Threading::{
-    OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE, QueryFullProcessImageNameW,
-    TerminateProcess,
+    GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE,
+    QueryFullProcessImageNameW, TerminateProcess,
 };
 #[cfg(windows)]
 use windows::Win32::UI::Shell::PropertiesSystem::{IPropertyStore, SHGetPropertyStoreForWindow};
@@ -343,6 +345,40 @@ pub fn terminate_process(process_id: u32) -> bool {
     }
     let _guard = HandleGuard(handle);
     unsafe { TerminateProcess(handle, 0) }.is_ok()
+}
+
+#[cfg(windows)]
+pub fn process_birth_id(process_id: u32) -> Option<u64> {
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, process_id).ok()? };
+    if handle.is_invalid() {
+        return None;
+    }
+    let _guard = HandleGuard(handle);
+    let mut creation_time = FILETIME::default();
+    let mut exit_time = FILETIME::default();
+    let mut kernel_time = FILETIME::default();
+    let mut user_time = FILETIME::default();
+    unsafe {
+        GetProcessTimes(
+            handle,
+            &mut creation_time,
+            &mut exit_time,
+            &mut kernel_time,
+            &mut user_time,
+        )
+        .ok()?;
+    }
+    Some(((creation_time.dwHighDateTime as u64) << 32) | creation_time.dwLowDateTime as u64)
+}
+
+#[cfg(windows)]
+pub fn process_started_at_secs_from_birth_id(birth_id: u64) -> Option<u64> {
+    const WINDOWS_TO_UNIX_EPOCH_100NS: u64 = 116_444_736_000_000_000;
+    const TICKS_PER_SECOND: u64 = 10_000_000;
+
+    birth_id
+        .checked_sub(WINDOWS_TO_UNIX_EPOCH_100NS)
+        .map(|unix_ticks| unix_ticks / TICKS_PER_SECOND)
 }
 
 #[cfg(windows)]

--- a/crates/codex-plus-data/Cargo.toml
+++ b/crates/codex-plus-data/Cargo.toml
@@ -10,6 +10,7 @@ anyhow.workspace = true
 base64.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 codex-plus-core = { path = "../codex-plus-core" }
+fs2.workspace = true
 rusqlite.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }

--- a/crates/codex-plus-data/src/lib.rs
+++ b/crates/codex-plus-data/src/lib.rs
@@ -6,8 +6,8 @@ pub mod storage;
 pub use backup::BackupStore;
 pub use markdown::{MarkdownExportService, export_markdown_from_paths};
 pub use provider_sync::{
-    ProviderSyncAudit, ProviderSyncLockState, ProviderSyncResult, ProviderSyncStatus,
-    ProviderSyncTargetList, ProviderSyncTargetOption, ProviderSyncTargetSource,
+    ProviderSyncAudit, ProviderSyncLifecycleGuard, ProviderSyncLockState, ProviderSyncResult,
+    ProviderSyncStatus, ProviderSyncTargetList, ProviderSyncTargetOption, ProviderSyncTargetSource,
     SessionIndexCleanupApplyError, SessionIndexCleanupCandidate, SessionIndexCleanupPreview,
     SessionIndexCleanupResult, apply_session_index_cleanup, inspect_provider_sync_lock,
     load_provider_sync_targets, preview_session_index_cleanup,
@@ -15,5 +15,6 @@ pub use provider_sync::{
     run_provider_sync_with_target,
     run_remote_control_session_catalog_recovery_for_thread_with_target,
     run_remote_control_session_finalization_for_thread_with_target,
+    try_acquire_provider_sync_lifecycle_guard,
 };
 pub use storage::{LocalSession, SQLiteStorageAdapter, delete_local_from_paths};

--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -1,3 +1,4 @@
+use fs2::FileExt;
 use rusqlite::{Connection, OptionalExtension, params_from_iter, types::Value as SqlValue};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
@@ -17,12 +18,23 @@ const REMOTE_CONTROL_CREATION_WINDOW_SECS: i64 = 15 * 60;
 /// 该窗口只有几毫秒，因此超过这个时长仍缺 owner 的锁一定是中断残留，可以安全回收；
 /// 反过来说，宽限期内的无主锁必须保留，否则会把正在建锁的同伴进程挤掉。
 const LOCK_INTERRUPTED_GRACE_SECS: u64 = 60;
+/// Legacy owner files do not record the OS process creation time. A live PID whose process began
+/// well after the lock was created is a reused PID, not the original lock owner.
+const LEGACY_PID_REUSE_TOLERANCE_SECS: u64 = 5 * 60;
+const LEGACY_PID_REUSE_MIN_LOCK_AGE_SECS: u64 = 24 * 60 * 60;
+const PROCESS_START_MATCH_TOLERANCE_SECS: u64 = 5;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ProviderSyncLockOwner {
     pid: u32,
     started_at: u64,
+    #[serde(default)]
+    process_started_at: Option<u64>,
+    #[serde(default)]
+    process_birth_id: Option<String>,
+    #[serde(default)]
+    lock_id: Option<String>,
 }
 
 /// provider sync 锁的可观测状态。管理器在强杀 launcher 前用它判断
@@ -41,6 +53,55 @@ pub enum ProviderSyncLockState {
     Indeterminate,
 }
 
+#[derive(Debug)]
+pub struct ProviderSyncLifecycleGuard {
+    lock_dir: PathBuf,
+    lock_file: File,
+    lock_id: String,
+    directory_released: bool,
+    file_unlocked: bool,
+}
+
+impl ProviderSyncLifecycleGuard {
+    /// Releases both compatibility and OS ownership before a caller starts a successor process.
+    /// A mismatched owner is an ABA conflict and must block the successor instead of deleting it.
+    pub fn release(mut self) -> std::io::Result<()> {
+        if !release_owned_lock(&self.lock_dir, &self.lock_id)? {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "provider-sync lock ownership changed before release",
+            ));
+        }
+        self.directory_released = true;
+        FileExt::unlock(&self.lock_file)?;
+        self.file_unlocked = true;
+        Ok(())
+    }
+}
+
+impl Drop for ProviderSyncLifecycleGuard {
+    fn drop(&mut self) {
+        if !self.directory_released {
+            let _ = release_owned_lock(&self.lock_dir, &self.lock_id);
+        }
+        if !self.file_unlocked {
+            let _ = FileExt::unlock(&self.lock_file);
+        }
+    }
+}
+
+/// Atomically reserves provider-sync lifecycle ownership for a restart or a real sync.
+/// The OS file lock is released automatically if the process exits; the legacy directory remains
+/// present while held so older launchers also stay out of the critical section.
+pub fn try_acquire_provider_sync_lifecycle_guard(
+    codex_home: Option<&Path>,
+) -> std::io::Result<ProviderSyncLifecycleGuard> {
+    let home = codex_home
+        .map(Path::to_path_buf)
+        .unwrap_or_else(default_codex_home_dir);
+    acquire_lock_inner(&home.join("tmp/provider-sync.lock"), false)
+}
+
 /// 读取 provider sync 锁的当前状态，不获取也不修改它。
 pub fn inspect_provider_sync_lock(codex_home: Option<&Path>) -> ProviderSyncLockState {
     let home = codex_home
@@ -56,7 +117,7 @@ fn inspect_lock(path: &Path) -> ProviderSyncLockState {
     classify_lock(
         read_lock_owner(path).as_ref(),
         lock_dir_age_secs(path),
-        codex_plus_core::watcher::process_id_is_running,
+        codex_plus_core::watcher::inspect_process_instance,
     )
 }
 
@@ -64,7 +125,7 @@ fn inspect_lock(path: &Path) -> ProviderSyncLockState {
 fn classify_lock(
     owner: Option<&ProviderSyncLockOwner>,
     age_secs: Option<u64>,
-    process_alive: impl Fn(u32) -> Option<bool>,
+    inspect_process: impl Fn(u32) -> codex_plus_core::watcher::ProcessInstanceState,
 ) -> ProviderSyncLockState {
     let Some(owner) = owner else {
         // owner.json 缺失或损坏。持有者只在建锁的几毫秒内处于这个状态，
@@ -75,15 +136,61 @@ fn classify_lock(
             ProviderSyncLockState::Indeterminate
         };
     };
-    match process_alive(owner.pid) {
-        Some(false) => ProviderSyncLockState::Stale {
+    use codex_plus_core::watcher::ProcessInstanceState;
+    match inspect_process(owner.pid) {
+        ProcessInstanceState::NotRunning => ProviderSyncLockState::Stale {
             pid: Some(owner.pid),
         },
-        // `None` 表示进程枚举失败，无法证明持有者已死；按「仍在持有」保守处理。
-        _ => ProviderSyncLockState::Held {
+        ProcessInstanceState::Running {
+            started_at_secs,
+            birth_id: current_birth_id,
+        } => {
+            let birth_mismatch = owner
+                .process_birth_id
+                .as_deref()
+                .zip(current_birth_id.as_deref())
+                .is_some_and(|(expected, current)| expected != current);
+            let recorded_start_mismatch = owner.process_birth_id.is_none()
+                && owner.process_started_at.zip(started_at_secs).is_some_and(
+                    |(expected, current)| {
+                        expected.abs_diff(current) > PROCESS_START_MATCH_TOLERANCE_SECS
+                    },
+                );
+            let legacy_pid_reuse = owner.process_birth_id.is_none()
+                && owner.process_started_at.is_none()
+                && age_secs.is_some_and(|age| age >= LEGACY_PID_REUSE_MIN_LOCK_AGE_SECS)
+                && started_at_secs.is_some_and(|current| {
+                    current
+                        > owner
+                            .started_at
+                            .saturating_add(LEGACY_PID_REUSE_TOLERANCE_SECS)
+                });
+            if birth_mismatch || recorded_start_mismatch || legacy_pid_reuse {
+                ProviderSyncLockState::Stale {
+                    pid: Some(owner.pid),
+                }
+            } else {
+                ProviderSyncLockState::Held {
+                    pid: owner.pid,
+                    started_at: owner.started_at,
+                }
+            }
+        }
+        // Unknown process identity cannot prove that the owner is gone. Preserve the lock.
+        ProcessInstanceState::Unknown => ProviderSyncLockState::Held {
             pid: owner.pid,
             started_at: owner.started_at,
         },
+    }
+}
+
+fn current_process_identity() -> (Option<u64>, Option<String>) {
+    match codex_plus_core::watcher::inspect_process_instance(std::process::id()) {
+        codex_plus_core::watcher::ProcessInstanceState::Running {
+            started_at_secs,
+            birth_id,
+        } => (started_at_secs, birth_id),
+        _ => (None, None),
     }
 }
 
@@ -436,16 +543,19 @@ pub fn run_remote_control_session_catalog_recovery_for_thread_with_target(
         .map(Path::to_path_buf)
         .unwrap_or_else(default_codex_home_dir);
     let lock_dir = home.join("tmp/provider-sync.lock");
-    if acquire_lock(&lock_dir).is_err() {
-        return result(
-            ProviderSyncStatus::Skipped,
-            format!("Provider sync lock exists: {}", lock_dir.to_string_lossy()),
-            target_provider,
-            None,
-            0,
-            0,
-        );
-    }
+    let _lock_guard = match acquire_lock(&lock_dir) {
+        Ok(guard) => guard,
+        Err(_) => {
+            return result(
+                ProviderSyncStatus::Skipped,
+                format!("Provider sync lock exists: {}", lock_dir.to_string_lossy()),
+                target_provider,
+                None,
+                0,
+                0,
+            );
+        }
+    };
     let thread_ids = HashSet::from([thread_id.to_string()]);
     let recovery = run_remote_control_catalog_recovery_for_threads(
         &home,
@@ -453,7 +563,6 @@ pub fn run_remote_control_session_catalog_recovery_for_thread_with_target(
         target_provider,
         &thread_ids,
     );
-    let _ = release_lock(&lock_dir);
     recovery.unwrap_or_else(|error| {
         result(
             ProviderSyncStatus::Skipped,
@@ -491,16 +600,19 @@ pub fn run_remote_control_session_finalization_for_thread_with_target(
         .map(Path::to_path_buf)
         .unwrap_or_else(default_codex_home_dir);
     let lock_dir = home.join("tmp/provider-sync.lock");
-    if acquire_lock(&lock_dir).is_err() {
-        return result(
-            ProviderSyncStatus::Skipped,
-            format!("Provider sync lock exists: {}", lock_dir.to_string_lossy()),
-            target_provider,
-            None,
-            0,
-            0,
-        );
-    }
+    let _lock_guard = match acquire_lock(&lock_dir) {
+        Ok(guard) => guard,
+        Err(_) => {
+            return result(
+                ProviderSyncStatus::Skipped,
+                format!("Provider sync lock exists: {}", lock_dir.to_string_lossy()),
+                target_provider,
+                None,
+                0,
+                0,
+            );
+        }
+    };
     let recovery = (|| -> anyhow::Result<ProviderSyncResult> {
         let sqlite_paths = provider_sync_db_paths(&home);
         let rollout_path = match remote_control_rollout_for_thread(
@@ -595,7 +707,6 @@ pub fn run_remote_control_session_finalization_for_thread_with_target(
         synced.sqlite_catalog_rows_removed = sqlite_updates.catalog_remove_rows;
         Ok(synced)
     })();
-    let _ = release_lock(&lock_dir);
     recovery.unwrap_or_else(|error| {
         result(
             ProviderSyncStatus::Skipped,
@@ -706,16 +817,19 @@ pub fn run_provider_sync_with_target(
         }
     }
     let lock_dir = home.join("tmp/provider-sync.lock");
-    if acquire_lock(&lock_dir).is_err() {
-        return result(
-            ProviderSyncStatus::Skipped,
-            format!("Provider sync lock exists: {}", lock_dir.to_string_lossy()),
-            &target_provider,
-            None,
-            0,
-            0,
-        );
-    }
+    let _lock_guard = match acquire_lock(&lock_dir) {
+        Ok(guard) => guard,
+        Err(_) => {
+            return result(
+                ProviderSyncStatus::Skipped,
+                format!("Provider sync lock exists: {}", lock_dir.to_string_lossy()),
+                &target_provider,
+                None,
+                0,
+                0,
+            );
+        }
+    };
     let sync_result = (|| -> anyhow::Result<ProviderSyncResult> {
         let sqlite_paths = provider_sync_db_paths(&home);
         let thread_kinds = sqlite_provider_sync_thread_kinds(&sqlite_paths)?;
@@ -847,7 +961,6 @@ pub fn run_provider_sync_with_target(
         synced.message = provider_sync_message_with_audit(&synced.message, &synced.repair_audit);
         Ok(synced)
     })();
-    let _ = release_lock(&lock_dir);
     sync_result.unwrap_or_else(|err| {
         result(
             ProviderSyncStatus::Skipped,
@@ -1180,16 +1293,42 @@ fn toml_string_value(raw: &str) -> Option<String> {
     None
 }
 
-fn acquire_lock(path: &Path) -> std::io::Result<()> {
+fn acquire_lock(path: &Path) -> std::io::Result<ProviderSyncLifecycleGuard> {
+    acquire_lock_inner(path, true)
+}
+
+fn acquire_lock_inner(path: &Path, log_busy: bool) -> std::io::Result<ProviderSyncLifecycleGuard> {
     fs::create_dir_all(path.parent().unwrap_or_else(|| Path::new(".")))?;
-    match create_lock(path) {
-        Ok(()) => Ok(()),
+    let lifecycle_path = path.with_file_name("provider-sync.lifecycle.lock");
+    let lock_file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(lifecycle_path)?;
+    if let Err(error) = lock_file.try_lock_exclusive() {
+        let error = normalize_lock_contention_error(error);
+        if log_busy {
+            log_lock_busy(path);
+        }
+        return Err(error);
+    }
+    let lock_id = uuid::Uuid::new_v4().to_string();
+    match create_lock(path, &lock_id) {
+        Ok(()) => Ok(ProviderSyncLifecycleGuard {
+            lock_dir: path.to_path_buf(),
+            lock_file,
+            lock_id,
+            directory_released: false,
+            file_unlocked: false,
+        }),
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
             let Some((owner, isolated_path)) = isolate_stale_lock(path) else {
-                log_lock_busy(path);
+                if log_busy {
+                    log_lock_busy(path);
+                }
                 return Err(error);
             };
-            match create_lock(path) {
+            match create_lock(path, &lock_id) {
                 Ok(()) => {
                     let quarantine_cleanup_failed = fs::remove_dir_all(&isolated_path).is_err();
                     let _ = codex_plus_core::diagnostic_log::append_diagnostic_log(
@@ -1197,12 +1336,21 @@ fn acquire_lock(path: &Path) -> std::io::Result<()> {
                         json!({
                             "owner_pid": owner.as_ref().map(|owner| owner.pid),
                             "owner_started_at": owner.as_ref().map(|owner| owner.started_at),
+                            "owner_process_started_at": owner
+                                .as_ref()
+                                .and_then(|owner| owner.process_started_at),
                             // owner 缺失说明持有者是在建锁中途被强杀的（issue #1901）
                             "interrupted": owner.is_none(),
                             "quarantine_cleanup_failed": quarantine_cleanup_failed,
                         }),
                     );
-                    Ok(())
+                    Ok(ProviderSyncLifecycleGuard {
+                        lock_dir: path.to_path_buf(),
+                        lock_file,
+                        lock_id,
+                        directory_released: false,
+                        file_unlocked: false,
+                    })
                 }
                 Err(retry_error) => {
                     let _ = fs::remove_dir_all(isolated_path);
@@ -1212,6 +1360,14 @@ fn acquire_lock(path: &Path) -> std::io::Result<()> {
         }
         Err(error) => Err(error),
     }
+}
+
+fn normalize_lock_contention_error(error: std::io::Error) -> std::io::Error {
+    #[cfg(windows)]
+    if error.raw_os_error() == Some(33) {
+        return std::io::Error::new(std::io::ErrorKind::WouldBlock, error);
+    }
+    error
 }
 
 /// 锁没能拿到时留下现场，用于区分「另一个同步真的在跑」和「残留锁把同步永久卡死」。
@@ -1227,11 +1383,19 @@ fn log_lock_busy(path: &Path) {
     );
 }
 
-fn create_lock(path: &Path) -> std::io::Result<()> {
+fn create_lock(path: &Path, lock_id: &str) -> std::io::Result<()> {
     fs::create_dir(path)?;
+    let (process_started_at, process_birth_id) = current_process_identity();
     let write_result = fs::write(
         path.join("owner.json"),
-        json!({"pid": std::process::id(), "startedAt": now_secs()}).to_string(),
+        json!({
+            "pid": std::process::id(),
+            "startedAt": now_secs(),
+            "processStartedAt": process_started_at,
+            "processBirthId": process_birth_id,
+            "lockId": lock_id,
+        })
+        .to_string(),
     );
     if let Err(error) = write_result {
         let _ = fs::remove_dir_all(path);
@@ -1240,18 +1404,28 @@ fn create_lock(path: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-/// 把一把可以证明已经失效的锁挪到隔离路径，让调用方重新建锁。
+/// 在已经持有 OS 生命周期锁时，把可回收的兼容目录挪到隔离路径，让调用方重新建锁。
 ///
-/// 两种可回收的形态：
+/// 三种可回收的形态：
+/// - owner.json 带 `lockId`，证明目录来自新版协议；OS 锁既然已取得，该目录必为孤儿；
 /// - owner.json 可读且持有进程已退出（正常的崩溃残留）；
 /// - owner.json 缺失/损坏，且锁目录存在时间已超过 [`LOCK_INTERRUPTED_GRACE_SECS`]
 ///   ——持有者在 `create_lock` 中途被强杀，不会再有人来补写 owner（issue #1901）。
 ///
 /// 其余情况一律保留锁：宁可跳过一次同步，也不能抢走仍在写入的进程的锁。
 fn isolate_stale_lock(path: &Path) -> Option<(Option<ProviderSyncLockOwner>, PathBuf)> {
-    let owner = match inspect_lock(path) {
-        ProviderSyncLockState::Stale { .. } => read_lock_owner(path),
-        _ => return None,
+    let parsed_owner = read_lock_owner(path);
+    let owner = if parsed_owner
+        .as_ref()
+        .and_then(|owner| owner.lock_id.as_ref())
+        .is_some()
+    {
+        parsed_owner
+    } else {
+        match inspect_lock(path) {
+            ProviderSyncLockState::Stale { .. } => parsed_owner,
+            _ => return None,
+        }
     };
     let file_name = path.file_name()?.to_string_lossy();
     let owner_tag = owner
@@ -1265,11 +1439,18 @@ fn isolate_stale_lock(path: &Path) -> Option<(Option<ProviderSyncLockOwner>, Pat
     Some((owner, isolated_path))
 }
 
-fn release_lock(path: &Path) -> std::io::Result<()> {
-    if path.exists() {
-        fs::remove_dir_all(path)?;
+fn release_owned_lock(path: &Path, lock_id: &str) -> std::io::Result<bool> {
+    if !path.exists() {
+        return Ok(true);
     }
-    Ok(())
+    if read_lock_owner(path)
+        .and_then(|owner| owner.lock_id)
+        .is_some_and(|owner_lock_id| owner_lock_id == lock_id)
+    {
+        fs::remove_dir_all(path)?;
+        return Ok(true);
+    }
+    Ok(false)
 }
 
 fn collect_session_changes(
@@ -1923,7 +2104,7 @@ pub fn apply_session_index_cleanup(
         .map(Path::to_path_buf)
         .unwrap_or_else(default_codex_home_dir);
     let lock_dir = home.join("tmp/provider-sync.lock");
-    acquire_lock(&lock_dir).map_err(|error| cleanup_apply_error(error, None))?;
+    let _lock_guard = acquire_lock(&lock_dir).map_err(|error| cleanup_apply_error(error, None))?;
     let result = (|| {
         let sqlite_paths =
             codex_plus_core::codex_sqlite::codex_thread_reference_db_paths_from_home(&home);
@@ -1993,7 +2174,6 @@ pub fn apply_session_index_cleanup(
             backup_dir: Some(backup_dir),
         })
     })();
-    let _ = release_lock(&lock_dir);
     result
 }
 
@@ -3921,17 +4101,28 @@ mod non_root_agent_tests {
 #[cfg(test)]
 mod lock_state_tests {
     use super::*;
+    use codex_plus_core::watcher::ProcessInstanceState;
 
     fn owner(pid: u32) -> ProviderSyncLockOwner {
         ProviderSyncLockOwner {
             pid,
             started_at: 1234,
+            process_started_at: Some(1200),
+            process_birth_id: Some("birth-1200".to_string()),
+            lock_id: Some("lock-1".to_string()),
+        }
+    }
+
+    fn running(started_at_secs: Option<u64>) -> ProcessInstanceState {
+        ProcessInstanceState::Running {
+            started_at_secs,
+            birth_id: started_at_secs.map(|started_at| format!("birth-{started_at}")),
         }
     }
 
     #[test]
     fn live_owner_counts_as_held() {
-        let state = classify_lock(Some(&owner(42)), Some(0), |_| Some(true));
+        let state = classify_lock(Some(&owner(42)), Some(0), |_| running(Some(1200)));
 
         assert_eq!(
             state,
@@ -3944,14 +4135,112 @@ mod lock_state_tests {
 
     #[test]
     fn dead_owner_counts_as_stale() {
-        let state = classify_lock(Some(&owner(42)), Some(0), |_| Some(false));
+        let state = classify_lock(Some(&owner(42)), Some(0), |_| {
+            ProcessInstanceState::NotRunning
+        });
 
         assert_eq!(state, ProviderSyncLockState::Stale { pid: Some(42) });
     }
 
     #[test]
-    fn unknown_liveness_is_treated_as_held_rather_than_stolen() {
-        let state = classify_lock(Some(&owner(42)), Some(9_999), |_| None);
+    fn reused_pid_with_a_different_process_start_is_stale() {
+        let state = classify_lock(Some(&owner(42)), Some(9_999), |_| running(Some(5000)));
+
+        assert_eq!(state, ProviderSyncLockState::Stale { pid: Some(42) });
+    }
+
+    #[test]
+    fn matching_birth_id_tolerates_approximate_unix_start_time_drift() {
+        let state = classify_lock(Some(&owner(42)), Some(0), |_| {
+            ProcessInstanceState::Running {
+                started_at_secs: Some(1201),
+                birth_id: Some("birth-1200".to_string()),
+            }
+        });
+
+        assert_eq!(
+            state,
+            ProviderSyncLockState::Held {
+                pid: 42,
+                started_at: 1234
+            }
+        );
+    }
+
+    #[test]
+    fn legacy_owner_with_a_much_newer_process_is_stale() {
+        let legacy_owner = ProviderSyncLockOwner {
+            process_started_at: None,
+            process_birth_id: None,
+            lock_id: None,
+            ..owner(42)
+        };
+        let state = classify_lock(
+            Some(&legacy_owner),
+            Some(LEGACY_PID_REUSE_MIN_LOCK_AGE_SECS),
+            |_| {
+                running(Some(
+                    legacy_owner.started_at + LEGACY_PID_REUSE_TOLERANCE_SECS + 1,
+                ))
+            },
+        );
+
+        assert_eq!(state, ProviderSyncLockState::Stale { pid: Some(42) });
+    }
+
+    #[test]
+    fn legacy_owner_keeps_a_process_started_before_the_lock() {
+        let legacy_owner = ProviderSyncLockOwner {
+            process_started_at: None,
+            process_birth_id: None,
+            lock_id: None,
+            ..owner(42)
+        };
+        let state = classify_lock(Some(&legacy_owner), Some(9_999), |_| {
+            running(Some(legacy_owner.started_at - 1))
+        });
+
+        assert_eq!(
+            state,
+            ProviderSyncLockState::Held {
+                pid: 42,
+                started_at: 1234
+            }
+        );
+    }
+
+    #[test]
+    fn recent_legacy_lock_remains_held_even_if_wall_clock_evidence_looks_newer() {
+        let legacy_owner = ProviderSyncLockOwner {
+            process_started_at: None,
+            process_birth_id: None,
+            lock_id: None,
+            ..owner(42)
+        };
+        let state = classify_lock(
+            Some(&legacy_owner),
+            Some(LEGACY_PID_REUSE_MIN_LOCK_AGE_SECS - 1),
+            |_| {
+                running(Some(
+                    legacy_owner.started_at + LEGACY_PID_REUSE_TOLERANCE_SECS + 1,
+                ))
+            },
+        );
+
+        assert_eq!(
+            state,
+            ProviderSyncLockState::Held {
+                pid: 42,
+                started_at: 1234
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_process_identity_is_treated_as_held_rather_than_stolen() {
+        let state = classify_lock(Some(&owner(42)), Some(9_999), |_| {
+            ProcessInstanceState::Unknown
+        });
 
         assert_eq!(
             state,
@@ -3964,22 +4253,121 @@ mod lock_state_tests {
 
     #[test]
     fn aged_lock_without_owner_is_recoverable_interrupted_leftover() {
-        let state = classify_lock(None, Some(LOCK_INTERRUPTED_GRACE_SECS), |_| Some(true));
+        let state = classify_lock(None, Some(LOCK_INTERRUPTED_GRACE_SECS), |_| {
+            running(Some(1200))
+        });
 
         assert_eq!(state, ProviderSyncLockState::Stale { pid: None });
     }
 
     #[test]
     fn fresh_lock_without_owner_is_left_alone_for_the_process_still_creating_it() {
-        let state = classify_lock(None, Some(LOCK_INTERRUPTED_GRACE_SECS - 1), |_| Some(true));
+        let state = classify_lock(None, Some(LOCK_INTERRUPTED_GRACE_SECS - 1), |_| {
+            running(Some(1200))
+        });
 
         assert_eq!(state, ProviderSyncLockState::Indeterminate);
     }
 
     #[test]
     fn unreadable_lock_age_is_left_alone() {
-        let state = classify_lock(None, None, |_| Some(true));
+        let state = classify_lock(None, None, |_| running(Some(1200)));
 
         assert_eq!(state, ProviderSyncLockState::Indeterminate);
+    }
+
+    #[test]
+    fn legacy_owner_json_remains_compatible() {
+        let owner: ProviderSyncLockOwner =
+            serde_json::from_str(r#"{"pid":42,"startedAt":1234}"#).unwrap();
+
+        assert_eq!(owner.pid, 42);
+        assert_eq!(owner.started_at, 1234);
+        assert_eq!(owner.process_started_at, None);
+        assert_eq!(owner.process_birth_id, None);
+        assert_eq!(owner.lock_id, None);
+    }
+
+    #[test]
+    fn lifecycle_guard_serializes_and_releases_the_legacy_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let lock_dir = temp.path().join("tmp/provider-sync.lock");
+        let first = acquire_lock_inner(&lock_dir, false).unwrap();
+
+        assert!(lock_dir.join("owner.json").is_file());
+        let error = acquire_lock_inner(&lock_dir, false).unwrap_err();
+        assert!(
+            matches!(
+                error.kind(),
+                std::io::ErrorKind::AlreadyExists | std::io::ErrorKind::WouldBlock
+            ),
+            "unexpected lock contention error: {error:?}; raw={:?}",
+            error.raw_os_error()
+        );
+
+        drop(first);
+        assert!(!lock_dir.exists());
+        let second = acquire_lock_inner(&lock_dir, false).unwrap();
+        drop(second);
+        assert!(!lock_dir.exists());
+    }
+
+    #[test]
+    fn a_guard_cannot_remove_a_directory_owned_by_another_lock_id() {
+        let temp = tempfile::tempdir().unwrap();
+        let lock_dir = temp.path().join("tmp/provider-sync.lock");
+        let guard = acquire_lock_inner(&lock_dir, false).unwrap();
+
+        assert!(!release_owned_lock(&lock_dir, "not-the-owner").unwrap());
+        assert!(lock_dir.join("owner.json").is_file());
+
+        drop(guard);
+        assert!(!lock_dir.exists());
+    }
+
+    #[test]
+    fn explicit_release_rejects_changed_directory_ownership() {
+        let temp = tempfile::tempdir().unwrap();
+        let lock_dir = temp.path().join("tmp/provider-sync.lock");
+        let guard = acquire_lock_inner(&lock_dir, false).unwrap();
+        fs::write(
+            lock_dir.join("owner.json"),
+            json!({
+                "pid": std::process::id(),
+                "startedAt": now_secs(),
+                "lockId": "replacement-owner",
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let error = guard.release().unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert!(lock_dir.exists());
+    }
+
+    #[test]
+    fn os_lock_authoritatively_recovers_an_orphaned_new_protocol_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let lock_dir = temp.path().join("tmp/provider-sync.lock");
+        let guard = acquire_lock_inner(&lock_dir, false).unwrap();
+        fs::write(
+            lock_dir.join("owner.json"),
+            json!({
+                "pid": std::process::id(),
+                "startedAt": now_secs(),
+                "lockId": "orphaned-owner",
+            })
+            .to_string(),
+        )
+        .unwrap();
+        drop(guard);
+        assert!(lock_dir.exists());
+
+        let recovered = acquire_lock_inner(&lock_dir, false).unwrap();
+        recovered.release().unwrap();
+
+        assert!(!lock_dir.exists());
     }
 }

--- a/crates/codex-plus-data/tests/provider_sync.rs
+++ b/crates/codex-plus-data/tests/provider_sync.rs
@@ -2651,7 +2651,7 @@ fn provider_sync_recovers_lock_owned_by_dead_process() {
             .unwrap()
             .contains("provider_sync.stale_lock_recovered")
     );
-    assert!(fs::read_dir(home.join("tmp")).unwrap().next().is_none());
+    assert!(home.join("tmp/provider-sync.lifecycle.lock").is_file());
 }
 
 #[test]


### PR DESCRIPTION
## 背景

这是按 #2023 维护者意见拆出的第一个基础 PR。原 PR 同时覆盖 restart、Provider Sync 文件事务、缓存、协议代理和 App 注入，超过 5500 行；本 PR 只保留 Provider Sync 与重启都需要的生命周期锁和进程身份基础。

## 改动

- 使用 OS 文件锁串行化 Provider Sync lifecycle，同时保留旧目录锁协议兼容。
- guard 带唯一 ownership id；显式释放和 Drop 都不会删除已被其他进程接管的锁目录。
- stale 判断绑定进程实例，而不只看 PID：
  - Windows 使用进程创建 FILETIME。
  - macOS/Linux 使用进程启动时间/身份信息，并对不可判定状态保持保守。
- 旧 owner.json、残留目录锁和崩溃后的新协议锁均保持可恢复。
- 上层可通过 try_acquire_provider_sync_lifecycle_guard fail-fast 获取所有权。

## 范围边界

本 PR 不包含：

- Manager restart 编排或停止 Codex App；
- rollout 流式重写、journal、备份/回滚事务；
- unchanged-rollout cache；
- protocol proxy 或 renderer 注入。

后续 restart 与 Provider Sync recovery PR 都将基于这个小型基础，不再复制锁协议。

## 验证

- Provider Sync integration: 43/43
- Core 进程身份测试通过
- Watcher 聚焦测试通过
- git diff --check
- 已重放到最新 main 2a918aa，保留 #2056 的 macOS helper runtime 修复

拆分前的组合构建已在 Windows 11 真人验证；本 PR 的 latest-main 拆分分支完成了上述聚焦自动化验证。