### PR TITLE
fix(app): preserve native typography

### DIFF
--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -104,7 +104,6 @@
     const installationKey = `2:${enabled ? "on" : "off"}:${locale}`;
     if (window.__codexPlusForceChineseLocaleInstalled === installationKey) return;
     window.__codexPlusForceChineseLocaleInstalled = installationKey;
-    const languages = [locale, "zh", "en-US", "en"];
     const managedLocaleStorageKey = "codexPlus.forceChineseLocale.managed.v1";
     const localeReloadStorageKey = "codexPlus.forceChineseLocale.reload.v1";
 
@@ -240,26 +239,6 @@
 
     syncOfficialLocaleSetting().catch(() => {});
     if (!enabled) return;
-
-    const defineNavigatorGetter = (name, value) => {
-      try {
-        Object.defineProperty(Navigator.prototype, name, {
-          configurable: true,
-          get: () => value,
-        });
-      } catch {
-        try {
-          Object.defineProperty(navigator, name, {
-            configurable: true,
-            get: () => value,
-          });
-        } catch {
-        }
-      }
-    };
-
-    defineNavigatorGetter("language", locale);
-    defineNavigatorGetter("languages", languages);
 
     const patchI18nConfig = (dynamicConfig) => {
       if (!dynamicConfig || typeof dynamicConfig !== "object") return dynamicConfig;

--- a/crates/codex-plus-core/src/assets.rs
+++ b/crates/codex-plus-core/src/assets.rs
@@ -116,6 +116,7 @@ fn dream_skin_target_runtime_script(settings: &BackendSettings, include_art: boo
     }
 
     let (engine, renderer, base_css) = dream_skin_target_assets(settings);
+    let base_css = preserve_host_typography(base_css);
     let managed_css = managed_dream_skin_css(settings);
     let css = format!("{base_css}\n{managed_css}");
     let theme = serde_json::to_string(&settings.codex_app_dream_skin_theme_config)
@@ -190,6 +191,27 @@ fn dream_skin_target_runtime_script(settings: &BackendSettings, include_art: boo
         serde_json::to_string(&payload_revision).unwrap(),
     );
     payload
+}
+
+fn preserve_host_typography(css: &str) -> String {
+    let mut output = String::with_capacity(css.len());
+    let mut host_body_rule = false;
+    for line in css.split_inclusive('\n') {
+        let trimmed = line.trim();
+        if matches!(
+            trimmed,
+            "html.codex-dream-skin body {" | "html.codex-glass-vision-skin body {"
+        ) {
+            host_body_rule = true;
+        }
+        if !(host_body_rule && trimmed.starts_with("font-family:")) {
+            output.push_str(line);
+        }
+        if host_body_rule && trimmed == "}" {
+            host_body_rule = false;
+        }
+    }
+    output
 }
 
 fn managed_dream_skin_css(settings: &BackendSettings) -> String {
@@ -468,6 +490,9 @@ pub fn dream_skin_art_content_signature(settings: &BackendSettings) -> String {
 
 pub fn dream_skin_runtime_content_signature(settings: &BackendSettings) -> String {
     let (engine, _, css) = dream_skin_target_assets(settings);
+    let css = preserve_host_typography(css);
+    let managed_css = managed_dream_skin_css(settings);
+    let css = format!("{css}\n{managed_css}");
     let theme = serde_json::to_string(&settings.codex_app_dream_skin_theme_config)
         .expect("dream skin target theme should serialize");
     let style_revision = dream_skin_content_signature(css.as_bytes());
@@ -738,6 +763,50 @@ mod tests {
         let config = image_overlay_config(57321, &settings);
 
         assert_eq!(config["fitMode"].as_str(), Some("fill"));
+    }
+
+    #[test]
+    fn dream_skin_preserves_host_body_typography() {
+        let css = concat!(
+            "html.codex-dream-skin body {\n",
+            "  color: white;\n",
+            "  font-family: Example, sans-serif !important;\n",
+            "}\n",
+            "html.codex-dream-skin button {\n",
+            "  font-family: inherit !important;\n",
+            "}\n",
+        );
+
+        let preserved = preserve_host_typography(css);
+
+        assert!(!preserved.contains("font-family: Example"));
+        assert!(preserved.contains("font-family: inherit !important"));
+    }
+
+    #[test]
+    fn bundled_dream_skins_drop_only_the_host_body_font_rule() {
+        for css in [
+            DREAM_TARGET_CSS,
+            CIDALA_TARGET_CSS,
+            CODEX_SNOW_CSS,
+            GLASS_VISION_CSS,
+        ] {
+            let preserved = preserve_host_typography(css);
+
+            assert_eq!(css.lines().count(), preserved.lines().count() + 1);
+        }
+    }
+
+    #[test]
+    fn dream_skin_runtime_signature_matches_the_filtered_payload() {
+        let settings = BackendSettings {
+            codex_app_dream_skin_enabled: true,
+            ..BackendSettings::default()
+        };
+        let signature = dream_skin_runtime_content_signature(&settings);
+        let script = dream_skin_live_update_script(&settings, false);
+
+        assert!(script.contains(&serde_json::to_string(&signature).unwrap()));
     }
 
     #[test]

--- a/crates/codex-plus-core/tests/force_chinese_locale_settings.rs
+++ b/crates/codex-plus-core/tests/force_chinese_locale_settings.rs
@@ -90,6 +90,8 @@ fn injection_script_includes_force_chinese_locale_global_and_patch() {
     assert!(script.contains("window.location.reload()"));
     assert!(script.contains("codexPlus.forceChineseLocale.managed.v1"));
     assert!(!script.contains("setItem(\"localeOverride\""));
+    assert!(!script.contains("defineNavigatorGetter"));
+    assert!(!script.contains("Object.defineProperty(Navigator.prototype"));
 
     settings.codex_app_force_chinese_locale = false;
     let script = injection_script_with_settings(0, &settings);


### PR DESCRIPTION
## 背景

这是从 #2023 的 App 注入补丁中独立拆出的字体保护，不包含默认模型修复。

上游 #2056 已修复 renderer 根样式覆盖和 stale helper runtime，本 PR 保留的是另外两条仍独立存在的字体来源：

1. “强制中文”通过覆盖 Navigator.prototype.language/languages 改变 App 的浏览器语言环境，可能改变字体 fallback。
2. Dream Skin vendored CSS 对 host body 写入全局 font-family。

## 改动

- 强制中文继续使用官方 localeOverride 设置与 Statsig i18n gate，不再覆盖 Navigator 全局 language getters。
- Dream Skin runtime 只过滤 host body 的 font-family，保留作用域内皮肤字体规则。
- runtime payload 与 content signature 使用同一份过滤后 CSS，避免错误重复注入。

## 范围边界

- 不修改 Statsig default_model 或线程模型选择。
- 不涉及 restart、Provider Sync 或 protocol proxy。
- 保留 #2056 的 renderer 根 typography 和 macOS helper runtime 修复。

## 验证

- Manager Node tests: 119/119
- Force Chinese locale: 5/5
- Dream Skin 聚焦测试通过
- git diff --check
- 基于最新 main 2a918aa

拆分前组合构建已在 Windows 11 真人确认原生字体恢复；本 latest-main 小分支完成聚焦自动化验证。