### PR TITLE
fix: replace stale model catalog on provider switch

### DIFF
--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -1901,13 +1901,15 @@ fn apply_model_catalog_to_config(
     let official_deepseek_responses =
         uses_official_deepseek_responses_for_config(profile, &config_text);
     let fallback = parse_optional_positive_u64(&profile.context_window, "上下文大小")?;
-    // 用户已手写 model_catalog_json 指针时保留，不覆盖（保 preserves_user_model_catalog_json 测试）
-    // 仅当现有指针指向本 profile 自己生成的 catalog 时才重新生成。
+    // 用户已手写 model_catalog_json 指针时保留，不覆盖（保 preserves_user_model_catalog_json 测试）。
+    // Codex++ 管理的 catalog 必须随当前 profile 切换；否则前一个供应商的模型列表会残留。
     // cc-switch 的固定文件名属于已知的其他管理器投影，不视为用户手写 catalog；
     // 切换到 Codex++ profile 时应接管，否则旧 catalog 会继续覆盖本 profile 的模型元数据。
     if let Some(existing) = root_key_string(&config_text, "model_catalog_json") {
         if existing != catalog_relative {
-            if is_cc_switch_model_catalog(&existing) {
+            if is_codex_plus_managed_model_catalog(home, &existing)
+                || is_cc_switch_model_catalog(&existing)
+            {
                 config_text = remove_root_key(&config_text, "model_catalog_json");
             } else {
                 if has_per_model_overrides {

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -5010,6 +5010,57 @@ experimental_bearer_token = "sk-new"
 }
 
 #[test]
+fn apply_relay_profile_replaces_catalog_generated_for_another_profile() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(temp.path().join("model-catalogs")).unwrap();
+    std::fs::write(
+        temp.path().join("model-catalogs/relay-a6.json"),
+        r#"{"models":[{"slug":"gpt-5.6-sol"},{"slug":"gpt-5.6-terra"},{"slug":"gpt-5.6-luna"},{"slug":"gpt-image-2"}]}"#,
+    )
+    .unwrap();
+
+    let profile = RelayProfile {
+        id: "relay-fusheng".to_string(),
+        name: "Fusheng".to_string(),
+        model: "gpt-5.6-sol".to_string(),
+        relay_mode: RelayMode::PureApi,
+        config_contents: r#"model = "gpt-5.6-sol"
+model_provider = "custom"
+model_catalog_json = "model-catalogs/relay-a6.json"
+
+[model_providers.custom]
+name = "custom"
+wire_api = "responses"
+requires_openai_auth = true
+base_url = "https://relay.example/v1"
+experimental_bearer_token = "sk-new"
+"#
+        .to_string(),
+        auth_contents: r#"{"OPENAI_API_KEY":"sk-new"}"#.to_string(),
+        model_list: "gpt-5.6-sol\ngpt-5.6-terra\ngpt-6-astra".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_to_home_with_switch_rules(temp.path(), &profile, "").unwrap();
+
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    assert!(config.contains(
+        r#"model_catalog_json = "model-catalogs/relay-fusheng.json""#
+    ));
+    assert!(!config.contains("model-catalogs/relay-a6.json"));
+
+    let catalog = std::fs::read_to_string(
+        temp.path().join("model-catalogs/relay-fusheng.json"),
+    )
+    .unwrap();
+    assert!(catalog.contains(r#""slug": "gpt-5.6-sol""#));
+    assert!(catalog.contains(r#""slug": "gpt-5.6-terra""#));
+    assert!(catalog.contains(r#""slug": "gpt-6-astra""#));
+    assert!(!catalog.contains("gpt-5.6-luna"));
+    assert!(!catalog.contains("gpt-image-2"));
+}
+
+#[test]
 fn apply_relay_profile_uses_first_model_list_entry_when_model_empty() {
     let temp = tempfile::tempdir().unwrap();
     let profile = RelayProfile {


### PR DESCRIPTION
## Summary

- replace a stale Codex++-managed `model_catalog_json` when switching to a different provider profile
- preserve genuinely external user-managed catalogs and the existing cc-switch takeover behavior
- add a regression test covering an A6-style catalog being replaced by a three-model provider catalog

## Problem

When `config.toml` points to a catalog generated for another Codex++ profile, `apply_model_catalog_to_config` treats the path like an external user-managed catalog. For custom Responses providers whose catalog already has the expected wire-format flags, `copy_standard_responses_catalog` reports no changes and the function returns without replacing the pointer. Codex then continues showing the previous provider's models after a provider switch and full restart.

## Fix

Treat paths under Codex++'s managed `model-catalogs` directory as owned projections. If the existing managed path does not match the selected profile, remove the stale pointer and let the normal generation path create and select the current profile's catalog.

## Validation

- added `apply_relay_profile_replaces_catalog_generated_for_another_profile`
- `git diff --check` passes
- Rust tests were not run locally because Cargo is not installed in the test environment; CI should run the full suite
