### PR TITLE
fix(proxy): Kimi-provider-fix. inline local $ref siblings in chat tool parameters / 内联 chat 工具参数中携带 sibling 的本地 $ref

### DIFF
--- a/crates/codex-plus-core/src/protocol_proxy.rs
+++ b/crates/codex-plus-core/src/protocol_proxy.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeSet;
 use std::time::Duration;
 
 use anyhow::Context;
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 
 use crate::relay_rotation::{RotationContext, RotationEvent};
 use crate::settings::{RelayProtocol, SettingsStore};
@@ -3107,16 +3107,120 @@ fn normalize_chat_tool_parameters(parameters: &Value) -> Value {
     } else {
         json!({})
     };
-    if normalized.get("type").is_none() {
-        normalized["type"] = json!("object");
+    // 裸 `$ref` 已经是完整 schema，补默认字段会人为制造 sibling。
+    let is_bare_ref = normalized
+        .as_object()
+        .is_some_and(|object| object.len() == 1 && object.contains_key("$ref"));
+    if !is_bare_ref {
+        if normalized.get("type").is_none() {
+            normalized["type"] = json!("object");
+        }
+        if normalized.get("properties").is_none() {
+            normalized["properties"] = json!({});
+        }
+        if normalized.get("required").is_none() {
+            normalized["required"] = json!([]);
+        }
     }
-    if normalized.get("properties").is_none() {
-        normalized["properties"] = json!({});
+    inline_ref_siblings(&normalized)
+}
+
+fn inline_ref_siblings(root: &Value) -> Value {
+    let defs = root.get("$defs").and_then(Value::as_object);
+    let mut resolving = Vec::new();
+    normalize_schema_value(root, defs, &mut resolving).unwrap_or_else(|_| root.clone())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LocalRefNormalizationError {
+    Cycle,
+}
+
+fn normalize_schema_value(
+    node: &Value,
+    defs: Option<&Map<String, Value>>,
+    resolving: &mut Vec<String>,
+) -> Result<Value, LocalRefNormalizationError> {
+    match node {
+        Value::Array(items) => Ok(Value::Array(
+            items
+                .iter()
+                .map(|item| normalize_schema_value(item, defs, resolving))
+                .collect::<Result<Vec<_>, _>>()?,
+        )),
+        Value::Object(object) => normalize_schema_object(object, defs, resolving),
+        _ => Ok(node.clone()),
     }
-    if normalized.get("required").is_none() {
-        normalized["required"] = json!([]);
+}
+
+fn normalize_schema_object(
+    object: &Map<String, Value>,
+    defs: Option<&Map<String, Value>>,
+    resolving: &mut Vec<String>,
+) -> Result<Value, LocalRefNormalizationError> {
+    if object.len() > 1
+        && let Some(reference) = object.get("$ref").and_then(Value::as_str)
+        && let Some(name) = local_definition_name(reference)
+    {
+        match resolve_local_definition(name, defs, resolving)? {
+            Some(Value::Object(mut merged)) if merged.get("$ref").is_none() => {
+                for (key, value) in object {
+                    if key != "$ref" {
+                        merged.insert(key.clone(), normalize_schema_value(value, defs, resolving)?);
+                    }
+                }
+                return Ok(Value::Object(merged));
+            }
+            Some(_) | None => {}
+        }
     }
-    normalized
+
+    let mut normalized = Map::new();
+    for (key, value) in object {
+        normalized.insert(key.clone(), normalize_schema_value(value, defs, resolving)?);
+    }
+    Ok(Value::Object(normalized))
+}
+
+fn resolve_local_definition(
+    name: &str,
+    defs: Option<&Map<String, Value>>,
+    resolving: &mut Vec<String>,
+) -> Result<Option<Value>, LocalRefNormalizationError> {
+    let Some(defs) = defs else {
+        return Ok(None);
+    };
+    let Some(target) = defs.get(name) else {
+        return Ok(None);
+    };
+    if resolving.iter().any(|current| current == name) {
+        return Err(LocalRefNormalizationError::Cycle);
+    }
+
+    resolving.push(name.to_string());
+    let resolved = if let Some(alias) = bare_local_ref_name(target) {
+        resolve_local_definition(alias, Some(defs), resolving)
+    } else {
+        normalize_schema_value(target, Some(defs), resolving).map(Some)
+    };
+    resolving.pop();
+    resolved
+}
+
+fn bare_local_ref_name(node: &Value) -> Option<&str> {
+    let object = node.as_object()?;
+    if object.len() != 1 {
+        return None;
+    }
+    local_definition_name(object.get("$ref")?.as_str()?)
+}
+
+fn local_definition_name(reference: &str) -> Option<&str> {
+    let name = reference.strip_prefix("#/$defs/")?;
+    if name.is_empty() || name.contains('/') {
+        return None;
+    }
+    Some(name)
 }
 
 fn generic_custom_proxy_tool(name: &str, description: &str) -> Value {

--- a/crates/codex-plus-core/tests/protocol_proxy.rs
+++ b/crates/codex-plus-core/tests/protocol_proxy.rs
@@ -16,7 +16,7 @@ use codex_plus_core::settings::{
     AggregateRelayMember, AggregateRelayProfile, AggregateRelayStrategy, BackendSettings,
     RelayMode, RelayModelRoute, RelayProfile, RelayProtocol, RelaySessionProvider,
 };
-use serde_json::json;
+use serde_json::{Value, json};
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
@@ -24,6 +24,21 @@ use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+fn contains_problematic_local_ref_siblings(value: &Value) -> bool {
+    match value {
+        Value::Array(items) => items.iter().any(contains_problematic_local_ref_siblings),
+        Value::Object(object) => {
+            let has_local_ref_siblings = object.len() > 1
+                && object
+                    .get("$ref")
+                    .and_then(Value::as_str)
+                    .is_some_and(|reference| reference.starts_with("#/$defs/"));
+            has_local_ref_siblings || object.values().any(contains_problematic_local_ref_siblings)
+        }
+        _ => false,
+    }
+}
 
 #[test]
 fn responses_request_converts_to_chat_completions() {
@@ -740,6 +755,334 @@ fn responses_request_drops_tool_controls_when_no_chat_tools_survive() {
     assert!(converted.get("tools").is_none());
     assert!(converted.get("tool_choice").is_none());
     assert!(converted.get("parallel_tool_calls").is_none());
+}
+
+#[test]
+fn responses_request_to_chat_inlines_ref_siblings_in_tool_defs() {
+    let converted = responses_to_chat_completions(json!({
+        "model": "k3",
+        "input": "hi",
+        "tools": [{
+            "type": "function",
+            "name": "automation_update",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "targetThreadId": {
+                        "$ref": "#/$defs/__schema20"
+                    }
+                },
+                "$defs": {
+                    "__schema2": {
+                        "type": "string"
+                    },
+                    "__schema20": {
+                        "$ref": "#/$defs/__schema2",
+                        "type": "string",
+                        "format": "uuid",
+                        "minLength": 1
+                    }
+                }
+            }
+        }]
+    }))
+    .unwrap();
+
+    let parameters = &converted["tools"][0]["function"]["parameters"];
+    let schema20 = &parameters["$defs"]["__schema20"];
+    assert!(schema20.get("$ref").is_none());
+    assert_eq!(schema20["type"], "string");
+    assert_eq!(schema20["format"], "uuid");
+    assert_eq!(schema20["minLength"], 1);
+    assert!(!contains_problematic_local_ref_siblings(parameters));
+    assert_eq!(
+        parameters["properties"]["targetThreadId"]["$ref"],
+        "#/$defs/__schema20"
+    );
+}
+
+#[test]
+fn invalid_defs_container_does_not_panic() {
+    let converted = responses_to_chat_completions(json!({
+        "model": "k3",
+        "input": "hi",
+        "tools": [{
+            "type": "function",
+            "name": "lookup",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "$ref": "#/$defs/id",
+                        "description": "foo"
+                    }
+                },
+                "$defs": "invalid"
+            }
+        }]
+    }))
+    .unwrap();
+
+    assert_eq!(
+        converted["tools"][0]["function"]["parameters"]["properties"]["id"],
+        json!({
+            "$ref": "#/$defs/id",
+            "description": "foo"
+        })
+    );
+}
+
+#[test]
+fn non_object_local_ref_target_is_preserved() {
+    let converted = responses_to_chat_completions(json!({
+        "model": "k3",
+        "input": "hi",
+        "tools": [{
+            "type": "function",
+            "name": "lookup",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "$ref": "#/$defs/id",
+                        "description": "foo"
+                    }
+                },
+                "$defs": {
+                    "id": "invalid"
+                }
+            }
+        }]
+    }))
+    .unwrap();
+
+    assert_eq!(
+        converted["tools"][0]["function"]["parameters"]["properties"]["id"],
+        json!({
+            "$ref": "#/$defs/id",
+            "description": "foo"
+        })
+    );
+}
+
+#[test]
+fn nested_ref_is_normalized_through_properties_and_items() {
+    let converted = responses_to_chat_completions(json!({
+        "model": "k3",
+        "input": "hi",
+        "tools": [{
+            "type": "function",
+            "name": "lookup",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/$defs/foo",
+                            "description": "nested"
+                        }
+                    }
+                },
+                "$defs": {
+                    "foo": {
+                        "type": "string"
+                    }
+                }
+            }
+        }]
+    }))
+    .unwrap();
+
+    let nested = &converted["tools"][0]["function"]["parameters"]["properties"]["items"]["items"];
+    assert!(nested.get("$ref").is_none());
+    assert_eq!(nested["type"], "string");
+    assert_eq!(nested["description"], "nested");
+}
+
+#[test]
+fn cyclic_ref_alias_does_not_recurse_forever() {
+    let converted = responses_to_chat_completions(json!({
+        "model": "k3",
+        "input": "hi",
+        "tools": [{
+            "type": "function",
+            "name": "lookup",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "cycle": {
+                        "$ref": "#/$defs/a",
+                        "description": "cycle"
+                    }
+                },
+                "$defs": {
+                    "a": {
+                        "$ref": "#/$defs/b"
+                    },
+                    "b": {
+                        "$ref": "#/$defs/a"
+                    }
+                }
+            }
+        }]
+    }))
+    .unwrap();
+
+    let cycle = &converted["tools"][0]["function"]["parameters"]["properties"]["cycle"];
+    assert_eq!(cycle["$ref"], "#/$defs/a");
+    assert_eq!(cycle["description"], "cycle");
+}
+
+#[test]
+fn external_ref_is_not_inlined() {
+    let converted = responses_to_chat_completions(json!({
+        "model": "k3",
+        "input": "hi",
+        "tools": [{
+            "type": "function",
+            "name": "lookup",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "$ref": "https://example.com/schema.json",
+                        "description": "foo"
+                    }
+                }
+            }
+        }]
+    }))
+    .unwrap();
+
+    assert_eq!(
+        converted["tools"][0]["function"]["parameters"]["properties"]["id"],
+        json!({
+            "$ref": "https://example.com/schema.json",
+            "description": "foo"
+        })
+    );
+}
+
+#[test]
+fn unknown_local_ref_is_preserved() {
+    let converted = responses_to_chat_completions(json!({
+        "model": "k3",
+        "input": "hi",
+        "tools": [{
+            "type": "function",
+            "name": "lookup",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "$ref": "#/$defs/not_exists",
+                        "description": "foo"
+                    }
+                },
+                "$defs": {}
+            }
+        }]
+    }))
+    .unwrap();
+
+    assert_eq!(
+        converted["tools"][0]["function"]["parameters"]["properties"]["id"],
+        json!({
+            "$ref": "#/$defs/not_exists",
+            "description": "foo"
+        })
+    );
+}
+
+#[test]
+fn bare_top_level_ref_is_preserved() {
+    let converted = responses_to_chat_completions(json!({
+        "model": "k3",
+        "input": "hi",
+        "tools": [{
+            "type": "function",
+            "name": "lookup",
+            "parameters": {
+                "$ref": "#/$defs/lookup"
+            }
+        }]
+    }))
+    .unwrap();
+
+    assert_eq!(
+        converted["tools"][0]["function"]["parameters"],
+        json!({ "$ref": "#/$defs/lookup" })
+    );
+}
+
+#[test]
+fn bare_local_ref_without_siblings_is_preserved() {
+    let converted = responses_to_chat_completions(json!({
+        "model": "k3",
+        "input": "hi",
+        "tools": [{
+            "type": "function",
+            "name": "lookup",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "$ref": "#/$defs/id"
+                    }
+                },
+                "$defs": {
+                    "id": {
+                        "type": "string"
+                    }
+                }
+            }
+        }]
+    }))
+    .unwrap();
+
+    assert_eq!(
+        converted["tools"][0]["function"]["parameters"]["properties"]["id"],
+        json!({ "$ref": "#/$defs/id" })
+    );
+}
+
+#[test]
+fn responses_request_to_chat_resolves_ref_alias_before_merging_siblings() {
+    let converted = responses_to_chat_completions(json!({
+        "model": "k3",
+        "input": "hi",
+        "tools": [{
+            "type": "function",
+            "name": "lookup",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "$ref": "#/$defs/alias",
+                        "format": "uuid"
+                    }
+                },
+                "$defs": {
+                    "concrete": {
+                        "type": "string",
+                        "format": "hostname"
+                    },
+                    "alias": {
+                        "$ref": "#/$defs/concrete"
+                    }
+                }
+            }
+        }]
+    }))
+    .unwrap();
+
+    let parameters = &converted["tools"][0]["function"]["parameters"];
+    let id = &parameters["properties"]["id"];
+    assert!(id.get("$ref").is_none());
+    assert_eq!(id["type"], "string");
+    assert_eq!(id["format"], "uuid");
+    assert_eq!(parameters["$defs"]["alias"]["$ref"], "#/$defs/concrete");
 }
 
 #[test]


### PR DESCRIPTION
## 中文

### 背景

Codex 客户端发送的工具定义中，会出现 JSON Schema `$ref` 携带 sibling 关键字的形式，例如 `$defs` 里的 `{"$ref": "#/$defs/__schema2", "type": "string", "format": "uuid", "minLength": 1}`。按 JSON Schema draft-07 及更早版本的语义，`$ref` 的 sibling 会被直接忽略；严格的 OpenAI 兼容上游（如 Kimi For Coding）会拒绝或静默丢弃这类 schema，导致工具参数校验异常。

同时，`normalize_chat_tool_parameters` 此前会无条件为 parameters 补 `type` / `properties` / `required` 默认值。当 parameters 本身是裸 `$ref` 时，补默认值反而人为制造了 `$ref` sibling。

### 改动

- parameters 为裸 `$ref`（对象仅含 `$ref` 一个键）时不再补 `type` / `properties` / `required` 默认值，避免人为制造 sibling
- 新增 `inline_ref_siblings`：递归遍历参数 schema，将携带 sibling 的本地 `#/$defs/` 引用展开为目标定义的副本，sibling 键覆盖定义中的同名键
- 支持 `$defs` 别名链（裸 `$ref` 指向另一个 `$ref`），内置循环检测；一旦发现环，整体回退为原 schema，不做任何内联（行为由测试锚定）
- 保守保留：外部 URL 引用、未知本地引用、非对象定义目标均原样输出

### 测试

`crates/codex-plus-core/tests/protocol_proxy.rs` 新增 10 个测试，覆盖：sibling 内联与覆盖优先级、别名链解析顺序、嵌套 `properties` / `items` 中的引用、循环引用不死循环、外部 / 未知 / 非对象目标保留、裸 `$ref` 不再被补默认值等。

本地 `cargo test -p codex-plus-core --test protocol_proxy` 87/87 通过；`cargo fmt --check` 与 `cargo clippy` 对本次改动无新增告警。`cargo test -p codex-plus-core` 全量中仅 `launcher` 的 1 个用例在本机失败（`a_busy_floating_helper_port_fails_immediately_without_waiting`，改动未触及 launcher 代码，为预存问题）。

---

## English

### Background

Tool definitions sent by the Codex client may contain JSON Schema `$ref` values carrying sibling keys, e.g. inside `$defs`: `{"$ref": "#/$defs/__schema2", "type": "string", "format": "uuid", "minLength": 1}`. Under JSON Schema draft-07 and earlier, siblings of `$ref` are ignored entirely; strict OpenAI-compatible upstreams (such as Kimi For Coding) reject or silently drop such schemas, which breaks tool-parameter validation.

In addition, `normalize_chat_tool_parameters` previously injected `type` / `properties` / `required` defaults unconditionally. When `parameters` itself is a bare `$ref`, those defaults *create* `$ref` siblings that never existed in the original schema.

### Changes

- Bare `$ref` parameter schemas (objects whose only key is `$ref`) no longer receive synthetic `type` / `properties` / `required` defaults, so normalization never manufactures `$ref` siblings.
- New `inline_ref_siblings`: recursively walks the parameter schema and expands local `#/$defs/` references that carry siblings into a copy of the resolved definition, with sibling keys overriding same-named definition keys.
- Supports alias chains inside `$defs` (a bare `$ref` pointing at another `$ref`) with cycle detection; if a cycle is found, the whole schema is returned untouched (behaviour pinned by tests).
- Conservative fallbacks: external URL references, unknown local names, and non-object definition targets are preserved as-is.

### Testing

10 new tests in `crates/codex-plus-core/tests/protocol_proxy.rs`, covering: sibling inlining and override precedence, alias-chain resolution order, refs nested inside `properties` / `items`, cycle safety, preservation of external / unknown / non-object targets, and bare `$ref` schemas staying default-free.

Local `cargo test -p codex-plus-core --test protocol_proxy` passes 87/87; `cargo fmt --check` and `cargo clippy` report no new warnings for this change. In the full `cargo test -p codex-plus-core` run, one pre-existing `launcher` test fails on this machine (`a_busy_floating_helper_port_fails_immediately_without_waiting`); the change does not touch launcher code.
