### PR TITLE
补齐 Astra 元数据与 Max/Ultra 支持 / Add Astra metadata and reasoning efforts

### DIFF
--- a/assets/astra-model-metadata-compat.json
+++ b/assets/astra-model-metadata-compat.json
@@ -1,0 +1,30 @@
+{
+  "models": [
+    {
+      "slug": "gpt-6-astra",
+      "display_name": "GPT-6-Astra",
+      "description": "GPT-6 Astra",
+      "default_reasoning_level": "medium",
+      "supported_reasoning_levels": [
+        { "effort": "low", "description": "Fast responses with lighter reasoning" },
+        { "effort": "medium", "description": "Balances speed and reasoning depth for everyday tasks" },
+        { "effort": "high", "description": "Greater reasoning depth for complex problems" },
+        { "effort": "xhigh", "description": "Extra high reasoning depth for complex problems" },
+        { "effort": "max", "description": "Maximum reasoning depth for the hardest problems" },
+        { "effort": "ultra", "description": "Ultra reasoning depth for the most demanding problems" }
+      ],
+      "context_window": 272000,
+      "max_context_window": 272000,
+      "effective_context_window_percent": 100,
+      "additional_speed_tiers": [],
+      "service_tiers": [],
+      "supports_reasoning_summaries": true,
+      "support_verbosity": true,
+      "supports_parallel_tool_calls": true,
+      "supports_image_detail_original": true,
+      "input_modalities": ["text", "image"],
+      "supports_search_tool": true,
+      "use_responses_lite": false
+    }
+  ]
+}

--- a/assets/astra-model-metadata-compat.json
+++ b/assets/astra-model-metadata-compat.json
@@ -16,8 +16,10 @@
       "context_window": 272000,
       "max_context_window": 272000,
       "effective_context_window_percent": 100,
-      "additional_speed_tiers": [],
-      "service_tiers": [],
+      "additional_speed_tiers": ["fast"],
+      "service_tiers": [
+        { "id": "priority", "name": "Fast", "description": "Faster responses, increased usage" }
+      ],
       "supports_reasoning_summaries": true,
       "support_verbosity": true,
       "supports_parallel_tool_calls": true,

--- a/crates/codex-plus-core/src/model_suffix.rs
+++ b/crates/codex-plus-core/src/model_suffix.rs
@@ -189,12 +189,17 @@ const DEEPSEEK_METADATA_JSON: &str = include_str!(concat!(
     "/../../assets/deepseek-model-metadata.json"
 ));
 
+const ASTRA_METADATA_JSON: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../assets/astra-model-metadata-compat.json"
+));
+
 pub fn requires_bundled_metadata_catalog(slug: &str) -> bool {
-    gpt56_metadata_entry(slug).is_some()
+    compatibility_metadata_entry(slug).is_some()
 }
 
 pub fn model_ui_metadata(slug: &str) -> Option<Value> {
-    let metadata = gpt56_metadata_entry(slug)?;
+    let metadata = compatibility_metadata_entry(slug)?;
     let levels = metadata
         .get("supported_reasoning_levels")?
         .as_array()?
@@ -345,7 +350,7 @@ fn model_template_entry(slug: &str) -> (Value, bool) {
     if let Some(entry) = bundled_template_entry(slug) {
         return (entry, true);
     }
-    if let Some(compatibility) = gpt56_metadata_entry(slug) {
+    if let Some(compatibility) = compatibility_metadata_entry(slug) {
         let mut template = first_bundled_template_entry().unwrap_or_else(|| json!({}));
         if let (Some(target), Some(source)) = (template.as_object_mut(), compatibility.as_object())
         {
@@ -376,8 +381,9 @@ fn first_bundled_template_entry() -> Option<Value> {
     catalog.get("models")?.as_array()?.first().cloned()
 }
 
-fn gpt56_metadata_entry(slug: &str) -> Option<Value> {
+fn compatibility_metadata_entry(slug: &str) -> Option<Value> {
     catalog_metadata_entry(GPT56_METADATA_JSON, slug)
+        .or_else(|| catalog_metadata_entry(ASTRA_METADATA_JSON, slug))
 }
 
 fn catalog_metadata_entry(catalog_json: &str, slug: &str) -> Option<Value> {

--- a/crates/codex-plus-core/tests/model_suffix.rs
+++ b/crates/codex-plus-core/tests/model_suffix.rs
@@ -168,6 +168,49 @@ fn build_catalog_json_preserves_template_responses_lite_behavior() {
 }
 
 #[test]
+fn astra_metadata_exposes_max_ultra_in_catalog_and_ui() {
+    use codex_plus_core::model_suffix::requires_bundled_metadata_catalog;
+
+    assert!(requires_bundled_metadata_catalog("gpt-6-astra"));
+    assert!(!requires_bundled_metadata_catalog("gpt-6-astra-custom"));
+    assert!(model_ui_metadata("gpt-6-astra-custom").is_none());
+    let entries =
+        collect_catalog_entries("gpt-6-astra", &HashMap::new(), &HashMap::new(), "");
+    let catalog: serde_json::Value =
+        serde_json::from_str(&build_model_catalog_json(&entries, None)).unwrap();
+    let model = &catalog["models"][0];
+    let metadata = model_ui_metadata("gpt-6-astra").unwrap();
+    let expected = vec!["low", "medium", "high", "xhigh", "max", "ultra"];
+    for (levels, key) in [
+        (&model["supported_reasoning_levels"], "effort"),
+        (&metadata["supportedReasoningEfforts"], "reasoningEffort"),
+    ] {
+        let efforts: Vec<_> = levels
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|level| level[key].as_str().unwrap())
+            .collect();
+        assert_eq!(efforts, expected);
+    }
+    assert_eq!(model["display_name"], "GPT-6-Astra");
+    assert_eq!(metadata["displayName"], model["display_name"]);
+    assert_eq!(model["default_reasoning_level"], "medium");
+    assert_eq!(metadata["defaultReasoningEffort"], "medium");
+    assert_eq!(model["context_window"], 272_000);
+    assert_eq!(model["max_context_window"], 272_000);
+    assert_eq!(model["supports_search_tool"], true);
+    assert_eq!(model["supports_image_detail_original"], true);
+    assert_eq!(model["use_responses_lite"], false);
+    assert_eq!(model["additional_speed_tiers"], serde_json::json!([]));
+    assert_eq!(metadata["serviceTiers"], serde_json::json!([]));
+
+    let overridden: serde_json::Value =
+        serde_json::from_str(&build_model_catalog_json(&entries, Some(200_000))).unwrap();
+    assert_eq!(overridden["models"][0]["context_window"], 200_000);
+}
+
+#[test]
 fn model_ui_metadata_exposes_fast_service_tier_capability() {
     let metadata = model_ui_metadata("gpt-5.6-sol").expect("Sol metadata should exist");
 

--- a/crates/codex-plus-core/tests/model_suffix.rs
+++ b/crates/codex-plus-core/tests/model_suffix.rs
@@ -202,8 +202,11 @@ fn astra_metadata_exposes_max_ultra_in_catalog_and_ui() {
     assert_eq!(model["supports_search_tool"], true);
     assert_eq!(model["supports_image_detail_original"], true);
     assert_eq!(model["use_responses_lite"], false);
-    assert_eq!(model["additional_speed_tiers"], serde_json::json!([]));
-    assert_eq!(metadata["serviceTiers"], serde_json::json!([]));
+    assert_eq!(model["additional_speed_tiers"], serde_json::json!(["fast"]));
+    assert_eq!(metadata["additionalSpeedTiers"], model["additional_speed_tiers"]);
+    assert_eq!(model["service_tiers"][0]["id"], "priority");
+    assert_eq!(model["service_tiers"][0]["name"], "Fast");
+    assert_eq!(metadata["serviceTiers"], model["service_tiers"]);
 
     let overridden: serde_json::Value =
         serde_json::from_str(&build_model_catalog_json(&entries, Some(200_000))).unwrap();

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -4266,6 +4266,47 @@ experimental_bearer_token = "sk-new"
 }
 
 #[test]
+fn apply_relay_profile_generates_astra_catalog_without_suffix() {
+    let temp = tempfile::tempdir().unwrap();
+    let profile = RelayProfile {
+        id: "relay-astra".to_string(),
+        model: "gpt-6-astra".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model = "gpt-6-astra"
+model_provider = "custom"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+base_url = "https://relay.example/v1"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-test"}"#.to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(config.contains(r#"model_catalog_json = "model-catalogs/relay-astra.json""#));
+    let catalog: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(temp.path().join("model-catalogs/relay-astra.json")).unwrap(),
+    )
+    .unwrap();
+    let astra = &catalog["models"][0];
+    assert_eq!(astra["slug"], "gpt-6-astra");
+    assert_eq!(astra["context_window"], 272_000);
+    assert_eq!(astra["use_responses_lite"], false);
+    let efforts: Vec<_> = astra["supported_reasoning_levels"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|level| level["effort"].as_str().unwrap())
+        .collect();
+    assert_eq!(efforts, vec!["low", "medium", "high", "xhigh", "max", "ultra"]);
+}
+
+#[test]
 fn apply_deepseek_responses_official_mix_writes_official_tool_compatibility() {
     let temp = tempfile::tempdir().unwrap();
     let profile = RelayProfile {

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -4297,6 +4297,8 @@ base_url = "https://relay.example/v1"
     assert_eq!(astra["slug"], "gpt-6-astra");
     assert_eq!(astra["context_window"], 272_000);
     assert_eq!(astra["use_responses_lite"], false);
+    assert_eq!(astra["additional_speed_tiers"], serde_json::json!(["fast"]));
+    assert_eq!(astra["service_tiers"][0]["id"], "priority");
     let efforts: Vec<_> = astra["supported_reasoning_levels"]
         .as_array()
         .unwrap()

--- a/scripts/installer/macos/package-dmg.sh
+++ b/scripts/installer/macos/package-dmg.sh
@@ -212,7 +212,23 @@ cleanup_dmg_work_dir() {
 
 trap cleanup_dmg_work_dir EXIT
 
-hdiutil create -volname "Codex++" -srcfolder "$STAGE" -ov -format UDRW "$DMG_WORK_PATH"
+DMG_CREATED=false
+for attempt in 1 2 3 4 5; do
+  if hdiutil create -volname "Codex++" -srcfolder "$STAGE" -ov -format UDRW "$DMG_WORK_PATH"; then
+    DMG_CREATED=true
+    break
+  fi
+
+  rm -f "$DMG_WORK_PATH"
+  if [ "$attempt" -lt 5 ]; then
+    sleep "$((attempt * 2))"
+  fi
+done
+
+if [ "$DMG_CREATED" != true ]; then
+  echo "error: failed to create writable DMG after 5 attempts" >&2
+  exit 1
+fi
 
 MOUNT_OUTPUT="$(hdiutil attach "$DMG_WORK_PATH" -readwrite -noverify -noautoopen -nobrowse)"
 MOUNT_DEVICE="$(printf '%s\n' "$MOUNT_OUTPUT" | awk '/^\/dev\/disk/ {print $1; exit}')"


### PR DESCRIPTION
## 中文

### 问题与范围

`gpt-6-astra` 尚未进入内置兼容元数据查询，使用自定义供应商时会回落到通用模型信息，缺少原生 `max` / `ultra` 推理档位。用户已通过本地 catalog 配置验证这两个档位可用；此 PR 将对应元数据单独补齐。

- 新增 Astra 元数据：`low / medium / high / xhigh / max / ultra`，默认 `medium`，默认上下文窗口 **272K**。
- 补齐 Fast 能力：`additional_speed_tiers: ["fast"]`，沿用现有 `priority` service tier，使 catalog 与 UI 元数据一致。
- 复用现有 catalog 生成与 UI descriptor 元数据通路，无窗口后缀、无 model list 时也能为当前 Astra 模型生成 catalog。
- 保留显式窗口覆盖及其他模型行为；仅精确匹配 `gpt-6-astra`，不猜测别名。
- 不新增推理控件、代理或请求重写，不改安装流程，不包含其他功能。

推理能力字段依据本地工作的兼容配置；272K 为本补丁的默认值。未将这些兼容值宣称为独立核验的官方模型规格。Responses Lite 保持关闭。

Fast 能力依据 [OpenAI Fast mode 文档](https://developers.openai.com/api/docs/guides/fast-mode)：请求接受 `service_tier: "fast"` 或兼容值 `"priority"`。本补丁沿用 Codex++ 现有 `priority` 通路，不修改请求逻辑。官方注明 Astra 的 Fast 不包含延迟 SLA，且不支持 EU 数据驻留；第三方供应商仍需自行支持此能力。

### 验证

`cargo test --offline -q -p codex-plus-core --test model_suffix --test relay_config -j 2 -- --test-threads=1`

- `model_suffix`: 16 passed
- `relay_config`: 146 passed
- `git diff --check`: passed

覆盖 catalog/UI 六档及 Fast 能力一致性、272K 默认值、显式窗口覆盖、未知别名隔离及 PureApi 自动生成 catalog。未安装此分支产物，也未重新验证真实 API 请求；真人验证来自已有本地配置。

## English

Add an exact-match Astra compatibility metadata entry through the existing catalog and UI metadata lookup. Expose native `max` and `ultra` alongside low/medium/high/xhigh, with a medium default and a **272K** default context window.

This is a metadata-only fix: no new reasoning controls, request rewriting, proxy behavior or installation changes. Explicit window overrides and existing model behavior remain intact. Capability values follow a locally working catalog configuration, not independently verified official model specifications; the user's personal 300K override is deliberately excluded.

Fast support is separately verified against the [official Fast mode guide](https://developers.openai.com/api/docs/guides/fast-mode), which accepts both `fast` and `priority`. Declare `additional_speed_tiers: ["fast"]` and reuse the existing `priority` service tier. Astra Fast has no latency SLA and is unavailable with EU data residency; third-party provider support is still required.

Validation: 16 model-suffix tests and 146 relay-config tests pass, including catalog/UI effort and Fast parity and no-suffix PureApi catalog generation. `git diff --check` passes. No build from this branch was installed and no fresh real API request was tested.
