### PR TITLE
fix: improve Codex app dir detection and fix manager white screen

### DIFF
--- a/apps/codex-plus-manager/src-tauri/src/lib.rs
+++ b/apps/codex-plus-manager/src-tauri/src/lib.rs
@@ -58,6 +58,10 @@ pub fn run() {
                 main_window_builder = main_window_builder.icon(icon)?;
             }
             let main_window = main_window_builder.build()?;
+            // 确保窗口在创建后立即可见并获得焦点，
+            // 避免某些 Windows 环境下窗口被系统最小化或隐藏。
+            let _ = main_window.show();
+            let _ = main_window.set_focus();
             install_tray(app)?;
             commands::start_weixin_connect_from_saved_settings();
             register_main_window_events(main_window, startup_is_transient());
@@ -318,8 +322,17 @@ fn register_main_window_events<R: tauri::Runtime>(
     let close_event_app = event_window.app_handle().clone();
     let focus_event_window = event_window.clone();
 
+    // 启动保护期：窗口创建后前 2 秒内的 Resized 事件不触发 hide，
+    // 避免系统在窗口初始化阶段误报 minimized 状态导致白屏。
+    let created_at = std::time::Instant::now();
+    let startup_grace = std::time::Duration::from_secs(2);
+
     event_window.on_window_event(move |event| match event {
         WindowEvent::Resized(_) => {
+            // 启动保护期内跳过 minimize 检测，避免初始化阶段的误触发
+            if created_at.elapsed() < startup_grace {
+                return;
+            }
             if matches!(minimized_window.is_minimized(), Ok(true)) {
                 let _ = minimized_window.hide();
             }

--- a/crates/codex-plus-core/src/app_paths.rs
+++ b/crates/codex-plus-core/src/app_paths.rs
@@ -292,28 +292,76 @@ pub fn resolve_codex_app_dir(app_dir: Option<&Path>) -> Option<PathBuf> {
 /// - %LOCALAPPDATA%\OpenAI\Codex\bin\  (standalone installer)
 /// - %LOCALAPPDATA%\OpenAI\Codex\      (user data root)
 /// - %LOCALAPPDATA%\Programs\OpenAI\Codex\ (alternative)
+/// - %LOCALAPPDATA%\OpenAI\ChatGPT\    (ChatGPT Desktop rebrand)
+/// - %APPDATA%\OpenAI\Codex\           (roaming profile)
 pub fn find_standalone_codex_app_dir() -> Option<PathBuf> {
     let local_appdata = std::env::var_os("LOCALAPPDATA")?;
+    let roaming_appdata = std::env::var_os("APPDATA");
 
-    let candidates: &[PathBuf] = &[
+    let mut candidates: Vec<PathBuf> = vec![
+        // Primary: OpenAI Codex standalone installer paths
         PathBuf::from(&local_appdata)
             .join("OpenAI")
             .join("Codex")
             .join("bin"),
-        PathBuf::from(&local_appdata).join("OpenAI").join("Codex"),
+        PathBuf::from(&local_appdata)
+            .join("OpenAI")
+            .join("Codex"),
         PathBuf::from(&local_appdata)
             .join("Programs")
             .join("OpenAI")
             .join("Codex"),
+        // ChatGPT Desktop (rebranded) paths
+        PathBuf::from(&local_appdata)
+            .join("OpenAI")
+            .join("ChatGPT")
+            .join("bin"),
+        PathBuf::from(&local_appdata)
+            .join("OpenAI")
+            .join("ChatGPT"),
+        PathBuf::from(&local_appdata)
+            .join("Programs")
+            .join("OpenAI")
+            .join("ChatGPT"),
     ];
 
-    for candidate in candidates {
+    // Also check roaming profile paths
+    if let Some(roaming) = roaming_appdata {
+        candidates.push(PathBuf::from(&roaming).join("OpenAI").join("Codex"));
+        candidates.push(PathBuf::from(&roaming).join("OpenAI").join("ChatGPT"));
+    }
+
+    for candidate in &candidates {
         if let Some(path) = normalize_codex_app_path(candidate) {
             if build_codex_executable(&path).exists() {
                 return Some(path);
             }
         }
     }
+
+    // Fallback: scan %LOCALAPPDATA%\OpenAI\ for any Codex-like directory
+    let openai_dir = PathBuf::from(&local_appdata).join("OpenAI");
+    if openai_dir.is_dir() {
+        if let Ok(entries) = std::fs::read_dir(&openai_dir) {
+            for entry in entries.filter_map(Result::ok) {
+                let path = entry.path();
+                if !path.is_dir() {
+                    continue;
+                }
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    let lower = name.to_ascii_lowercase();
+                    if lower.contains("codex") || lower.contains("chatgpt") {
+                        if let Some(normalized) = normalize_codex_app_path(&path) {
+                            if build_codex_executable(&normalized).exists() {
+                                return Some(normalized);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     None
 }
 
@@ -329,10 +377,19 @@ pub fn resolve_codex_app_dir_with_saved(
         .map(str::trim)
         .filter(|saved| !saved.is_empty())
     {
-        // 已保存路径无效（例如误选 Codex++）时回退自动探测
-        if let Some(path) = normalize_codex_app_path(Path::new(saved)) {
-            return Some(path);
+        let saved_path = Path::new(saved);
+
+        // 快速拒绝：已保存路径明显是 Codex++ 而非 Codex 桌面应用
+        if is_codex_plus_plus_path(saved_path) {
+            // 不 return，继续走自动探测
+        } else if let Some(path) = normalize_codex_app_path(saved_path) {
+            // 路径有效且包含可执行文件，直接返回
+            if executable_in_dir(&path).is_some() || is_codex_store_package_dir(&path) {
+                return Some(path);
+            }
+            // 路径被 normalize 但不含可执行文件（可能是残留的旧路径），继续探测
         }
+        // saved 无效或不含可执行文件 → 回退自动探测
     }
     resolve_codex_app_dir(None)
 }

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -413,9 +413,19 @@ fn app_paths_saved_path_is_used_when_no_explicit_path_is_provided() {
     let app = temp.path().join("Codex.app");
     std::fs::create_dir_all(&app).unwrap();
 
+    // macOS .app bundle 路径无需含可执行文件即被接受
     assert_eq!(
         resolve_codex_app_dir_with_saved(None, Some(&app.to_string_lossy())).as_deref(),
         Some(app.as_path())
+    );
+
+    // Windows 独立安装目录必须含可执行文件才被接受
+    let standalone = temp.path().join("OpenAI").join("Codex").join("bin");
+    std::fs::create_dir_all(&standalone).unwrap();
+    std::fs::write(standalone.join("codex.exe"), "").unwrap();
+    assert_eq!(
+        resolve_codex_app_dir_with_saved(None, Some(&standalone.to_string_lossy())).as_deref(),
+        Some(standalone.as_path())
     );
 }
 


### PR DESCRIPTION
## Summary

Two bug fixes:

### Bug 1: Codex app installation directory not detected
- `find_standalone_codex_app_dir()`: Added ChatGPT Desktop paths, roaming profile paths, and fallback scan under `%LOCALAPPDATA%\OpenAI\`
- `resolve_codex_app_dir_with_saved()`: Validate saved path contains executable before accepting; stale paths fall back to auto-detection

### Bug 2: Manager shows minimized white screen on startup
- Added 2s startup grace period to prevent Resized events from hiding window during init
- Added explicit `show()` + `set_focus()` after window creation

### Files changed
- `crates/codex-plus-core/src/app_paths.rs`
- `apps/codex-plus-manager/src-tauri/src/lib.rs`
- `crates/codex-plus-core/tests/launcher.rs`
