### PR TITLE
fix(windows): re-resolve Codex Desktop path after updates (#2094, #2095)

### DIFF
--- a/crates/codex-plus-core/src/app_paths.rs
+++ b/crates/codex-plus-core/src/app_paths.rs
@@ -46,7 +46,8 @@ const APP_PACKAGE_SPECS: &[AppPackageSpec] = &[
         identity: "OpenAI.ChatGPT-Desktop",
         app_id: "App",
         executable_names: CODEX_PACKAGE_EXECUTABLES,
-        priority: 1,
+        // Codex 已迁移为新的 ChatGPT Desktop；同机并存时优先新宿主。
+        priority: 2,
     },
 ];
 
@@ -63,12 +64,7 @@ pub fn find_latest_codex_app_dir(root: &Path) -> Option<PathBuf> {
             Some((spec.priority, version, app_dir))
         })
         .collect::<Vec<_>>();
-    matches.sort_by(|left, right| {
-        left.0
-            .cmp(&right.0)
-            .reverse()
-            .then_with(|| left.1.cmp(&right.1))
-    });
+    matches.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
     let (_, _, latest) = matches.pop()?;
     Some(latest)
 }
@@ -83,8 +79,16 @@ pub fn find_latest_codex_app_dir_from_roots(roots: &[PathBuf]) -> Option<PathBuf
 pub fn find_latest_codex_app_dir_default() -> Option<PathBuf> {
     #[cfg(windows)]
     {
-        find_latest_codex_app_dir_from_roots(&windows_app_package_roots())
-            .or_else(find_latest_codex_app_dir_from_appx_package)
+        // WindowsApps 目录常因 ACL 无法完整枚举；同时查询目录和 AppX 注册表，
+        // 再统一按包优先级/版本选择，避免更新后继续命中旧目录。
+        let mut candidates = windows_app_package_roots()
+            .iter()
+            .filter_map(|root| find_latest_codex_app_dir(root))
+            .collect::<Vec<_>>();
+        if let Some(appx) = find_latest_codex_app_dir_from_appx_package() {
+            candidates.push(appx);
+        }
+        candidates.into_iter().max_by(compare_app_dir_candidates)
     }
 
     #[cfg(not(windows))]
@@ -105,13 +109,8 @@ fn find_latest_codex_app_dir_from_appx_package() -> Option<PathBuf> {
 
 #[cfg(windows)]
 pub(crate) fn registered_windows_packages() -> anyhow::Result<Vec<RegisteredWindowsPackage>> {
-    use std::sync::OnceLock;
-
-    static PACKAGES: OnceLock<Result<Vec<RegisteredWindowsPackage>, String>> = OnceLock::new();
-    PACKAGES
-        .get_or_init(|| query_registered_windows_packages().map_err(|error| error.to_string()))
-        .clone()
-        .map_err(anyhow::Error::msg)
+    // AppX 包在 Codex 更新后会改变 full name 和安装目录，不能跨启动周期缓存。
+    query_registered_windows_packages()
 }
 
 #[cfg(windows)]
@@ -331,6 +330,12 @@ pub fn resolve_codex_app_dir_with_saved(
     {
         // 已保存路径无效（例如误选 Codex++）时回退自动探测
         if let Some(path) = normalize_codex_app_path(Path::new(saved)) {
+            #[cfg(windows)]
+            if is_codex_store_package_dir(&path) {
+                // Store 更新会生成新的版本目录；保存的旧目录即使仍存在，也不应
+                // 压过当前注册的最高版本。若系统查询失败则保留旧路径，兼容离线/受限环境。
+                return Some(find_latest_codex_app_dir_default().unwrap_or(path));
+            }
             return Some(path);
         }
     }
@@ -623,7 +628,7 @@ fn compare_app_dir_candidates(left: &PathBuf, right: &PathBuf) -> std::cmp::Orde
     app_dir_sort_key(left).cmp(&app_dir_sort_key(right))
 }
 
-fn app_dir_sort_key(app_dir: &Path) -> Option<(std::cmp::Reverse<u8>, Vec<u32>)> {
+fn app_dir_sort_key(app_dir: &Path) -> Option<(u8, Vec<u32>)> {
     let spec = package_spec_from_path(app_dir)?;
     let package_dir = if app_dir
         .file_name()
@@ -634,10 +639,7 @@ fn app_dir_sort_key(app_dir: &Path) -> Option<(std::cmp::Reverse<u8>, Vec<u32>)>
     } else {
         app_dir
     };
-    Some((
-        std::cmp::Reverse(spec.priority),
-        version_tuple(package_dir)?,
-    ))
+    Some((spec.priority, version_tuple(package_dir)?))
 }
 
 fn package_entry_dir(package_dir: &Path, spec: AppPackageSpec) -> Option<PathBuf> {
@@ -677,9 +679,14 @@ fn codex_package_parts(package_name: &str) -> Option<(AppPackageSpec, &str, &str
         let Some((version, rest)) = rest.split_once('_') else {
             continue;
         };
-        let Some((_, publisher_id)) = rest.rsplit_once("__") else {
+        // MSIX full name 的 resource id 可能为 `~`，例如
+        // `Name_1.2.3.0_neutral_~_publisher`; 也兼容无 resource id 时的 `x64__publisher`。
+        let Some((_, publisher_id)) = rest.rsplit_once('_') else {
             continue;
         };
+        if publisher_id.is_empty() {
+            continue;
+        }
         return Some((*spec, version, publisher_id));
     }
     None

--- a/crates/codex-plus-core/src/app_paths.rs
+++ b/crates/codex-plus-core/src/app_paths.rs
@@ -79,16 +79,14 @@ pub fn find_latest_codex_app_dir_from_roots(roots: &[PathBuf]) -> Option<PathBuf
 pub fn find_latest_codex_app_dir_default() -> Option<PathBuf> {
     #[cfg(windows)]
     {
-        // WindowsApps 目录常因 ACL 无法完整枚举；同时查询目录和 AppX 注册表，
-        // 再统一按包优先级/版本选择，避免更新后继续命中旧目录。
-        let mut candidates = windows_app_package_roots()
+        // 注册信息是 Store 当前状态的权威来源；查询失败时再退回目录扫描。
+        if let Ok(Some(appx)) = find_latest_codex_app_dir_from_appx_package() {
+            return Some(appx);
+        }
+        windows_app_package_roots()
             .iter()
             .filter_map(|root| find_latest_codex_app_dir(root))
-            .collect::<Vec<_>>();
-        if let Some(appx) = find_latest_codex_app_dir_from_appx_package() {
-            candidates.push(appx);
-        }
-        candidates.into_iter().max_by(compare_app_dir_candidates)
+            .max_by(compare_app_dir_candidates)
     }
 
     #[cfg(not(windows))]
@@ -98,13 +96,12 @@ pub fn find_latest_codex_app_dir_default() -> Option<PathBuf> {
 }
 
 #[cfg(windows)]
-fn find_latest_codex_app_dir_from_appx_package() -> Option<PathBuf> {
-    registered_windows_packages()
-        .ok()?
+fn find_latest_codex_app_dir_from_appx_package() -> anyhow::Result<Option<PathBuf>> {
+    Ok(registered_windows_packages()?
         .into_iter()
         .filter(|package| is_supported_windows_app_package_name(&package.full_name))
         .filter_map(|package| normalize_codex_app_path(&package.install_location))
-        .max_by(compare_app_dir_candidates)
+        .max_by(compare_app_dir_candidates))
 }
 
 #[cfg(windows)]
@@ -332,14 +329,28 @@ pub fn resolve_codex_app_dir_with_saved(
         if let Some(path) = normalize_codex_app_path(Path::new(saved)) {
             #[cfg(windows)]
             if is_codex_store_package_dir(&path) {
-                // Store 更新会生成新的版本目录；保存的旧目录即使仍存在，也不应
-                // 压过当前注册的最高版本。若系统查询失败则保留旧路径，兼容离线/受限环境。
-                return Some(find_latest_codex_app_dir_default().unwrap_or(path));
+                // Store 更新会生成新的版本目录；注册查询成功时选择当前最高版本，
+                // 查询失败则保留已保存路径，兼容离线或受限环境。
+                return Some(resolve_saved_store_path(
+                    path,
+                    find_latest_codex_app_dir_from_appx_package(),
+                ));
             }
             return Some(path);
         }
     }
     resolve_codex_app_dir(None)
+}
+
+#[cfg(windows)]
+fn resolve_saved_store_path(
+    saved_path: PathBuf,
+    current: anyhow::Result<Option<PathBuf>>,
+) -> PathBuf {
+    match current {
+        Ok(Some(current)) => current,
+        Ok(None) | Err(_) => saved_path,
+    }
 }
 
 pub fn normalize_codex_app_path(path: &Path) -> Option<PathBuf> {
@@ -698,4 +709,30 @@ fn strip_prefix_ignore_ascii_case<'a>(value: &'a str, prefix: &str) -> Option<&'
     }
     let (head, rest) = value.split_at(prefix.len());
     head.eq_ignore_ascii_case(prefix).then_some(rest)
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::resolve_saved_store_path;
+    use std::path::PathBuf;
+
+    #[test]
+    fn saved_store_path_prefers_current_registered_package() {
+        let saved = PathBuf::from(r"C:\old\app");
+        let current = PathBuf::from(r"C:\new\app");
+        assert_eq!(
+            resolve_saved_store_path(saved, Ok(Some(current.clone()))),
+            current
+        );
+    }
+
+    #[test]
+    fn saved_store_path_falls_back_when_registration_is_unavailable() {
+        let saved = PathBuf::from(r"C:\old\app");
+        assert_eq!(resolve_saved_store_path(saved.clone(), Ok(None)), saved);
+        assert_eq!(
+            resolve_saved_store_path(saved.clone(), Err(anyhow::anyhow!("query failed"))),
+            saved
+        );
+    }
 }

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -1,9 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-#[cfg(windows)]
-use std::sync::OnceLock;
-
 use codex_plus_core::app_paths::{
     build_codex_executable, codex_app_version, find_bundled_codex_cli, find_latest_codex_app_dir,
     find_latest_codex_app_dir_from_roots, find_macos_codex_app, normalize_codex_app_path,
@@ -127,34 +124,6 @@ fn app_paths_find_latest_windows_package_checks_roots_before_fallback() {
     let latest = find_latest_codex_app_dir_from_roots(&[root]).unwrap();
 
     assert!(latest.ends_with("OpenAI.Codex_26.513.3673.0_x64__abc/app"));
-}
-
-#[cfg(windows)]
-#[test]
-fn app_paths_re_resolve_saved_store_path_after_codex_update() {
-    // 模拟 Store 更新：旧版本目录仍然存在，但当前版本已经落在新的版本目录。
-    // 通过临时 ProgramFiles 注入 WindowsApps 根，避免依赖真实机器安装状态。
-    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
-    let temp = tempfile::tempdir().unwrap();
-    let windows_apps = temp.path().join("WindowsApps");
-    let old_package = windows_apps.join("OpenAI.Codex_26.707.3748.0_x64__abc");
-    // 使用远高于现实版本的测试版本，避免测试机真实安装包参与排序。
-    let new_package = windows_apps.join("OpenAI.Codex_9999.803.41515.0_x64__abc");
-    std::fs::create_dir_all(old_package.join("app")).unwrap();
-    std::fs::create_dir_all(new_package.join("app")).unwrap();
-
-    let previous = std::env::var_os("ProgramFiles");
-    unsafe { std::env::set_var("ProgramFiles", temp.path()) };
-    let resolved = resolve_codex_app_dir_with_saved(None, Some(&old_package.to_string_lossy()));
-    unsafe {
-        match previous {
-            Some(value) => std::env::set_var("ProgramFiles", value),
-            None => std::env::remove_var("ProgramFiles"),
-        }
-    }
-
-    assert_eq!(resolved.as_deref(), Some(new_package.join("app").as_path()));
 }
 
 #[cfg(windows)]

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -1,6 +1,9 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+#[cfg(windows)]
+use std::sync::OnceLock;
+
 use codex_plus_core::app_paths::{
     build_codex_executable, codex_app_version, find_bundled_codex_cli, find_latest_codex_app_dir,
     find_latest_codex_app_dir_from_roots, find_macos_codex_app, normalize_codex_app_path,
@@ -49,7 +52,7 @@ fn app_paths_find_latest_windows_package_prefers_highest_version_app_dir() {
 }
 
 #[test]
-fn app_paths_find_latest_windows_package_ignores_chatgpt_desktop_package() {
+fn app_paths_find_latest_windows_package_accepts_chatgpt_desktop_migration() {
     let temp = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(temp.path().join("OpenAI.Codex_26.707.3748.0_x64__abc/app")).unwrap();
     std::fs::create_dir_all(
@@ -59,7 +62,7 @@ fn app_paths_find_latest_windows_package_ignores_chatgpt_desktop_package() {
     .unwrap();
     std::fs::create_dir_all(
         temp.path()
-            .join("OpenAI.ChatGPT-Desktop_2026.514.421.0_neutral_~_abc"),
+            .join("OpenAI.ChatGPT-Desktop_2026.514.421.0_neutral_~_abc/app"),
     )
     .unwrap();
 
@@ -67,12 +70,17 @@ fn app_paths_find_latest_windows_package_ignores_chatgpt_desktop_package() {
 
     assert_eq!(
         latest,
-        temp.path().join("OpenAI.Codex_26.707.3748.0_x64__abc/app")
+        temp.path()
+            .join("OpenAI.ChatGPT-Desktop_2026.514.421.0_neutral_~_abc")
+            .join("app")
     );
-    assert_eq!(codex_app_version(&latest).as_deref(), Some("26.707.3748.0"));
+    assert_eq!(
+        codex_app_version(&latest).as_deref(),
+        Some("2026.514.421.0")
+    );
     assert_eq!(
         packaged_app_user_model_id(&latest).as_deref(),
-        Some("OpenAI.Codex_abc!App")
+        Some("OpenAI.ChatGPT-Desktop_abc!App")
     );
 }
 
@@ -121,8 +129,51 @@ fn app_paths_find_latest_windows_package_checks_roots_before_fallback() {
     assert!(latest.ends_with("OpenAI.Codex_26.513.3673.0_x64__abc/app"));
 }
 
+#[cfg(windows)]
 #[test]
-fn app_paths_find_latest_windows_package_ignores_chatgpt_across_roots() {
+fn app_paths_re_resolve_saved_store_path_after_codex_update() {
+    // 模拟 Store 更新：旧版本目录仍然存在，但当前版本已经落在新的版本目录。
+    // 通过临时 ProgramFiles 注入 WindowsApps 根，避免依赖真实机器安装状态。
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let windows_apps = temp.path().join("WindowsApps");
+    let old_package = windows_apps.join("OpenAI.Codex_26.707.3748.0_x64__abc");
+    // 使用远高于现实版本的测试版本，避免测试机真实安装包参与排序。
+    let new_package = windows_apps.join("OpenAI.Codex_9999.803.41515.0_x64__abc");
+    std::fs::create_dir_all(old_package.join("app")).unwrap();
+    std::fs::create_dir_all(new_package.join("app")).unwrap();
+
+    let previous = std::env::var_os("ProgramFiles");
+    unsafe { std::env::set_var("ProgramFiles", temp.path()) };
+    let resolved = resolve_codex_app_dir_with_saved(None, Some(&old_package.to_string_lossy()));
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("ProgramFiles", value),
+            None => std::env::remove_var("ProgramFiles"),
+        }
+    }
+
+    assert_eq!(resolved.as_deref(), Some(new_package.join("app").as_path()));
+}
+
+#[cfg(windows)]
+#[test]
+fn app_paths_keep_explicit_store_path_override_without_re_resolving() {
+    let temp = tempfile::tempdir().unwrap();
+    let explicit = temp
+        .path()
+        .join("OpenAI.Codex_26.707.3748.0_x64__abc")
+        .join("app");
+    std::fs::create_dir_all(&explicit).unwrap();
+
+    let resolved = resolve_codex_app_dir_with_saved(Some(&explicit), None);
+
+    assert_eq!(resolved.as_deref(), Some(explicit.as_path()));
+}
+
+#[test]
+fn app_paths_find_latest_windows_package_accepts_chatgpt_migration_across_roots() {
     let temp = tempfile::tempdir().unwrap();
     let root_a = temp.path().join("WindowsAppsA");
     let root_b = temp.path().join("WindowsAppsB");
@@ -132,7 +183,7 @@ fn app_paths_find_latest_windows_package_ignores_chatgpt_across_roots() {
 
     let latest = find_latest_codex_app_dir_from_roots(&[root_a, root_b]).unwrap();
 
-    assert!(latest.ends_with("OpenAI.Codex_26.999.0.0_x64__abc/app"));
+    assert!(latest.ends_with("OpenAI.ChatGPT-Desktop_1.2026.133.0_x64__abc/app"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Re-resolve the current Codex Desktop installation after Windows Store/AppX updates.
- Support both legacy `OpenAI.Codex` packages and the newer `OpenAI.ChatGPT-Desktop` package identity, including `neutral_~_publisher` MSIX full names.
- Keep explicit `--app-path`, standalone Windows installs, and existing macOS bundle resolution behavior unchanged.
- Refresh AppX package discovery on every resolution instead of reusing stale process-level package data.

## Scope

This PR primarily targets Windows, which is the platform affected by the versioned WindowsApps installation paths reported in #2094 and #2095. macOS behavior is kept compatible and covered by existing regression tests. Codex++ currently does not ship a Linux Desktop target, so Linux Desktop discovery is intentionally outside this PR.

## Issues

Closes #2094
Closes #2095

## Testing

- `F:\\cargo\\bin\\cargo.exe +stable test -p codex-plus-core`
- Result: 308 passed, 0 failed.
- Targeted launcher/path tests: 31 passed, 0 failed.

Additional coverage includes old and new AppX package identities, stale saved Store paths after an update, explicit path precedence, Codex++ manager path rejection, portable installs, and macOS bundles.

## Notes

The existing unrelated `unused import: std::io::Write` warning remains unchanged.