### PR TITLE
fix: 修复 Codex++ 页面下切换会话

### DIFF
--- a/apps/codex-plus-manager/src/renderer-inject.test.ts
+++ b/apps/codex-plus-manager/src/renderer-inject.test.ts
@@ -193,8 +193,12 @@ describe("renderer injection header compatibility", () => {
     assert.match(renderer, /openCodexPlusPage\(\)/);
     assert.match(renderer, /codex-plus-page-overlay/);
     assert.match(renderer, /positionCodexPlusPage/);
+    assert.match(renderer, /overlay\.remove\(\);\s*if \(pageMode\) setCodexPlusSidebarNavActive\(false\);/);
     assert.match(renderer, /function closeCodexPlusPage\(\)/);
-    assert.match(renderer, /target\?\.closest\("button, a"\)\) closeCodexPlusPage\(\)/);
+    assert.match(renderer, /function installCodexPlusPageNavigationCloseHandler\(\)/);
+    assert.match(renderer, /target\?\.closest\(selectors\.sidebarThread\)/);
+    assert.match(renderer, /closeCodexPlusPageAfterNativeNavigation\(\)/);
+    assert.match(renderer, /setTimeout\(\(\) => \{\s*window\.__codexPlusPageNavigationCloseTimer = null;\s*closeCodexPlusPage\(\);/);
     assert.match(renderer, /installCodexPlusSidebarNavigation\(\);/);
     assert.match(renderer, /document\.querySelectorAll\(`#\$\{codexPlusMenuId\}/);
   });

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -4339,6 +4339,7 @@
       event.preventDefault();
       event.stopPropagation();
       overlay.remove();
+      if (pageMode) setCodexPlusSidebarNavActive(false);
     }, true);
     overlay.addEventListener("input", (event) => {
       const target = event.target instanceof Element ? event.target : event.target?.parentElement;
@@ -4479,6 +4480,26 @@
     setCodexPlusSidebarNavActive(false);
   }
 
+  function closeCodexPlusPageAfterNativeNavigation() {
+    clearTimeout(window.__codexPlusPageNavigationCloseTimer);
+    window.__codexPlusPageNavigationCloseTimer = setTimeout(() => {
+      window.__codexPlusPageNavigationCloseTimer = null;
+      closeCodexPlusPage();
+    }, 0);
+  }
+
+  function installCodexPlusPageNavigationCloseHandler() {
+    document.removeEventListener("click", window.__codexPlusPageNavigationCloseHandler, true);
+    window.__codexPlusPageNavigationCloseHandler = (event) => {
+      if (!document.querySelector(`.${codexPlusPageClass}`)) return;
+      const target = event.target instanceof Element ? event.target : event.target?.parentElement;
+      if (!target?.closest(selectors.sidebarThread)) return;
+      // Let Codex's own click handler update its route before removing our page.
+      closeCodexPlusPageAfterNativeNavigation();
+    };
+    document.addEventListener("click", window.__codexPlusPageNavigationCloseHandler, true);
+  }
+
   function installCodexPlusSidebarNavigation() {
     document.querySelectorAll(`#${codexPlusMenuId}, [data-codex-plus-menu="true"]`).forEach((node) => node.remove());
     const navigation = document.querySelector('aside.app-shell-left-panel nav[role="navigation"], nav[role="navigation"]');
@@ -4498,7 +4519,7 @@
       navigation.addEventListener("click", (event) => {
         const target = event.target instanceof Element ? event.target : event.target?.parentElement;
         if (target?.closest(`#${codexPlusSidebarNavId}`)) return;
-        if (target?.closest("button, a")) closeCodexPlusPage();
+        if (target?.closest("button, a")) closeCodexPlusPageAfterNativeNavigation();
       }, true);
     }
     let wrapper = document.getElementById(codexPlusSidebarNavId);
@@ -9402,6 +9423,7 @@
       );
     }
     installCodexPlusSidebarNavigation();
+    installCodexPlusPageNavigationCloseHandler();
     installSessionShareImportListener();
     localizeCodexMenus();
     scheduleBackendHeartbeat();


### PR DESCRIPTION
## 问题

影响范围：界面 / 交互。

当用户从左侧栏打开 Codex++ 全页面后，点击任意已有会话，Codex 原生路由可以接收到点击，但 Codex++ 覆盖页面仍保留在前景。因此界面仍显示 Codex++，用户会误以为会话没有切换。

## 复现步骤

1. 启动带 Codex++ 注入的 Codex。
2. 点击侧栏的 `Codex++`，打开主内容区页面。
3. 在左侧已有会话列表中点击任意会话。
4. 观察页面仍被 Codex++ 覆盖，无法看到目标会话内容。

## 修复

- 使用实际会话行标识 `[data-app-action-sidebar-thread-id]` 监听侧栏会话点击。
- 命中会话后延迟到当前点击事件完成后关闭 Codex++ 页面，避免在捕获阶段移除节点而干扰 Codex 自身的 React 路由处理。
- 其它原生侧栏导航也采用相同的延迟关闭时序。
- 点击 Codex++ 页面的返回按钮时同步清除侧栏入口的激活态。

## 验证

- `npm test`：138 项通过。
- `npm run check`：通过。
- `cargo test --workspace`：通过。

不包含 API Key、Token、账号或配置文件内容。