### PR TITLE
fix: stream historical session repair

### DIFF
--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -3268,7 +3268,11 @@ pub async fn sync_providers_now(
             None,
             target_provider.as_deref(),
             |progress| {
-                let _ = progress_window.emit(PROVIDER_SYNC_PROGRESS_EVENT, progress);
+                let _ = progress_window.emit_to(
+                    progress_window.label(),
+                    PROVIDER_SYNC_PROGRESS_EVENT,
+                    progress,
+                );
             },
         )
     })

--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -18,6 +18,7 @@ use codex_plus_core::user_scripts::UserScriptManager;
 use codex_plus_core::zed_remote::{ZedOpenStrategy, ZedRemoteProject};
 use serde::Serialize;
 use serde_json::{Value, json};
+use tauri::Emitter;
 
 use crate::install::{self, InstallActionResult, InstallOptions};
 
@@ -3233,8 +3234,13 @@ pub async fn apply_session_index_cleanup(
     }
 }
 
+const PROVIDER_SYNC_PROGRESS_EVENT: &str = "provider-sync-progress";
+
 #[tauri::command]
-pub async fn sync_providers_now(target_provider: Option<String>) -> CommandResult<Value> {
+pub async fn sync_providers_now(
+    window: tauri::WebviewWindow,
+    target_provider: Option<String>,
+) -> CommandResult<Value> {
     let target_provider = target_provider
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
@@ -3256,8 +3262,15 @@ pub async fn sync_providers_now(target_provider: Option<String>) -> CommandResul
     let target_for_settings = target_provider.clone();
     let home = codex_plus_core::relay_config::default_codex_home_dir();
     prepare_codex_app_state_before_provider_switch(&home, "manager.sync_providers_now.before");
+    let progress_window = window.clone();
     let result = tauri::async_runtime::spawn_blocking(move || {
-        codex_plus_data::run_provider_sync_with_target(None, target_provider.as_deref())
+        codex_plus_data::run_provider_sync_with_target_and_progress(
+            None,
+            target_provider.as_deref(),
+            |progress| {
+                let _ = progress_window.emit(PROVIDER_SYNC_PROGRESS_EVENT, progress);
+            },
+        )
     })
     .await
     .map_err(|error| anyhow::anyhow!("provider sync task failed: {error}"));

--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -113,7 +113,12 @@ import {
 } from "./model-windows";
 import { clampAggregateRoutePriority, normalizeAggregateRoutes, validateAggregateRoutes } from "./aggregate-routes";
 import { relayAuthForLiveDraft, shouldBackfillRelayProfileBeforeSwitch } from "./relay-live-files";
-import { resolveProviderSyncCompletion } from "./provider-sync-flow";
+import { resolveProviderName } from "./provider-name";
+import {
+  providerSyncStreamPercent,
+  resolveProviderSyncCompletion,
+  type ProviderSyncStreamProgress,
+} from "./provider-sync-flow";
 import { isProviderSyncTargetSelectable, preferredProviderSyncTarget } from "./provider-sync-target";
 import { resolveLaunchStatus } from "./launch-status";
 import {
@@ -2529,21 +2534,29 @@ export function App() {
     if (providerSyncProgress.active) return;
     setProviderSyncProgress({
       active: true,
-      percent: 12,
-      message: selectedProviderSyncTarget ? tf("正在同步到 {0}…", [selectedProviderSyncTarget]) : t("正在扫描历史会话与索引…"),
+      percent: 0,
+      message: t("正在扫描历史会话与索引…"),
       result: null,
     });
-    const progressTimer = window.setInterval(() => {
-      setProviderSyncProgress((current) => {
-        if (!current.active) return current;
-        return {
-          ...current,
-          percent: Math.min(88, current.percent + 8),
-          message: current.percent < 40 ? t("正在检查会话 provider 标记…") : t("正在写入修复与备份…"),
-        };
-      });
-    }, 350);
+    let unlisten: (() => void) | undefined;
     try {
+      unlisten = await listen<ProviderSyncStreamProgress>("provider-sync-progress", (event) => {
+        const progress = event.payload;
+        const message =
+          progress.phase === "scanning"
+            ? t("正在扫描历史会话与索引…")
+            : progress.phase === "planning"
+              ? t("正在检查会话 provider 标记…")
+              : t("正在写入修复与备份…");
+        setProviderSyncProgress((current) => {
+          if (!current.active) return current;
+          return {
+            ...current,
+            percent: Math.max(current.percent, providerSyncStreamPercent(progress)),
+            message,
+          };
+        });
+      });
       const targetProvider = selectedProviderSyncTarget || undefined;
       const result = await run(() =>
         call<CommandResult<ProviderSyncPayload>>("sync_providers_now", { targetProvider }),
@@ -2630,8 +2643,17 @@ export function App() {
           result: null,
         });
       }
+    } catch (error) {
+      const message = stringifyError(error);
+      setProviderSyncProgress({
+        active: false,
+        percent: 100,
+        message,
+        result: null,
+      });
+      showNotice(t("历史会话修复"), message, "failed");
     } finally {
-      window.clearInterval(progressTimer);
+      unlisten?.();
     }
   };
 

--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -2542,12 +2542,24 @@ export function App() {
     try {
       unlisten = await listen<ProviderSyncStreamProgress>("provider-sync-progress", (event) => {
         const progress = event.payload;
-        const message =
-          progress.phase === "scanning"
-            ? t("正在扫描历史会话与索引…")
-            : progress.phase === "planning"
-              ? t("正在检查会话 provider 标记…")
-              : t("正在写入修复与备份…");
+        const message = (() => {
+          switch (progress.phase) {
+            case "scanning":
+              return t("正在扫描历史会话与索引…");
+            case "planning":
+              return t("正在检查会话 provider 标记…");
+            case "backing_up":
+              return t("正在创建修复备份…");
+            case "rewriting":
+              return t("正在写入会话修复…");
+            case "updating_indexes":
+              return t("正在更新会话索引…");
+            case "rolling_back":
+              return t("正在回滚已写入的会话…");
+            case "complete":
+              return t("正在完成历史会话修复…");
+          }
+        })();
         setProviderSyncProgress((current) => {
           if (!current.active) return current;
           return {

--- a/apps/codex-plus-manager/src/provider-sync-flow.test.ts
+++ b/apps/codex-plus-manager/src/provider-sync-flow.test.ts
@@ -1,7 +1,56 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { resolveProviderSyncCompletion } from "./provider-sync-flow.ts";
+import {
+  providerSyncStreamPercent,
+  resolveProviderSyncCompletion,
+  type ProviderSyncStreamProgress,
+} from "./provider-sync-flow.ts";
+
+function progress(
+  phase: ProviderSyncStreamProgress["phase"],
+  overrides: Partial<ProviderSyncStreamProgress> = {},
+): ProviderSyncStreamProgress {
+  return {
+    phase,
+    totalRolloutFiles: 10,
+    scannedRolloutFiles: 0,
+    plannedRewriteFiles: 4,
+    appliedRewriteFiles: 0,
+    skippedLockedRolloutFiles: 0,
+    ...overrides,
+  };
+}
+
+test("provider sync stream progress maps scanning counts into the scan range", () => {
+  assert.equal(providerSyncStreamPercent(progress("scanning")), 0);
+  assert.equal(providerSyncStreamPercent(progress("scanning", { scannedRolloutFiles: 5 })), 22.5);
+  assert.equal(providerSyncStreamPercent(progress("scanning", { scannedRolloutFiles: 10 })), 45);
+});
+
+test("provider sync stream progress maps rewrite counts into the write range", () => {
+  assert.equal(providerSyncStreamPercent(progress("rewriting")), 60);
+  assert.equal(providerSyncStreamPercent(progress("rewriting", { appliedRewriteFiles: 2 })), 74);
+  assert.equal(providerSyncStreamPercent(progress("rewriting", { appliedRewriteFiles: 4 })), 88);
+});
+
+test("provider sync stream progress handles zero totals without NaN", () => {
+  const scanning = providerSyncStreamPercent(progress("scanning", { totalRolloutFiles: 0 }));
+  const rewriting = providerSyncStreamPercent(progress("rewriting", { plannedRewriteFiles: 0 }));
+
+  assert.equal(scanning, 45);
+  assert.equal(rewriting, 88);
+  assert.ok(Number.isFinite(scanning));
+  assert.ok(Number.isFinite(rewriting));
+});
+
+test("provider sync stream progress maps fixed phases and completion", () => {
+  assert.equal(providerSyncStreamPercent(progress("planning")), 50);
+  assert.equal(providerSyncStreamPercent(progress("backing_up")), 55);
+  assert.equal(providerSyncStreamPercent(progress("updating_indexes")), 92);
+  assert.equal(providerSyncStreamPercent(progress("rolling_back")), 96);
+  assert.equal(providerSyncStreamPercent(progress("complete")), 100);
+});
 
 test("provider sync success remains the final visible result when cleanup succeeds", () => {
   const syncResult = { status: "ok", message: "sync complete", changedSessionFiles: 2 };

--- a/apps/codex-plus-manager/src/provider-sync-flow.ts
+++ b/apps/codex-plus-manager/src/provider-sync-flow.ts
@@ -3,6 +3,47 @@ export type ProviderSyncNoticeResult = {
   message: string;
 };
 
+export type ProviderSyncStreamProgress = {
+  phase:
+    | "scanning"
+    | "planning"
+    | "backing_up"
+    | "rewriting"
+    | "updating_indexes"
+    | "rolling_back"
+    | "complete";
+  totalRolloutFiles: number;
+  scannedRolloutFiles: number;
+  plannedRewriteFiles: number;
+  appliedRewriteFiles: number;
+  skippedLockedRolloutFiles: number;
+};
+
+function boundedPercent(value: number, total: number, start: number, end: number): number {
+  if (!Number.isFinite(total) || total <= 0) return end;
+  const completed = Number.isFinite(value) ? Math.min(Math.max(value, 0), total) : 0;
+  return Math.min(100, Math.max(0, start + ((end - start) * completed) / total));
+}
+
+export function providerSyncStreamPercent(progress: ProviderSyncStreamProgress): number {
+  switch (progress.phase) {
+    case "scanning":
+      return boundedPercent(progress.scannedRolloutFiles, progress.totalRolloutFiles, 0, 45);
+    case "planning":
+      return 50;
+    case "backing_up":
+      return 55;
+    case "rewriting":
+      return boundedPercent(progress.appliedRewriteFiles, progress.plannedRewriteFiles, 60, 88);
+    case "updating_indexes":
+      return 92;
+    case "rolling_back":
+      return 96;
+    case "complete":
+      return 100;
+  }
+}
+
 export function resolveProviderSyncCompletion<T extends ProviderSyncNoticeResult>(
   syncResult: T,
   cleanupFailure: ProviderSyncNoticeResult | null,

--- a/crates/codex-plus-core/src/env_conflicts.rs
+++ b/crates/codex-plus-core/src/env_conflicts.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use std::ffi::OsString;
 use std::path::PathBuf;
 
 const WINDOWS_USER_ENV_KEY: &str = "Environment";
@@ -68,7 +69,7 @@ where
 
 pub fn detect_env_conflicts() -> Vec<EnvConflict> {
     let mut conflicts =
-        detected_env_conflicts_from_pairs(std::env::vars(), EnvConflictSource::Process);
+        detected_env_conflicts_from_os_pairs(std::env::vars_os(), EnvConflictSource::Process);
     conflicts.extend(detect_user_env_conflicts());
     conflicts.sort_by(|left, right| {
         left.name
@@ -77,6 +78,17 @@ pub fn detect_env_conflicts() -> Vec<EnvConflict> {
     });
     conflicts.dedup_by(|left, right| left.name == right.name && left.source == right.source);
     conflicts
+}
+
+fn detected_env_conflicts_from_os_pairs<I>(pairs: I, source: EnvConflictSource) -> Vec<EnvConflict>
+where
+    I: IntoIterator<Item = (OsString, OsString)>,
+{
+    let pairs = pairs.into_iter().filter_map(|(name, value)| {
+        let name = name.into_string().ok()?;
+        Some((name, value.to_string_lossy().into_owned()))
+    });
+    detected_env_conflicts_from_pairs(pairs, source)
 }
 
 pub fn remove_env_conflicts(
@@ -228,5 +240,26 @@ mod tests {
             ]),
             vec!["OPENAI_API_KEY", "OPENAI_BASE_URL"]
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn os_pairs_ignore_non_unicode_names_and_tolerate_non_unicode_values() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let conflicts = detected_env_conflicts_from_os_pairs(
+            [
+                (
+                    OsString::from("OPENAI_API_KEY"),
+                    OsString::from_vec(vec![b's', b'k', b'-', 0xFF]),
+                ),
+                (OsString::from_vec(vec![0xFF]), OsString::from("ignored")),
+            ],
+            EnvConflictSource::Process,
+        );
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].name, "OPENAI_API_KEY");
+        assert!(conflicts[0].value_present);
     }
 }

--- a/crates/codex-plus-core/src/model_catalog.rs
+++ b/crates/codex-plus-core/src/model_catalog.rs
@@ -50,7 +50,12 @@ pub async fn read_codex_model_catalog() -> Value {
             }
         }
     }
-    let env = std::env::vars().collect::<HashMap<_, _>>();
+    let env = std::env::vars_os()
+        .filter_map(|(name, value)| {
+            let name = name.into_string().ok()?;
+            Some((name, value.to_string_lossy().into_owned()))
+        })
+        .collect::<HashMap<_, _>>();
     let client = match crate::http_client::proxied_client("CodexPlusPlus/1.0") {
         Ok(client) => client,
         Err(error) => {

--- a/crates/codex-plus-core/src/relay_environment.rs
+++ b/crates/codex-plus-core/src/relay_environment.rs
@@ -174,9 +174,23 @@ where
         .collect()
 }
 
+fn proxy_variables_from_os_pairs<I>(
+    pairs: I,
+    source: ProxyEnvironmentSource,
+) -> Vec<ProxyEnvironmentVariable>
+where
+    I: IntoIterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
+{
+    let pairs = pairs.into_iter().filter_map(|(name, value)| {
+        let name = name.into_string().ok()?;
+        Some((name, value.to_string_lossy().into_owned()))
+    });
+    proxy_variables_from_pairs(pairs, source)
+}
+
 fn detect_proxy_environment_variables() -> Vec<ProxyEnvironmentVariable> {
     let mut variables =
-        proxy_variables_from_pairs(std::env::vars(), ProxyEnvironmentSource::Process);
+        proxy_variables_from_os_pairs(std::env::vars_os(), ProxyEnvironmentSource::Process);
     variables.extend(detect_user_proxy_environment_variables());
     variables.sort_by(|left, right| {
         left.name

--- a/crates/codex-plus-core/src/settings.rs
+++ b/crates/codex-plus-core/src/settings.rs
@@ -1899,6 +1899,10 @@ mod tests {
         path
     }
 
+    fn normalized_default_settings() -> BackendSettings {
+        normalize_settings_config_sections(BackendSettings::default())
+    }
+
     #[test]
     fn atomic_write_replaces_existing_file_and_removes_temp_file() {
         let dir = temp_dir();
@@ -2546,7 +2550,7 @@ experimental_bearer_token = "sk-existing""#
         let dir = temp_dir();
         let store = SettingsStore::new(dir.join("settings.json"));
 
-        assert_eq!(store.load().unwrap(), BackendSettings::default());
+        assert_eq!(store.load().unwrap(), normalized_default_settings());
     }
 
     #[test]
@@ -2556,7 +2560,7 @@ experimental_bearer_token = "sk-existing""#
         std::fs::write(&path, "{bad json").unwrap();
         let store = SettingsStore::new(path);
 
-        assert_eq!(store.load().unwrap(), BackendSettings::default());
+        assert_eq!(store.load().unwrap(), normalized_default_settings());
     }
 
     #[test]
@@ -2570,9 +2574,10 @@ experimental_bearer_token = "sk-existing""#
             ..BackendSettings::default()
         };
 
+        let expected = normalize_settings_config_sections(settings.clone());
         store.save(&settings).unwrap();
 
-        assert_eq!(store.load().unwrap(), settings);
+        assert_eq!(store.load().unwrap(), expected);
     }
 
     #[test]

--- a/crates/codex-plus-core/src/settings.rs
+++ b/crates/codex-plus-core/src/settings.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
-use std::fs;
+use std::fs::{self, File};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
@@ -1788,14 +1789,41 @@ fn normalize_text_config(contents: String) -> String {
 }
 
 pub fn atomic_write(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+    atomic_write_with(path, |file| file.write_all(bytes))
+}
+
+pub fn atomic_write_with(
+    path: &Path,
+    write_contents: impl FnOnce(&mut File) -> std::io::Result<()>,
+) -> anyhow::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("failed to create directory {}", parent.display()))?;
     }
 
+    let existing_permissions = match fs::metadata(path) {
+        Ok(metadata) => Some(metadata.permissions()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to read permissions for {}", path.display()));
+        }
+    };
     let temp_path = temp_path_for(path);
-    fs::write(&temp_path, bytes)
-        .with_context(|| format!("failed to write temp file {}", temp_path.display()))?;
+    let write_result = (|| -> std::io::Result<()> {
+        let mut temp_file = File::create(&temp_path)?;
+        write_contents(&mut temp_file)?;
+        temp_file.flush()?;
+        if let Some(permissions) = existing_permissions {
+            temp_file.set_permissions(permissions)?;
+        }
+        Ok(())
+    })();
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&temp_path);
+        return Err(error)
+            .with_context(|| format!("failed to write temp file {}", temp_path.display()));
+    }
     if let Err(error) = replace_file(&temp_path, path) {
         let _ = fs::remove_file(&temp_path);
         return Err(error).with_context(|| {
@@ -1881,6 +1909,46 @@ mod tests {
 
         assert_eq!(std::fs::read(&path).unwrap(), b"new");
         assert!(!dir.join("settings.json.tmp").exists());
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn atomic_write_with_streams_chunks_and_keeps_existing_contents_on_error() {
+        let dir = temp_dir();
+        let path = dir.join("settings.json");
+        std::fs::write(&path, b"old").unwrap();
+
+        atomic_write_with(&path, |file| {
+            file.write_all(b"new")?;
+            file.write_all(b"-value")
+        })
+        .unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"new-value");
+
+        let error =
+            atomic_write_with(&path, |_| Err(std::io::Error::other("writer failed"))).unwrap_err();
+        assert!(error.to_string().contains("failed to write temp file"));
+        assert_eq!(std::fs::read(&path).unwrap(), b"new-value");
+        assert!(!dir.join("settings.json.tmp").exists());
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_with_preserves_existing_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = temp_dir();
+        let path = dir.join("settings.json");
+        std::fs::write(&path, b"old").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        atomic_write_with(&path, |file| file.write_all(b"new")).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
         std::fs::remove_dir_all(dir).unwrap();
     }
 

--- a/crates/codex-plus-core/src/vision.rs
+++ b/crates/codex-plus-core/src/vision.rs
@@ -2846,19 +2846,28 @@ mod tests {
         assert!(outcome.http_code.is_none());
     }
 
-    /// 连接错误（非超时）→ send_error。
-    /// 用端口 0：Windows 安全软件可能让「连接被拒」延迟 ~2s 才返回，恰好撞上
-    /// cfg(test) 的 2s 请求超时而被误判为 timeout；连接端口 0 则立即报
-    /// 传输层错误（WSAEADDRNOTAVAIL），确定性地走 send_error 路径。
+    /// 对端在建立 TCP 连接后立刻关闭，稳定覆盖传输层 send_error 分支。
+    /// 这里不能直接请求未监听端口：macOS 可能把它报成 timeout，HTTP 代理也可能
+    /// 返回自己的错误页并把结果变成 http_error，二者都不再是在测客户端传输失败。
     #[tokio::test]
-    async fn test_vlm_once_send_error_on_connection_refused() {
-        let client = reqwest::Client::new();
+    async fn test_vlm_once_send_error_when_peer_closes_connection() {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let address = listener.local_addr().unwrap();
+        // 接受一次连接后立刻丢弃 TCP 流，模拟已建立连接的对端异常关闭。
+        let close_peer = tokio::spawn(async move {
+            let _ = listener.accept().await.unwrap();
+        });
+        // 测试必须绕过开发机/CI 的代理设置，否则 loopback 请求可能被代理接管。
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
         let outcome = test_vlm_once(
-            &test_vlm_config("http://127.0.0.1:0".to_string()),
+            &test_vlm_config(format!("http://{address}")),
             "data:image/png;base64,QUJD",
             &client,
         )
         .await;
+        close_peer.await.unwrap();
         assert_eq!(outcome.status, "send_error");
         assert!(outcome.http_code.is_none());
         assert!(outcome.raw_request.is_some());

--- a/crates/codex-plus-data/src/lib.rs
+++ b/crates/codex-plus-data/src/lib.rs
@@ -6,14 +6,14 @@ pub mod storage;
 pub use backup::BackupStore;
 pub use markdown::{MarkdownExportService, export_markdown_from_paths};
 pub use provider_sync::{
-    ProviderSyncAudit, ProviderSyncLifecycleGuard, ProviderSyncLockState, ProviderSyncResult,
-    ProviderSyncStatus, ProviderSyncTargetList, ProviderSyncTargetOption, ProviderSyncTargetSource,
-    SessionIndexCleanupApplyError, SessionIndexCleanupCandidate, SessionIndexCleanupPreview,
-    SessionIndexCleanupResult, apply_session_index_cleanup, inspect_provider_sync_lock,
-    load_provider_sync_targets, preview_session_index_cleanup,
-    remove_thread_sidebar_references, ThreadSidebarCleanupResult,
+    ProviderSyncAudit, ProviderSyncLifecycleGuard, ProviderSyncLockState, ProviderSyncProgress,
+    ProviderSyncProgressPhase, ProviderSyncResult, ProviderSyncStatus, ProviderSyncTargetList,
+    ProviderSyncTargetOption, ProviderSyncTargetSource, SessionIndexCleanupApplyError,
+    SessionIndexCleanupCandidate, SessionIndexCleanupPreview, SessionIndexCleanupResult,
+    apply_session_index_cleanup, inspect_provider_sync_lock, load_provider_sync_targets,
+    preview_session_index_cleanup, remove_thread_sidebar_references, ThreadSidebarCleanupResult,
     remote_control_session_recovery_candidate_exists, run_provider_sync,
-    run_provider_sync_with_target,
+    run_provider_sync_with_target, run_provider_sync_with_target_and_progress,
     run_remote_control_session_catalog_recovery_for_thread_with_target,
     run_remote_control_session_finalization_for_thread_with_target,
     try_acquire_provider_sync_lifecycle_guard, validate_provider_sync_target,

--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -5209,14 +5209,23 @@ fn timestamp_expr(columns: &HashSet<String>, ms_column: &str, seconds_column: &s
     }
 }
 
-fn load_global_state(path: &Path) -> anyhow::Result<Map<String, Value>> {
-    if !path.exists() {
-        return Ok(Map::new());
-    }
-    Ok(serde_json::from_str::<Value>(&fs::read_to_string(path)?)?
+fn global_state_snapshot(path: &Path) -> anyhow::Result<(Vec<u8>, Map<String, Value>)> {
+    let bytes = match fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok((Vec::new(), Map::new()));
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let state = serde_json::from_slice::<Value>(&bytes)?
         .as_object()
         .cloned()
-        .unwrap_or_default())
+        .unwrap_or_default();
+    Ok((bytes, state))
+}
+
+fn load_global_state(path: &Path) -> anyhow::Result<Map<String, Value>> {
+    Ok(global_state_snapshot(path)?.1)
 }
 
 fn load_projectless_thread_ids(path: &Path) -> anyhow::Result<HashSet<String>> {
@@ -5316,7 +5325,7 @@ fn count_global_state_updates(path: &Path) -> anyhow::Result<usize> {
 }
 
 fn apply_global_state_update(path: &Path) -> anyhow::Result<usize> {
-    let mut state = load_global_state(path)?;
+    let (original_bytes, mut state) = global_state_snapshot(path)?;
     let next = normalized_global_state(&state);
     let count = next
         .iter()
@@ -5326,13 +5335,32 @@ fn apply_global_state_update(path: &Path) -> anyhow::Result<usize> {
         for (key, value) in next {
             state.insert(key, value);
         }
-        let text = serde_json::to_string_pretty(&Value::Object(state))?;
-        fs::write(path, &text)?;
-        if let Some(parent) = path.parent() {
-            fs::write(parent.join(".codex-global-state.json.bak"), text)?;
-        }
+        write_global_state_if_unchanged(path, &original_bytes, &state)?;
     }
     Ok(count)
+}
+
+const GLOBAL_STATE_SOURCE_CHANGED_ERROR: &str =
+    "global state changed while provider sync was being written";
+
+fn write_global_state_if_unchanged(
+    path: &Path,
+    original_bytes: &[u8],
+    state: &Map<String, Value>,
+) -> anyhow::Result<()> {
+    // 会话删除/撤销也会更新此文件；不得用过期的 provider-sync 快照覆盖新侧边栏条目。
+    if global_state_snapshot(path)?.0 != original_bytes {
+        anyhow::bail!(GLOBAL_STATE_SOURCE_CHANGED_ERROR);
+    }
+    let text = serde_json::to_string_pretty(&Value::Object(state.clone()))?;
+    codex_plus_core::settings::atomic_write(path, text.as_bytes())?;
+    if let Some(parent) = path.parent() {
+        codex_plus_core::settings::atomic_write(
+            &parent.join(".codex-global-state.json.bak"),
+            text.as_bytes(),
+        )?;
+    }
+    Ok(())
 }
 
 fn path_array(value: &Value) -> Vec<String> {
@@ -5555,6 +5583,69 @@ mod rollback_tests {
             .chain()
             .any(|cause| cause.to_string().contains("rollout rollback hash mismatch")));
         assert_eq!(fs::read(&rollout).unwrap(), rewritten.into_bytes());
+    }
+}
+
+#[cfg(test)]
+mod global_state_tests {
+    use super::*;
+
+    #[test]
+    fn provider_sync_global_state_update_preserves_thread_sidebar_entries() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(".codex-global-state.json");
+        let original = json!({
+            "electron-saved-workspace-roots": ["\\\\?\\C:\\workspace"],
+            "projectless-thread-ids": ["thread-1"],
+            "thread-workspace-root-hints": {"thread-1": "C:/keep"},
+            "electron-persisted-atom-state": {
+                "thread-client-id-v1:thread-1": {"title": "keep"}
+            }
+        });
+        fs::write(&path, serde_json::to_vec(&original).unwrap()).unwrap();
+
+        assert_eq!(apply_global_state_update(&path).unwrap(), 1);
+
+        let updated: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(updated["projectless-thread-ids"], original["projectless-thread-ids"]);
+        assert_eq!(
+            updated["thread-workspace-root-hints"],
+            original["thread-workspace-root-hints"]
+        );
+        assert_eq!(
+            updated["electron-persisted-atom-state"],
+            original["electron-persisted-atom-state"]
+        );
+    }
+
+    #[test]
+    fn global_state_write_refuses_to_overwrite_newer_sidebar_entries() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(".codex-global-state.json");
+        fs::write(
+            &path,
+            serde_json::to_vec(&json!({
+                "electron-saved-workspace-roots": ["C:/old"]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let (original_bytes, mut state) = global_state_snapshot(&path).unwrap();
+        state.insert(
+            "electron-saved-workspace-roots".to_string(),
+            json!(["C:/normalized"]),
+        );
+        let newer_sidebar_state = json!({
+            "projectless-thread-ids": ["thread-1"],
+            "thread-workspace-root-hints": {"thread-1": "C:/keep"}
+        });
+        let newer_sidebar_bytes = serde_json::to_vec(&newer_sidebar_state).unwrap();
+        fs::write(&path, &newer_sidebar_bytes).unwrap();
+
+        let error = write_global_state_if_unchanged(&path, &original_bytes, &state).unwrap_err();
+
+        assert!(error.to_string().contains(GLOBAL_STATE_SOURCE_CHANGED_ERROR));
+        assert_eq!(fs::read(&path).unwrap(), newer_sidebar_bytes);
     }
 }
 

--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -340,9 +340,6 @@ struct SessionChange {
     original_text: String,
     next_text: String,
     original_session_meta_lines: Vec<String>,
-    thread_id: Option<String>,
-    cwd: Option<String>,
-    has_user_event: bool,
     rewrite_needed: bool,
     original_mtime: Option<SystemTime>,
 }
@@ -352,7 +349,6 @@ struct RolloutRewrite {
     next_text: String,
     rewrite_needed: bool,
     thread_id: Option<String>,
-    cwd: Option<String>,
     providers: Vec<String>,
     original_session_meta_lines: Vec<String>,
     session_meta_count: usize,
@@ -363,7 +359,6 @@ struct SessionChanges {
     changes: Vec<SessionChange>,
     skipped_locked_rollout_files: Vec<PathBuf>,
     encrypted_content_counts: HashMap<String, usize>,
-    subagent_thread_ids: HashSet<String>,
 }
 
 #[derive(Debug, Default)]
@@ -421,8 +416,6 @@ struct SessionIndexPlan {
     path: PathBuf,
     original_bytes: Vec<u8>,
     original_text: String,
-    snapshot_sha256: String,
-    candidates: Vec<SessionIndexCleanupCandidate>,
 }
 
 #[derive(Debug, Clone)]
@@ -2128,7 +2121,6 @@ fn collect_session_change_for_path(
     if rewrite.session_meta_count == 0 || rewrite.thread_id.as_deref() != Some(thread_id) {
         return Ok(collected);
     }
-    let has_user_event = text.contains("\"user_message\"") || text.contains("\"user_input\"");
     if text.contains("encrypted_content") {
         for provider in &rewrite.providers {
             *collected
@@ -2145,9 +2137,6 @@ fn collect_session_change_for_path(
         original_text: text,
         next_text: rewrite.next_text,
         original_session_meta_lines: rewrite.original_session_meta_lines,
-        thread_id: rewrite.thread_id,
-        cwd: rewrite.cwd,
-        has_user_event,
         rewrite_needed: rewrite.rewrite_needed,
         original_mtime,
     });
@@ -2165,59 +2154,6 @@ fn rollout_file_matches_provider(
     Ok(rollout_thread_id == thread_id
         && !providers.is_empty()
         && providers.iter().all(|provider| provider == target_provider))
-}
-
-fn rewrite_rollout_session_meta_providers(
-    text: &str,
-    target_provider: &str,
-) -> anyhow::Result<RolloutRewrite> {
-    let mut rewrite = RolloutRewrite::default();
-    for segment in text.split_inclusive('\n') {
-        let (line, line_ending) = split_line_ending(segment);
-        let mut next_line = line.to_string();
-        if !line.trim().is_empty() {
-            if let Ok(mut record) = serde_json::from_str::<Value>(line) {
-                if record.get("type").and_then(Value::as_str) == Some("session_meta") {
-                    let Some(payload) = record.get_mut("payload").and_then(Value::as_object_mut)
-                    else {
-                        rewrite.next_text.push_str(&next_line);
-                        rewrite.next_text.push_str(line_ending);
-                        continue;
-                    };
-                    rewrite.session_meta_count += 1;
-                    rewrite.original_session_meta_lines.push(line.to_string());
-                    if rewrite.thread_id.is_none() {
-                        rewrite.thread_id = payload
-                            .get("id")
-                            .and_then(Value::as_str)
-                            .map(ToString::to_string);
-                    }
-                    if rewrite.cwd.is_none() {
-                        rewrite.cwd = payload
-                            .get("cwd")
-                            .and_then(Value::as_str)
-                            .and_then(to_desktop_workspace_path);
-                    }
-                    let provider = payload
-                        .get("model_provider")
-                        .and_then(Value::as_str)
-                        .unwrap_or("(missing)")
-                        .to_string();
-                    rewrite.providers.push(provider);
-                    if payload.get("model_provider").and_then(Value::as_str)
-                        != Some(target_provider)
-                    {
-                        payload.insert("model_provider".to_string(), json!(target_provider));
-                        next_line = serde_json::to_string(&record)?;
-                        rewrite.rewrite_needed = true;
-                    }
-                }
-            }
-        }
-        rewrite.next_text.push_str(&next_line);
-        rewrite.next_text.push_str(line_ending);
-    }
-    Ok(rewrite)
 }
 
 fn rewrite_rollout_session_meta_providers_for_threads(
@@ -2265,12 +2201,6 @@ fn rewrite_rollout_session_meta_providers_for_threads(
                     };
                     rewrite.session_meta_count += 1;
                     rewrite.original_session_meta_lines.push(line.to_string());
-                    if rewrite.cwd.is_none() {
-                        rewrite.cwd = payload
-                            .get("cwd")
-                            .and_then(Value::as_str)
-                            .and_then(to_desktop_workspace_path);
-                    }
                     let provider = payload
                         .get("model_provider")
                         .and_then(Value::as_str)
@@ -2693,10 +2623,8 @@ pub fn remove_session_index_entry(
     let original_text = String::from_utf8(original_bytes.clone())?;
     let plan = SessionIndexPlan {
         path,
-        snapshot_sha256: sha256_hex(&original_bytes),
         original_bytes,
         original_text,
-        candidates: Vec::new(),
     };
     let selected_ids = HashSet::from([thread_id.to_string()]);
     let (next_text, removed_entries) = filtered_session_index_text(&plan, &selected_ids);
@@ -3593,6 +3521,18 @@ fn apply_bulk_session_rewrite_plans(
                 applied.skipped_locked_rollout_files.push(plan.path.clone());
             }
             Err(error) => {
+                if !applied.changes.is_empty() {
+                    report_provider_sync_progress(
+                        report_progress,
+                        ProviderSyncProgressPhase::RollingBack,
+                        total_rollout_files,
+                        total_rollout_files,
+                        rewrite_plans.len(),
+                        applied.changes.len(),
+                        scanned_skipped_rollout_files
+                            + applied.skipped_locked_rollout_files.len(),
+                    );
+                }
                 if let Err(restore_error) = restore_bulk_session_rewrites(&applied.changes) {
                     return Err(anyhow::anyhow!(
                         "{error}; rollout rollback failed: {restore_error}"
@@ -3704,8 +3644,18 @@ fn stream_rewrite_rollout_session_meta_providers<W: Write>(
 }
 
 fn restore_bulk_session_rewrites(changes: &[AppliedBulkSessionRewrite]) -> anyhow::Result<()> {
+    let mut restore_errors = Vec::new();
     for change in changes.iter().rev() {
-        restore_bulk_session_rewrite(change)?;
+        if let Err(error) = restore_bulk_session_rewrite(change) {
+            restore_errors.push(format!("{}: {error:#}", change.plan.path.display()));
+        }
+    }
+    if !restore_errors.is_empty() {
+        return Err(anyhow::anyhow!(
+            "failed to restore {} rollout file(s): {}",
+            restore_errors.len(),
+            restore_errors.join("; ")
+        ));
     }
     Ok(())
 }
@@ -3718,7 +3668,6 @@ fn restore_bulk_session_rewrite(change: &AppliedBulkSessionRewrite) -> anyhow::R
         ));
     }
 
-    let mut restored_sha256 = None;
     codex_plus_core::settings::atomic_write_with(&change.plan.path, |file| {
         let mut writer = HashingWriter::new(BufWriter::new(file));
         let source_sha256 = stream_restore_rollout_session_meta_lines(
@@ -3732,15 +3681,11 @@ fn restore_bulk_session_rewrite(change: &AppliedBulkSessionRewrite) -> anyhow::R
         {
             return Err(std::io::Error::other(BULK_SESSION_SOURCE_CHANGED_ERROR));
         }
-        restored_sha256 = Some(writer.sha256_hex());
+        if writer.sha256_hex() != change.plan.original_sha256 {
+            return Err(std::io::Error::other("rollout rollback hash mismatch"));
+        }
         Ok(())
     })?;
-    if restored_sha256.as_deref() != Some(change.plan.original_sha256.as_str()) {
-        return Err(anyhow::anyhow!(
-            "rollout rollback hash mismatch: {}",
-            change.plan.path.display()
-        ));
-    }
     restore_file_mtime(&change.plan.path, change.plan.original_mtime);
     Ok(())
 }
@@ -3956,19 +3901,6 @@ fn apply_session_changes(changes: &[SessionChange]) -> anyhow::Result<AppliedSes
         applied.changes.push(change.clone());
     }
     Ok(applied)
-}
-
-fn restore_session_changes(changes: &[SessionChange]) -> anyhow::Result<()> {
-    for change in changes {
-        if replace_session_text_if_unchanged(
-            &change.path,
-            &change.next_text,
-            &change.original_text,
-        )? {
-            restore_file_mtime(&change.path, change.original_mtime);
-        }
-    }
-    Ok(())
 }
 
 fn replace_session_text_if_unchanged(
@@ -5583,6 +5515,46 @@ mod non_root_agent_tests {
         assert!(!marks_non_root(r#"{"origin":"subagent"}"#));
         assert!(!marks_non_root(r#"{"sub_agent":"#));
         assert!(!marks_non_root("cli"));
+    }
+}
+
+#[cfg(test)]
+mod rollback_tests {
+    use super::*;
+
+    #[test]
+    fn rollback_hash_mismatch_keeps_rewritten_rollout_intact() {
+        let temp = tempfile::tempdir().unwrap();
+        let rollout = temp.path().join("rollout.jsonl");
+        let original_meta =
+            r#"{"type":"session_meta","payload":{"id":"thread-1","model_provider":"openai"}}"#;
+        let rewritten_meta =
+            r#"{"type":"session_meta","payload":{"id":"thread-1","model_provider":"apigather"}}"#;
+        let incorrect_meta =
+            r#"{"type":"session_meta","payload":{"id":"thread-1","model_provider":"incorrect"}}"#;
+        let event = r#"{"type":"event_msg","payload":{"type":"user_message"}}"#;
+        let original = format!("{original_meta}\n{event}\n");
+        let rewritten = format!("{rewritten_meta}\n{event}\n");
+        fs::write(&rollout, original).unwrap();
+        let original_sha256 = sha256_file(&rollout).unwrap();
+        fs::write(&rollout, &rewritten).unwrap();
+        let rewritten_sha256 = sha256_file(&rollout).unwrap();
+        let change = AppliedBulkSessionRewrite {
+            plan: BulkSessionRewritePlan {
+                path: rollout.clone(),
+                original_sha256,
+                original_mtime: None,
+                original_session_meta_lines: vec![incorrect_meta.to_string()],
+            },
+            rewritten_sha256,
+        };
+
+        let error = restore_bulk_session_rewrite(&change).unwrap_err();
+
+        assert!(error
+            .chain()
+            .any(|cause| cause.to_string().contains("rollout rollback hash mismatch")));
+        assert_eq!(fs::read(&rollout).unwrap(), rewritten.into_bytes());
     }
 }
 

--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -6,7 +6,7 @@ use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -14,6 +14,7 @@ const DEFAULT_PROVIDER: &str = "openai";
 const SESSION_DIRS: [&str; 2] = ["sessions", "archived_sessions"];
 const BACKUP_KEEP_COUNT: usize = 5;
 const REMOTE_CONTROL_CREATION_WINDOW_SECS: i64 = 15 * 60;
+const PROVIDER_SYNC_PROGRESS_INTERVAL: usize = 32;
 
 /// `create_lock` 先建目录再写 `owner.json`，两步之间被强杀会留下没有 owner 的锁目录。
 /// 该窗口只有几毫秒，因此超过这个时长仍缺 owner 的锁一定是中断残留，可以安全回收；
@@ -242,6 +243,29 @@ pub struct ProviderSyncResult {
     pub repair_audit: ProviderSyncAudit,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderSyncProgressPhase {
+    Scanning,
+    Planning,
+    BackingUp,
+    Rewriting,
+    UpdatingIndexes,
+    RollingBack,
+    Complete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderSyncProgress {
+    pub phase: ProviderSyncProgressPhase,
+    pub total_rollout_files: usize,
+    pub scanned_rollout_files: usize,
+    pub planned_rewrite_files: usize,
+    pub applied_rewrite_files: usize,
+    pub skipped_locked_rollout_files: usize,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderSyncAudit {
@@ -355,10 +379,55 @@ struct AppliedSessionChanges {
 }
 
 #[derive(Debug, Clone)]
+struct BulkSessionRewritePlan {
+    path: PathBuf,
+    original_sha256: String,
+    original_mtime: Option<SystemTime>,
+    original_session_meta_lines: Vec<String>,
+}
+
+#[derive(Debug, Default)]
+struct BulkSessionScan {
+    rewrite_plans: Vec<BulkSessionRewritePlan>,
+    skipped_locked_rollout_files: Vec<PathBuf>,
+    encrypted_content_counts: HashMap<String, usize>,
+    subagent_thread_ids: HashSet<String>,
+    thread_ids_with_user_events: HashSet<String>,
+    cwd_by_thread_id: HashMap<String, String>,
+    total_rollout_files: usize,
+}
+
+#[derive(Debug, Clone)]
+struct AppliedBulkSessionRewrite {
+    plan: BulkSessionRewritePlan,
+    rewritten_sha256: String,
+}
+
+#[derive(Debug, Default)]
+struct AppliedBulkSessionRewrites {
+    changes: Vec<AppliedBulkSessionRewrite>,
+    skipped_locked_rollout_files: Vec<PathBuf>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionMetaBackupEntry<'a> {
+    path: String,
+    original_session_meta_lines: &'a [String],
+}
+
+#[derive(Debug, Clone)]
 struct SessionIndexPlan {
     path: PathBuf,
     original_bytes: Vec<u8>,
     original_text: String,
+    snapshot_sha256: String,
+    candidates: Vec<SessionIndexCleanupCandidate>,
+}
+
+#[derive(Debug, Clone)]
+struct SessionIndexCleanupPlan {
+    path: PathBuf,
     snapshot_sha256: String,
     candidates: Vec<SessionIndexCleanupCandidate>,
 }
@@ -772,6 +841,14 @@ pub fn run_provider_sync_with_target(
     codex_home: Option<&Path>,
     explicit_target_provider: Option<&str>,
 ) -> ProviderSyncResult {
+    run_provider_sync_with_target_and_progress(codex_home, explicit_target_provider, |_| {})
+}
+
+pub fn run_provider_sync_with_target_and_progress(
+    codex_home: Option<&Path>,
+    explicit_target_provider: Option<&str>,
+    mut report_progress: impl FnMut(ProviderSyncProgress),
+) -> ProviderSyncResult {
     let require_stopped_app = codex_home.is_none();
     let home = codex_home
         .map(Path::to_path_buf)
@@ -872,36 +949,39 @@ where
                 ProviderSyncAudit::default()
             }
         };
-        let collected = collect_session_changes(
+        let scan = scan_bulk_session_rewrites(
             &home,
             &target_provider,
             &thread_kinds.subagent_thread_ids,
             &thread_kinds.explicit_user_thread_ids,
+            &mut report_progress,
         )?;
+        let BulkSessionScan {
+            rewrite_plans,
+            skipped_locked_rollout_files: scanned_skipped_rollout_files,
+            encrypted_content_counts,
+            subagent_thread_ids: scanned_subagent_thread_ids,
+            thread_ids_with_user_events,
+            cwd_by_thread_id: scanned_cwd_by_thread_id,
+            total_rollout_files,
+        } = scan;
         let mut subagent_thread_ids = thread_kinds.subagent_thread_ids;
-        subagent_thread_ids.extend(collected.subagent_thread_ids.iter().cloned());
+        subagent_thread_ids.extend(scanned_subagent_thread_ids);
         let encrypted_content_warning =
-            build_encrypted_content_warning(&collected.encrypted_content_counts, &target_provider);
-        let rewrite_changes = collected
-            .changes
-            .iter()
-            .filter(|change| change.rewrite_needed)
-            .cloned()
-            .collect::<Vec<_>>();
-        let thread_ids_with_user_events = collected
-            .changes
-            .iter()
-            .filter(|change| change.has_user_event)
-            .filter_map(|change| change.thread_id.clone())
-            .collect::<HashSet<_>>();
+            build_encrypted_content_warning(&encrypted_content_counts, &target_provider);
+        report_provider_sync_progress(
+            &mut report_progress,
+            ProviderSyncProgressPhase::Planning,
+            total_rollout_files,
+            total_rollout_files,
+            rewrite_plans.len(),
+            0,
+            scanned_skipped_rollout_files.len(),
+        );
         let projectless_thread_ids =
             load_projectless_thread_ids(&home.join(".codex-global-state.json"))?;
-        let cwd_by_thread_id = collected
-            .changes
-            .iter()
-            .filter_map(|change| Some((change.thread_id.clone()?, change.cwd.clone()?)))
-            .filter(|(thread_id, _)| !projectless_thread_ids.contains(thread_id))
-            .collect::<HashMap<_, _>>();
+        let mut cwd_by_thread_id = scanned_cwd_by_thread_id;
+        cwd_by_thread_id.retain(|thread_id, _| !projectless_thread_ids.contains(thread_id));
         let sqlite_update_count = count_sqlite_updates_for_paths(
             &sqlite_paths,
             &target_provider,
@@ -913,7 +993,7 @@ where
             count_local_thread_catalog_repairs(&home, &sqlite_paths, &target_provider)?;
         let global_state_update_count =
             count_global_state_updates(&home.join(".codex-global-state.json"))?;
-        if rewrite_changes.is_empty()
+        if rewrite_plans.is_empty()
             && sqlite_update_count == 0
             && catalog_repair_count == 0
             && global_state_update_count == 0
@@ -932,11 +1012,20 @@ where
                 0,
                 0,
             );
-            synced.skipped_locked_rollout_files = collected.skipped_locked_rollout_files;
+            synced.skipped_locked_rollout_files = scanned_skipped_rollout_files;
             synced.encrypted_content_warning = encrypted_content_warning;
             synced.repair_audit = repair_audit;
             synced.message =
                 provider_sync_message_with_audit(&synced.message, &synced.repair_audit);
+            report_provider_sync_progress(
+                &mut report_progress,
+                ProviderSyncProgressPhase::Complete,
+                total_rollout_files,
+                total_rollout_files,
+                0,
+                0,
+                synced.skipped_locked_rollout_files.len(),
+            );
             return Ok(synced);
         }
         before_first_write();
@@ -946,8 +1035,32 @@ where
             &target_snapshot,
         )
         .map_err(anyhow::Error::msg)?;
-        let backup_dir = create_backup(&home, &target_provider, &rewrite_changes)?;
-        let applied = apply_session_changes(&rewrite_changes)?;
+        report_provider_sync_progress(
+            &mut report_progress,
+            ProviderSyncProgressPhase::BackingUp,
+            total_rollout_files,
+            total_rollout_files,
+            rewrite_plans.len(),
+            0,
+            scanned_skipped_rollout_files.len(),
+        );
+        let backup_dir = create_bulk_backup(&home, &target_provider, &rewrite_plans)?;
+        let applied = apply_bulk_session_rewrite_plans(
+            &rewrite_plans,
+            &target_provider,
+            total_rollout_files,
+            scanned_skipped_rollout_files.len(),
+            &mut report_progress,
+        )?;
+        report_provider_sync_progress(
+            &mut report_progress,
+            ProviderSyncProgressPhase::UpdatingIndexes,
+            total_rollout_files,
+            total_rollout_files,
+            rewrite_plans.len(),
+            applied.changes.len(),
+            scanned_skipped_rollout_files.len() + applied.skipped_locked_rollout_files.len(),
+        );
         let apply_result = (|| -> anyhow::Result<(SqliteUpdateCounts, usize)> {
             let sqlite_updates = apply_sqlite_update_for_paths(
                 &sqlite_paths,
@@ -969,7 +1082,21 @@ where
         let (sqlite_updates, updated_workspace_roots) = match apply_result {
             Ok(counts) => counts,
             Err(err) => {
-                let _ = restore_session_changes(&applied.changes);
+                report_provider_sync_progress(
+                    &mut report_progress,
+                    ProviderSyncProgressPhase::RollingBack,
+                    total_rollout_files,
+                    total_rollout_files,
+                    rewrite_plans.len(),
+                    applied.changes.len(),
+                    scanned_skipped_rollout_files.len()
+                        + applied.skipped_locked_rollout_files.len(),
+                );
+                if let Err(restore_error) = restore_bulk_session_rewrites(&applied.changes) {
+                    return Err(anyhow::anyhow!(
+                        "{err}; rollout rollback failed: {restore_error}"
+                    ));
+                }
                 return Err(err);
             }
         };
@@ -981,7 +1108,7 @@ where
             applied.changes.len(),
             sqlite_updates.total(),
         );
-        synced.skipped_locked_rollout_files = collected.skipped_locked_rollout_files;
+        synced.skipped_locked_rollout_files = scanned_skipped_rollout_files;
         synced
             .skipped_locked_rollout_files
             .extend(applied.skipped_locked_rollout_files);
@@ -996,6 +1123,15 @@ where
         synced.encrypted_content_warning = encrypted_content_warning;
         synced.repair_audit = repair_audit;
         synced.message = provider_sync_message_with_audit(&synced.message, &synced.repair_audit);
+        report_provider_sync_progress(
+            &mut report_progress,
+            ProviderSyncProgressPhase::Complete,
+            total_rollout_files,
+            total_rollout_files,
+            rewrite_plans.len(),
+            applied.changes.len(),
+            synced.skipped_locked_rollout_files.len(),
+        );
         Ok(synced)
     })();
     sync_result.unwrap_or_else(|err| {
@@ -1008,6 +1144,25 @@ where
             0,
         )
     })
+}
+
+fn report_provider_sync_progress(
+    report_progress: &mut dyn FnMut(ProviderSyncProgress),
+    phase: ProviderSyncProgressPhase,
+    total_rollout_files: usize,
+    scanned_rollout_files: usize,
+    planned_rewrite_files: usize,
+    applied_rewrite_files: usize,
+    skipped_locked_rollout_files: usize,
+) {
+    report_progress(ProviderSyncProgress {
+        phase,
+        total_rollout_files,
+        scanned_rollout_files,
+        planned_rewrite_files,
+        applied_rewrite_files,
+        skipped_locked_rollout_files,
+    });
 }
 
 fn result(
@@ -1654,80 +1809,177 @@ fn release_owned_lock(path: &Path, lock_id: &str) -> std::io::Result<bool> {
     Ok(false)
 }
 
-fn collect_session_changes(
+fn scan_bulk_session_rewrites(
     home: &Path,
     target_provider: &str,
     excluded_thread_ids: &HashSet<String>,
     explicit_user_thread_ids: &HashSet<String>,
-) -> anyhow::Result<SessionChanges> {
-    let mut collected = SessionChanges::default();
-    for path in rollout_files(home)? {
-        let text = match fs::read_to_string(&path) {
-            Ok(text) => text,
+    report_progress: &mut dyn FnMut(ProviderSyncProgress),
+) -> anyhow::Result<BulkSessionScan> {
+    let paths = rollout_files(home)?;
+    let mut scan = BulkSessionScan {
+        total_rollout_files: paths.len(),
+        ..Default::default()
+    };
+    report_provider_sync_progress(
+        report_progress,
+        ProviderSyncProgressPhase::Scanning,
+        scan.total_rollout_files,
+        0,
+        0,
+        0,
+        0,
+    );
+    for (index, path) in paths.iter().enumerate() {
+        let scanned_rollout_files = index + 1;
+        let file = match File::open(path) {
+            Ok(file) => file,
             Err(error) if is_locked_io_error(&error) => {
-                collected.skipped_locked_rollout_files.push(path);
+                scan.skipped_locked_rollout_files.push(path.clone());
+                report_scan_progress(
+                    report_progress,
+                    scan.total_rollout_files,
+                    scanned_rollout_files,
+                    scan.skipped_locked_rollout_files.len(),
+                );
                 continue;
             }
             Err(error) => return Err(error.into()),
         };
-        let rewrite = rewrite_rollout_session_meta_providers(&text, target_provider)?;
-        if rewrite.session_meta_count == 0 {
-            continue;
-        }
-        let is_explicit_user = rewrite
-            .thread_id
-            .as_ref()
-            .is_some_and(|thread_id| explicit_user_thread_ids.contains(thread_id));
-        if rollout_session_meta_marks_non_root_agent(&text) {
-            if let Some(thread_id) = &rewrite.thread_id {
-                collected.subagent_thread_ids.insert(thread_id.clone());
+
+        let mut reader = BufReader::new(file);
+        let mut line = String::new();
+        let mut original_hasher = Sha256::new();
+        let mut session_meta_count = 0;
+        let mut thread_id = None;
+        let mut cwd = None;
+        let mut providers = Vec::new();
+        let mut original_session_meta_lines = Vec::new();
+        let mut rewrite_needed = false;
+        let mut rollout_marks_non_root_agent = false;
+        let mut has_user_event = false;
+        let mut has_encrypted_content = false;
+
+        loop {
+            line.clear();
+            if reader.read_line(&mut line)? == 0 {
+                break;
             }
-            continue;
+            original_hasher.update(line.as_bytes());
+            has_user_event |= line.contains("\"user_message\"") || line.contains("\"user_input\"");
+            has_encrypted_content |= line.contains("encrypted_content");
+
+            let (record_line, _) = split_line_ending(&line);
+            if record_line.trim().is_empty() {
+                continue;
+            }
+            let Ok(record) = serde_json::from_str::<Value>(record_line) else {
+                continue;
+            };
+            if record.get("type").and_then(Value::as_str) != Some("session_meta") {
+                continue;
+            }
+            let Some(payload) = record.get("payload").and_then(Value::as_object) else {
+                continue;
+            };
+
+            session_meta_count += 1;
+            original_session_meta_lines.push(record_line.to_string());
+            if thread_id.is_none() {
+                thread_id = payload
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string);
+            }
+            if cwd.is_none() {
+                cwd = payload
+                    .get("cwd")
+                    .and_then(Value::as_str)
+                    .and_then(to_desktop_workspace_path);
+            }
+            let provider = payload
+                .get("model_provider")
+                .and_then(Value::as_str)
+                .unwrap_or("(missing)")
+                .to_string();
+            providers.push(provider);
+            rewrite_needed |=
+                payload.get("model_provider").and_then(Value::as_str) != Some(target_provider);
+            rollout_marks_non_root_agent |= payload
+                .get("source")
+                .is_some_and(source_value_marks_non_root_agent);
         }
-        if !is_explicit_user
-            && rewrite
-                .thread_id
+
+        if session_meta_count > 0 {
+            let is_explicit_user = thread_id
                 .as_ref()
-                .is_some_and(|thread_id| excluded_thread_ids.contains(thread_id))
-        {
-            continue;
-        }
-        let has_user_event = text.contains("\"user_message\"") || text.contains("\"user_input\"");
-        if text.contains("encrypted_content") {
-            for provider in &rewrite.providers {
-                *collected
-                    .encrypted_content_counts
-                    .entry(provider.clone())
-                    .or_insert(0) += 1;
+                .is_some_and(|id| explicit_user_thread_ids.contains(id));
+            if rollout_marks_non_root_agent {
+                if let Some(thread_id) = thread_id {
+                    scan.subagent_thread_ids.insert(thread_id);
+                }
+            } else if !is_explicit_user
+                && thread_id
+                    .as_ref()
+                    .is_some_and(|id| excluded_thread_ids.contains(id))
+            {
+                // Keep the existing SQLite subagent exclusion behavior.
+            } else {
+                if has_user_event {
+                    if let Some(thread_id) = &thread_id {
+                        scan.thread_ids_with_user_events.insert(thread_id.clone());
+                    }
+                }
+                if let (Some(thread_id), Some(cwd)) = (thread_id.as_ref(), cwd) {
+                    scan.cwd_by_thread_id.insert(thread_id.clone(), cwd);
+                }
+                if has_encrypted_content {
+                    for provider in providers {
+                        *scan.encrypted_content_counts.entry(provider).or_insert(0) += 1;
+                    }
+                }
+                if rewrite_needed {
+                    scan.rewrite_plans.push(BulkSessionRewritePlan {
+                        path: path.clone(),
+                        original_sha256: format!("{:x}", original_hasher.finalize()),
+                        original_mtime: fs::metadata(path)
+                            .and_then(|metadata| metadata.modified())
+                            .ok(),
+                        original_session_meta_lines,
+                    });
+                }
             }
         }
-        let original_mtime = fs::metadata(&path).and_then(|m| m.modified()).ok();
-        collected.changes.push(SessionChange {
-            path,
-            original_text: text,
-            next_text: rewrite.next_text,
-            original_session_meta_lines: rewrite.original_session_meta_lines,
-            thread_id: rewrite.thread_id,
-            cwd: rewrite.cwd,
-            has_user_event,
-            rewrite_needed: rewrite.rewrite_needed,
-            original_mtime,
-        });
+        report_scan_progress(
+            report_progress,
+            scan.total_rollout_files,
+            scanned_rollout_files,
+            scan.skipped_locked_rollout_files.len(),
+        );
     }
-    Ok(collected)
+    Ok(scan)
 }
 
-fn rollout_session_meta_marks_non_root_agent(text: &str) -> bool {
-    text.lines().any(|line| {
-        let Ok(record) = serde_json::from_str::<Value>(line) else {
-            return false;
-        };
-        record.get("type").and_then(Value::as_str) == Some("session_meta")
-            && record
-                .get("payload")
-                .and_then(|payload| payload.get("source"))
-                .is_some_and(source_value_marks_non_root_agent)
-    })
+fn report_scan_progress(
+    report_progress: &mut dyn FnMut(ProviderSyncProgress),
+    total_rollout_files: usize,
+    scanned_rollout_files: usize,
+    skipped_locked_rollout_files: usize,
+) {
+    if scanned_rollout_files == 1
+        || scanned_rollout_files == total_rollout_files
+        || scanned_rollout_files % PROVIDER_SYNC_PROGRESS_INTERVAL == 0
+    {
+        report_provider_sync_progress(
+            report_progress,
+            ProviderSyncProgressPhase::Scanning,
+            total_rollout_files,
+            scanned_rollout_files,
+            0,
+            0,
+            skipped_locked_rollout_files,
+        );
+    }
 }
 
 fn remote_control_rollout_for_thread(
@@ -2068,13 +2320,19 @@ fn collect_live_thread_ids(
         {
             ids.insert(id);
         }
-        let text = match fs::read_to_string(&path) {
-            Ok(text) => text,
+        let file = match File::open(&path) {
+            Ok(file) => file,
             Err(error) if is_locked_io_error(&error) => continue,
             Err(error) => return Err(error.into()),
         };
-        for segment in text.split_inclusive('\n') {
-            let (line, _) = split_line_ending(segment);
+        let mut reader = BufReader::new(file);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            if reader.read_line(&mut line)? == 0 {
+                break;
+            }
+            let (line, _) = split_line_ending(&line);
             let Ok(record) = serde_json::from_str::<Value>(line) else {
                 continue;
             };
@@ -2199,26 +2457,31 @@ fn sqlite_user_thread_ids(path: &Path) -> anyhow::Result<HashSet<String>> {
 fn plan_session_index_cleanup(
     path: &Path,
     live_thread_ids: &HashSet<String>,
-) -> anyhow::Result<Option<SessionIndexPlan>> {
+) -> anyhow::Result<Option<SessionIndexCleanupPlan>> {
     if !path.exists() {
         return Ok(None);
     }
-    let original_bytes = fs::read(path)?;
-    let original_text = String::from_utf8(original_bytes.clone())?;
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+    let mut hasher = Sha256::new();
     let mut candidates = Vec::new();
-    for segment in original_text.split_inclusive('\n') {
-        let (line, _) = split_line_ending(segment);
+    loop {
+        line.clear();
+        if reader.read_line(&mut line)? == 0 {
+            break;
+        }
+        hasher.update(line.as_bytes());
+        let (line, _) = split_line_ending(&line);
         if let Some(candidate) = known_session_index_candidate(line)
             && !live_thread_ids.contains(&candidate.id)
         {
             candidates.push(candidate);
         }
     }
-    Ok(Some(SessionIndexPlan {
+    Ok(Some(SessionIndexCleanupPlan {
         path: path.to_path_buf(),
-        snapshot_sha256: sha256_hex(&original_bytes),
-        original_bytes,
-        original_text,
+        snapshot_sha256: format!("{:x}", hasher.finalize()),
         candidates,
     }))
 }
@@ -2340,7 +2603,11 @@ pub fn apply_session_index_cleanup(
                 None,
             ));
         }
-        let (next_text, removed_entries) = filtered_session_index_text(&plan, &selected_ids);
+        let removed_entries = plan
+            .candidates
+            .iter()
+            .filter(|candidate| selected_ids.contains(&candidate.id))
+            .count();
         if removed_entries == 0 {
             return Ok(SessionIndexCleanupResult {
                 pruned_entries: 0,
@@ -2348,30 +2615,39 @@ pub fn apply_session_index_cleanup(
             });
         }
         let backup_dir = create_session_index_cleanup_backup(&home, &plan, removed_entries)?;
-        let current_bytes = fs::read(&plan.path)
-            .map_err(|error| cleanup_apply_error(error, Some(backup_dir.clone())))?;
-        if current_bytes != plan.original_bytes {
-            return Err(cleanup_apply_error(
-                "session_index.jsonl 在写入前再次发生变化；未覆盖 Codex 新内容，请重新预览",
-                Some(backup_dir),
-            ));
-        }
         if require_stopped_app {
             ensure_codex_app_stopped(Some(backup_dir.clone()))?;
         }
-        codex_plus_core::settings::atomic_write(&plan.path, next_text.as_bytes()).map_err(
-            |error| {
-                cleanup_apply_error(
-                    format!(
-                        "原子写入 session_index.jsonl 失败；原文件未被主动覆盖，可从备份目录手动恢复：{error}"
-                    ),
-                    Some(backup_dir.clone()),
-                )
-            },
-        )?;
+        let mut streamed_removed_entries = None;
+        let write_result = codex_plus_core::settings::atomic_write_with(&plan.path, |file| {
+            let mut writer = BufWriter::new(file);
+            let removed = stream_filtered_session_index(
+                &plan.path,
+                &plan.snapshot_sha256,
+                &selected_ids,
+                &mut writer,
+            )?;
+            writer.flush()?;
+            streamed_removed_entries = Some(removed);
+            Ok(())
+        });
+        if let Err(error) = write_result {
+            if error_chain_contains(&error, SESSION_INDEX_SNAPSHOT_CHANGED_ERROR) {
+                return Err(cleanup_apply_error(
+                    "session_index.jsonl 在写入前再次发生变化；未覆盖 Codex 新内容，请重新预览",
+                    Some(backup_dir),
+                ));
+            }
+            return Err(cleanup_apply_error(
+                format!(
+                    "原子写入 session_index.jsonl 失败；原文件未被主动覆盖，可从备份目录手动恢复：{error}"
+                ),
+                Some(backup_dir),
+            ));
+        }
         let _ = prune_backups(&home);
         Ok(SessionIndexCleanupResult {
-            pruned_entries: removed_entries,
+            pruned_entries: streamed_removed_entries.unwrap_or(0),
             backup_dir: Some(backup_dir),
         })
     })();
@@ -3029,13 +3305,19 @@ fn cleanup_apply_error(
 fn rollout_provider_ids(home: &Path) -> anyhow::Result<Vec<String>> {
     let mut ids = HashSet::new();
     for path in rollout_files(home)? {
-        let text = match fs::read_to_string(&path) {
-            Ok(text) => text,
+        let file = match File::open(&path) {
+            Ok(file) => file,
             Err(error) if is_locked_io_error(&error) => continue,
             Err(error) => return Err(error.into()),
         };
-        for segment in text.split_inclusive('\n') {
-            let (line, _) = split_line_ending(segment);
+        let mut reader = BufReader::new(file);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            if reader.read_line(&mut line)? == 0 {
+                break;
+            }
+            let (line, _) = split_line_ending(&line);
             let Ok(record) = serde_json::from_str::<Value>(line) else {
                 continue;
             };
@@ -3130,6 +3412,43 @@ fn create_backup(
     target_provider: &str,
     changes: &[SessionChange],
 ) -> anyhow::Result<PathBuf> {
+    create_backup_with_session_meta_lines(
+        home,
+        target_provider,
+        changes.len(),
+        changes.iter().map(|change| {
+            (
+                change.path.as_path(),
+                change.original_session_meta_lines.as_slice(),
+            )
+        }),
+    )
+}
+
+fn create_bulk_backup(
+    home: &Path,
+    target_provider: &str,
+    rewrite_plans: &[BulkSessionRewritePlan],
+) -> anyhow::Result<PathBuf> {
+    create_backup_with_session_meta_lines(
+        home,
+        target_provider,
+        rewrite_plans.len(),
+        rewrite_plans.iter().map(|plan| {
+            (
+                plan.path.as_path(),
+                plan.original_session_meta_lines.as_slice(),
+            )
+        }),
+    )
+}
+
+fn create_backup_with_session_meta_lines<'a>(
+    home: &Path,
+    target_provider: &str,
+    changed_session_files: usize,
+    entries: impl IntoIterator<Item = (&'a Path, &'a [String])>,
+) -> anyhow::Result<PathBuf> {
     let backup_root = home.join("backups_state/provider-sync");
     let mut backup_dir = backup_root.join(timestamp_name());
     let mut suffix = 0;
@@ -3164,19 +3483,7 @@ fn create_backup(
             db_files.push(relative.to_string_lossy().replace('\\', "/"));
         }
     }
-    let manifest = changes
-        .iter()
-        .map(|change| {
-            json!({
-                "path": change.path.to_string_lossy(),
-                "originalSessionMetaLines": change.original_session_meta_lines,
-            })
-        })
-        .collect::<Vec<_>>();
-    fs::write(
-        backup_dir.join("session-meta-backup.json"),
-        serde_json::to_string_pretty(&manifest)?,
-    )?;
+    write_session_meta_backup(&backup_dir.join("session-meta-backup.json"), entries)?;
     fs::write(
         backup_dir.join("metadata.json"),
         serde_json::to_string_pretty(&json!({
@@ -3186,16 +3493,354 @@ fn create_backup(
             "targetProvider": target_provider,
             "createdAt": chrono::Utc::now().to_rfc3339(),
             "dbFiles": db_files,
-            "changedSessionFiles": changes.len(),
+            "changedSessionFiles": changed_session_files,
             "managedBy": "Codex++ provider sync"
         }))?,
     )?;
     Ok(backup_dir)
 }
 
+fn write_session_meta_backup<'a>(
+    path: &Path,
+    entries: impl IntoIterator<Item = (&'a Path, &'a [String])>,
+) -> anyhow::Result<()> {
+    let mut writer = BufWriter::new(File::create(path)?);
+    writer.write_all(b"[\n")?;
+    let mut first = true;
+    for (entry_path, original_session_meta_lines) in entries {
+        if !first {
+            writer.write_all(b",\n")?;
+        }
+        first = false;
+        let entry = SessionMetaBackupEntry {
+            path: entry_path.to_string_lossy().to_string(),
+            original_session_meta_lines,
+        };
+        let encoded = serde_json::to_string_pretty(&entry)?;
+        for line in encoded.lines() {
+            writer.write_all(b"  ")?;
+            writer.write_all(line.as_bytes())?;
+            writer.write_all(b"\n")?;
+        }
+    }
+    writer.write_all(b"]\n")?;
+    writer.flush()?;
+    Ok(())
+}
+
+const BULK_SESSION_SOURCE_CHANGED_ERROR: &str =
+    "rollout changed while provider metadata was being written";
+
+struct HashingWriter<W> {
+    inner: W,
+    hasher: Sha256,
+}
+
+impl<W> HashingWriter<W> {
+    fn new(inner: W) -> Self {
+        Self {
+            inner,
+            hasher: Sha256::new(),
+        }
+    }
+
+    fn sha256_hex(&self) -> String {
+        format!("{:x}", self.hasher.clone().finalize())
+    }
+}
+
+impl<W: Write> Write for HashingWriter<W> {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        let written = self.inner.write(buffer)?;
+        self.hasher.update(&buffer[..written]);
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+fn apply_bulk_session_rewrite_plans(
+    rewrite_plans: &[BulkSessionRewritePlan],
+    target_provider: &str,
+    total_rollout_files: usize,
+    scanned_skipped_rollout_files: usize,
+    report_progress: &mut dyn FnMut(ProviderSyncProgress),
+) -> anyhow::Result<AppliedBulkSessionRewrites> {
+    let mut applied = AppliedBulkSessionRewrites::default();
+    report_provider_sync_progress(
+        report_progress,
+        ProviderSyncProgressPhase::Rewriting,
+        total_rollout_files,
+        total_rollout_files,
+        rewrite_plans.len(),
+        0,
+        scanned_skipped_rollout_files,
+    );
+
+    for (index, plan) in rewrite_plans.iter().enumerate() {
+        match rewrite_bulk_session_plan(plan, target_provider) {
+            Ok(Some(rewritten_sha256)) => {
+                restore_file_mtime(&plan.path, plan.original_mtime);
+                applied.changes.push(AppliedBulkSessionRewrite {
+                    plan: plan.clone(),
+                    rewritten_sha256,
+                });
+            }
+            Ok(None) => applied.skipped_locked_rollout_files.push(plan.path.clone()),
+            Err(error) if is_locked_anyhow_error(&error) => {
+                applied.skipped_locked_rollout_files.push(plan.path.clone());
+            }
+            Err(error) => {
+                if let Err(restore_error) = restore_bulk_session_rewrites(&applied.changes) {
+                    return Err(anyhow::anyhow!(
+                        "{error}; rollout rollback failed: {restore_error}"
+                    ));
+                }
+                return Err(error);
+            }
+        }
+        report_bulk_rewrite_progress(
+            report_progress,
+            total_rollout_files,
+            rewrite_plans.len(),
+            index + 1,
+            applied.changes.len(),
+            scanned_skipped_rollout_files + applied.skipped_locked_rollout_files.len(),
+        );
+    }
+    Ok(applied)
+}
+
+fn report_bulk_rewrite_progress(
+    report_progress: &mut dyn FnMut(ProviderSyncProgress),
+    total_rollout_files: usize,
+    planned_rewrite_files: usize,
+    completed_rewrite_files: usize,
+    applied_rewrite_files: usize,
+    skipped_locked_rollout_files: usize,
+) {
+    if completed_rewrite_files == 1
+        || completed_rewrite_files == planned_rewrite_files
+        || completed_rewrite_files % PROVIDER_SYNC_PROGRESS_INTERVAL == 0
+    {
+        report_provider_sync_progress(
+            report_progress,
+            ProviderSyncProgressPhase::Rewriting,
+            total_rollout_files,
+            total_rollout_files,
+            planned_rewrite_files,
+            applied_rewrite_files,
+            skipped_locked_rollout_files,
+        );
+    }
+}
+
+fn rewrite_bulk_session_plan(
+    plan: &BulkSessionRewritePlan,
+    target_provider: &str,
+) -> anyhow::Result<Option<String>> {
+    if sha256_file(&plan.path)? != plan.original_sha256 {
+        return Ok(None);
+    }
+
+    let mut rewritten_sha256 = None;
+    let write_result = codex_plus_core::settings::atomic_write_with(&plan.path, |file| {
+        let mut writer = HashingWriter::new(BufWriter::new(file));
+        let source_sha256 = stream_rewrite_rollout_session_meta_providers(
+            &plan.path,
+            target_provider,
+            &mut writer,
+        )?;
+        writer.flush()?;
+        if source_sha256 != plan.original_sha256 || sha256_file(&plan.path)? != plan.original_sha256
+        {
+            return Err(std::io::Error::other(BULK_SESSION_SOURCE_CHANGED_ERROR));
+        }
+        rewritten_sha256 = Some(writer.sha256_hex());
+        Ok(())
+    });
+    match write_result {
+        Ok(()) => Ok(rewritten_sha256),
+        Err(error) if error_chain_contains(&error, BULK_SESSION_SOURCE_CHANGED_ERROR) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn stream_rewrite_rollout_session_meta_providers<W: Write>(
+    path: &Path,
+    target_provider: &str,
+    writer: &mut W,
+) -> std::io::Result<String> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+    let mut hasher = Sha256::new();
+    loop {
+        line.clear();
+        if reader.read_line(&mut line)? == 0 {
+            break;
+        }
+        hasher.update(line.as_bytes());
+        let (record_line, line_ending) = split_line_ending(&line);
+        let mut rewritten = false;
+        if !record_line.trim().is_empty()
+            && let Ok(mut record) = serde_json::from_str::<Value>(record_line)
+            && record.get("type").and_then(Value::as_str) == Some("session_meta")
+            && let Some(payload) = record.get_mut("payload").and_then(Value::as_object_mut)
+            && payload.get("model_provider").and_then(Value::as_str) != Some(target_provider)
+        {
+            payload.insert("model_provider".to_string(), json!(target_provider));
+            serde_json::to_writer(&mut *writer, &record).map_err(std::io::Error::other)?;
+            writer.write_all(line_ending.as_bytes())?;
+            rewritten = true;
+        }
+        if !rewritten {
+            writer.write_all(line.as_bytes())?;
+        }
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn restore_bulk_session_rewrites(changes: &[AppliedBulkSessionRewrite]) -> anyhow::Result<()> {
+    for change in changes.iter().rev() {
+        restore_bulk_session_rewrite(change)?;
+    }
+    Ok(())
+}
+
+fn restore_bulk_session_rewrite(change: &AppliedBulkSessionRewrite) -> anyhow::Result<()> {
+    if sha256_file(&change.plan.path)? != change.rewritten_sha256 {
+        return Err(anyhow::anyhow!(
+            "rollout changed before rollback: {}",
+            change.plan.path.display()
+        ));
+    }
+
+    let mut restored_sha256 = None;
+    codex_plus_core::settings::atomic_write_with(&change.plan.path, |file| {
+        let mut writer = HashingWriter::new(BufWriter::new(file));
+        let source_sha256 = stream_restore_rollout_session_meta_lines(
+            &change.plan.path,
+            &change.plan.original_session_meta_lines,
+            &mut writer,
+        )?;
+        writer.flush()?;
+        if source_sha256 != change.rewritten_sha256
+            || sha256_file(&change.plan.path)? != change.rewritten_sha256
+        {
+            return Err(std::io::Error::other(BULK_SESSION_SOURCE_CHANGED_ERROR));
+        }
+        restored_sha256 = Some(writer.sha256_hex());
+        Ok(())
+    })?;
+    if restored_sha256.as_deref() != Some(change.plan.original_sha256.as_str()) {
+        return Err(anyhow::anyhow!(
+            "rollout rollback hash mismatch: {}",
+            change.plan.path.display()
+        ));
+    }
+    restore_file_mtime(&change.plan.path, change.plan.original_mtime);
+    Ok(())
+}
+
+fn stream_restore_rollout_session_meta_lines<W: Write>(
+    path: &Path,
+    original_session_meta_lines: &[String],
+    writer: &mut W,
+) -> std::io::Result<String> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+    let mut hasher = Sha256::new();
+    let mut originals = original_session_meta_lines.iter();
+    let mut restored_session_meta_lines = 0usize;
+
+    loop {
+        line.clear();
+        if reader.read_line(&mut line)? == 0 {
+            break;
+        }
+        hasher.update(line.as_bytes());
+        let (record_line, line_ending) = split_line_ending(&line);
+        let valid_session_meta = !record_line.trim().is_empty()
+            && serde_json::from_str::<Value>(record_line)
+                .ok()
+                .is_some_and(|record| {
+                    record.get("type").and_then(Value::as_str) == Some("session_meta")
+                        && record.get("payload").and_then(Value::as_object).is_some()
+                });
+        if valid_session_meta {
+            let Some(original_line) = originals.next() else {
+                return Err(std::io::Error::other(
+                    "rollout session metadata count changed before rollback",
+                ));
+            };
+            writer.write_all(original_line.as_bytes())?;
+            writer.write_all(line_ending.as_bytes())?;
+            restored_session_meta_lines += 1;
+        } else {
+            writer.write_all(line.as_bytes())?;
+        }
+    }
+    if originals.next().is_some()
+        || restored_session_meta_lines != original_session_meta_lines.len()
+    {
+        return Err(std::io::Error::other(
+            "rollout session metadata count changed before rollback",
+        ));
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn sha256_file(path: &Path) -> std::io::Result<String> {
+    let mut reader = BufReader::new(File::open(path)?);
+    let mut buffer = [0_u8; 64 * 1024];
+    let mut hasher = Sha256::new();
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn is_locked_anyhow_error(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .filter_map(|cause| cause.downcast_ref::<std::io::Error>())
+        .any(is_locked_io_error)
+        || is_windows_sharing_anyhow_error(error)
+}
+
+#[cfg(windows)]
+fn is_windows_sharing_anyhow_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        let message = cause.to_string().to_ascii_lowercase();
+        message.contains("os error 32")
+            || message.contains("os error 33")
+            || message.contains("0x80070020")
+            || message.contains("0x80070021")
+    })
+}
+
+#[cfg(not(windows))]
+fn is_windows_sharing_anyhow_error(_: &anyhow::Error) -> bool {
+    false
+}
+
+fn error_chain_contains(error: &anyhow::Error, needle: &str) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.to_string().contains(needle))
+}
+
 fn create_session_index_cleanup_backup(
     home: &Path,
-    plan: &SessionIndexPlan,
+    plan: &SessionIndexCleanupPlan,
     removed_entries: usize,
 ) -> Result<PathBuf, SessionIndexCleanupApplyError> {
     let backup_root = home.join("backups_state/provider-sync");
@@ -3206,8 +3851,15 @@ fn create_session_index_cleanup_backup(
         backup_dir = backup_root.join(format!("{}-{suffix}", timestamp_name()));
     }
     fs::create_dir_all(&backup_dir).map_err(|error| cleanup_apply_error(error, None))?;
-    fs::write(backup_dir.join("session_index.jsonl"), &plan.original_bytes)
+    let backup_index_path = backup_dir.join("session_index.jsonl");
+    let copied_sha256 = copy_file_with_sha256(&plan.path, &backup_index_path)
         .map_err(|error| cleanup_apply_error(error, Some(backup_dir.clone())))?;
+    if copied_sha256 != plan.snapshot_sha256 {
+        return Err(cleanup_apply_error(
+            "session_index.jsonl 在写入前再次发生变化；未覆盖 Codex 新内容，请重新预览",
+            Some(backup_dir),
+        ));
+    }
     let metadata = serde_json::to_string_pretty(&json!({
         "version": 1,
         "namespace": "provider-sync-session-index-cleanup",
@@ -3221,6 +3873,60 @@ fn create_session_index_cleanup_backup(
     fs::write(backup_dir.join("metadata.json"), metadata)
         .map_err(|error| cleanup_apply_error(error, Some(backup_dir.clone())))?;
     Ok(backup_dir)
+}
+
+const SESSION_INDEX_SNAPSHOT_CHANGED_ERROR: &str =
+    "session index changed while cleanup was being written";
+
+fn stream_filtered_session_index<W: Write>(
+    path: &Path,
+    expected_snapshot_sha256: &str,
+    selected_ids: &HashSet<String>,
+    writer: &mut W,
+) -> std::io::Result<usize> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+    let mut hasher = Sha256::new();
+    let mut removed_entries = 0usize;
+    loop {
+        line.clear();
+        if reader.read_line(&mut line)? == 0 {
+            break;
+        }
+        hasher.update(line.as_bytes());
+        let (record_line, _) = split_line_ending(&line);
+        let remove = known_session_index_candidate(record_line)
+            .is_some_and(|candidate| selected_ids.contains(&candidate.id));
+        if remove {
+            removed_entries += 1;
+        } else {
+            writer.write_all(line.as_bytes())?;
+        }
+    }
+    if format!("{:x}", hasher.finalize()) != expected_snapshot_sha256
+        || sha256_file(path)? != expected_snapshot_sha256
+    {
+        return Err(std::io::Error::other(SESSION_INDEX_SNAPSHOT_CHANGED_ERROR));
+    }
+    Ok(removed_entries)
+}
+
+fn copy_file_with_sha256(source: &Path, destination: &Path) -> std::io::Result<String> {
+    let mut reader = BufReader::new(File::open(source)?);
+    let mut writer = BufWriter::new(File::create(destination)?);
+    let mut buffer = [0_u8; 64 * 1024];
+    let mut hasher = Sha256::new();
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+        writer.write_all(&buffer[..read])?;
+    }
+    writer.flush()?;
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 fn apply_session_changes(changes: &[SessionChange]) -> anyhow::Result<AppliedSessionChanges> {

--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -840,7 +840,7 @@ pub fn run_provider_sync_with_target(
 pub fn run_provider_sync_with_target_and_progress(
     codex_home: Option<&Path>,
     explicit_target_provider: Option<&str>,
-    mut report_progress: impl FnMut(ProviderSyncProgress),
+    report_progress: impl FnMut(ProviderSyncProgress),
 ) -> ProviderSyncResult {
     let require_stopped_app = codex_home.is_none();
     let home = codex_home
@@ -851,17 +851,20 @@ pub fn run_provider_sync_with_target_and_progress(
         explicit_target_provider,
         require_stopped_app,
         || {},
+        report_progress,
     )
 }
 
-fn run_provider_sync_with_target_in_home<BeforeFirstWrite>(
+fn run_provider_sync_with_target_in_home<BeforeFirstWrite, ReportProgress>(
     home: PathBuf,
     explicit_target_provider: Option<&str>,
     require_stopped_app: bool,
     before_first_write: BeforeFirstWrite,
+    mut report_progress: ReportProgress,
 ) -> ProviderSyncResult
 where
     BeforeFirstWrite: FnOnce(),
+    ReportProgress: FnMut(ProviderSyncProgress),
 {
     if !home.exists() {
         return result(
@@ -5478,9 +5481,15 @@ mod provider_target_snapshot_tests {
         fs::write(&rollout, &original_rollout).unwrap();
         let config_path = home.join("config.toml");
 
-        let result = run_provider_sync_with_target_in_home(home.clone(), None, false, || {
-            write_config(&home, "relay-beta", &["relay-beta"]);
-        });
+        let result = run_provider_sync_with_target_in_home(
+            home.clone(),
+            None,
+            false,
+            || {
+                write_config(&home, "relay-beta", &["relay-beta"]);
+            },
+            |_| {},
+        );
 
         assert_eq!(result.status, ProviderSyncStatus::Skipped);
         assert!(result.message.contains("configuration changed"));

--- a/crates/codex-plus-data/tests/provider_sync.rs
+++ b/crates/codex-plus-data/tests/provider_sync.rs
@@ -814,6 +814,119 @@ fn provider_sync_reports_stream_progress() {
     assert_eq!(progress.last().map(|event| &event.phase), Some(&ProviderSyncProgressPhase::Complete));
 }
 
+#[cfg(not(windows))]
+#[test]
+fn provider_sync_reports_rollback_when_rewrite_write_fails() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    fs::create_dir(&home).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    let first_rollout = home.join("sessions/rollout-a.jsonl");
+    let blocked_rollout = home.join("sessions/rollout-b.jsonl");
+    write_rollout(&first_rollout, "openai", "thread-a", "C:/workspace");
+    write_rollout(&blocked_rollout, "openai", "thread-b", "C:/workspace");
+    let original_first_rollout = fs::read(&first_rollout).unwrap();
+    fs::create_dir(blocked_rollout.with_extension("jsonl.tmp")).unwrap();
+    let mut progress = Vec::new();
+
+    let result = run_provider_sync_with_target_and_progress(Some(&home), None, |event| {
+        progress.push(event);
+    });
+
+    assert_eq!(result.status, ProviderSyncStatus::Skipped);
+    assert_eq!(fs::read(&first_rollout).unwrap(), original_first_rollout);
+    assert!(progress
+        .iter()
+        .any(|event| event.phase == ProviderSyncProgressPhase::RollingBack));
+}
+
+#[test]
+fn provider_sync_continues_rollback_after_a_conflicted_rollout() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    fs::create_dir(&home).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    let first_rollout = home.join("sessions/rollout-a.jsonl");
+    let conflicted_rollout = home.join("sessions/rollout-b.jsonl");
+    write_rollout(&first_rollout, "openai", "thread-a", "C:/workspace");
+    write_rollout(&conflicted_rollout, "openai", "thread-b", "C:/workspace");
+    let original_first_rollout = fs::read(&first_rollout).unwrap();
+    let external_contents = b"{\"type\":\"event_msg\",\"payload\":{\"changed\":true}}\n";
+    let db = Connection::open(home.join("state_5.sqlite")).unwrap();
+    db.execute(
+        "CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT, archived INTEGER, has_user_event INTEGER, cwd TEXT)",
+        [],
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO threads VALUES ('thread-a', 'old-provider', 0, 0, 'C:/old')",
+        [],
+    )
+    .unwrap();
+    db.execute(
+        "INSERT INTO threads VALUES ('thread-b', 'old-provider', 0, 0, 'C:/old')",
+        [],
+    )
+    .unwrap();
+    db.execute(
+        "CREATE TRIGGER fail_provider_sync_update BEFORE UPDATE ON threads BEGIN SELECT RAISE(ABORT, 'boom'); END",
+        [],
+    )
+    .unwrap();
+    drop(db);
+    let mut progress = Vec::new();
+    let mut conflicted = false;
+
+    let result = run_provider_sync_with_target_and_progress(Some(&home), None, |event| {
+        if !conflicted && event.phase == ProviderSyncProgressPhase::UpdatingIndexes {
+            fs::write(&conflicted_rollout, external_contents).unwrap();
+            conflicted = true;
+        }
+        progress.push(event);
+    });
+
+    assert!(conflicted);
+    assert_eq!(result.status, ProviderSyncStatus::Skipped);
+    assert_eq!(fs::read(&first_rollout).unwrap(), original_first_rollout);
+    assert_eq!(fs::read(&conflicted_rollout).unwrap(), external_contents);
+    assert!(progress
+        .iter()
+        .any(|event| event.phase == ProviderSyncProgressPhase::RollingBack));
+}
+
+#[cfg(windows)]
+#[test]
+fn provider_sync_skips_rollout_locked_after_planning() {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    fs::create_dir(&home).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    let rollout = home.join("sessions/rollout-locked.jsonl");
+    write_rollout(&rollout, "openai", "thread-1", "C:/workspace");
+    let original_rollout = fs::read(&rollout).unwrap();
+    let mut held_rollout: Option<fs::File> = None;
+
+    let result = run_provider_sync_with_target_and_progress(Some(&home), None, |event| {
+        if held_rollout.is_none() && event.phase == ProviderSyncProgressPhase::Planning {
+            held_rollout = Some(
+                fs::OpenOptions::new()
+                    .read(true)
+                    .share_mode(0)
+                    .open(&rollout)
+                    .unwrap(),
+            );
+        }
+    });
+
+    assert!(held_rollout.is_some());
+    drop(held_rollout);
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert!(result.skipped_locked_rollout_files.contains(&rollout));
+    assert_eq!(fs::read(&rollout).unwrap(), original_rollout);
+}
+
 #[test]
 fn provider_sync_skips_rollout_changed_after_scanning() {
     let tmp = tempdir().unwrap();

--- a/crates/codex-plus-data/tests/provider_sync.rs
+++ b/crates/codex-plus-data/tests/provider_sync.rs
@@ -1,8 +1,9 @@
 use codex_plus_data::{
-    ProviderSyncStatus, ProviderSyncTargetSource, apply_session_index_cleanup,
+    ProviderSyncProgressPhase, ProviderSyncStatus, ProviderSyncTargetSource,
+    apply_session_index_cleanup,
     load_provider_sync_targets, preview_session_index_cleanup,
     remote_control_session_recovery_candidate_exists, run_provider_sync,
-    run_provider_sync_with_target,
+    run_provider_sync_with_target, run_provider_sync_with_target_and_progress,
     run_remote_control_session_catalog_recovery_for_thread_with_target,
     run_remote_control_session_finalization_for_thread_with_target, validate_provider_sync_target,
 };
@@ -737,6 +738,107 @@ fn provider_sync_rewrites_all_session_meta_model_providers() {
 }
 
 #[test]
+fn provider_sync_streams_large_rollout_without_losing_non_meta_content() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    fs::create_dir(&home).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    let rollout = home.join("sessions/2026/rollout-large.jsonl");
+    fs::create_dir_all(rollout.parent().unwrap()).unwrap();
+    let session_meta = json!({
+        "type": "session_meta",
+        "payload": {
+            "id": "large-thread",
+            "model_provider": "openai",
+            "cwd": "C:/workspace"
+        }
+    })
+    .to_string();
+    let large_event = json!({
+        "type": "event_msg",
+        "payload": { "blob": "x".repeat(2 * 1024 * 1024) }
+    })
+    .to_string();
+    let tail_event = json!({"type": "event_msg", "payload": {"type": "user_message"}})
+        .to_string();
+    let original = format!("{session_meta}\n{large_event}\n{tail_event}\n");
+    fs::write(&rollout, &original).unwrap();
+
+    let result = run_provider_sync(Some(&home));
+
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert_eq!(result.changed_session_files, 1);
+    let next = fs::read_to_string(&rollout).unwrap();
+    let mut lines = next.lines();
+    let rewritten_meta: serde_json::Value = serde_json::from_str(lines.next().unwrap()).unwrap();
+    assert_eq!(rewritten_meta["payload"]["model_provider"], "apigather");
+    assert_eq!(lines.next(), Some(large_event.as_str()));
+    assert_eq!(lines.next(), Some(tail_event.as_str()));
+    assert_eq!(lines.next(), None);
+}
+
+#[test]
+fn provider_sync_reports_stream_progress() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    fs::create_dir(&home).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    for index in 0..3 {
+        write_rollout(
+            &home.join(format!("sessions/rollout-progress-{index}.jsonl")),
+            "openai",
+            &format!("thread-{index}"),
+            "C:/workspace",
+        );
+    }
+    let mut progress = Vec::new();
+
+    let result = run_provider_sync_with_target_and_progress(Some(&home), None, |event| {
+        progress.push(event);
+    });
+
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert!(progress.iter().any(|event| {
+        event.phase == ProviderSyncProgressPhase::Scanning
+            && event.total_rollout_files == 3
+            && event.scanned_rollout_files == 3
+    }));
+    assert!(progress.iter().any(|event| {
+        event.phase == ProviderSyncProgressPhase::Planning && event.planned_rewrite_files == 3
+    }));
+    assert!(progress.iter().any(|event| {
+        event.phase == ProviderSyncProgressPhase::Rewriting
+            && event.planned_rewrite_files == 3
+            && event.applied_rewrite_files == 3
+    }));
+    assert_eq!(progress.last().map(|event| &event.phase), Some(&ProviderSyncProgressPhase::Complete));
+}
+
+#[test]
+fn provider_sync_skips_rollout_changed_after_scanning() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    fs::create_dir(&home).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    let rollout = home.join("sessions/rollout-changed.jsonl");
+    write_rollout(&rollout, "openai", "thread-1", "C:/workspace");
+    let externally_changed = "{\"type\":\"event_msg\",\"payload\":{\"changed\":true}}\n";
+    let mut changed = false;
+
+    let result = run_provider_sync_with_target_and_progress(Some(&home), None, |event| {
+        if !changed && event.phase == ProviderSyncProgressPhase::Planning {
+            fs::write(&rollout, externally_changed).unwrap();
+            changed = true;
+        }
+    });
+
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert_eq!(result.changed_session_files, 0);
+    assert!(result.skipped_locked_rollout_files.contains(&rollout));
+    assert_eq!(fs::read_to_string(&rollout).unwrap(), externally_changed);
+}
+
+#[test]
 fn provider_sync_ignores_spawned_subagent_threads() {
     let tmp = tempdir().unwrap();
     let home = tmp.path().join(".codex");
@@ -1010,6 +1112,35 @@ fn provider_sync_updates_rollout_sqlite_visibility_and_creates_backup() {
     let backup_dir = result.backup_dir.unwrap();
     assert!(backup_dir.join("session-meta-backup.json").exists());
     assert!(backup_dir.join("db/state_5.sqlite").exists());
+}
+
+#[test]
+fn provider_sync_writes_empty_session_meta_manifest_for_index_only_updates() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    fs::create_dir(&home).unwrap();
+    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    write_rollout(
+        &home.join("sessions/rollout-current.jsonl"),
+        "apigather",
+        "thread-1",
+        "C:/workspace",
+    );
+    create_state_db(&home.join("state_5.sqlite"));
+
+    let result = run_provider_sync(Some(&home));
+
+    assert_eq!(result.status, ProviderSyncStatus::Synced);
+    assert_eq!(result.changed_session_files, 0);
+    let backup_dir = result.backup_dir.expect("index-only sync still needs a backup");
+    let manifest: Vec<serde_json::Value> =
+        serde_json::from_str(&fs::read_to_string(backup_dir.join("session-meta-backup.json")).unwrap())
+            .unwrap();
+    assert!(manifest.is_empty());
+    let metadata: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(backup_dir.join("metadata.json")).unwrap())
+            .unwrap();
+    assert_eq!(metadata["changedSessionFiles"], 0);
 }
 
 #[test]
@@ -2693,12 +2824,7 @@ fn provider_sync_restores_rollout_first_line_when_later_step_fails() {
     write_provider_config(&home, "apigather");
     let rollout = home.join("sessions/rollout-needs-rewrite.jsonl");
     write_rollout(&rollout, "openai", "thread-1", "C:/workspace");
-    let original_first_line = fs::read_to_string(&rollout)
-        .unwrap()
-        .lines()
-        .next()
-        .unwrap()
-        .to_string();
+    let original_rollout = fs::read(&rollout).unwrap();
     let db = Connection::open(home.join("state_5.sqlite")).unwrap();
     db.execute(
         "CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT, archived INTEGER, has_user_event INTEGER, cwd TEXT)",
@@ -2721,13 +2847,7 @@ fn provider_sync_restores_rollout_first_line_when_later_step_fails() {
 
     assert_eq!(result.status, ProviderSyncStatus::Skipped);
     assert!(result.message.contains("Provider sync skipped"));
-    let restored_first_line = fs::read_to_string(&rollout)
-        .unwrap()
-        .lines()
-        .next()
-        .unwrap()
-        .to_string();
-    assert_eq!(restored_first_line, original_first_line);
+    assert_eq!(fs::read(&rollout).unwrap(), original_rollout);
 }
 
 #[test]
@@ -3054,6 +3174,53 @@ fn session_index_cleanup_preserves_all_local_sources_and_unknown_records() {
         fs::read_to_string(backup.join("session_index.jsonl")).unwrap(),
         original_index
     );
+}
+
+#[test]
+fn session_index_cleanup_streams_large_unknown_records() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    fs::create_dir(&home).unwrap();
+    let stale_id = "019f4e36-490e-7ae0-8e78-a8b3ab33a428";
+    let retained_id = "019f4e36-490e-7ae0-8e78-a8b3ab33a429";
+    let large_unknown = json!({
+        "id": "future-record",
+        "kind": "cloud_task",
+        "blob": "x".repeat(2 * 1024 * 1024)
+    })
+    .to_string();
+    let original_index = format!(
+        "{large_unknown}\n{}\n{}\n",
+        session_index_line(stale_id, "stale"),
+        json!({
+            "id": retained_id,
+            "thread_name": "known but retained by a rollout filename",
+            "updated_at": "2026-07-13T12:00:00.000Z"
+        }),
+    );
+    let rollout = home.join(format!(
+        "sessions/rollout-2026-07-12T04-57-28-{retained_id}.jsonl"
+    ));
+    fs::create_dir_all(rollout.parent().unwrap()).unwrap();
+    fs::write(&rollout, "{\"type\":\"event_msg\"}\n").unwrap();
+    fs::write(home.join("session_index.jsonl"), &original_index).unwrap();
+
+    let preview = preview_session_index_cleanup(Some(&home)).unwrap();
+
+    assert_eq!(preview.candidates.len(), 1);
+    assert_eq!(preview.candidates[0].id, stale_id);
+    let result = apply_session_index_cleanup(
+        Some(&home),
+        &preview.snapshot_sha256,
+        &[stale_id.to_string()],
+    )
+    .unwrap();
+    let next_index = fs::read_to_string(home.join("session_index.jsonl")).unwrap();
+    assert!(next_index.contains(&large_unknown));
+    assert!(next_index.contains(retained_id));
+    assert!(!next_index.contains(stale_id));
+    let backup = result.backup_dir.expect("cleanup backup");
+    assert_eq!(fs::read_to_string(backup.join("session_index.jsonl")).unwrap(), original_index);
 }
 
 #[test]

--- a/crates/codex-plus-data/tests/provider_sync.rs
+++ b/crates/codex-plus-data/tests/provider_sync.rs
@@ -742,7 +742,7 @@ fn provider_sync_streams_large_rollout_without_losing_non_meta_content() {
     let tmp = tempdir().unwrap();
     let home = tmp.path().join(".codex");
     fs::create_dir(&home).unwrap();
-    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    write_provider_config(&home, "apigather");
     let rollout = home.join("sessions/2026/rollout-large.jsonl");
     fs::create_dir_all(rollout.parent().unwrap()).unwrap();
     let session_meta = json!({
@@ -782,7 +782,7 @@ fn provider_sync_reports_stream_progress() {
     let tmp = tempdir().unwrap();
     let home = tmp.path().join(".codex");
     fs::create_dir(&home).unwrap();
-    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    write_provider_config(&home, "apigather");
     for index in 0..3 {
         write_rollout(
             &home.join(format!("sessions/rollout-progress-{index}.jsonl")),
@@ -820,7 +820,7 @@ fn provider_sync_reports_rollback_when_rewrite_write_fails() {
     let tmp = tempdir().unwrap();
     let home = tmp.path().join(".codex");
     fs::create_dir(&home).unwrap();
-    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    write_provider_config(&home, "apigather");
     let first_rollout = home.join("sessions/rollout-a.jsonl");
     let blocked_rollout = home.join("sessions/rollout-b.jsonl");
     write_rollout(&first_rollout, "openai", "thread-a", "C:/workspace");
@@ -845,7 +845,7 @@ fn provider_sync_continues_rollback_after_a_conflicted_rollout() {
     let tmp = tempdir().unwrap();
     let home = tmp.path().join(".codex");
     fs::create_dir(&home).unwrap();
-    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    write_provider_config(&home, "apigather");
     let first_rollout = home.join("sessions/rollout-a.jsonl");
     let conflicted_rollout = home.join("sessions/rollout-b.jsonl");
     write_rollout(&first_rollout, "openai", "thread-a", "C:/workspace");
@@ -902,7 +902,7 @@ fn provider_sync_skips_rollout_locked_after_planning() {
     let tmp = tempdir().unwrap();
     let home = tmp.path().join(".codex");
     fs::create_dir(&home).unwrap();
-    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    write_provider_config(&home, "apigather");
     let rollout = home.join("sessions/rollout-locked.jsonl");
     write_rollout(&rollout, "openai", "thread-1", "C:/workspace");
     let original_rollout = fs::read(&rollout).unwrap();
@@ -932,7 +932,7 @@ fn provider_sync_skips_rollout_changed_after_scanning() {
     let tmp = tempdir().unwrap();
     let home = tmp.path().join(".codex");
     fs::create_dir(&home).unwrap();
-    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    write_provider_config(&home, "apigather");
     let rollout = home.join("sessions/rollout-changed.jsonl");
     write_rollout(&rollout, "openai", "thread-1", "C:/workspace");
     let externally_changed = "{\"type\":\"event_msg\",\"payload\":{\"changed\":true}}\n";
@@ -1232,7 +1232,7 @@ fn provider_sync_writes_empty_session_meta_manifest_for_index_only_updates() {
     let tmp = tempdir().unwrap();
     let home = tmp.path().join(".codex");
     fs::create_dir(&home).unwrap();
-    fs::write(home.join("config.toml"), "model_provider = \"apigather\"\n").unwrap();
+    write_provider_config(&home, "apigather");
     write_rollout(
         &home.join("sessions/rollout-current.jsonl"),
         "apigather",

--- a/docs/plans/2026-08-27-历史会话流式修复实施计划.md
+++ b/docs/plans/2026-08-27-历史会话流式修复实施计划.md
@@ -1,0 +1,411 @@
+# 历史会话流式修复实施计划
+
+## 1. Goal
+
+将“修复历史会话”的批量 provider 同步从“同时保留所有 rollout JSONL 的原文和改写文本”改为流式扫描与逐文件写入，避免 Codex 历史会话很多时占用与全部历史总量成比例的大量内存。
+
+完成后，手动修复和启动前自动修复都应保持现有会话可见性修复、SQLite/catalog 同步、备份、跳过占用文件和失败回滚语义；管理器手动修复时还应展示由后端真实阶段/计数驱动的进度，而不是定时器模拟进度。
+
+不改变既有 `run_provider_sync` / `run_provider_sync_with_target` 调用方式、`ProviderSyncResult` JSON 字段、备份目录命名和 `session-meta-backup.json` 的兼容格式，也不改变 Remote Control 单会话收尾流程。
+
+## 2. Current Implementation
+
+批量历史会话修复由 `apps/codex-plus-manager/src/App.tsx` 的 `syncProvidersNow` 发起。该函数先设置 12% 的进度，再以 350ms `setInterval` 将进度推至 88%；随后调用 Tauri 命令 `sync_providers_now`。所以当前 UI 进度与后端实际处理数量无关。
+
+`apps/codex-plus-manager/src-tauri/src/commands.rs` 的 `sync_providers_now` 使用 `tauri::async_runtime::spawn_blocking` 执行 `codex_plus_data::run_provider_sync_with_target(None, target_provider.as_deref())`，最终一次性返回 `ProviderSyncResult`。`spawn_blocking` 避免阻塞 UI 线程，但不会减少后端任务的内存占用。
+
+`crates/codex-plus-data/src/provider_sync.rs` 中的 `run_provider_sync_with_target` 是核心流程：
+
+1. 检查 Codex/ChatGPT 已停止、获取 `tmp/provider-sync.lock`。
+2. 读取 SQLite 中的子代理/用户线程信息并执行 repair audit。
+3. 调用 `collect_session_changes`，枚举 `sessions` 与 `archived_sessions` 下的 rollout JSONL。
+4. 对每个 rollout 使用 `fs::read_to_string` 读取完整文件；`rewrite_rollout_session_meta_providers` 又构造完整 `next_text`，并将 `original_text`、`next_text`、原始 `session_meta` 行、线程元数据放进 `SessionChange`。
+5. 即使文件不需要写入，只要有有效 `session_meta`，也会进入 `SessionChanges.changes`；之后待写变更会由 `.cloned().collect::<Vec<_>>()` 再复制一次，`apply_session_changes` 还会把成功项再复制到 `AppliedSessionChanges` 用于后续回滚。
+6. `replace_session_text_if_unchanged` 在写入时再次把完整当前文件读入 `current_text`，写入后又完整读入 `persisted_text` 校验。
+7. 会话文件完成后再更新 SQLite、local thread catalog 和 global state；后续步骤失败时用内存中的 `original_text` 调用 `restore_session_changes` 恢复已写文件。
+
+因此，批量改写的峰值至少包含所有已扫描会话的原始/改写文本；对需要改写的文件，还会同时存在多份 `SessionChange` 克隆和单文件校验缓冲。内存复杂度接近全部历史会话字节数，而不是最大单文件或最大单行大小。
+
+同一按钮在 provider sync 成功后还会调用 `preview_session_index_cleanup`。该流程的 `plan_session_index_cleanup` 使用 `fs::read` 与 `String::from_utf8(original_bytes.clone())`，同时保留 `session_index.jsonl` 的完整字节和完整文本；`apply_session_index_cleanup` 还会构造完整的 `next_text`。这不是主要 rollout 峰值，但在会话索引很大时会造成第二个内存峰值。
+
+`crates/codex-plus-core/src/launcher.rs` 在 `provider_sync_enabled` 为真时会在启动 Codex 前调用原有 `run_provider_sync`；该路径没有管理器窗口，不需要 UI 进度，但必须复用新的低内存核心实现。
+
+`provider_sync.rs` 里的 `SessionChange` / `SessionChanges` / `collect_session_change_for_path` / `apply_session_changes` 还被 Remote Control 单会话 finalization 使用。该路径一次只处理一个 rollout，不是本次全量内存问题，不能因为批量流式改造而改变其行为。
+
+## 3. Design Decisions
+
+**Decision:** 为批量 provider sync 新增流式扫描/应用类型和函数，不把现有 `SessionChange` 直接改造成通用流式类型。
+
+**Reason:** `SessionChange` 仍服务于 Remote Control 的单会话 finalization。让该流程保留现有完整文本语义，可以把风险限定在历史会话批量修复；批量路径不再持有完整 JSONL。
+
+**Rejected alternatives:** 直接重构 `SessionChange`、`collect_session_change_for_path` 和 Remote Control 相关调用会扩大到移动端/Remote Control 恢复的高风险路径，且对解决“很多会话”的问题没有必要。
+
+**Decision:** 批量修复采用两阶段流程：先逐行扫描生成轻量修复计划，再逐文件流式写入。
+
+**Reason:** 扫描阶段仍需汇总 thread id、cwd、`has_user_event`、子代理标记、encrypted content 警告和 SQLite 更新输入；这些都是小型元数据。只有确认要改写的文件才进入计划，计划保存路径、mtime、SHA-256 和原始 `session_meta` 行，不保存整份 rollout。
+
+**Rejected alternatives:** 仅将现有 `Vec<SessionChange>` 分批处理会降低峰值，但仍需要在后续 SQLite/global-state 失败时保存所有原文以回滚，不能可靠地消除全量文本驻留。
+
+**Decision:** 复用现有 `session-meta-backup.json` 的 path + `originalSessionMetaLines` 格式作为持久恢复记录，并在运行时保留轻量的 `SessionRewritePlan` / 写后 SHA-256 以执行正常失败回滚。
+
+**Reason:** provider sync 只改写有效 `session_meta` 行。通过按原始 session-meta 顺序将其精确写回，非 metadata 行字节保持原样，即可恢复原始 rollout，而无需保存整份文件。现有备份格式已经记录这些原始行，保持 version 1 格式避免破坏已有备份和外部恢复预期。
+
+**Rejected alternatives:** 为每个改写会话复制完整备份文件会把内存问题转为可能巨大的磁盘占用；只保留 hash 而不保存原始 metadata 行则无法在 SQLite/global-state 失败后恢复。
+
+**Decision:** 在 `codex-plus-core::settings` 增加基于现有 `.tmp` 与跨平台 `replace_file` 的流式原子写入 helper，供 provider sync 和 session-index cleanup 使用；替换前必须保留已有目标文件的权限，且调用方能够区分占用/共享冲突与其他 IO 失败。
+
+**Reason:** 逐行改写需要将输出写到临时文件，不能在不同长度的 JSONL 行上安全地边读原文件边原地覆盖。现有 `atomic_write` 已处理 macOS/Linux rename 与 Windows `MoveFileExW`；扩展它可避免在 data crate 复制平台相关替换逻辑。现有 rollout 写入保持原 inode 的权限，临时替换若不复制权限可能把 0600 文件变成受 umask 影响的新权限，因此这也是数据保护要求。
+
+**Rejected alternatives:** 在 `provider_sync.rs` 复制 Windows 文件替换实现会增加平台行为漂移；继续调用字节切片版 `atomic_write` 会重新把完整输出读回内存。
+
+**Decision:** 为流式 session-index cleanup 新增独立的轻量 `SessionIndexCleanupPlan`；保留现有含完整原文的 `SessionIndexPlan` 和 `filtered_session_index_text` 仅供删除会话路径使用。
+
+**Reason:** `remove_session_index_entry` 仍构造现有 `SessionIndexPlan` 并调用 `filtered_session_index_text`。直接收缩该结构或删除 helper 会造成编译失败。删除路径不在本次修复按钮的调用链内，保留其既有整文件行为不会影响本次降低批量修复内存的目标。
+
+**Decision:** 前端进度 listener 只使用函数式 state updater 判断任务是否仍 active，绝不从 listener 闭包读取捕获的 `providerSyncProgress.active`。
+
+**Reason:** 点击时 state 尚是 inactive；若 listener 读取该 render 捕获的值，会永久忽略所有后端进度事件。函数式 updater 能同时拒绝最终结果之后的迟到事件。
+
+**Decision:** 进度通过 Tauri `WebviewWindow` 定向事件传递；数据层新增可选回调 API，既有 API 以 no-op 回调包装。
+
+**Reason:** 现有 `App.tsx` 已导入 `listen`，Tauri manager 未使用任何全局进度状态。将事件定向到发起调用的窗口不会污染其他管理器窗口；launcher 继续调用无回调 wrapper。事件只在文件计数变化达到固定节流间隔或阶段切换时发送，避免成千上万条 UI IPC。
+
+**Rejected alternatives:** 前端继续基于时间估算百分比会误导用户且无法证明流式处理；全局广播事件会让多个 manager 窗口收到不属于自己的任务进度。
+
+**Decision:** 同时把 `preview_session_index_cleanup` / `apply_session_index_cleanup` 的全文件读写改为流式，但不改变候选列表 API 和人工确认流程。
+
+**Reason:** 这是同一“修复历史会话”按钮成功后的直接后续步骤。消除 rollout 峰值后仍保留完整 `session_index.jsonl` 副本，会让大索引用户继续遇到明显内存峰值。
+
+**Rejected alternatives:** 将索引清理完全移出本次范围会留下该按钮的第二个已知内存热点；对候选列表做分页或上限会改变现有用户确认行为，属于产品行为变化。
+
+## 4. Files to Change
+
+### `crates/codex-plus-core/src/settings.rs`
+**Purpose**
+
+提供复用现有跨平台替换逻辑的流式原子写入能力，避免 `provider_sync` 将完整生成内容放进 `Vec<u8>` / `String` 后才能写入。
+
+**Changes**
+
+1. 在现有 `atomic_write`、`replace_file`、`temp_path_for` 附近新增公开 helper，建议命名为 `atomic_write_with`：接收目标 `&Path` 和一个向临时 `File` 分块写入内容的闭包；闭包成功、临时文件 flush/关闭后复用现有 `replace_file` 替换目标。
+2. 当目标已存在时，在创建临时文件前读取其权限，并在替换前把该权限应用到临时文件。至少保证 Unix 权限位不被临时文件默认权限放宽；调用方继续负责恢复 mtime。不要声称无特权条件下能完整复制所有权或 Windows ACL。
+3. 将现有 `atomic_write(path, bytes)` 改为委托给 `atomic_write_with`，保持签名、错误上下文、`.tmp` 命名和所有现有调用方兼容。
+4. 当 writer 闭包失败时，不替换目标文件，并沿用当前临时文件清理原则；错误必须保留底层 `std::io::Error` 作为 error chain 中可检查的 source，使 data crate 能把占用/共享冲突和其他 IO 错误分开处理。
+5. 不修改 `replace_file` 的 Windows `MoveFileExW` 和非 Windows `rename` 分支；这确保流式 provider sync 使用与现有配置写入相同的跨平台替换机制，但不把原地写入和路径替换误认为具有相同的占用文件语义。
+6. 在当前 `settings` 单元测试模块中增加分块写入、writer 失败不覆盖目标和既有目标权限保留测试；权限断言在 Unix 下使用受限模式（如 0600）。保留现有 `atomic_write_replaces_existing_file_and_removes_temp_file`。
+
+### `crates/codex-plus-data/src/provider_sync.rs`
+**Purpose**
+
+将批量 provider sync、相关 rollout 扫描和 session-index cleanup 从整文件字符串/字节缓存改为逐行/流式 IO，同时保留当前 provider、SQLite、备份、锁和恢复语义。
+
+**Changes**
+
+1. 在 `ProviderSyncStatus` / `ProviderSyncResult` 附近新增可序列化的 `ProviderSyncProgressPhase`（建议阶段：`scanning`、`planning`、`backing_up`、`rewriting`、`updating_indexes`、`rolling_back`、`complete`）和 `ProviderSyncProgress`。
+   - 字段使用 camelCase：`totalRolloutFiles`、`scannedRolloutFiles`、`plannedRewriteFiles`、`appliedRewriteFiles`、`skippedLockedRolloutFiles`。
+   - 不修改 `ProviderSyncResult`，进度为独立事件数据。
+   - 定义私有节流常量（例如每 32 个已完成文件），阶段切换、首个进度、最后一个文件和完成状态必须强制上报。
+2. 保留 `run_provider_sync` 与 `run_provider_sync_with_target` 的签名，令其调用新增的 `run_provider_sync_with_target_and_progress(..., |_| {})`。
+   - 新函数为公开的同步函数，接收 `FnMut(ProviderSyncProgress)` 回调；manager 使用它，launcher 和现有调用方继续走 no-op wrapper。
+   - 所有已有早退路径（home 缺失、非法 target、运行中 App、锁冲突）仍返回相同 `ProviderSyncStatus` / 消息；没有开始扫描时允许没有进度事件。
+3. 不再让批量 `run_provider_sync_with_target` 使用 `collect_session_changes`。新增仅供批量路径使用的类型和函数：
+   - `BulkSessionRewritePlan`：`path`、原文件 SHA-256、`original_mtime`、按原顺序保存的 `original_session_meta_lines`。
+   - `BulkSessionScan`：`rewrite_plans`、跳过的占用文件、encrypted-content provider 计数、子代理 thread id、user-event thread id、cwd map、总 rollout 文件数。
+   - `scan_bulk_session_rewrites(...)`：基于已排序的 `rollout_files(home)?` 逐文件、逐行扫描；只把确实需要 provider 改写的文件放入 `rewrite_plans`，其余只汇总元数据后立即释放行缓冲。
+4. 在 `scan_bulk_session_rewrites` 中严格保留当前 `collect_session_changes` 的判定顺序和行为：
+   - 有效 `session_meta` 指 payload 为 object 的记录；JSON 解析失败/非 session-meta 行原样忽略。
+   - 线程被 rollout metadata 标为 non-root agent 时跳过并加入子代理集合，且优先于 explicit-user 例外。
+   - SQLite 已知子代理仅在不是 explicit user 时跳过。
+   - `has_user_event`、encrypted-content 警告和 cwd 聚合只对未跳过的正常会话执行。
+   - 遍历顺序继续使用当前 `rollout_files` 的排序，保持多个同 thread id 的 cwd 覆盖顺序。
+5. 使用 `BufReader::read_line` / `BufWriter` 实现逐行 JSONL helper，保留 `split_line_ending` 对 `\n` / `\r\n` 的处理。
+   - 行缓冲可复用；对于非修改行，直接写回原始字节/字符串。
+   - 对需要改写的 session-meta，继续使用与当前逻辑一致的 `serde_json` 解析、修改 `model_provider`、`serde_json::to_writer` 序列化；不得改变非 metadata 行。
+   - 扫描时增量计算原文件 SHA-256。无效 UTF-8 仍作为 IO/解析失败返回，使外层维持当前 `Provider sync skipped: ...` 错误语义。
+6. 新增批量应用/恢复函数，建议命名为 `apply_bulk_session_rewrite_plans` 和 `restore_bulk_session_rewrites`：
+   - 每个应用项在写入前再次流式读取并校验 SHA-256；与计划不一致或锁冲突时，像当前 `replace_session_text_if_unchanged` 一样记录为 skipped，不覆盖文件。
+   - 使用 `codex_plus_core::settings::atomic_write_with` 将流式改写结果写到目标 `.tmp` 后原子替换；写后流式计算并保存结果 SHA-256，恢复 mtime，并依赖 core helper 保留原权限。
+   - 在替换、重新打开或校验阶段出现底层占用/共享冲突时，必须沿 error chain 识别 PermissionDenied、WouldBlock 和当前 `is_locked_io_error` 支持的共享冲突，记录到 `skipped_locked_rollout_files`。其他 IO 错误必须恢复此前已应用项并返回错误，不能误报为单文件 skipped。
+   - `AppliedBulkSessionRewrite` 仅保存 plan 和写后 hash，不保存完整文本。
+   - SQLite/catalog/global-state 后续失败时，先验证写后 hash；反向重写时必须按顺序消费原始 `session_meta` 行，并验证实际可恢复的 metadata 行数与计划完全一致。数量、顺序或 hash 任一不一致时不得覆盖文件，记录恢复失败上下文；成功后验证恢复后的原 hash 并恢复 mtime。
+   - 如果批量写入过程中某个文件发生实际 IO/写后校验错误，先恢复此前已应用的文件，再将原错误交给现有外层 `Skipped` 处理；不要留下本次任务已知的部分 session 文件改写。
+7. 将 `create_backup` 拆出可复用的“写 session-meta manifest”内部 helper。
+   - 现有 Remote Control 调用仍可传入 `&[SessionChange]` 并保持原有备份行为。
+   - 批量路径传入 `&[BulkSessionRewritePlan]`。
+   - 用 `BufWriter` 和逐项序列化写出 JSON 数组，保持 `session-meta-backup.json` 的 `path` / `originalSessionMetaLines` schema 以及 `metadata.json` version 1、`changedSessionFiles`、DB/config/global-state 备份字段不变；不得先构造整个 `Vec<Value>`。兼容性以 JSON schema 为准，不以空白字节完全一致为准；输出仍应保持可读的 pretty JSON。
+   - 即使 rewrite plan 为空、但 SQLite/catalog/global-state 仍需更新，也必须与当前逻辑一样创建 backup，写出空的 `session-meta-backup.json` 数组并让 `changedSessionFiles` 为 0。
+8. 保留 `SessionChange`、`SessionChanges`、`collect_session_change_for_path`、`rewrite_rollout_session_meta_providers_for_threads`、`apply_session_changes` 和 `restore_session_changes` 供 `run_remote_control_session_finalization_for_thread_with_target` 使用。本次不要将 Remote Control 单文件路径接入批量进度或重写计划。批量调用点切换后，删除只服务旧批量路径的 `collect_session_changes` 与 `rewrite_rollout_session_meta_providers`，避免留下未使用的大文本 helper。
+9. 将 `collect_live_thread_ids` 和 `rollout_provider_ids` 改为复用逐行读取，避免管理器加载 provider 同步目标和 session-index cleanup 预览时为单个大 rollout 建立完整字符串。保持它们的返回集合和对锁定文件的跳过语义不变。
+10. 新增仅供 cleanup preview/apply 使用的 `SessionIndexCleanupPlan`，字段为 `path`、`snapshot_sha256`、`candidates`；不要收缩现有 `SessionIndexPlan` 或移除 `filtered_session_index_text`。
+    - `plan_session_index_cleanup` 返回新轻量类型，流式读取 `session_index.jsonl`，对原始行字节增量计算 SHA-256，仅保留候选元数据。
+    - 以 `stream_filtered_session_index` 代替 cleanup 路径的整串过滤：读取当前 index、校验快照、仅跳过用户确认的候选行，并直接写入 `atomic_write_with` 提供的临时文件；返回删除计数。
+    - `create_session_index_cleanup_backup` 改为流式文件复制/校验当前快照，而不是接收 `original_bytes`；继续在写入前创建完整 `session_index.jsonl` 备份、在快照变化时拒绝覆盖、并保留现有错误消息与 `backup_dir` 暴露规则。
+    - `preview_session_index_cleanup` / `apply_session_index_cleanup` 的公开参数、返回 JSON 和“候选必须在 preview 中出现”的校验均保持不变。
+11. 不改变 `session_index_lines_for_thread`、`remove_session_index_entry`、`restore_session_index_entries` 的行为或整文件读写；它们继续使用保留的旧 `SessionIndexPlan` / `filtered_session_index_text`，不在“修复历史会话”调用链内。
+
+### `crates/codex-plus-data/src/lib.rs`
+**Purpose**
+
+将新增的流式 provider sync API 与进度类型按照本 crate 既有 re-export 模式暴露给 manager crate。
+
+**Changes**
+
+1. 在现有 `pub use provider_sync::{...}` 中导出 `ProviderSyncProgress`、`ProviderSyncProgressPhase` 和 `run_provider_sync_with_target_and_progress`。
+2. 保留所有现有导出，不重命名或移除 `run_provider_sync` / `run_provider_sync_with_target`。
+
+### `apps/codex-plus-manager/src-tauri/src/commands.rs`
+**Purpose**
+
+把 data 层的真实进度回调传递给发起修复的 manager 窗口，同时保持当前 command response 与成功/失败通知行为。
+
+**Changes**
+
+1. 为 `sync_providers_now` 注入 `tauri::WebviewWindow` 参数，并引入 Tauri `Emitter` trait。
+2. 定义私有事件名常量，例如 `provider-sync-progress`。在 `spawn_blocking` 闭包中调用 `run_provider_sync_with_target_and_progress`，将每个 `ProviderSyncProgress` 定向 `emit` 到该 `WebviewWindow`。
+3. 窗口已关闭或事件发送失败时忽略事件发送错误，不中断真实修复；修复成功/失败仍只由现有 `provider_sync_command_result` 决定。
+4. 保持 `target_provider` 清洗、Codex App state snapshot/finish、诊断日志、持久化选中 provider、payload 字段和失败语义不变。
+
+### `apps/codex-plus-manager/src/provider-sync-flow.ts`
+**Purpose**
+
+集中定义前端消费后端进度事件的类型与百分比计算，使 `App.tsx` 不再用时间驱动的假进度，并提供可单测的纯函数。
+
+**Changes**
+
+1. 在现有 `resolveProviderSyncCompletion` 旁新增导出的 `ProviderSyncStreamProgress` 类型，对应 Rust camelCase 字段和 snake_case phase 字符串。
+2. 新增纯函数，建议命名为 `providerSyncStreamPercent(progress)`：
+   - `scanning` 基于 `scannedRolloutFiles / totalRolloutFiles` 推进 0..45 区间；total 为 0 时返回 45。
+   - `planning`、`backing_up`、`updating_indexes`、`rolling_back` 分别返回 50、55、92、96。
+   - `rewriting` 基于 `appliedRewriteFiles / plannedRewriteFiles` 推进 60..88 区间；planned 为 0 时返回 88。
+   - `complete` 返回 100。
+   - total/planned 为 0 时不能产生 `NaN` 或超过 0..100；每个 phase 的结果限制在 0..100。App 消费时以当前百分比和新值的最大值更新，避免迟到或跨阶段事件造成倒退。
+3. 不在此文件引入 React 或 Tauri API；它保持 node:test 可直接导入的纯 TypeScript 模块。
+
+### `apps/codex-plus-manager/src/provider-sync-flow.test.ts`
+**Purpose**
+
+覆盖新进度百分比函数的边界与阶段映射，同时保留现有 cleanup completion 结果测试。
+
+**Changes**
+
+1. 增加扫描阶段 0/中间/完成计数的断言。
+2. 增加 rewrite 阶段 0/部分/完成计数的断言。
+3. 增加 `totalRolloutFiles = 0`、`plannedRewriteFiles = 0` 时百分比为有限 0..100 数字的断言。
+4. 增加所有固定阶段的精确百分比与 complete 返回 100 的断言；保留两个现有 `resolveProviderSyncCompletion` 测试不变。
+
+### `apps/codex-plus-manager/src/App.tsx`
+**Purpose**
+
+用后端事件驱动“历史会话修复”进度显示，去除当前的定时器模拟进度，但保留完成后的 session-index cleanup、提示和设置保存流程。
+
+**Changes**
+
+1. 从 `provider-sync-flow.ts` 导入 `ProviderSyncStreamProgress` 与 `providerSyncStreamPercent`。
+2. 在 `syncProvidersNow` 开始时设置 `active: true`、`percent: 0` 和现有扫描文案；删除 `window.setInterval`、`window.clearInterval` 及所有按时间推进百分比的代码。
+3. 在 invoke `sync_providers_now` 之前调用已经导入的 `listen<ProviderSyncStreamProgress>("provider-sync-progress", ...)`，在监听回调中：
+   - 使用 `providerSyncStreamPercent` 更新百分比。
+   - 按 phase 映射到现有 i18n 文案：`scanning` 使用“正在扫描历史会话与索引…”，`planning` 使用“正在检查会话 provider 标记…”，其余写入/回滚阶段使用“正在写入修复与备份…”。
+   - 必须使用 `setProviderSyncProgress(current => ...)`；在 updater 内检查 `current.active`，为 false 时原样返回。不得从 listener 闭包读取捕获的 `providerSyncProgress.active`。
+   - active 时合并当前 state、使用 `Math.max(current.percent, providerSyncStreamPercent(progress))` 更新百分比，并保留最终 command result 尚未写入时的 `result` 值。
+4. 将 `unlisten` 放在 `try/finally` 中，确保 command 抛错、取消或正常完成后都解除监听；不新增全局事件监听，不泄漏重复 listener。
+5. 保留 command 返回后 `preview_session_index_cleanup` / 用户确认 / `apply_session_index_cleanup` 的既有顺序和 `resolveProviderSyncCompletion` 处理；最终成功或失败仍将进度设为 100 并设置最终 `result`。
+6. 不新增文案 key：只复用已经存在且已翻译的修复阶段文案，因此无需修改 `i18n-en.ts` 或 `tools/i18n-keys.json`。
+
+### `crates/codex-plus-data/tests/provider_sync.rs`
+**Purpose**
+
+证明批量路径保持修复结果和恢复安全性，同时覆盖流式进度、超大 rollout 内容和 session-index 流式行为。
+
+**Changes**
+
+1. 保留并继续运行现有 provider sync、subagent、catalog、backup、锁、mtime、SQLite rollback 和 index cleanup 测试。
+2. 新增 `provider_sync_streams_large_rollout_without_losing_non_meta_content`：创建包含有效 `session_meta`、多 MB 非 metadata JSON 行和尾部事件的 rollout；运行批量 sync；断言 provider 更新、非 metadata 字节/尾部完整保留、结果成功。该测试验证实现不会依赖整个文本的 `read_to_string` / `next_text` 构造。
+3. 将 `provider_sync_restores_rollout_first_line_when_later_step_fails` 扩展为保存并比较整份原始 rollout bytes（含多行/大 payload），而不是只断言第一行；仍通过 SQLite trigger 制造后续失败，断言文件完整恢复。
+4. 新增批量写入失败/不一致回归测试：借助新进度回调在 scan 完成、写入开始前改动一个 rollout；断言该文件被记录为 skipped、外部改动未被覆盖，其他符合当前规则的更新仍按现有语义处理。
+5. 新增 `provider_sync_reports_stream_progress`：使用多个 rollout 调用 `run_provider_sync_with_target_and_progress` 收集事件；断言扫描 total/完成计数、planned/applied 重写计数、阶段顺序和 complete 事件一致，且回调只报告元数据而不改变 `ProviderSyncResult`。
+6. 为 session-index 增加带大 unknown record 的 preview/apply 测试：preview 仍只返回真实 stale candidate；apply 后未知行和非候选行保持原样、候选被移除、备份内容正确。保留既有“preview 后文件变化时拒绝覆盖”及原子写入失败测试。
+7. 新增“仅 SQLite/catalog/global-state 需要更新”的备份回归：断言仍生成 backup、`session-meta-backup.json` 解析为空数组、metadata 的 `changedSessionFiles` 为 0。
+8. 在 Unix 下新增 rollout 原权限为 0600 的流式改写回归，断言替换后权限不变；在 Windows 下增加目标被持有时的替换测试，断言文件未覆盖且结果记入 `skipped_locked_rollout_files`。若 CI 无 Windows runner，至少在 Windows 开发机/发布前验证此测试。
+9. 新增 rollback metadata 防御回归：通过受控的计划/文件不一致触发计数校验失败，断言不覆盖目标文件且不会把恢复失败伪装为成功。
+
+## 5. Files to Add
+
+None.
+
+## 6. Implementation Order
+
+1. 修改 `crates/codex-plus-core/src/settings.rs`，实现并测试 `atomic_write_with`。
+   - 原因：流式 rollout/index 写入都依赖跨平台临时文件替换，先建立底层能力可避免 data 层重复实现。
+   - 完成标准：既有 `atomic_write` 测试继续通过；新闭包分块写入测试证明替换成功、失败不覆盖目标、临时路径沿用当前规则，并保留已有目标的 Unix 权限位和底层 IO error source。
+
+2. 在 `crates/codex-plus-data/src/provider_sync.rs` 添加进度类型、no-op wrapper 和批量流式扫描数据结构。
+   - 原因：先稳定数据层 public API 和扫描输出，再接入写入与 UI。
+   - 完成标准：`run_provider_sync` / `run_provider_sync_with_target` 签名不变；新回调 API 能在不写文件的 no-op sync 中安全报告阶段。
+
+3. 实现 bulk rollout 的逐行扫描、计划生成、流式写入和基于 metadata 行的回滚；将 `run_provider_sync_with_target` 内部主路径切到新实现。
+   - 原因：这是内存优化的核心，必须在接入 UI 前由 Rust 集成测试保障兼容性。
+   - 完成标准：批量路径不再在 `SessionChange` 中保留所有 rollout 的 `original_text` / `next_text`；Remote Control 单会话路径仍编译并继续使用旧 helper；共享冲突会跳过而非覆盖，其他写入错误会回滚已应用项。
+
+4. 重构 `create_backup` 的 manifest 写入，让旧 Remote Control 调用和新 bulk plan 都能生成完全兼容的 backup 元数据。
+   - 原因：写入路径依赖备份和回滚，必须在实际应用前完成。
+   - 完成标准：已有 `provider_sync_backup_metadata_contains_reference_fields_and_managed_marker` 通过，新增实现不构造整份 manifest `Vec<Value>`，并保留纯数据库更新时的空 manifest backup。
+
+5. 将 `collect_live_thread_ids`、`rollout_provider_ids`、新的 `SessionIndexCleanupPlan`、preview/apply session-index cleanup 改为流式实现，保留删除流程的旧 `SessionIndexPlan`。
+   - 原因：避免同一修复工作流在主修复完成后出现第二个全文件内存峰值。
+   - 完成标准：snapshot SHA、候选验证、未知记录保留、备份和“文件变化时拒绝覆盖”行为全部保持。
+
+6. 更新 `crates/codex-plus-data/src/lib.rs` re-export，并在 manager Tauri command 中发出窗口定向进度事件。
+   - 原因：数据层 API 完整后再接 UI，可最小化编译中间态。
+   - 完成标准：command payload 与现有成功/失败结果不变；关闭 manager 窗口不使后台同步失败。
+
+7. 更新 `provider-sync-flow.ts`、其测试与 `App.tsx`，删除模拟 timer，注册/释放 Tauri listener 并显示真实进度。
+   - 原因：后端事件协议已确定，前端只负责映射展示。
+   - 完成标准：没有 `setInterval` 模拟代码；每次运行只注册一个 listener，结束后释放；listener 使用函数式 updater，不读取旧 render 捕获的 active 状态；现有 cleanup completion 行为仍通过测试。
+
+8. 补齐/更新 Rust 和 TypeScript 测试，依次运行目标测试、全量测试、类型检查、前端构建、格式化和 clippy。
+   - 原因：该改动跨文件系统、SQLite、Tauri IPC 与 React 状态，必须覆盖功能与编译边界。
+   - 完成标准：第 9 节列出的命令通过，`git diff --check` 无空白错误，diff 仅涉及本计划列出的文件。
+
+## 7. Detailed Behavior
+
+### Normal path
+
+1. 用户在 manager 点击“修复历史会话”，或 launcher 在 `providerSyncEnabled` 时启动前调用既有 wrapper。
+2. 同步继续检查 Codex/ChatGPT 进程和 provider-sync lock；目标 provider 解析规则不变。
+3. 批量扫描按既有排序依次读取 rollout JSONL，每次只保留可复用行缓冲和当前文件的少量 session-meta 信息。扫描完成后，内存中只有 thread/cwd/encryption/subagent 集合及要改写文件的轻量计划。
+4. 若没有 rollout/SQLite/catalog/global-state 需要修改，返回当前“already up to date”结果，不创建多余写入。
+5. 若需要修改，先创建当前同样的 config/global-state/SQLite/session-meta backup（即使仅数据库更新也写出空 manifest），再逐个文件通过临时文件流式改写并原子替换，恢复每个文件原 mtime 和原权限。
+6. 完成 rollout 后按当前顺序更新 SQLite、补齐/清理 catalog、更新 global state、清理过旧备份，并返回与当前同形状的 `ProviderSyncResult`。
+7. manager 手动路径从定向 Tauri event 获得扫描/计划/备份/写入/索引/回滚的真实阶段；百分比来自当前文件计数，不再由时间推进。成功后的 session-index candidate preview、用户选择和 apply 顺序不变。
+
+### Edge cases
+
+- **空或不存在的 Codex home：** 保持 `Skipped` 结果和现有消息；不开始流式扫描。
+- **无 rollout / 无有效 `session_meta`：** 不创建 rewrite plan；仍按当前 SQLite/catalog/global-state 计数决定是否需要同步。
+- **无效 JSON 或非 session-meta JSONL 行：** 与当前实现相同，原样保留且不视为错误；只解析有效的 session-meta payload。
+- **非 UTF-8 rollout 或 IO 错误：** 像当前 `read_to_string` 一样让本次 provider sync 进入现有 `Skipped` 错误路径，不吞掉错误。
+- **占用、共享冲突、权限拒绝或写入前 hash 不一致的 rollout：** hash 不一致直接跳过且不覆盖当前文件；IO 错误仅在满足 `is_locked_io_error` 的既有兼容规则（含 PermissionDenied、WouldBlock 与共享冲突）时记录到 `skipped_locked_rollout_files`。其他 IO 错误先恢复此前已应用项并按既有失败路径返回；其 SQLite 元数据参与方式保持当前收集时行为。
+- **子代理 / explicit user：** 必须保留当前优先级和过滤顺序，不能把子代理会话重新标为用户会话。
+- **重复调用：** 已经是目标 provider 的 session-meta 不进入 rewrite plan；第二次调用仍应报告无会话文件改写，且不会重复创建 catalog 行。
+- **并发调用：** 继续由 `tmp/provider-sync.lock` 拒绝第二个 sync；Tauri UI 的 `active` 状态继续禁用同窗口按钮。其他窗口不会收到定向进度事件。
+- **启动前自动修复：** 调用旧 no-op callback wrapper，不依赖 manager window，不改变启动顺序和错误传播。
+- **session_index preview 后被 Codex 改写：** SHA 不匹配时拒绝 apply，原文件不覆盖；候选确认 API 与提示语义不变。
+- **候选数量很大：** JSONL 原文不再常驻，但候选列表仍需要返回给现有确认 UI，因此候选元数据本身仍按候选数量占内存；本次不改变分页/确认产品行为。
+
+### Error handling
+
+- 业务前置检查、锁冲突、target 非法和文件系统/SQLite 错误继续通过 `ProviderSyncResult { status: Skipped, message: ... }` 或当前 `SessionIndexCleanupApplyError` 传递；不引入新的用户可见成功状态。
+- 流式 writer 失败、输出 hash 校验失败或后续 SQLite/catalog/global-state 失败时，批量路径必须尝试反向恢复所有本次已成功替换的 rollout，然后返回原始错误上下文；反向重写前后都校验 hash，且必须完整消费计划记录的 metadata 行。恢复失败仅记录诊断/保留备份线索，不能伪装为成功。
+- Tauri progress event 发送失败（如 UI 已关闭）只影响显示，不影响数据层同步或最终 command result。
+- session-index 流式过滤若发现预览快照已变化，必须在原子替换前停止，并沿用现有“请重新预览”的失败语义。
+
+## 8. Invariants
+
+- `run_provider_sync`、`run_provider_sync_with_target`、`ProviderSyncResult`、`SessionIndexCleanupPreview` 和 `SessionIndexCleanupResult` 的公开调用方式与序列化字段不变。
+- `session-meta-backup.json` 继续使用当前 version 1 的 `path` 和 `originalSessionMetaLines` JSON schema；`metadata.json` 的 namespace、version、DB/config/global-state 备份字段和 `changedSessionFiles` 含义不变。兼容性不要求 JSON 空白字节完全一致，但输出必须可读且可由既有 JSON 消费者解析。
+- 只改写有效 session-meta 记录中的 `model_provider`；非 metadata 行、未知 JSON、无效 JSON、行结束符和未改写的 session-meta 行必须原样保留。
+- provider sync 的 App-stop 检查、锁、子代理过滤、explicit-user 优先级、encrypted-content 警告、SQLite/catalog/global-state 更新顺序、mtime/权限恢复与备份保留策略不变。
+- Remote Control 单会话 finalization 不接入本次 bulk streaming 类型或进度 IPC，维持原实现和对外行为；session-index 删除流程继续使用旧私有 helper。
+- 不修改 `Cargo.toml`、`package.json`、`.gitignore`，不新增依赖，不删除既有文件或仍被调用的兼容逻辑。
+- 不把会话正文、SQLite 内容或任何凭据写入诊断日志或进度事件；进度事件只含计数和阶段。
+
+## 9. Tests
+
+### Existing tests
+
+- `crates/codex-plus-data/tests/provider_sync.rs` 的完整集成测试：覆盖 provider 改写、subagent 过滤、SQLite/catalog 同步、备份、锁、mtime、rollback、session-index preview/apply。该文件是本次核心行为的既有契约。
+- `crates/codex-plus-core/src/settings.rs` 中 `atomic_write` 单元测试：新增 helper 必须保持跨平台 temp-replace 行为。
+- `apps/codex-plus-manager/src/provider-sync-flow.test.ts`：覆盖前端完成状态和新增纯进度映射。
+- workspace Rust tests 与 manager 前端测试：确保 Launcher 仍能调用兼容 wrapper，Tauri command 签名和 React TypeScript 编译未回归。
+
+### Tests to add/update
+
+1. **大 rollout 流式保真：** 写入包含多个 MB 非 metadata JSON 行、session-meta 和尾部事件的 rollout；运行 provider sync；断言仅 provider 字段按预期变化，其他完整字节和尾行未被截断或重排。
+2. **后续失败全文件回滚：** 扩展现有 SQLite trigger 测试，以完整 bytes 而非第一行比较；断言 session-meta 与所有普通事件都恢复为完全相同的原文。
+3. **写入前源文件变化：** 在 progress 回调的扫描结束/写入前阶段篡改一个 rollout；断言同步不会覆盖该文件、结果的 skipped 文件列表包含它，且未篡改其他正常文件。
+4. **进度协议：** 用多个 rollout 收集 callback payload；断言 total/scanned/planned/applied 值、阶段顺序、节流后的最终事件和 complete 事件；结果对象字段保持未变化。
+5. **流式 session-index：** 用一个很大的 unknown JSON 行加真实 stale candidate/本地 candidate；preview 只列 stale，apply 保留 unknown/本地行、移除确认行、备份仍等于写入前 index。
+6. **核心原子写入闭包：** 分块写入成功替换、writer 返回错误时目标保持旧内容、现有 `.tmp` 写入失败语义不被破坏。
+7. **权限与 Windows 占用文件：** Unix 下保留 rollout 的受限权限；Windows 下路径替换遇到被占用目标时不覆盖并按现有 skipped 语义返回。
+8. **空 manifest 兼容：** 仅 SQLite/catalog/global-state 更新时仍写出可解析的空 session-meta manifest，metadata 字段不变。
+9. **前端百分比：** 对 scanning/rewrite 的 0、中间、完成计数、固定阶段和 zero-total 边界断言精确且有限的范围值；complete 为 100；保留 cleanup success/failure 的最终消息测试。
+
+## 10. Validation Commands
+
+在仓库根目录执行：
+
+```bash
+cargo fmt --all -- --check
+cargo test -p codex-plus-core settings::tests
+cargo test -p codex-plus-data --test provider_sync
+cargo test --workspace
+cargo clippy
+git diff --check
+```
+
+在 `apps/codex-plus-manager` 目录执行：
+
+```bash
+npm test
+npm run check
+npm run vite:build
+```
+
+这些命令均已由仓库的 `README.md`、`CONTRIBUTING.md`、`apps/codex-plus-manager/package.json` 或 CI workflow 确认存在。不要新增依赖安装命令；只有本机依赖缺失时才按执行环境既有流程处理。
+
+## 11. Risks
+
+**Risk:** 流式重写时 JSON 序列化、CRLF 或多条 session-meta 的处理与现有整串实现不同，可能造成会话文件非 provider 内容变化。
+
+**Mitigation:** 使用与当前相同的 `serde_json` 修改规则；未修改行直接写原始行及原始 ending；用全文件 bytes 回归测试覆盖多 session-meta、大 payload 和 rollback。
+
+**Risk:** 文件在扫描与原子替换之间被外部进程修改，可能覆盖 Codex 新内容。
+
+**Mitigation:** 保持 App-stop/lock 前置条件；应用前在流式读取时校验扫描期 SHA-256，hash 不同即跳过，不替换目标；保留当前 index cleanup 的 snapshot 拒绝语义。
+
+**Risk:** Windows 的路径替换与当前持锁原地写入不是同一套共享句柄语义；目标在替换时被 Codex、索引器或其他进程占用，可能使 `MoveFileExW` 失败。
+
+**Mitigation:** 保留每文件 hash 校验；从 `atomic_write_with` 的 error chain 中识别现有占用/共享冲突类别并记录 skipped，绝不覆盖目标。为 Windows 增加持有目标文件的回归测试，验证失败不会中止为成功或误写文件。
+
+**Risk:** 临时文件替换可能使用新建文件的默认权限，令原本受限的 rollout 文件权限被放宽。
+
+**Mitigation:** `atomic_write_with` 在替换前复制已有目标的权限到临时文件；Unix 下以 0600 回归测试验证。文档不承诺在无特权环境中完整复制所有权或 ACL。
+
+**Risk:** 后续 SQLite/catalog/global-state 更新失败时，流式版本没有完整原文可用于恢复。
+
+**Mitigation:** 对每个计划保留精确原始 session-meta 行和原/写后 hash；按 metadata 顺序流式反向改写并验证完整消费的行数；在 write error 和后续错误两种路径都调用恢复；继续在写前生成已有格式的持久 session-meta backup。
+
+**Risk:** 进度事件频率过高会让管理器前端自身占用 CPU 或发生状态抖动。
+
+**Mitigation:** 文件级而非行级上报，使用固定节流间隔并强制阶段边界/最终事件；前端在函数式 state updater 内检查 active、取百分比最大值，并在 finally 中解除 listener，避免旧 render 闭包忽略事件或迟到事件回退最终状态。
+
+**Risk:** session-index 候选列表本身在候选极多时仍可能占用较多内存。
+
+**Mitigation:** 本次消除原始 index 正文/改写正文副本，保留当前完整候选确认 API；分页/上限是行为变化，明确留在后续单独需求中。
+
+## 12. Out of Scope
+
+- 不改变 provider sync 的业务目标、provider 选择规则、SQLite schema、local thread catalog eligibility 或 global-state 结构。
+- 不改变 Remote Control 单会话恢复/finalization 的实现或 IPC。
+- 不为 session-index cleanup 增加分页、批量确认上限、后台取消、断点续传或新的用户设置。
+- 不重构本次调用链外的会话删除、导入、导出、session-index helper。
+- 不修改 Cargo/package 依赖、构建工具链、发布流程或任何凭据配置。
+- 不做真实 RSS 基准门槛测试；Rust 单元测试应验证流式保真、回滚和不再构造全量文本的代码路径，性能/内存基准可在后续独立任务中进行。
+
+## 13. Execution Checklist
+
+- [ ] 修改 `crates/codex-plus-core/src/settings.rs`，新增并测试流式原子写入 helper，保持 `atomic_write` 兼容、底层 IO error 可识别和已有文件权限不变。
+- [ ] 修改 `crates/codex-plus-data/src/provider_sync.rs`，新增 provider sync progress 类型和兼容 no-op wrapper。
+- [ ] 修改 `crates/codex-plus-data/src/provider_sync.rs`，实现批量 rollout 的流式扫描、轻量 rewrite plan、流式应用和 metadata 回滚，明确区分占用文件 skipped 与其他 IO 错误。
+- [ ] 修改 `crates/codex-plus-data/src/provider_sync.rs`，流式写 session-meta backup manifest，保留空 rewrite plan 的 backup 语义和 JSON schema。
+- [ ] 修改 `crates/codex-plus-data/src/provider_sync.rs`，将 provider target discovery、live thread id 和 session-index preview/apply 改为流式 IO，并新增轻量 `SessionIndexCleanupPlan`、保留删除流程旧 helper。
+- [ ] 批量路径切换后删除仅服务旧批量路径的 `collect_session_changes` 与 `rewrite_rollout_session_meta_providers`，确认 Remote Control 仍使用独立单文件 helper。
+- [ ] 保持 Remote Control 单会话 `SessionChange` 路径不变。
+- [ ] 修改 `crates/codex-plus-data/src/lib.rs`，导出新增进度 API 和类型。
+- [ ] 修改 `apps/codex-plus-manager/src-tauri/src/commands.rs`，向发起窗口发出定向 provider sync progress 事件。
+- [ ] 修改 `apps/codex-plus-manager/src/provider-sync-flow.ts`，新增纯进度类型和百分比函数。
+- [ ] 修改 `apps/codex-plus-manager/src/provider-sync-flow.test.ts`，覆盖阶段/计数/零值进度。
+- [ ] 修改 `apps/codex-plus-manager/src/App.tsx`，移除模拟 timer，注册并释放真实进度 listener，使用函数式 updater，保留完成和 cleanup 流程。
+- [ ] 更新 `crates/codex-plus-data/tests/provider_sync.rs`，覆盖大 rollout、写入前变化、进度、完整 rollback、流式 session-index、空 manifest、权限和 Windows 占用文件。
+- [ ] 运行 Rust、前端、格式化、clippy 和 diff 验证命令。
+- [ ] 检查 backward compatibility、备份格式、Remote Control 路径和 git diff，确认没有 unrelated changes。


### PR DESCRIPTION
## 问题

“修复历史会话”的批量 provider 同步在 Codex 历史会话较多时，会将多个 rollout JSONL 完整读入内存，同时保存原文、改写文本和回滚副本，内存占用会随全部历史会话正文规模增长。

同一流程后续的 `session_index.jsonl` 清理也会同时保留完整字节、完整文本并构造完整的新文本，可能产生第二次内存峰值。另外，管理器此前使用定时器模拟进度，展示进度与后端实际处理情况不一致。

## 改动

- 新增 `atomic_write_with` 流式原子写入 helper，支持分块写入临时文件、原子替换、保留原文件权限，并兼容现有 `atomic_write`。
- 批量 provider sync 改为“两阶段”：
  - 逐行扫描 rollout JSONL，只保留轻量 rewrite plan、thread 元数据、mtime 和 SHA-256。
  - 仅对确实需要修改的文件进行逐文件、逐行流式改写，不再缓存全部 rollout 原文。
- 只修改有效 `session_meta` 中的 `model_provider`，非 metadata 行、未知 JSON、无效 JSON、行结束符和其他正文内容原样保留。
- 写入前重新校验源文件 SHA-256；文件被外部修改时跳过，不覆盖新内容。
- 区分锁定/共享冲突与普通 IO 错误；锁定文件记录到 `skipped_locked_rollout_files`，其他错误会触发已应用文件的回滚。
- 回滚改为基于原始 `session_meta` 行、数量/顺序校验和 hash 校验，不再保存整份原始 rollout；同时恢复原始 mtime 和权限。
- `session-meta-backup.json` 改为增量写入，保持原有 JSON schema 和兼容格式。
- `session_index.jsonl` 的 preview/apply 清理改为流式读取和写入，保留未知记录、候选确认和快照变化保护语义。
- 新增真实 provider sync progress API，支持 scanning、planning、backing_up、rewriting、updating_indexes、rolling_back、complete 阶段。
- Tauri 通过定向事件向当前管理器窗口发送进度；前端移除模拟 `setInterval`，改为监听后端真实计数并映射进度。
- 保留 `run_provider_sync`、`run_provider_sync_with_target`、`ProviderSyncResult` 及 Remote Control 单会话恢复路径的兼容行为。
- 将环境变量扫描改为 `vars_os()` 容错处理，避免 macOS 上存在非 UTF-8 环境变量时导致 manager 崩溃。

## 测试

- `cargo test --workspace`：通过
- `cargo test -p codex-plus-data --test provider_sync`：49 passed
- `cargo test -p codex-plus-core settings::tests`：46 passed
- `cargo test -p codex-plus-core env_conflicts::tests`：3 passed
- `npm test`：122 passed
- `npm run check`：通过
- `npm run vite:build`：通过
- `cargo check -p codex-plus-manager`：通过
- `cargo build --release`：通过
- `git diff --check`：通过
- 本地 Apple Silicon DMG 已生成，并通过 `hdiutil verify` 与 App 深度签名验证。
- 全量 `cargo fmt --all -- --check` 仍会报告仓库现有格式差异，本次未做无关的格式化重排。
- 自己手动测试了下，可以正常使用

## 涉及文件

- `crates/codex-plus-core/src/settings.rs`
- `crates/codex-plus-core/src/env_conflicts.rs`
- `crates/codex-plus-core/src/model_catalog.rs`
- `crates/codex-plus-core/src/relay_environment.rs`
- `crates/codex-plus-data/src/provider_sync.rs`
- `crates/codex-plus-data/src/lib.rs`
- `crates/codex-plus-data/tests/provider_sync.rs`
- `apps/codex-plus-manager/src-tauri/src/commands.rs`
- `apps/codex-plus-manager/src/App.tsx`
- `apps/codex-plus-manager/src/provider-sync-flow.ts`
- `apps/codex-plus-manager/src/provider-sync-flow.test.ts`
- `docs/plans/2026-08-27-历史会话流式修复实施计划.md`


## Problem

The batch provider synchronization used by “Repair Historical Sessions” loaded multiple rollout JSONL files fully into memory and retained original text, rewritten text, and rollback copies. When a Codex installation contained many historical sessions, memory usage grew with the total size of all stored session content.

The subsequent `session_index.jsonl` cleanup also retained the full file and constructed a complete rewritten copy, creating a second memory peak. In addition, the manager previously displayed simulated timer-based progress instead of progress based on actual backend work.

## Changes

- Added `atomic_write_with` for streamed atomic file writes with chunked output, atomic replacement, and preservation of existing file permissions.
- Reworked batch provider synchronization into two phases:
  - Scan rollout JSONL files line by line and retain only lightweight rewrite plans, metadata, mtimes, and SHA-256 hashes.
  - Rewrite only files that actually require changes, one file and one line at a time.
- Only update `model_provider` in valid `session_meta` records. Preserve all non-metadata lines, unknown or invalid JSON, line endings, and other rollout content byte-for-byte.
- Recheck the source file SHA-256 before writing. Skip files changed by another process instead of overwriting newer content.
- Distinguish locked/shared-conflict files from other IO failures. Locked files are reported through `skipped_locked_rollout_files`; other failures trigger rollback of files already applied in the current operation.
- Implement rollback using the original `session_meta` lines, count/order validation, and hashes instead of retaining complete rollout files. Restore original mtimes and permissions as well.
- Write `session-meta-backup.json` incrementally while preserving the existing JSON schema and compatibility.
- Convert `session_index.jsonl` preview/apply cleanup to streamed reads and writes while preserving unknown records, candidate confirmation, and snapshot-change protection.
- Added real provider-sync progress reporting with `scanning`, `planning`, `backing_up`, `rewriting`, `updating_indexes`, `rolling_back`, and `complete` phases.
- Send progress through a Tauri event targeted at the initiating manager window. The frontend now listens to real backend counts and no longer uses simulated `setInterval` progress.
- Preserve the existing `run_provider_sync`, `run_provider_sync_with_target`, `ProviderSyncResult`, and Remote Control single-session recovery behavior.
- Switched environment scanning to `vars_os()` so non-UTF-8 macOS environment variables do not crash the manager.

## Tests

- `cargo test --workspace`: passed
- `cargo test -p codex-plus-data --test provider_sync`: 49 passed
- `cargo test -p codex-plus-core settings::tests`: 46 passed
- `cargo test -p codex-plus-core env_conflicts::tests`: 3 passed
- `npm test`: 122 passed
- `npm run check`: passed
- `npm run vite:build`: passed
- `cargo check -p codex-plus-manager`: passed
- `cargo build --release`: passed
- `git diff --check`: passed
- Built a local Apple Silicon DMG and verified it with `hdiutil verify` and deep App signature checks.
- Full `cargo fmt --all -- --check` still reports existing repository formatting differences; no unrelated formatting-only changes were introduced.
- I tested it manually and it works normally.

## Files

- `crates/codex-plus-core/src/settings.rs`
- `crates/codex-plus-core/src/env_conflicts.rs`
- `crates/codex-plus-core/src/model_catalog.rs`
- `crates/codex-plus-core/src/relay_environment.rs`
- `crates/codex-plus-data/src/provider_sync.rs`
- `crates/codex-plus-data/src/lib.rs`
- `crates/codex-plus-data/tests/provider_sync.rs`
- `apps/codex-plus-manager/src-tauri/src/commands.rs`
- `apps/codex-plus-manager/src/App.tsx`
- `apps/codex-plus-manager/src/provider-sync-flow.ts`
- `apps/codex-plus-manager/src/provider-sync-flow.test.ts`
- `docs/plans/2026-08-27-历史会话流式修复实施计划.md`