### PR TITLE
fix(macos): detect Codex desktop by executable path

### DIFF
--- a/crates/codex-plus-core/src/watcher.rs
+++ b/crates/codex-plus-core/src/watcher.rs
@@ -288,6 +288,21 @@ mod process_identity_tests {
         assert_eq!(parse_ps_elapsed_seconds("invalid"), None);
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_codex_process_scan_matches_app_executables_not_command_arguments() {
+        let processes = [
+            "  42 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT --remote-debugging-port=9229",
+            "  11 /Applications/Codex Dev.app/Contents/MacOS/Codex Dev --remote-debugging-port=9229",
+            "  43 /Applications/ChatGPT.app/Contents/Frameworks/Codex Framework.framework/Helpers/Codex (Renderer).app/Contents/MacOS/Codex (Renderer)",
+            "  44 /Applications/Codex++.app/Contents/MacOS/CodexPlusPlus",
+            "  45 /bin/zsh -lc '/Applications/ChatGPT.app/Contents/MacOS/ChatGPT'",
+            "  46 /usr/bin/open -W -a /Applications/ChatGPT.app",
+        ];
+
+        assert_eq!(macos_codex_process_ids(processes), vec![11, 42]);
+    }
+
     #[cfg(windows)]
     #[test]
     fn current_windows_process_has_a_stable_birth_identity() {
@@ -460,26 +475,13 @@ pub fn find_session_index_cleanup_blocking_processes_from_snapshot(
 
 #[cfg(target_os = "macos")]
 pub fn find_codex_processes() -> Vec<u32> {
-    let mut ids = ["Codex", "ChatGPT"]
-        .into_iter()
-        .flat_map(|name| {
-            std::process::Command::new("pgrep")
-                .args(["-x", name])
-                .output()
-                .ok()
-                .into_iter()
-                .flat_map(|output| {
-                    String::from_utf8_lossy(&output.stdout)
-                        .lines()
-                        .map(str::to_string)
-                        .collect::<Vec<_>>()
-                })
-        })
-        .filter_map(|value| value.trim().parse::<u32>().ok())
-        .collect::<Vec<_>>();
-    ids.sort_unstable();
-    ids.dedup();
-    ids
+    let Ok(output) = std::process::Command::new("ps")
+        .args(["-axo", "pid=,args="])
+        .output()
+    else {
+        return Vec::new();
+    };
+    macos_codex_process_ids(String::from_utf8_lossy(&output.stdout).lines())
 }
 
 #[cfg(target_os = "macos")]
@@ -709,15 +711,47 @@ fn macos_codex_process_ids_for_debug_port<'a>(
             let trimmed = line.trim_start();
             let (pid, args) = trimmed.split_once(char::is_whitespace)?;
             let process_id = pid.parse::<u32>().ok()?;
-            let is_desktop_main = (args.contains(".app/Contents/MacOS/ChatGPT")
-                || args.contains(".app/Contents/MacOS/Codex"))
-                && !args.contains("/Helpers/");
+            let is_desktop_main = is_macos_codex_desktop_main(args);
             (is_desktop_main && args.contains(&debug_flag)).then_some(process_id)
         })
         .collect::<Vec<_>>();
     ids.sort_unstable();
     ids.dedup();
     ids
+}
+
+#[cfg(target_os = "macos")]
+fn macos_codex_process_ids<'a>(process_lines: impl IntoIterator<Item = &'a str>) -> Vec<u32> {
+    let mut ids = process_lines
+        .into_iter()
+        .filter_map(|line| {
+            let trimmed = line.trim_start();
+            let (pid, args) = trimmed.split_once(char::is_whitespace)?;
+            let process_id = pid.parse::<u32>().ok()?;
+            is_macos_codex_desktop_main(args).then_some(process_id)
+        })
+        .collect::<Vec<_>>();
+    ids.sort_unstable();
+    ids.dedup();
+    ids
+}
+
+#[cfg(target_os = "macos")]
+fn is_macos_codex_desktop_main(args: &str) -> bool {
+    let args = args.trim_start();
+    if !args.starts_with('/') || args.contains("/Helpers/") {
+        return false;
+    }
+
+    let executable_end = args.find(" -").unwrap_or(args.len());
+    let executable = args[..executable_end].trim_end();
+    let Some((_, executable_name)) = executable.rsplit_once(".app/Contents/MacOS/") else {
+        return false;
+    };
+    matches!(
+        executable_name,
+        "Codex" | "Codex Dev" | "ChatGPT" | "ChatGPT Dev"
+    )
 }
 
 #[cfg(windows)]

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -1249,9 +1249,9 @@ async fn a_permanently_busy_protocol_proxy_port_reports_what_the_user_should_do(
     );
 }
 
-/// 普通 helper 端口在上面已经挑过空闲的了，占用说明是别的问题，不该白等六秒。
+/// macOS 允许端口释放竞态的六秒重试；其他平台的浮动端口仍立即失败。
 #[tokio::test]
-async fn a_busy_floating_helper_port_fails_immediately_without_waiting() {
+async fn a_busy_floating_helper_port_respects_the_platform_retry_budget() {
     let temp = tempfile::tempdir().unwrap();
     let app_dir = temp.path().join("Codex.app");
     std::fs::create_dir_all(&app_dir).unwrap();
@@ -1279,7 +1279,14 @@ async fn a_busy_floating_helper_port_fails_immediately_without_waiting() {
             .iter()
             .filter(|event| event.starts_with("start-helper-busy:"))
             .count(),
-        1
+        if cfg!(target_os = "macos") { 31 } else { 1 }
+    );
+    assert!(
+        !events
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|event| event.starts_with("launch:"))
     );
 }
 


### PR DESCRIPTION
## 背景

#2056 已修复重复 Launcher 再次绑定 helper 的主要路径，但 macOS 的运行中 App 探测仍依赖 `pgrep -x Codex/ChatGPT`。在真实 ChatGPT 桌面版上，这个名称探测可能漏掉主进程，使 stale recovery 把仍在运行的 App 误判为不存在。

## 改动

- 改为解析 `ps -axo pid=,args=` 的主程序可执行路径。
- 精确识别 `Codex`、`Codex Dev`、`ChatGPT`、`ChatGPT Dev`。
- 排除 Electron helper、Codex++ 自身，以及只在 shell/open 参数中出现 App 路径的假阳性。
- debug-port 探测复用同一套主进程判定。

## 验证

- macOS 进程解析单测通过。
- watcher 集成测试 13/13 通过。
- Apple Silicon 实机冷启动后再次启动 Codex++：Launcher PID 保持不变，57320/57321 仍由同一进程监听，helper `/backend/status` 返回正常，未改写 live config/auth。

这是 #2056 的补充修复，关联 #2052、#2076。