### PR TITLE
fix: 删除会话时同步清理侧边栏索引

### DIFF
--- a/crates/codex-plus-data/src/lib.rs
+++ b/crates/codex-plus-data/src/lib.rs
@@ -11,6 +11,7 @@ pub use provider_sync::{
     SessionIndexCleanupApplyError, SessionIndexCleanupCandidate, SessionIndexCleanupPreview,
     SessionIndexCleanupResult, apply_session_index_cleanup, inspect_provider_sync_lock,
     load_provider_sync_targets, preview_session_index_cleanup,
+    remove_thread_sidebar_references, ThreadSidebarCleanupResult,
     remote_control_session_recovery_candidate_exists, run_provider_sync,
     run_provider_sync_with_target,
     run_remote_control_session_catalog_recovery_for_thread_with_target,

--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -1,5 +1,6 @@
 use fs2::FileExt;
-use rusqlite::{Connection, OptionalExtension, params_from_iter, types::Value as SqlValue};
+use crate::storage::{has_table, json_to_sql_value, select_dicts};
+use rusqlite::{Connection, OptionalExtension, ToSql, params_from_iter, types::Value as SqlValue};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
@@ -2243,6 +2244,372 @@ pub fn remove_session_index_entry(
 pub struct ThreadSidebarCleanupResult {
     pub global_state_entries_removed: usize,
     pub catalog_rows_removed: usize,
+}
+
+/// Capture the thread-specific sidebar data that is about to be removed.
+/// The snapshot is embedded in the normal delete backup so undo can restore only
+/// this thread's entries without replacing unrelated global state.
+pub fn snapshot_thread_sidebar_references(
+    codex_home: &Path,
+    thread_id: &str,
+) -> anyhow::Result<Value> {
+    let thread_id = thread_id.strip_prefix("local:").unwrap_or(thread_id);
+    let global_state = snapshot_thread_from_global_state(codex_home, thread_id)?;
+    let catalog = snapshot_thread_from_catalog_dbs(codex_home, thread_id)?;
+    Ok(json!({
+        "thread_id": thread_id,
+        "global_state": global_state,
+        "catalog": catalog,
+    }))
+}
+
+/// Restore a previously captured sidebar snapshot. Existing values are kept so
+/// an undo cannot overwrite changes made after deletion.
+pub fn restore_thread_sidebar_references(
+    codex_home: &Path,
+    snapshot: &Value,
+) -> anyhow::Result<usize> {
+    validate_thread_sidebar_snapshot(codex_home, snapshot)?;
+    let thread_id = snapshot
+        .get("thread_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let mut restored = restore_thread_to_global_state(codex_home, thread_id, snapshot)?;
+    restored += restore_thread_to_catalog_dbs(codex_home, thread_id, snapshot)?;
+    Ok(restored)
+}
+
+pub fn validate_thread_sidebar_snapshot(
+    codex_home: &Path,
+    snapshot: &Value,
+) -> anyhow::Result<()> {
+    let thread_id = snapshot
+        .get("thread_id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.trim().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("sidebar snapshot is missing thread_id"))?;
+    if let Some(catalog) = snapshot.get("catalog") {
+        let entries = catalog
+            .as_array()
+            .ok_or_else(|| anyhow::anyhow!("sidebar snapshot catalog must be an array"))?;
+        let allowed_paths = sidebar_catalog_db_paths(codex_home)?;
+        for entry in entries {
+            let table = entry
+                .get("table")
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow::anyhow!("sidebar catalog entry is missing table"))?;
+            if !SIDEBAR_CATALOG_TABLES.contains(&table) {
+                anyhow::bail!("unsupported sidebar catalog table: {table}");
+            }
+            let path = entry
+                .get("db_path")
+                .and_then(Value::as_str)
+                .map(PathBuf::from)
+                .ok_or_else(|| anyhow::anyhow!("sidebar catalog entry is missing db_path"))?;
+            let canonical = fs::canonicalize(&path)?;
+            if !allowed_paths.contains(&canonical) {
+                anyhow::bail!("sidebar catalog database is not an allowed Codex database");
+            }
+            let rows = entry
+                .get("rows")
+                .and_then(Value::as_array)
+                .ok_or_else(|| anyhow::anyhow!("sidebar catalog entry rows must be an array"))?;
+            for row in rows {
+                let row_id = row
+                    .get("thread_id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow::anyhow!("sidebar catalog row is missing thread_id"))?;
+                if row_id != thread_id {
+                    anyhow::bail!("sidebar catalog row thread_id does not match snapshot");
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+const SIDEBAR_CATALOG_TABLES: [&str; 3] = [
+    "local_thread_catalog",
+    "thread_timeline_ledger",
+    "local_thread_catalog_scan_entries",
+];
+
+fn snapshot_thread_from_global_state(
+    codex_home: &Path,
+    thread_id: &str,
+) -> anyhow::Result<Value> {
+    let path = codex_home.join(".codex-global-state.json");
+    if !path.exists() {
+        return Ok(json!({}));
+    }
+    let value: Value = serde_json::from_slice(&fs::read(path)?)?;
+    let Some(root) = value.as_object() else {
+        return Ok(json!({}));
+    };
+    let mut snapshot = Map::new();
+    if let Some(ids) = root.get("projectless-thread-ids").and_then(Value::as_array) {
+        let values = ids
+            .iter()
+            .filter(|value| thread_value_matches(value, thread_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        if !values.is_empty() {
+            snapshot.insert("projectless-thread-ids".to_string(), Value::Array(values));
+        }
+    }
+    let mut maps = Map::new();
+    for key in [
+        "thread-projectless-output-directories",
+        "thread-workspace-root-hints",
+        "thread-writable-roots",
+    ] {
+        if let Some(map) = root.get(key).and_then(Value::as_object) {
+            let entries = map
+                .iter()
+                .filter(|(key, _)| thread_key_matches(key, thread_id))
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect::<Map<_, _>>();
+            if !entries.is_empty() {
+                maps.insert(key.to_string(), Value::Object(entries));
+            }
+        }
+    }
+    if !maps.is_empty() {
+        snapshot.insert("thread_maps".to_string(), Value::Object(maps));
+    }
+    if let Some(atom) = root
+        .get("electron-persisted-atom-state")
+        .and_then(Value::as_object)
+    {
+        let entries = atom
+            .iter()
+            .filter(|(key, _)| sidebar_atom_key_matches(key, thread_id))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect::<Map<_, _>>();
+        if !entries.is_empty() {
+            snapshot.insert("atom_entries".to_string(), Value::Object(entries));
+        }
+    }
+    Ok(Value::Object(snapshot))
+}
+
+fn snapshot_thread_from_catalog_dbs(
+    codex_home: &Path,
+    thread_id: &str,
+) -> anyhow::Result<Value> {
+    let mut entries = Vec::new();
+    for path in codex_plus_core::codex_sqlite::codex_thread_reference_db_paths_from_home(codex_home)
+    {
+        if !path.exists() {
+            continue;
+        }
+        let db = Connection::open_with_flags(&path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        for table in SIDEBAR_CATALOG_TABLES {
+            let columns = table_columns(&db, table)?;
+            if !columns.contains("thread_id") {
+                continue;
+            }
+            let rows = select_dicts(
+                &db,
+                &format!("SELECT * FROM {table} WHERE thread_id = ?1"),
+                &[&thread_id],
+            )?;
+            if !rows.is_empty() {
+                entries.push(json!({
+                    "db_path": path.to_string_lossy(),
+                    "table": table,
+                    "rows": rows,
+                }));
+            }
+        }
+    }
+    Ok(Value::Array(entries))
+}
+
+fn restore_thread_to_global_state(
+    codex_home: &Path,
+    _thread_id: &str,
+    snapshot: &Value,
+) -> anyhow::Result<usize> {
+    let global = snapshot.get("global_state").unwrap_or(&Value::Null);
+    if !global.is_object() {
+        return Ok(0);
+    }
+    let path = codex_home.join(".codex-global-state.json");
+    let original_bytes = if path.exists() {
+        fs::read(&path)?
+    } else {
+        Vec::new()
+    };
+    let mut state = if original_bytes.is_empty() {
+        json!({})
+    } else {
+        serde_json::from_slice::<Value>(&original_bytes)?
+    };
+    let Some(root) = state.as_object_mut() else {
+        return Ok(0);
+    };
+    let mut restored = 0usize;
+    if let Some(values) = global
+        .get("projectless-thread-ids")
+        .and_then(Value::as_array)
+    {
+        let ids = root
+            .entry("projectless-thread-ids")
+            .or_insert_with(|| Value::Array(Vec::new()));
+        if let Some(ids) = ids.as_array_mut() {
+            for value in values {
+                if !ids.iter().any(|existing| existing == value) {
+                    ids.push(value.clone());
+                    restored += 1;
+                }
+            }
+        }
+    }
+    if let Some(maps) = global.get("thread_maps").and_then(Value::as_object) {
+        restored += restore_missing_map_entries(root, maps);
+    }
+    if let Some(entries) = global.get("atom_entries").and_then(Value::as_object) {
+        let atom = root
+            .entry("electron-persisted-atom-state")
+            .or_insert_with(|| Value::Object(Map::new()));
+        if let Some(atom) = atom.as_object_mut() {
+            for (key, value) in entries {
+                if !atom.contains_key(key) {
+                    atom.insert(key.clone(), value.clone());
+                    restored += 1;
+                }
+            }
+        }
+    }
+    if restored == 0 {
+        return Ok(0);
+    }
+    if path.exists() && fs::read(&path)? != original_bytes {
+        anyhow::bail!(".codex-global-state.json changed while restoring sidebar state");
+    }
+    codex_plus_core::settings::atomic_write(&path, serde_json::to_string_pretty(&state)?.as_bytes())?;
+    Ok(restored)
+}
+
+fn restore_missing_map_entries(root: &mut Map<String, Value>, maps: &Map<String, Value>) -> usize {
+    let mut restored = 0usize;
+    for (key, entries) in maps {
+        let value = root
+            .entry(key.clone())
+            .or_insert_with(|| Value::Object(Map::new()));
+        if let (Some(target), Some(entries)) = (value.as_object_mut(), entries.as_object()) {
+            for (entry_key, entry_value) in entries {
+                if !target.contains_key(entry_key) {
+                    target.insert(entry_key.clone(), entry_value.clone());
+                    restored += 1;
+                }
+            }
+        }
+    }
+    restored
+}
+
+fn restore_thread_to_catalog_dbs(
+    codex_home: &Path,
+    _thread_id: &str,
+    snapshot: &Value,
+) -> anyhow::Result<usize> {
+    let Some(entries) = snapshot.get("catalog").and_then(Value::as_array) else {
+        return Ok(0);
+    };
+    let allowed_paths = sidebar_catalog_db_paths(codex_home)?;
+    let mut restored_total = 0usize;
+    for entry in entries {
+        let path = PathBuf::from(entry["db_path"].as_str().unwrap_or_default());
+        let canonical = fs::canonicalize(&path)?;
+        if !allowed_paths.contains(&canonical) {
+            anyhow::bail!("sidebar catalog database is not an allowed Codex database");
+        }
+        let table = entry["table"].as_str().unwrap_or_default();
+        let rows = entry["rows"].as_array().cloned().unwrap_or_default();
+        let mut db = Connection::open(&path)?;
+        let tx = db.transaction()?;
+        if !has_table(&tx, table)? {
+            tx.commit()?;
+            continue;
+        }
+        let columns = table_columns(&tx, table)?;
+        if !columns.contains("thread_id") {
+            tx.commit()?;
+            continue;
+        }
+        let mut restored = 0usize;
+        for row in rows {
+            if let Some(row) = row.as_object() {
+                restored += insert_row_ignore(&tx, table, row)?;
+            }
+        }
+        if restored > 0 {
+            let metadata_columns = table_columns(&tx, "local_thread_catalog_metadata")?;
+            update_local_catalog_metadata(&tx, &metadata_columns, restored)?;
+        }
+        tx.commit()?;
+        restored_total += restored;
+    }
+    Ok(restored_total)
+}
+
+fn insert_row_ignore(db: &Connection, table: &str, row: &Map<String, Value>) -> anyhow::Result<usize> {
+    let columns: Vec<&String> = row.keys().collect();
+    if columns.is_empty() {
+        return Ok(0);
+    }
+    let quoted = columns
+        .iter()
+        .map(|column| format!("\"{}\"", column.replace('\"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let marks = (0..columns.len())
+        .map(|index| format!("?{}", index + 1))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let values = columns
+        .iter()
+        .map(|column| json_to_sql_value(&row[*column]))
+        .collect::<Vec<_>>();
+    let refs = values
+        .iter()
+        .map(|value| value as &dyn ToSql)
+        .collect::<Vec<_>>();
+    Ok(db.execute(
+        &format!("INSERT OR IGNORE INTO \"{table}\" ({quoted}) VALUES ({marks})"),
+        refs.as_slice(),
+    )?)
+}
+
+fn sidebar_catalog_db_paths(codex_home: &Path) -> anyhow::Result<HashSet<PathBuf>> {
+    Ok(codex_plus_core::codex_sqlite::codex_thread_reference_db_paths_from_home(codex_home)
+        .into_iter()
+        .filter_map(|path| fs::canonicalize(path).ok())
+        .collect())
+}
+
+fn thread_value_matches(value: &Value, thread_id: &str) -> bool {
+    value
+        .as_str()
+        .is_some_and(|value| value == thread_id || value == format!("local:{thread_id}"))
+}
+
+fn thread_key_matches(key: &str, thread_id: &str) -> bool {
+    key == thread_id || key == format!("local:{thread_id}")
+}
+
+fn sidebar_atom_key_matches(key: &str, thread_id: &str) -> bool {
+    let encoded_local = format!("local%3A{thread_id}");
+    [
+        format!("thread-client-id-v1:{thread_id}"),
+        format!("thread-client-id-v1:{encoded_local}"),
+        format!("thread-reference-capability:{thread_id}"),
+        format!("thread-reference-capability:{encoded_local}"),
+    ]
+    .iter()
+    .any(|candidate| key == candidate)
 }
 
 pub fn remove_thread_sidebar_references(

--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -2233,6 +2233,150 @@ pub fn remove_session_index_entry(
     Ok(removed_entries)
 }
 
+/// 删除 Codex 侧边栏对线程的本地引用。
+///
+/// 线程正文由 `state_5.sqlite`/rollout 文件保存，而侧边栏还会从全局状态和
+/// `sqlite/codex-dev.db` 的目录缓存读取条目。删除正文时必须同步清理这些缓存，
+/// 否则重启后仍会显示一个无法恢复的“幽灵会话”。该操作按 thread id 精确匹配，
+/// 可重复执行；缓存不存在或目标不存在均视为成功。
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ThreadSidebarCleanupResult {
+    pub global_state_entries_removed: usize,
+    pub catalog_rows_removed: usize,
+}
+
+pub fn remove_thread_sidebar_references(
+    codex_home: &Path,
+    thread_id: &str,
+) -> anyhow::Result<ThreadSidebarCleanupResult> {
+    let thread_id = thread_id.strip_prefix("local:").unwrap_or(thread_id);
+    let (global_state_entries_removed, global_error) =
+        match remove_thread_from_global_state(codex_home, thread_id) {
+            Ok(count) => (count, None),
+            Err(error) => (0, Some(error)),
+        };
+    let (catalog_rows_removed, catalog_error) =
+        match remove_thread_from_catalog_dbs(codex_home, thread_id) {
+            Ok(count) => (count, None),
+            Err(error) => (0, Some(error)),
+        };
+    if let Some(error) = global_error {
+        return Err(error);
+    }
+    if let Some(error) = catalog_error {
+        return Err(error);
+    }
+    Ok(ThreadSidebarCleanupResult {
+        global_state_entries_removed,
+        catalog_rows_removed,
+    })
+}
+
+fn remove_thread_from_global_state(codex_home: &Path, thread_id: &str) -> anyhow::Result<usize> {
+    let path = codex_home.join(".codex-global-state.json");
+    if !path.exists() {
+        return Ok(0);
+    }
+    let original_bytes = fs::read(&path)?;
+    let mut state: Value = serde_json::from_slice(&original_bytes)?;
+    let Some(root) = state.as_object_mut() else {
+        return Ok(0);
+    };
+    let mut removed = 0usize;
+    if let Some(ids) = root
+        .get_mut("projectless-thread-ids")
+        .and_then(Value::as_array_mut)
+    {
+        let before = ids.len();
+        ids.retain(|value| value.as_str() != Some(thread_id));
+        removed += before.saturating_sub(ids.len());
+    }
+    for key in [
+        "thread-projectless-output-directories",
+        "thread-workspace-root-hints",
+        "thread-writable-roots",
+    ] {
+        if let Some(map) = root.get_mut(key).and_then(Value::as_object_mut) {
+            for candidate in [thread_id, &format!("local:{thread_id}")] {
+                if map.remove(candidate).is_some() {
+                    removed += 1;
+                }
+            }
+        }
+    }
+    if let Some(atom) = root
+        .get_mut("electron-persisted-atom-state")
+        .and_then(Value::as_object_mut)
+    {
+        let encoded_local = format!("local%3A{thread_id}");
+        let client_id = format!("thread-client-id-v1:{thread_id}");
+        let client_id_encoded = format!("thread-client-id-v1:{encoded_local}");
+        let reference_capability = format!("thread-reference-capability:{thread_id}");
+        let reference_capability_encoded = format!("thread-reference-capability:{encoded_local}");
+        let keys = atom
+            .keys()
+            .filter(|key| {
+                *key == &client_id
+                    || *key == &client_id_encoded
+                    || *key == &reference_capability
+                    || *key == &reference_capability_encoded
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        for key in keys {
+            atom.remove(&key);
+            removed += 1;
+        }
+    }
+    if removed == 0 {
+        return Ok(0);
+    }
+    if fs::read(&path)? != original_bytes {
+        anyhow::bail!(".codex-global-state.json changed while deleting thread {thread_id}");
+    }
+    codex_plus_core::settings::atomic_write(&path, serde_json::to_string_pretty(&state)?.as_bytes())?;
+    Ok(removed)
+}
+
+fn remove_thread_from_catalog_dbs(codex_home: &Path, thread_id: &str) -> anyhow::Result<usize> {
+    let mut removed_total = 0usize;
+    for path in codex_plus_core::codex_sqlite::codex_thread_reference_db_paths_from_home(codex_home) {
+        if !path.exists() {
+            continue;
+        }
+        let mut db = Connection::open(&path)?;
+        db.busy_timeout(std::time::Duration::from_millis(500))?;
+        let tx = db.transaction()?;
+        let mut removed = 0usize;
+        for table in [
+            "local_thread_catalog",
+            "thread_timeline_ledger",
+            "local_thread_catalog_scan_entries",
+        ] {
+            let columns = table_columns(&tx, table)?;
+            if !columns.contains("thread_id") {
+                continue;
+            }
+            removed += tx.execute(
+                &format!("DELETE FROM {table} WHERE thread_id = ?1"),
+                [thread_id],
+            )?;
+        }
+        if removed > 0 {
+            let metadata_columns = table_columns(&tx, "local_thread_catalog_metadata")?;
+            if metadata_columns.contains("catalog_revision") {
+                tx.execute(
+                    "UPDATE local_thread_catalog_metadata SET catalog_revision = catalog_revision + ?1",
+                    [removed as i64],
+                )?;
+            }
+        }
+        tx.commit()?;
+        removed_total += removed;
+    }
+    Ok(removed_total)
+}
+
 /// Append previously removed `session_index.jsonl` lines back (undo flow).
 /// Lines whose `id` already exists are skipped. Returns the number of
 /// appended lines. Best-effort: returns `Ok(0)` without writing when the

--- a/crates/codex-plus-data/src/provider_sync.rs
+++ b/crates/codex-plus-data/src/provider_sync.rs
@@ -2655,7 +2655,7 @@ fn remove_thread_from_global_state(codex_home: &Path, thread_id: &str) -> anyhow
         .and_then(Value::as_array_mut)
     {
         let before = ids.len();
-        ids.retain(|value| value.as_str() != Some(thread_id));
+        ids.retain(|value| !thread_value_matches(value, thread_id));
         removed += before.saturating_sub(ids.len());
     }
     for key in [

--- a/crates/codex-plus-data/src/storage.rs
+++ b/crates/codex-plus-data/src/storage.rs
@@ -481,10 +481,14 @@ impl SQLiteStorageAdapter {
         } else {
             Vec::new()
         };
+        let mut tables = Map::new();
+        tables.insert("sessions".to_string(), Value::Array(sessions));
+        tables.insert("messages".to_string(), Value::Array(messages));
+        self.add_thread_sidebar_backups(&mut tables, &session.session_id)?;
         let token = self.backup_store.write_backup(
             &session.session_id,
             &self.db_path,
-            json!({"sessions": sessions, "messages": messages}),
+            Value::Object(tables),
         )?;
         let backup_path = self.backup_store.path_for(&token);
         let delete_result = (|| -> anyhow::Result<()> {
@@ -564,28 +568,7 @@ impl SQLiteStorageAdapter {
         if !file_backups.is_empty() {
             tables.insert("__files".to_string(), Value::Array(file_backups.clone()));
         }
-        let session_index_lines = self
-            .codex_home
-            .as_deref()
-            .and_then(|home| {
-                crate::provider_sync::session_index_lines_for_thread(home, &thread_id).ok()
-            })
-            .unwrap_or_default();
-        if !session_index_lines.is_empty() {
-            tables.insert(
-                "__session_index".to_string(),
-                Value::Array(
-                    session_index_lines
-                        .iter()
-                        .map(|line| Value::String(line.clone()))
-                        .collect(),
-                ),
-            );
-        }
-        if let Some(home) = self.codex_home.as_deref() {
-            let sidebar = crate::provider_sync::snapshot_thread_sidebar_references(home, &thread_id)?;
-            tables.insert("__sidebar".to_string(), sidebar);
-        }
+        self.add_thread_sidebar_backups(&mut tables, &thread_id)?;
         let token =
             self.backup_store
                 .write_backup(&thread_id, &self.db_path, Value::Object(tables))?;
@@ -659,6 +642,29 @@ impl SQLiteStorageAdapter {
         Ok(result)
     }
 
+    fn add_thread_sidebar_backups(
+        &self,
+        tables: &mut Map<String, Value>,
+        thread_id: &str,
+    ) -> anyhow::Result<()> {
+        let Some(home) = self.codex_home.as_deref() else {
+            return Ok(());
+        };
+        let session_index_lines =
+            crate::provider_sync::session_index_lines_for_thread(home, thread_id)?;
+        if !session_index_lines.is_empty() {
+            tables.insert(
+                "__session_index".to_string(),
+                Value::Array(session_index_lines.into_iter().map(Value::String).collect()),
+            );
+        }
+        tables.insert(
+            "__sidebar".to_string(),
+            crate::provider_sync::snapshot_thread_sidebar_references(home, thread_id)?,
+        );
+        Ok(())
+    }
+
     fn delete_codex_automation_run(
         &self,
         db: &mut Connection,
@@ -680,6 +686,7 @@ impl SQLiteStorageAdapter {
             "thread_id = ?1",
             &[&thread_id],
         )?;
+        self.add_thread_sidebar_backups(&mut tables, &thread_id)?;
         if tables.values().all(|rows| {
             rows.as_array()
                 .map(|items| items.is_empty())

--- a/crates/codex-plus-data/src/storage.rs
+++ b/crates/codex-plus-data/src/storage.rs
@@ -66,6 +66,20 @@ pub fn delete_local_from_paths(
                     format!("{}；session_index.jsonl 清理失败：{error}", result.message);
             }
         }
+        match crate::provider_sync::remove_thread_sidebar_references(home, &thread_id) {
+            Ok(cleanup) if cleanup.global_state_entries_removed > 0
+                || cleanup.catalog_rows_removed > 0 =>
+            {
+                if matches!(result.status, DeleteStatus::Failed) {
+                    result.status = DeleteStatus::LocalDeleted;
+                    result.message = "已清理侧边栏索引".to_string();
+                }
+            }
+            Ok(_) => {}
+            Err(error) => {
+                result.message = format!("{}；侧边栏索引清理失败：{error}", result.message);
+            }
+        }
     }
     result
 }
@@ -202,6 +216,11 @@ impl SQLiteStorageAdapter {
             if let Err(error) = crate::provider_sync::remove_session_index_entry(home, &thread_id) {
                 result.message =
                     format!("{}；session_index.jsonl 清理失败：{error}", result.message);
+            }
+            if let Err(error) =
+                crate::provider_sync::remove_thread_sidebar_references(home, &thread_id)
+            {
+                result.message = format!("{}；侧边栏索引清理失败：{error}", result.message);
             }
         }
         result

--- a/crates/codex-plus-data/src/storage.rs
+++ b/crates/codex-plus-data/src/storage.rs
@@ -582,6 +582,10 @@ impl SQLiteStorageAdapter {
                 ),
             );
         }
+        if let Some(home) = self.codex_home.as_deref() {
+            let sidebar = crate::provider_sync::snapshot_thread_sidebar_references(home, &thread_id)?;
+            tables.insert("__sidebar".to_string(), sidebar);
+        }
         let token =
             self.backup_store
                 .write_backup(&thread_id, &self.db_path, Value::Object(tables))?;
@@ -892,6 +896,11 @@ fn restore_backups(
         detect_restore_conflicts(&db, tables)?;
         detect_file_restore_conflicts(tables)?;
         preflight_restore_rows(&db, tables)?;
+        if let Some(sidebar) = tables.get("__sidebar") {
+            let home = codex_home
+                .ok_or_else(|| anyhow::anyhow!("sidebar restore requires a Codex home"))?;
+            crate::provider_sync::validate_thread_sidebar_snapshot(home, sidebar)?;
+        }
     }
 
     for backup in backups {
@@ -929,6 +938,11 @@ fn restore_backups(
                 if let Some(home) = codex_home {
                     let _ = crate::provider_sync::restore_session_index_entries(home, &lines);
                 }
+            }
+        }
+        if let Some(sidebar) = tables.get("__sidebar") {
+            if let Some(home) = codex_home {
+                let _ = crate::provider_sync::restore_thread_sidebar_references(home, sidebar)?;
             }
         }
     }
@@ -1009,7 +1023,7 @@ fn schema_kind(db: &Connection) -> anyhow::Result<Option<SchemaKind>> {
     Ok(None)
 }
 
-fn has_table(db: &Connection, table: &str) -> anyhow::Result<bool> {
+pub(crate) fn has_table(db: &Connection, table: &str) -> anyhow::Result<bool> {
     Ok(db
         .query_row(
             "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1",
@@ -1033,7 +1047,11 @@ fn table_columns(db: &Connection, table: &str) -> anyhow::Result<Vec<String>> {
     Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
 }
 
-fn select_dicts(db: &Connection, sql: &str, params: &[&dyn ToSql]) -> anyhow::Result<Vec<Value>> {
+pub(crate) fn select_dicts(
+    db: &Connection,
+    sql: &str,
+    params: &[&dyn ToSql],
+) -> anyhow::Result<Vec<Value>> {
     let mut stmt = db.prepare(sql)?;
     let columns: Vec<String> = stmt
         .column_names()
@@ -1064,6 +1082,7 @@ fn validate_restore_tables(tables: &Map<String, Value>) -> anyhow::Result<()> {
         "inbox_items",
         "__files",
         "__session_index",
+        "__sidebar",
     ];
     for table in tables.keys() {
         if !allowed.contains(&table.as_str()) {
@@ -1304,7 +1323,7 @@ fn sql_value_to_json(value: ValueRef<'_>) -> Value {
     }
 }
 
-fn json_to_sql_value(value: &Value) -> SqlValue {
+pub(crate) fn json_to_sql_value(value: &Value) -> SqlValue {
     match value {
         Value::Null => SqlValue::Null,
         Value::Bool(value) => SqlValue::Integer(i64::from(*value)),

--- a/crates/codex-plus-data/tests/storage_adapter.rs
+++ b/crates/codex-plus-data/tests/storage_adapter.rs
@@ -512,7 +512,7 @@ fn delete_codex_thread_clears_sidebar_global_state_and_catalog_cache() {
     fs::write(
         home.join(".codex-global-state.json"),
         json!({
-            "projectless-thread-ids": ["t1", keep_id],
+            "projectless-thread-ids": ["local:t1", "t1", keep_id],
             "thread-projectless-output-directories": {"t1": "C:/out", "keep": "C:/keep"},
             "thread-workspace-root-hints": {"local:t1": "C:/workspace", "keep": "C:/keep"},
             "thread-writable-roots": {"t1": ["C:/work"], "keep": ["C:/keep"]},
@@ -598,7 +598,10 @@ fn delete_codex_thread_clears_sidebar_global_state_and_catalog_cache() {
     let state: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(home.join(".codex-global-state.json")).unwrap())
             .unwrap();
-    assert_eq!(state["projectless-thread-ids"], json!([keep_id, "t1"]));
+    assert_eq!(
+        state["projectless-thread-ids"],
+        json!([keep_id, "local:t1", "t1"])
+    );
     assert_eq!(
         state["thread-projectless-output-directories"]["t1"],
         "C:/out"

--- a/crates/codex-plus-data/tests/storage_adapter.rs
+++ b/crates/codex-plus-data/tests/storage_adapter.rs
@@ -498,6 +498,98 @@ fn delete_codex_thread_sqlite_dir_layout_removes_session_index_entry_and_undo_re
 /// 三种 schema 里原先只有 delete_codex_thread 清了索引，这条覆盖 generic
 /// sessions 那条路径。
 #[test]
+fn delete_codex_thread_clears_sidebar_global_state_and_catalog_cache() {
+    let tmp = tempdir().unwrap();
+    let home = tmp.path().join(".codex");
+    let sqlite_dir = home.join("sqlite");
+    let rollout = home.join("sessions/rollout-t1.jsonl");
+    fs::create_dir_all(rollout.parent().unwrap()).unwrap();
+    fs::create_dir_all(&sqlite_dir).unwrap();
+    fs::write(&rollout, "{}\n").unwrap();
+    let state_db = home.join("state_5.sqlite");
+    create_codex_thread_db(&state_db, &rollout);
+    let keep_id = "keep";
+    fs::write(
+        home.join(".codex-global-state.json"),
+        json!({
+            "projectless-thread-ids": ["t1", keep_id],
+            "thread-projectless-output-directories": {"t1": "C:/out", "keep": "C:/keep"},
+            "thread-workspace-root-hints": {"local:t1": "C:/workspace", "keep": "C:/keep"},
+            "thread-writable-roots": {"t1": ["C:/work"], "keep": ["C:/keep"]},
+            "electron-persisted-atom-state": {
+                "thread-client-id-v1:t1": "client",
+                "thread-reference-capability:local%3At1": "capability",
+                "thread-client-id-v1:keep": "keep-client",
+                "sidebar-width": 296
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    fs::write(
+        home.join("session_index.jsonl"),
+        "{\"id\":\"t1\"}\n{\"id\":\"keep\"}\n",
+    )
+    .unwrap();
+    let catalog_db = Connection::open(sqlite_dir.join("codex-dev.db")).unwrap();
+    catalog_db
+        .execute("CREATE TABLE local_thread_catalog (thread_id TEXT PRIMARY KEY)", [])
+        .unwrap();
+    catalog_db
+        .execute("CREATE TABLE thread_timeline_ledger (thread_id TEXT)", [])
+        .unwrap();
+    catalog_db
+        .execute("CREATE TABLE local_thread_catalog_scan_entries (thread_id TEXT)", [])
+        .unwrap();
+    catalog_db
+        .execute("INSERT INTO local_thread_catalog VALUES ('t1'), ('keep')", [])
+        .unwrap();
+    catalog_db
+        .execute("INSERT INTO thread_timeline_ledger VALUES ('t1'), ('keep')", [])
+        .unwrap();
+    catalog_db
+        .execute("INSERT INTO local_thread_catalog_scan_entries VALUES ('t1'), ('keep')", [])
+        .unwrap();
+    drop(catalog_db);
+
+    let deleted = SQLiteStorageAdapter::new(
+        &state_db,
+        BackupStore::new(tmp.path().join("backups")),
+    )
+    .with_codex_home(&home)
+    .delete_local(&session("local:t1", "Codex Thread"));
+    assert_eq!(deleted.status, DeleteStatus::LocalDeleted);
+    let state: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(home.join(".codex-global-state.json")).unwrap())
+            .unwrap();
+    assert_eq!(state["projectless-thread-ids"], json!([keep_id]));
+    assert!(state["thread-projectless-output-directories"].get("t1").is_none());
+    assert!(state["thread-workspace-root-hints"].get("local:t1").is_none());
+    assert!(state["thread-writable-roots"].get("t1").is_none());
+    assert!(state["electron-persisted-atom-state"]
+        .get("thread-client-id-v1:t1")
+        .is_none());
+    assert!(state["electron-persisted-atom-state"]
+        .get("thread-client-id-v1:keep")
+        .is_some());
+    let catalog_db = Connection::open(sqlite_dir.join("codex-dev.db")).unwrap();
+    for table in [
+        "local_thread_catalog",
+        "thread_timeline_ledger",
+        "local_thread_catalog_scan_entries",
+    ] {
+        let count: i64 = catalog_db
+            .query_row(
+                &format!("SELECT COUNT(*) FROM {table} WHERE thread_id = 't1'"),
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0, "{table}");
+    }
+}
+
+#[test]
 fn delete_local_clears_the_session_index_for_generic_sessions() {
     let tmp = tempdir().unwrap();
     let home = tmp.path().join("codex-home");

--- a/crates/codex-plus-data/tests/storage_adapter.rs
+++ b/crates/codex-plus-data/tests/storage_adapter.rs
@@ -587,6 +587,41 @@ fn delete_codex_thread_clears_sidebar_global_state_and_catalog_cache() {
             .unwrap();
         assert_eq!(count, 0, "{table}");
     }
+
+    let restored = SQLiteStorageAdapter::new(
+        &state_db,
+        BackupStore::new(tmp.path().join("backups")),
+    )
+    .with_codex_home(&home)
+    .undo(deleted.undo_token.as_deref().unwrap());
+    assert_eq!(restored.status, DeleteStatus::Undone);
+    let state: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(home.join(".codex-global-state.json")).unwrap())
+            .unwrap();
+    assert_eq!(state["projectless-thread-ids"], json!([keep_id, "t1"]));
+    assert_eq!(
+        state["thread-projectless-output-directories"]["t1"],
+        "C:/out"
+    );
+    assert_eq!(
+        state["electron-persisted-atom-state"]["thread-client-id-v1:t1"],
+        "client"
+    );
+    let catalog_db = Connection::open(sqlite_dir.join("codex-dev.db")).unwrap();
+    for table in [
+        "local_thread_catalog",
+        "thread_timeline_ledger",
+        "local_thread_catalog_scan_entries",
+    ] {
+        let count: i64 = catalog_db
+            .query_row(
+                &format!("SELECT COUNT(*) FROM {table} WHERE thread_id = 't1'"),
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "{table}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## 问题现象
删除 Codex++ 会话后，侧边栏仍显示旧会话；点击后提示 no rollout found for thread id，无法恢复。
可见 #2073 

## 原因
删除流程只清理主线程数据库、rollout 文件和部分 session_index，没有同步清理 .codex-global-state.json 中的 projectless-thread-ids/线程元数据，也没有清理 sqlite/codex-dev.db 的 local_thread_catalog 等目录缓存，造成索引与实际存储不一致。

## 解决方案
- 删除成功后按 thread ID 原子清理全局状态中的线程引用。
- 参数化删除 local_thread_catalog、thread_timeline_ledger、local_thread_catalog_scan_entries 中的目标行。
- 统一清理 session_index.jsonl。
- 主线程记录已不存在但残留索引存在时，支持降级清理。
- 增加回归测试，确认其他会话不受影响。
