### PR TITLE
docs: clarify mixed API mode semantics (official login is not a quota fallback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Codex++ 将官方登录、混入 API 和纯 API 分开保存和切换：
 | 模式 | 用途 | 认证边界 |
 | --- | --- | --- |
 | 官方登录 | 只使用 ChatGPT / Codex 官方账号 | 清理自定义 provider 和 API Key，保留官方登录状态 |
-| 官方登录 + API | 保留官方账号与插件入口，模型请求走兼容 API | API Key 写入 provider bearer token，不写入纯 API 的 `auth.json` |
+| 官方登录 + API | 保留官方账号与插件入口，模型请求始终走兼容 API（不消耗官方额度，也不是官方优先回落） | API Key 写入 provider bearer token，不写入纯 API 的 `auth.json` |
 | 纯 API | 不依赖官方账号，完全使用自定义 Base URL / Key | 独立保存 `config.toml` 与 API Key，不混入官方认证 |
 | 聚合供应商 | 在多个普通 API 供应商之间路由 | 支持故障转移、按会话轮转、按请求轮转和权重轮转 |
 
@@ -233,6 +233,10 @@ Codex++ 通过 GitHub Release 发布安装包。Windows 会生成 NSIS 安装程
 ### 切换供应商后请求失败
 
 先在供应商详情中运行模型测试或 Provider Doctor，并确认协议、Base URL、Key 和测试模型匹配。纯 API 与官方混入模式使用不同的认证位置，不要手工复制两种模式的 `auth.json`。
+
+### 混入 API Key 模式是“官方优先、额度不足时 API 补偿”吗
+
+不是。官方登录 + API（混入）模式下，模型请求**始终走你配置的兼容 API**，官方账号只保留登录状态和插件入口，不会先消耗官方额度再回落到 API。需要“一个供应商失败时切到另一个”的行为时，使用聚合供应商：它支持故障转移、按会话轮转、按请求轮转和权重轮转。两种模式的认证保存位置不同，配置前先在供应商详情里用模型测试确认目标 API 可用。
 
 ### Upstream worktree 和 Codex 原生创建有什么区别
 


### PR DESCRIPTION
## 改了什么

README 供应商模式表与常见问题澄清：官方登录 + API（混入）模式下，模型请求始终走配置的兼容 API，官方账号只保留登录状态与插件入口，不消耗官方额度、也不是官方优先回落；需要失败切换行为时指向聚合供应商（故障转移/轮转）。

## 为什么改

#2087 中用户把混入模式理解为"官方额度优先、不足时 API 补偿"，与实际行为（`RelayMode::MixedApi`，见 `crates/codex-plus-core/src/settings.rs`）不符，README 未说明该语义。

## 怎么检查的

- 纯文档改动，review diff 与 Markdown 渲染；
- 描述与 `RelayMode` 枚举及 provider 同步逻辑核对一致。

Closes #2087