### PR TITLE
修复 Codex++ 重复注入导致卡死和白屏

### DIFF
--- a/apps/codex-plus-manager/src/renderer-inject.test.ts
+++ b/apps/codex-plus-manager/src/renderer-inject.test.ts
@@ -1,6 +1,110 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { readFile } from "node:fs/promises";
+import { runInNewContext } from "node:vm";
+
+describe("renderer lifecycle under repeated injection", () => {
+  const rendererPath = new URL("../../../assets/inject/renderer-inject.js", import.meta.url);
+
+  it("shares pending dictation discovery across bundle evaluations and stops after repeated misses", async () => {
+    const renderer = await readFile(rendererPath, "utf8");
+    const start = renderer.indexOf('  const codexDictationSupportVersion = ');
+    const end = renderer.indexOf('  async function loadBackendSettingsState()', start);
+    assert.ok(start >= 0 && end > start);
+    const source = renderer.slice(start, end);
+    const window: Record<string, any> = {};
+    let loads = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const diagnostics: string[] = [];
+    const timers = new Set<unknown>();
+    const frozenModule = Object.freeze({ supported: function(authMethod: string) { return authMethod === "chatgpt"; } });
+    const makeInstall = () => runInNewContext(`${source}\ninstallDictationSupportPatch`, {
+      window,
+      document: { querySelectorAll: () => [] },
+      loadOptionalCodexAppModule: async () => { loads += 1; await gate; return frozenModule; },
+      codexPlusSettings: () => ({ serviceTierControls: false }),
+      sendCodexPlusDiagnostic: (event: string) => diagnostics.push(event),
+      setInterval: () => { const id = {}; timers.add(id); return id; },
+      clearInterval: (id: unknown) => timers.delete(id),
+    }) as () => Promise<void>;
+    const first = makeInstall();
+    const second = makeInstall();
+    const pending = Array.from({ length: 20 }, (_, i) => i % 2 ? first() : second());
+    assert.equal(loads, 1);
+    release();
+    await Promise.all(pending);
+    assert.equal(loads, 5);
+    assert.equal(window.__codexDictationSupportPatched, undefined);
+    for (let i = 0; i < 20; i++) await first();
+    assert.equal(loads, 40);
+    assert.equal(timers.size, 1);
+    assert.deepEqual(diagnostics, ["dictation_support_patch_skipped"]);
+    // A settings reinjection retires the fallback timer; the disabled probe
+    // must still be able to install exactly one replacement fallback.
+    timers.delete(window.__codexDictationDomEnforcementTimer);
+    window.__codexDictationDomEnforcementTimer = null;
+    window.__codexDictationDomPatched = false;
+    await second();
+    assert.equal(timers.size, 1);
+    assert.equal(loads, 40);
+  });
+
+  it("does not call a patched dictation hook twice when it throws", async () => {
+    const renderer = await readFile(rendererPath, "utf8");
+    const start = renderer.indexOf('  const codexDictationSupportVersion = ');
+    const end = renderer.indexOf('  async function loadBackendSettingsState()', start);
+    let calls = 0;
+    const failure = new Error("hook failed");
+    const module = { supported: function(authMethod: string) { calls += 1; if (authMethod === "chatgpt") throw failure; return false; } };
+    const window: Record<string, unknown> = {};
+    const install = runInNewContext(`${renderer.slice(start, end)}\ninstallDictationSupportPatch`, {
+      window,
+      loadOptionalCodexAppModule: async () => module,
+      codexPlusSettings: () => ({ serviceTierControls: false }),
+      sendCodexPlusDiagnostic: () => {},
+      clearInterval: () => {},
+    });
+    await install();
+    assert.equal(window.__codexDictationSupportPatched, "1");
+    assert.throws(() => module.supported("chatgpt"), (error) => error === failure);
+    assert.equal(calls, 1);
+  });
+
+  it("replaces paste handlers and removes them when the feature is disabled", async () => {
+    const renderer = await readFile(rendererPath, "utf8");
+    const start = renderer.lastIndexOf("\n(() => {\n  document.removeEventListener('paste'");
+    assert.ok(start >= 0);
+    const handlers = new Set<unknown>();
+    const window = { __CODEX_PLUS_PASTE_FIX__: { enabled: true } };
+    const context = {
+      window,
+      document: {
+        addEventListener: (_event: string, handler: unknown) => handlers.add(handler),
+        removeEventListener: (_event: string, handler: unknown) => handlers.delete(handler),
+      },
+      console: { log() {} },
+    };
+    for (let i = 0; i < 20; i++) runInNewContext(renderer.slice(start), context);
+    assert.equal(handlers.size, 1);
+    window.__CODEX_PLUS_PASTE_FIX__.enabled = false;
+    runInNewContext(renderer.slice(start), context);
+    assert.equal(handlers.size, 0);
+  });
+
+  it("bounds repeated diagnostic failures by count and message length", async () => {
+    const renderer = await readFile(rendererPath, "utf8");
+    const start = renderer.indexOf("  function recordCodexPlusFailure(");
+    const end = renderer.indexOf("\n  }", start) + 4;
+    assert.ok(start >= 0 && end > start);
+    const window: Record<string, string[]> = {};
+    const record = runInNewContext(`${renderer.slice(start, end)}\nrecordCodexPlusFailure`, { window });
+    for (let i = 0; i < 100; i++) record("failures", `${i}:` + "x".repeat(10000));
+    assert.equal(window.failures.length, 32);
+    assert.ok(window.failures[0].startsWith("68:"));
+    assert.ok(window.failures.every((message) => message.length <= 4096));
+  });
+});
 
 const STEPWISE_FRAGMENT_PATHS = [
   "floating-panel/runtime/state.js",

--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -3,6 +3,13 @@
   // so this bundle cannot create UI in embedded browser documents.
   const codexPlusIsNodeTestHarness = typeof process === "object" && !!process.versions?.node;
   if (!codexPlusIsNodeTestHarness && (window.top !== window || window.self !== window || !window.electronBridge || !/^app:\/\/\-\//i.test(window.location.href))) return;
+  // Keep the bundle re-entrant for live setting changes, but retire resources
+  // retained by an earlier evaluation before installing their replacements.
+  if (window.__codexDictationDomEnforcementTimer) {
+    clearInterval(window.__codexDictationDomEnforcementTimer);
+    window.__codexDictationDomEnforcementTimer = null;
+    window.__codexDictationDomPatched = false;
+  }
   const codexPlusIsWindowsPlatform = /\bWindows\b/i.test(navigator.userAgent || "");
 
   function installCodexPlusFastStartup() {
@@ -552,12 +559,22 @@
   }
 
   function scheduleCodexPlusImageOverlay() {
+    if (window.__codexPlusImageOverlayDOMContentLoadedHandler) {
+      document.removeEventListener("DOMContentLoaded", window.__codexPlusImageOverlayDOMContentLoadedHandler);
+      window.__codexPlusImageOverlayDOMContentLoadedHandler = null;
+    }
+    clearTimeout(window.__codexPlusImageOverlayTimer);
+    window.__codexPlusImageOverlayTimer = null;
     if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", installCodexPlusImageOverlay, { once: true });
+      window.__codexPlusImageOverlayDOMContentLoadedHandler = installCodexPlusImageOverlay;
+      document.addEventListener("DOMContentLoaded", window.__codexPlusImageOverlayDOMContentLoadedHandler, { once: true });
       return;
     }
     installCodexPlusImageOverlay();
-    setTimeout(installCodexPlusImageOverlay, 250);
+    window.__codexPlusImageOverlayTimer = setTimeout(() => {
+      window.__codexPlusImageOverlayTimer = null;
+      installCodexPlusImageOverlay();
+    }, 250);
   }
 
   scheduleCodexPlusImageOverlay();
@@ -3746,67 +3763,93 @@
 
   // --- Dictation / Voice patch for apikey (ported from v1.2.34 preload) ---
   const codexDictationSupportVersion = "1";
+  const codexDictationSupportPatchMaxMisses = 8;
   function codexDictationSupportModuleCandidates() {
     const prefixes = ["use-is-dictation-supported-", "use-dictation-", "app-initial-", "setting-storage-", "vscode-api-"];
     return prefixes;
   }
   async function installDictationSupportPatch() {
     if (window.__codexDictationSupportPatched === codexDictationSupportVersion) return;
-    for (const prefix of codexDictationSupportModuleCandidates()) {
-      try {
-        const module = await loadOptionalCodexAppModule(prefix);
-        if (!module) continue;
-        for (const key of Object.keys(module)) {
-          const fn = module[key];
-          if (typeof fn !== "function") continue;
-          let src = "";
-          try { src = String(fn); } catch {}
-          if (!src.includes("authMethod") || !src.includes("chatgpt")) continue;
-          if (fn.__codexDictationPatched === codexDictationSupportVersion) continue;
-          const original = fn;
-          const wrapped = function(...args) {
-            try {
+    if (window.__codexDictationSupportPatchDisabled) {
+      installDictationDomFallback();
+      return;
+    }
+    if (window.__codexDictationSupportPatchPromise) {
+      return await window.__codexDictationSupportPatchPromise;
+    }
+    const patchPromise = (async () => {
+      for (const prefix of codexDictationSupportModuleCandidates()) {
+        try {
+          const module = await loadOptionalCodexAppModule(prefix);
+          if (!module) continue;
+          for (const key of Object.keys(module)) {
+            const fn = module[key];
+            if (typeof fn !== "function") continue;
+            let src = "";
+            try { src = String(fn); } catch {}
+            if (!src.includes("authMethod") || !src.includes("chatgpt")) continue;
+            if (fn.__codexDictationPatched === codexDictationSupportVersion) continue;
+            const original = fn;
+            const wrapped = function(...args) {
               const result = original.apply(this, args);
               if (result === false) {
                 const hasApikey = args.some(arg => arg && typeof arg === "object" && (arg.authMethod === "apikey" || arg.authMethod === "apiKey"));
                 if (hasApikey) return true;
-                if (typeof codexPlusSettings === "function" && codexPlusSettings().serviceTierControls) return true;
+                if (codexPlusSettings().serviceTierControls) return true;
               }
               return result;
-            } catch (e) {
-              return original.apply(this, args);
-            }
-          };
-          wrapped.__codexDictationPatched = codexDictationSupportVersion;
-          try { module[key] = wrapped; } catch {}
-          sendCodexPlusDiagnostic("dictation_support_patched", { prefix, key, version: codexDictationSupportVersion });
-          window.__codexDictationSupportPatched = codexDictationSupportVersion;
-          return;
-        }
-      } catch {}
-    }
-    // Fallback: DOM enforcement for voice button when module patch not found
-    try {
-      if (!window.__codexDictationDomPatched) {
-        window.__codexDictationDomPatched = true;
-        const enforceVoice = () => {
-          const selectors = ['button[aria-label*="Voice"]','button[aria-label*="Dictation"]','button[aria-label*="voice"]','[data-testid*="voice"]','[data-testid*="dictation"]','button:has(svg)'];
-          // generic: find buttons with microphone icon
-          document.querySelectorAll('button').forEach(btn => {
-            const label = (btn.getAttribute("aria-label") || btn.textContent || "").toLowerCase();
-            if (label.includes("voice") || label.includes("dictation") || label.includes("microphone") || label.includes("mic")) {
-              if (btn.hasAttribute("disabled")) {
-                btn.removeAttribute("disabled");
-                btn.setAttribute("aria-disabled","false");
-                btn.style.opacity = "";
-                btn.style.pointerEvents = "";
-              }
-            }
-          });
-        };
-        setInterval(enforceVoice, 1500);
-        enforceVoice();
+            };
+            wrapped.__codexDictationPatched = codexDictationSupportVersion;
+            try { module[key] = wrapped; } catch {}
+            if (module[key] !== wrapped) continue;
+            clearInterval(window.__codexDictationDomEnforcementTimer);
+            window.__codexDictationDomEnforcementTimer = null;
+            sendCodexPlusDiagnostic("dictation_support_patched", { prefix, key, version: codexDictationSupportVersion });
+            window.__codexDictationSupportPatched = codexDictationSupportVersion;
+            window.__codexDictationSupportPatchMissCount = 0;
+            return;
+          }
+        } catch {}
       }
+      installDictationDomFallback();
+      window.__codexDictationSupportPatchMissCount = (window.__codexDictationSupportPatchMissCount || 0) + 1;
+      if (window.__codexDictationSupportPatchMissCount >= codexDictationSupportPatchMaxMisses) {
+        window.__codexDictationSupportPatchDisabled = true;
+        sendCodexPlusDiagnostic("dictation_support_patch_skipped", {
+          misses: window.__codexDictationSupportPatchMissCount,
+        });
+      }
+    })();
+    window.__codexDictationSupportPatchPromise = patchPromise;
+    try {
+      return await patchPromise;
+    } finally {
+      if (window.__codexDictationSupportPatchPromise === patchPromise) {
+        window.__codexDictationSupportPatchPromise = null;
+      }
+    }
+  }
+
+  function installDictationDomFallback() {
+    try {
+        if (!window.__codexDictationDomPatched) {
+          window.__codexDictationDomPatched = true;
+          const enforceVoice = () => {
+            document.querySelectorAll('button').forEach(btn => {
+              const label = (btn.getAttribute("aria-label") || btn.textContent || "").toLowerCase();
+              if (label.includes("voice") || label.includes("dictation") || label.includes("microphone") || label.includes("mic")) {
+                if (btn.hasAttribute("disabled")) {
+                  btn.removeAttribute("disabled");
+                  btn.setAttribute("aria-disabled","false");
+                  btn.style.opacity = "";
+                  btn.style.pointerEvents = "";
+                }
+              }
+            });
+          };
+          window.__codexDictationDomEnforcementTimer = setInterval(enforceVoice, 1500);
+          enforceVoice();
+        }
     } catch {}
   }
 
@@ -3875,8 +3918,19 @@
   }
 
   let codexPlusUserScripts = { enabled: true, builtin_dir: "", user_dir: "", scripts: [] };
-  let codexPlusBackendStatus = { status: "checking", message: "正在检查后端…" };
+  let codexPlusBackendStatus = window.__codexPlusBackendStatus || { status: "checking", message: "正在检查后端…" };
   let codexPlusBackendCheckSeq = 0;
+  let codexPlusBackendCheckInFlight = false;
+  let codexPlusBackendFailureCount = 0;
+  const CODEX_PLUS_BACKEND_FAILURE_THRESHOLD = 3;
+  const codexPlusBackendGeneration = (Number(window.__codexPlusBackendGeneration) || 0) + 1;
+  window.__codexPlusBackendGeneration = codexPlusBackendGeneration;
+
+  function recordCodexPlusBridgeSuccess() {
+    if (codexPlusBackendGeneration !== window.__codexPlusBackendGeneration) return;
+    const health = window.__codexPlusBridgeHealth || (window.__codexPlusBridgeHealth = {});
+    health.lastSuccessAt = Date.now();
+  }
 
   function renderBackendStatus() {
     const status = codexPlusBackendStatus.status || "failed";
@@ -3911,22 +3965,35 @@
   }
 
   async function checkBackendStatus() {
+    if (codexPlusBackendCheckInFlight) return;
+    codexPlusBackendCheckInFlight = true;
     const seq = ++codexPlusBackendCheckSeq;
-    const nextStatus = await withBackendTimeout(postJson("/backend/status", {}));
-    if (seq !== codexPlusBackendCheckSeq) return;
-    codexPlusBackendStatus = nextStatus;
-    if (nextStatus?.status === "ok" && typeof nextStatus.hideOfficialUsageAlert === "boolean") {
-      window.__CODEX_PLUS_HIDE_OFFICIAL_USAGE_ALERT__ = nextStatus.hideOfficialUsageAlert;
-      refreshOfficialUsageAlertVisibility();
+    try {
+      const nextStatus = await postJson("/backend/status", {});
+      if (seq !== codexPlusBackendCheckSeq || codexPlusBackendGeneration !== window.__codexPlusBackendGeneration) return;
+      if (nextStatus?.status === "ok") {
+        codexPlusBackendFailureCount = 0;
+        codexPlusBackendStatus = window.__codexPlusBackendStatus = nextStatus;
+        if (typeof nextStatus.hideOfficialUsageAlert === "boolean") {
+          window.__CODEX_PLUS_HIDE_OFFICIAL_USAGE_ALERT__ = nextStatus.hideOfficialUsageAlert;
+          refreshOfficialUsageAlertVisibility();
+        }
+      } else {
+        codexPlusBackendFailureCount += 1;
+        sendCodexPlusDiagnostic("backend_check_failed", {
+          status: nextStatus?.status || "unknown",
+          message: nextStatus?.message || "",
+          timeout: !!nextStatus?.timeout,
+          consecutiveFailures: codexPlusBackendFailureCount,
+        });
+        if (codexPlusBackendFailureCount >= CODEX_PLUS_BACKEND_FAILURE_THRESHOLD) {
+          codexPlusBackendStatus = window.__codexPlusBackendStatus = nextStatus;
+        }
+      }
+      renderBackendStatus();
+    } finally {
+      codexPlusBackendCheckInFlight = false;
     }
-    if (nextStatus?.status !== "ok") {
-      sendCodexPlusDiagnostic("backend_check_failed", {
-        status: nextStatus?.status || "unknown",
-        message: nextStatus?.message || "",
-        timeout: !!nextStatus?.timeout,
-      });
-    }
-    renderBackendStatus();
   }
 
   async function openManagerFromCodex() {
@@ -3939,7 +4006,11 @@
   }
 
   function scheduleBackendHeartbeat() {
-    if (window.__codexPlusBackendHeartbeat) return;
+    if (codexPlusBackendGeneration !== window.__codexPlusBackendGeneration) return;
+    if (window.__codexPlusBackendHeartbeat &&
+        window.__codexPlusBackendHeartbeatGeneration === codexPlusBackendGeneration) return;
+    if (window.__codexPlusBackendHeartbeat) clearInterval(window.__codexPlusBackendHeartbeat);
+    window.__codexPlusBackendHeartbeatGeneration = codexPlusBackendGeneration;
     window.__codexPlusBackendHeartbeat = setInterval(checkBackendStatus, 5000);
     checkBackendStatus();
   }
@@ -4777,77 +4848,18 @@
     return restored === "openai-bundled" || restored === "openai-curated" || restored === "openai-primary-runtime" || restored === "openai-api-curated" || restored === "openai-curated-remote";
   }
 
-  const codexPluginFilterSourceCache = new WeakMap();
-
-  function codexPluginFilterCallbackSource(callback) {
-    if (codexPluginFilterSourceCache.has(callback)) {
-      return codexPluginFilterSourceCache.get(callback);
+  function restoreHistoricalPluginArrayFilterPatch() {
+    const originalFilter = Array.prototype.__codexPluginBuildFlavorOriginalFilter;
+    const activeFilter = Array.prototype.filter;
+    if (typeof originalFilter === "function" && activeFilter?.__codexPluginBuildFlavorPatched) {
+      Array.prototype.filter = originalFilter;
+      sendCodexPlusDiagnostic("plugin_global_array_filter_patch_removed", {});
     }
-    let source = "";
     try {
-      source = Function.prototype.toString.call(callback);
+      delete Array.prototype.__codexPluginBuildFlavorOriginalFilter;
     } catch {
     }
-    codexPluginFilterSourceCache.set(callback, source);
-    return source;
-  }
-
-  function isCodexPluginBuildFlavorFilter(callback, sample, filtered = null) {
-    if (!Array.isArray(sample) || sample.length === 0 || typeof callback !== "function") return false;
-    if (!sample.some((plugin) => codexPluginOfficialMarketplaceName(plugin?.marketplaceName))) return false;
-    const source = codexPluginFilterCallbackSource(callback);
-    if (!source) return false;
-    const isKnownFilterSource = source.includes("!u(e.marketplaceName)||e.marketplaceName===r")
-      || source.includes("!ne(e.marketplaceName)||e.marketplaceName===n")
-      || source.includes("!Eu(e.marketplaceName)||e.marketplaceName===n");
-    if (!isKnownFilterSource) return false;
-    return sample.some((plugin) => codexPluginOfficialMarketplaceName(plugin?.marketplaceName)
-      && (Array.isArray(filtered) ? !filtered.includes(plugin) : !callback(plugin)));
-  }
-
-  function isCodexPluginMarketplaceHiddenFilter(callback, sample, filtered = null) {
-    if (!Array.isArray(sample) || sample.length === 0 || typeof callback !== "function") return false;
-    if (!sample.some((marketplace) => codexPluginOfficialMarketplaceName(marketplace?.name))) return false;
-    const source = codexPluginFilterCallbackSource(callback);
-    if (!source) return false;
-    if (!source.includes("!t.includes(e.name)")) return false;
-    return sample.some((marketplace) => codexPluginOfficialMarketplaceName(marketplace?.name)
-      && (Array.isArray(filtered) ? !filtered.includes(marketplace) : !callback(marketplace)));
-  }
-
-  function installPluginBuildFlavorFilterPatch() {
-    if (window.__codexPluginBuildFlavorFilterPatch === codexPluginMarketplaceUnlockVersion) return;
-    if (pluginPatchDisabledInRelayMode()) return;
-    if (!codexPlusSettings().pluginMarketplaceUnlock) return;
-    const originalFilter = Array.prototype.__codexPluginBuildFlavorOriginalFilter || Array.prototype.filter;
-    if (!Array.prototype.__codexPluginBuildFlavorOriginalFilter) {
-      Object.defineProperty(Array.prototype, "__codexPluginBuildFlavorOriginalFilter", {
-        value: originalFilter,
-        configurable: true,
-        writable: true,
-      });
-    }
-    if (Array.prototype.filter.__codexPluginBuildFlavorPatched === codexPluginMarketplaceUnlockVersion) {
-      window.__codexPluginBuildFlavorFilterPatch = codexPluginMarketplaceUnlockVersion;
-      return;
-    }
-    const patchedFilter = function codexPluginBuildFlavorFilterPatch(callback, thisArg) {
-      const filtered = originalFilter.call(this, callback, thisArg);
-      if (filtered.length === this.length) return filtered;
-      if (isCodexPluginBuildFlavorFilter(callback, this, filtered)) {
-        sendCodexPlusDiagnostic("plugin_build_flavor_filter_bypassed", { pluginCount: this.length });
-        return Array.from(this);
-      }
-      if (isCodexPluginMarketplaceHiddenFilter(callback, this, filtered)) {
-        sendCodexPlusDiagnostic("plugin_marketplace_hidden_filter_bypassed", { marketplaceCount: this.length });
-        return Array.from(this);
-      }
-      return filtered;
-    };
-    patchedFilter.__codexPluginBuildFlavorPatched = codexPluginMarketplaceUnlockVersion;
-    Array.prototype.filter = patchedFilter;
-    window.__codexPluginBuildFlavorFilterPatch = codexPluginMarketplaceUnlockVersion;
-    sendCodexPlusDiagnostic("plugin_build_flavor_filter_patch_installed", {});
+    window.__codexPluginBuildFlavorFilterPatch = null;
   }
 
   function restorePluginMarketplaceRequestParams(params, method = "") {
@@ -5161,8 +5173,7 @@
       localFallback: localPluginMarketplaceFallbackResult,
       remoteOnlyFallback: remoteOnlyPluginMarketplaceFallbackResult,
       requestProfile: pluginMarketplaceRequestProfile,
-      isBuildFlavorFilter: isCodexPluginBuildFlavorFilter,
-      isHiddenMarketplaceFilter: isCodexPluginMarketplaceHiddenFilter,
+      restoreHistoricalArrayFilterPatch: restoreHistoricalPluginArrayFilterPatch,
       setCodexAppVersion: (version) => {
         codexPlusBackendSettings.codexAppVersion = String(version || "");
       },
@@ -5246,9 +5257,13 @@
         return originalDispatchEvent.call(this, event);
       };
     }
-    if (!window.__codexPluginMarketplaceResponseListenerInstalled) {
-      window.__codexPluginMarketplaceResponseListenerInstalled = true;
-      window.addEventListener("message", (event) => {
+    const responseListenerInstalled = window.__codexPluginMarketplaceResponseListenerInstalled;
+    // Legacy bundles did not retain the callback reference. Keep their single
+    // listener until navigation instead of adding an unremovable duplicate.
+    if (responseListenerInstalled && !window.__codexPluginMarketplaceResponseListener) return;
+    if (responseListenerInstalled !== codexPluginMarketplaceUnlockVersion) {
+      window.removeEventListener("message", window.__codexPluginMarketplaceResponseListener, true);
+      window.__codexPluginMarketplaceResponseListener = (event) => {
         try {
           patchPluginMarketplaceResponseData(event?.data);
         } catch (error) {
@@ -5257,7 +5272,9 @@
             errorMessage: error?.message || String(error),
           });
         }
-      }, true);
+      };
+      window.addEventListener("message", window.__codexPluginMarketplaceResponseListener, true);
+      window.__codexPluginMarketplaceResponseListenerInstalled = codexPluginMarketplaceUnlockVersion;
     }
     window.__codexPluginMarketplaceWindowEventPatch = codexPluginMarketplaceUnlockVersion;
   }
@@ -5596,6 +5613,13 @@
       body,
       keepalive: true,
     }).catch(() => {});
+  }
+
+  function recordCodexPlusFailure(key, error) {
+    const failures = Array.isArray(window[key]) ? window[key] : [];
+    if (failures.length >= 32) failures.splice(0, failures.length - 31);
+    failures.push(String(error?.stack || error).slice(0, 4096));
+    window[key] = failures;
   }
 
   sendCodexPlusDiagnostic("script_loaded", {
@@ -6223,44 +6247,50 @@
   }
 
   async function postJson(path, payload) {
-    if (!window.__codexSessionDeleteBridge) {
-      if (path === "/backend/status") {
-        try {
-          const response = await fetch(`${helperBase}${path}`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(payload || {}),
-          });
-          return await response.json();
-        } catch (error) {
-          return { status: "failed", message: "未连接" };
-        }
-      }
-      sendCodexPlusDiagnostic("bridge_missing_for_route", { path });
-      return { status: "failed", message: "桥接不可用，请重启启动器" };
-    }
-    function bridgeWithBackendTimeout(path, payload) {
-      return Promise.race([
-        window.__codexSessionDeleteBridge(path, payload),
-        new Promise((resolve) => setTimeout(() => resolve({ status: "failed", message: "后端检查超时", timeout: true }), 2000)),
-      ]);
-    }
     async function fetchBackendStatusFromHelper(path, payload) {
+      const controller = typeof AbortController === "function" ? new AbortController() : null;
+      const timeoutId = setTimeout(() => controller?.abort(), 2000);
       try {
         const response = await fetch(`${helperBase}${path}`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload || {}),
+          ...(controller ? { signal: controller.signal } : {}),
         });
         return await response.json();
       } catch (error) {
-        return { status: "failed", message: "未连接" };
+        return {
+          status: "failed",
+          message: error?.name === "AbortError" ? "后端检查超时" : "未连接",
+          timeout: error?.name === "AbortError",
+        };
+      } finally {
+        clearTimeout(timeoutId);
       }
+    }
+    if (!window.__codexSessionDeleteBridge) {
+      if (path === "/backend/status") {
+        return await fetchBackendStatusFromHelper(path, payload);
+      }
+      sendCodexPlusDiagnostic("bridge_missing_for_route", { path });
+      return { status: "failed", message: "桥接不可用，请重启启动器" };
+    }
+    function bridgeWithBackendTimeout(path, payload) {
+      let request;
+      try {
+        request = window.__codexSessionDeleteBridge(path, payload);
+      } catch (error) {
+        return Promise.resolve({ status: "failed", message: error?.message || "未连接" });
+      }
+      return withBackendTimeout(request);
     }
     try {
       if (path === "/backend/status") {
         const result = await bridgeWithBackendTimeout(path, payload);
-        if (result?.status === "ok") return result;
+        if (result?.status === "ok") {
+          recordCodexPlusBridgeSuccess();
+          return result;
+        }
         if (result?.timeout) sendCodexPlusDiagnostic("backend_bridge_timeout", { path });
         const fallback = await fetchBackendStatusFromHelper(path, payload);
         if (fallback?.status === "ok") {
@@ -6745,8 +6775,7 @@
     try {
       patchModelContainer(payload);
     } catch (error) {
-      window.__codexPlusModelPatchFailures = window.__codexPlusModelPatchFailures || [];
-      window.__codexPlusModelPatchFailures.push(String(error?.stack || error));
+      recordCodexPlusFailure("__codexPlusModelPatchFailures", error);
     }
     return payload;
   }
@@ -6813,9 +6842,12 @@
   }
 
   function patchAppServerModelMessages() {
-    if (window.__codexPlusModelMessagePatchInstalled) return;
-    window.__codexPlusModelMessagePatchInstalled = true;
-    window.addEventListener("codex-message-from-view", (event) => {
+    const patchVersion = "renderer-lifecycle-20260907-v1";
+    if (window.__codexPlusModelMessagePatchInstalled && !window.__codexPlusModelRequestHandler) return;
+    if (window.__codexPlusModelMessagePatchInstalled === patchVersion) return;
+    window.removeEventListener("codex-message-from-view", window.__codexPlusModelRequestHandler, true);
+    window.removeEventListener("message", window.__codexPlusModelResponseHandler, true);
+    window.__codexPlusModelRequestHandler = (event) => {
       try {
         const detail = event?.detail;
         const request = detail?.request;
@@ -6831,19 +6863,19 @@
           }
         }
       } catch (error) {
-        window.__codexPlusModelPatchFailures = window.__codexPlusModelPatchFailures || [];
-        window.__codexPlusModelPatchFailures.push(String(error?.stack || error));
+        recordCodexPlusFailure("__codexPlusModelPatchFailures", error);
       }
-    }, true);
-
-    window.addEventListener("message", (event) => {
+    };
+    window.__codexPlusModelResponseHandler = (event) => {
       try {
         patchMcpModelResponseData(event?.data);
       } catch (error) {
-        window.__codexPlusModelPatchFailures = window.__codexPlusModelPatchFailures || [];
-        window.__codexPlusModelPatchFailures.push(String(error?.stack || error));
+        recordCodexPlusFailure("__codexPlusModelPatchFailures", error);
       }
-    }, true);
+    };
+    window.addEventListener("codex-message-from-view", window.__codexPlusModelRequestHandler, true);
+    window.addEventListener("message", window.__codexPlusModelResponseHandler, true);
+    window.__codexPlusModelMessagePatchInstalled = patchVersion;
   }
 
   function patchMcpModelResponseData(data) {
@@ -6881,8 +6913,7 @@
         modelCount: Array.isArray(result?.data) ? result.data.length : Array.isArray(result?.models) ? result.models.length : Array.isArray(result) ? result.length : null,
       });
     } catch (error) {
-      window.__codexPlusModelPatchFailures = window.__codexPlusModelPatchFailures || [];
-      window.__codexPlusModelPatchFailures.push(String(error?.stack || error));
+      recordCodexPlusFailure("__codexPlusModelPatchFailures", error);
     }
     return result;
   }
@@ -7091,8 +7122,7 @@
       patchStatsigModelWhitelist();
       installAppServerModelRequestPatch();
     } catch (error) {
-      window.__codexPlusModelPatchFailures = window.__codexPlusModelPatchFailures || [];
-      window.__codexPlusModelPatchFailures.push(String(error?.stack || error));
+      recordCodexPlusFailure("__codexPlusModelPatchFailures", error);
     }
     return false;
   }
@@ -8122,15 +8152,18 @@
     window.__codexUpstreamBranchDropdownAdapterVersion = adapterVersion;
     if (window.__codexUpstreamBranchDropdownAdapterInstalled === adapterVersion) return;
     window.__codexUpstreamBranchDropdownObserver?.disconnect?.();
+    document.removeEventListener("click", window.__codexUpstreamBranchDropdownClickHandler, true);
+    clearTimeout(window.__codexUpstreamBranchDropdownInjectTimer);
+    window.__codexUpstreamBranchDropdownInjectTimer = null;
     window.__codexUpstreamBranchDropdownAdapterInstalled = adapterVersion;
-    let upstreamBranchInjectTimer = null;
     const schedule = () => {
-      clearTimeout(upstreamBranchInjectTimer);
-      upstreamBranchInjectTimer = setTimeout(() => {
+      clearTimeout(window.__codexUpstreamBranchDropdownInjectTimer);
+      window.__codexUpstreamBranchDropdownInjectTimer = setTimeout(() => {
+        window.__codexUpstreamBranchDropdownInjectTimer = null;
         injectUpstreamBranchOptions().catch((error) => reportDiagnostic("upstream_branch_inject_failed", { error: error?.message || String(error) }));
       }, 80);
     };
-    document.addEventListener("click", (event) => {
+    const clickHandler = (event) => {
       rememberStartNewChatProjectContext(event);
       const target = event.target instanceof Element ? event.target : event.target?.parentElement;
       const control = target?.closest?.('button, [role="button"]');
@@ -8154,7 +8187,9 @@
       syncUpstreamBranchTriggerLabel();
       syncUpstreamBranchMenuSelection(option.closest?.('[role="menu"], [data-radix-menu-content], [cmdk-list]'));
       showToast(`将从 ${upstreamBranchOptionLabel(option) || "upstream/main"} 创建新 worktree`, null);
-    }, true);
+    };
+    window.__codexUpstreamBranchDropdownClickHandler = clickHandler;
+    document.addEventListener("click", clickHandler, true);
     const branchMenuSelector = '[role="menu"], [data-radix-menu-content], [cmdk-list]';
     const addedNodeContainsBranchMenu = (node) => {
       if (!(node instanceof Element)) return false;
@@ -8287,10 +8322,12 @@
   function installUpstreamWorktreeNativeAdapter() {
     const adapterVersion = "2";
     if (window.__codexUpstreamWorktreeNativeAdapterInstalled === adapterVersion) return;
+    document.removeEventListener("click", window.__codexUpstreamWorktreeNativeAdapterHandler, true);
     window.__codexUpstreamWorktreeNativeAdapterInstalled = adapterVersion;
-    document.addEventListener("click", (event) => {
+    window.__codexUpstreamWorktreeNativeAdapterHandler = (event) => {
       handleUpstreamWorktreeNativeCreate(event);
-    }, true);
+    };
+    document.addEventListener("click", window.__codexUpstreamWorktreeNativeAdapterHandler, true);
   }
 
   function setUpstreamWorktreeMessage(dialog, message, status = "idle") {
@@ -10362,6 +10399,7 @@
   }
 
   function scanDeferred() {
+    restoreHistoricalPluginArrayFilterPatch();
     if (pluginPatchDisabledInRelayMode()) {
       clearPluginPatchArtifacts();
     } else {
@@ -10370,7 +10408,6 @@
       logCodexPluginUnlockStrategy(pluginUnlockStrategy);
       if ((pluginUnlockStrategy === "modern" || pluginUnlockStrategy === "unknown") && settings.pluginMarketplaceUnlock) {
         const marketplaceRequestPatchStrategy = codexPluginMarketplaceRequestPatchStrategy();
-        installPluginBuildFlavorFilterPatch();
         if (marketplaceRequestPatchStrategy === "bridge") {
           installPluginMarketplaceBridgePatch();
         } else if (marketplaceRequestPatchStrategy === "client") {
@@ -10398,8 +10435,7 @@
     try {
       step();
     } catch (error) {
-      window.__codexSessionDeleteScanFailures = window.__codexSessionDeleteScanFailures || [];
-      window.__codexSessionDeleteScanFailures.push(String(error?.stack || error));
+      recordCodexPlusFailure("__codexSessionDeleteScanFailures", error);
     }
   }
 
@@ -10565,16 +10601,14 @@
 // 关闭时不进入 if 体，行为与原 Codex 完全一致；开启时在 document 捕获阶段
 // 拦截 paste，若 text/plain 非空则阻止默认行为并调用 execCommand('insertText')
 // 插入纯文本，避免 Codex 把 Word 复制的内容识别为附件。
-// SENTINEL 保证多次执行（页面刷新、脚本重注入）只装一次 handler。
-if (window.__CODEX_PLUS_PASTE_FIX__ && window.__CODEX_PLUS_PASTE_FIX__.enabled === true) {
-  (() => {
-    const SENTINEL = '__codexPasteFixInstalled__';
-    if (window[SENTINEL]) return;
-    window[SENTINEL] = true;
-
+// 重入时先卸载旧 handler；设置关闭后也不会留下捕获阶段监听器。
+(() => {
+  document.removeEventListener('paste', window.__codexPasteFixHandler, true);
+  window.__codexPasteFixHandler = null;
+  if (window.__CODEX_PLUS_PASTE_FIX__ && window.__CODEX_PLUS_PASTE_FIX__.enabled === true) {
     const TAG = '[PasteFix]';
 
-    const handler = (e) => {
+    window.__codexPasteFixHandler = (e) => {
       const cd = e.clipboardData;
       if (!cd) return;
 
@@ -10595,7 +10629,7 @@ if (window.__CODEX_PLUS_PASTE_FIX__ && window.__CODEX_PLUS_PASTE_FIX__.enabled =
       }
     };
 
-    document.addEventListener('paste', handler, { capture: true });
+    document.addEventListener('paste', window.__codexPasteFixHandler, { capture: true });
     console.log(TAG, 'paste handler installed (capture phase)');
-  })();
-}
+  }
+})();

--- a/crates/codex-plus-core/src/bridge.rs
+++ b/crates/codex-plus-core/src/bridge.rs
@@ -15,6 +15,9 @@ use serde_json::{Value, json};
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message;
 
+type CdpWebSocket =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
 pub const BRIDGE_BINDING_NAME: &str = "codexSessionDeleteV2";
 const CDP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const CDP_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
@@ -34,6 +37,14 @@ static NEXT_MESSAGE_ID: AtomicU64 = AtomicU64::new(100);
 static NEXT_BRIDGE_GENERATION: AtomicU64 = AtomicU64::new(1);
 static CURRENT_BRIDGE_GENERATIONS: std::sync::LazyLock<std::sync::Mutex<HashMap<String, u64>>> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
+
+/// CDP keeps scripts registered through Page.addScriptToEvaluateOnNewDocument
+/// until the target closes. Retain their identifiers so a bridge reinstall
+/// replaces the old registrations instead of making every later navigation run
+/// another complete renderer bundle.
+static NEW_DOCUMENT_SCRIPT_REGISTRATIONS: std::sync::LazyLock<
+    std::sync::Mutex<HashMap<String, Vec<String>>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
 
 #[derive(Clone)]
 struct BridgeGeneration {
@@ -96,6 +107,8 @@ pub fn build_bridge_script(binding_name: &str) -> String {
 (() => {{
   window.__codexSessionDeleteCallbacks = new Map();
   window.__codexSessionDeleteSeq = 0;
+  window.__codexPlusBridgeHealth = window.__codexPlusBridgeHealth || {{}};
+  window.__codexPlusBridgeHealth.lastInjectionAt = Date.now();
   window.__codexSessionDeleteResolve = (id, result) => {{
     const callback = window.__codexSessionDeleteCallbacks.get(id);
     if (!callback) return;
@@ -121,18 +134,93 @@ pub fn build_bridge_script(binding_name: &str) -> String {
 pub fn bridge_health_check_script() -> &'static str {
     r#"
 (() => {
-  const bridge = window.__codexSessionDeleteBridge;
-  if (typeof bridge !== "function") return false;
-  try {
-    return Promise.race([
-      Promise.resolve(bridge("/backend/status", {})).then((result) => !!result && result.status === "ok"),
-      new Promise((resolve) => setTimeout(() => resolve(false), 2000)),
-    ]);
-  } catch (error) {
-    return false;
-  }
+  // Background renderers can throttle timers for longer than the old
+  // heartbeat window. Treating that delay as a broken bridge causes the
+  // watchdog to reinject the whole renderer bundle repeatedly, leaking the
+  // old closures and listeners. The binding's presence is the safe signal;
+  // health timestamps remain diagnostic data only.
+  return typeof window.__codexSessionDeleteBridge === "function";
 })()
 "#
+}
+
+fn take_new_document_script_registrations(target: &str) -> Vec<String> {
+    NEW_DOCUMENT_SCRIPT_REGISTRATIONS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(target)
+        .unwrap_or_default()
+}
+
+fn restore_new_document_script_registrations(target: &str, identifiers: Vec<String>) {
+    if identifiers.is_empty() {
+        return;
+    }
+    NEW_DOCUMENT_SCRIPT_REGISTRATIONS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .entry(target.to_string())
+        .or_default()
+        .extend(identifiers);
+}
+
+fn register_new_document_script(target: &str, response: &Value) {
+    let Some(identifier) = response
+        .get("result")
+        .and_then(|result| result.get("identifier"))
+        .and_then(Value::as_str)
+        .filter(|identifier| !identifier.is_empty())
+    else {
+        return;
+    };
+    NEW_DOCUMENT_SCRIPT_REGISTRATIONS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .entry(target.to_string())
+        .or_default()
+        .push(identifier.to_string());
+}
+
+async fn remove_registered_new_document_scripts(
+    session: &mut CdpSession<CdpWebSocket>,
+    target: &str,
+) -> anyhow::Result<()> {
+    let identifiers = take_new_document_script_registrations(target);
+    let mut remaining = identifiers.into_iter();
+    while let Some(identifier) = remaining.next() {
+        if let Err(error) = session
+            .send_command(
+                next_message_id(),
+                "Page.removeScriptToEvaluateOnNewDocument",
+                json!({ "identifier": identifier }),
+            )
+            .await
+        {
+            let mut unresolved = vec![identifier];
+            unresolved.extend(remaining);
+            restore_new_document_script_registrations(target, unresolved);
+            return Err(error)
+                .context("failed to remove a previously registered new-document script");
+        }
+    }
+    Ok(())
+}
+
+async fn add_new_document_script(
+    session: &mut CdpSession<CdpWebSocket>,
+    target: &str,
+    message_id: u64,
+    script: &str,
+) -> anyhow::Result<()> {
+    let response = session
+        .send_command(
+            message_id,
+            "Page.addScriptToEvaluateOnNewDocument",
+            json!({ "source": script }),
+        )
+        .await?;
+    register_new_document_script(target, &response);
+    Ok(())
 }
 
 pub async fn evaluate_script(websocket_url: &str, script: &str) -> anyhow::Result<Value> {
@@ -267,14 +355,14 @@ pub async fn install_bridge(
         .send_command(3, "Runtime.addBinding", json!({ "name": binding_name }))
         .await?;
 
+    // A reinjection must replace, rather than accumulate, the scripts that
+    // run on every future navigation. Do this only after the new binding has
+    // been installed so a failed binding setup leaves the existing page
+    // registration untouched.
+    remove_registered_new_document_scripts(&mut session, websocket_url).await?;
+
     let bridge_script = build_bridge_script(binding_name);
-    session
-        .send_command(
-            4,
-            "Page.addScriptToEvaluateOnNewDocument",
-            json!({ "source": bridge_script }),
-        )
-        .await?;
+    add_new_document_script(&mut session, websocket_url, 4, &bridge_script).await?;
     session
         .send_command(
             5,
@@ -285,13 +373,7 @@ pub async fn install_bridge(
 
     for script in new_document_scripts {
         let message_id = next_message_id();
-        session
-            .send_command(
-                message_id,
-                "Page.addScriptToEvaluateOnNewDocument",
-                json!({ "source": script }),
-            )
-            .await?;
+        add_new_document_script(&mut session, websocket_url, message_id, script).await?;
         let message_id = next_message_id();
         session
             .send_command(

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -21,6 +21,7 @@ use crate::status::{LaunchStatus, StatusStore};
 
 static PET_OVERLAY_SYNC_FAILED: AtomicBool = AtomicBool::new(false);
 static PET_CURSOR_DRIVER_FAILED: AtomicBool = AtomicBool::new(false);
+const BRIDGE_HEALTH_FAILURE_THRESHOLD: u8 = 2;
 const MACOS_DEBUG_TAKEOVER_WAIT_MS: u64 = 5_000;
 const MACOS_DEBUG_TAKEOVER_INTERVAL_MS: u64 = 100;
 
@@ -944,6 +945,7 @@ impl LaunchHooks for DefaultLaunchHooks {
             #[cfg(windows)]
             let pet_cursor_task = tokio::spawn(run_pet_real_mouse_cursor_driver(debug_port));
             let mut observed_browser_id: Option<String> = None;
+            let mut bridge_health_failures = 0u8;
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
             loop {
                 tokio::select! {
@@ -968,6 +970,7 @@ impl LaunchHooks for DefaultLaunchHooks {
                                 helper_port,
                                 identity_changed,
                                 bridge_reinjector.clone(),
+                                &mut bridge_health_failures,
                             ),
                         );
                         record_pet_overlay_sync_result(debug_port, helper_port, pet_result);
@@ -2424,7 +2427,10 @@ async fn retry_injection(debug_port: u16, helper_port: u16) -> anyhow::Result<()
 }
 
 pub async fn check_and_reinject_bridge(debug_port: u16, helper_port: u16) -> bool {
-    check_and_reinject_bridge_inner(debug_port, helper_port, false, None).await
+    // This one-shot entry point preserves its historical immediate-repair behavior.
+    let mut health_failures = BRIDGE_HEALTH_FAILURE_THRESHOLD.saturating_sub(1);
+    check_and_reinject_bridge_inner(debug_port, helper_port, false, None, &mut health_failures)
+        .await
 }
 
 pub fn browser_identity_changed(previous: Option<&str>, current: &str) -> bool {
@@ -2439,17 +2445,39 @@ fn should_probe_launcher_cdp(is_windows: bool, has_codex_process: bool) -> bool 
     is_windows && !has_codex_process
 }
 
+fn should_reinject_after_health_result(
+    healthy: Option<bool>,
+    browser_identity_changed: bool,
+    health_failures: &mut u8,
+) -> bool {
+    let Some(healthy) = healthy else {
+        *health_failures = 0;
+        return false;
+    };
+    if healthy {
+        *health_failures = 0;
+        return false;
+    }
+    if browser_identity_changed {
+        *health_failures = BRIDGE_HEALTH_FAILURE_THRESHOLD;
+    } else {
+        *health_failures = health_failures.saturating_add(1);
+    }
+    *health_failures >= BRIDGE_HEALTH_FAILURE_THRESHOLD
+}
+
 async fn check_and_reinject_bridge_inner(
     debug_port: u16,
     helper_port: u16,
     browser_identity_changed: bool,
     bridge_reinjector: Option<BridgeReinjector>,
+    health_failures: &mut u8,
 ) -> bool {
     let healthy = if browser_identity_changed {
-        false
+        Some(false)
     } else {
         match bridge_health_ok(debug_port).await {
-            Ok(healthy) => healthy,
+            Ok(healthy) => Some(healthy),
             Err(error) => {
                 let _ = crate::diagnostic_log::append_diagnostic_log(
                     "bridge.health_check_failed",
@@ -2459,11 +2487,15 @@ async fn check_and_reinject_bridge_inner(
                         "message": error.to_string()
                     }),
                 );
-                false
+                // A CDP timeout only means that the renderer did not answer
+                // this probe in time. The bridge heartbeat is the source of
+                // truth for actual availability; do not reinject on an
+                // indeterminate CDP result or a busy page will cause churn.
+                None
             }
         }
     };
-    if healthy {
+    if !should_reinject_after_health_result(healthy, browser_identity_changed, health_failures) {
         return false;
     }
 
@@ -2472,7 +2504,8 @@ async fn check_and_reinject_bridge_inner(
         serde_json::json!({
             "debug_port": debug_port,
             "helper_port": helper_port,
-            "browser_identity_changed": browser_identity_changed
+            "browser_identity_changed": browser_identity_changed,
+            "consecutive_health_failures": *health_failures
         }),
     );
     let default_reinjector: BridgeReinjector =
@@ -2487,6 +2520,7 @@ async fn check_and_reinject_bridge_inner(
                     "helper_port": helper_port
                 }),
             );
+            *health_failures = 0;
             true
         }
         Err(error) => {
@@ -2498,6 +2532,10 @@ async fn check_and_reinject_bridge_inner(
                     "message": error.to_string()
                 }),
             );
+            // A failed repair is not a new health observation. Require the
+            // threshold again before retrying, otherwise a busy page causes
+            // an uninterrupted reinjection loop every watchdog tick.
+            *health_failures = 0;
             false
         }
     }
@@ -3124,6 +3162,42 @@ mod tests {
         assert!(should_probe_launcher_cdp(true, false));
         assert!(!should_probe_launcher_cdp(true, true));
         assert!(!should_probe_launcher_cdp(false, false));
+    }
+
+    #[test]
+    fn bridge_health_failures_reinject_only_after_consecutive_unhealthy_results() {
+        let mut failures = 0;
+        assert!(!should_reinject_after_health_result(
+            Some(false),
+            false,
+            &mut failures
+        ));
+        assert_eq!(failures, 1);
+        assert!(should_reinject_after_health_result(
+            Some(false),
+            false,
+            &mut failures
+        ));
+        assert_eq!(failures, BRIDGE_HEALTH_FAILURE_THRESHOLD);
+        assert!(!should_reinject_after_health_result(
+            Some(true),
+            false,
+            &mut failures
+        ));
+        assert_eq!(failures, 0);
+
+        failures = 1;
+        assert!(!should_reinject_after_health_result(
+            None,
+            false,
+            &mut failures
+        ));
+        assert_eq!(failures, 0);
+        assert!(should_reinject_after_health_result(
+            Some(false),
+            true,
+            &mut failures
+        ));
     }
 
     #[test]

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -841,10 +841,75 @@ fn injection_script_times_out_backend_bridge_calls_and_falls_back_to_helper() {
     let script = assets::injection_script(57321);
 
     assert!(script.contains("bridgeWithBackendTimeout"));
+    assert!(script.contains("AbortController"));
+    assert!(script.contains("recordCodexPlusBridgeSuccess"));
+    assert!(script.contains("lastSuccessAt"));
+    assert!(script.contains("codexPlusBackendCheckInFlight"));
+    assert!(script.contains("CODEX_PLUS_BACKEND_FAILURE_THRESHOLD = 3"));
+    assert!(script.contains("codexPlusBackendGeneration !== window.__codexPlusBackendGeneration"));
+    assert!(script.contains("__codexPlusBackendHeartbeatGeneration"));
+    assert!(script.contains("clearInterval(window.__codexPlusBackendHeartbeat)"));
+    assert!(!script.contains("await withBackendTimeout(postJson(\"/backend/status\", {}))"));
     assert!(script.contains("backend_bridge_timeout"));
     assert!(!script.contains("/backend/repair"));
     assert!(script.contains("backend_status_bridge_failed_http_fallback_ok"));
     assert!(script.contains("backend_status_bridge_and_http_failed"));
+}
+
+#[test]
+fn injection_script_keeps_one_backend_heartbeat_per_generation() {
+    let script = assets::injection_script(57321);
+    let start = script
+        .find("function scheduleBackendHeartbeat()")
+        .expect("backend heartbeat scheduler should exist");
+    let end = script[start..]
+        .find("\n  function userScriptStatusLabel")
+        .map(|offset| start + offset)
+        .expect("backend heartbeat scheduler should have an end marker");
+    let scheduler = &script[start..end];
+    let scheduler_json = serde_json::to_string(scheduler).expect("scheduler should serialize");
+    let harness = format!(
+        r#"
+const vm = require("node:vm");
+const source = {scheduler};
+const runCase = (generation, heartbeat, heartbeatGeneration, expected) => {{
+  let timers = 0;
+  let clears = 0;
+  let checks = 0;
+  const context = {{
+    window: {{
+      __codexPlusBackendGeneration: generation,
+      __codexPlusBackendHeartbeat: heartbeat,
+      __codexPlusBackendHeartbeatGeneration: heartbeatGeneration,
+    }},
+    codexPlusBackendGeneration: generation,
+    setInterval: () => ++timers,
+    clearInterval: () => ++clears,
+    checkBackendStatus: () => ++checks,
+  }};
+  vm.runInNewContext(source + "\nthis.run = scheduleBackendHeartbeat;", context);
+  context.run();
+  context.run();
+  const actual = {{ timers, clears, checks }};
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) process.exit(1);
+}};
+runCase(1, null, null, {{ timers: 1, clears: 0, checks: 1 }});
+runCase(1, 99, 1, {{ timers: 0, clears: 0, checks: 0 }});
+runCase(2, 99, 1, {{ timers: 1, clears: 1, checks: 1 }});
+"#,
+        scheduler = scheduler_json
+    );
+    let output = Command::new("node")
+        .arg("-e")
+        .arg(harness)
+        .output()
+        .expect("node should run heartbeat scheduler harness");
+    assert!(
+        output.status.success(),
+        "heartbeat scheduler harness failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]
@@ -2141,7 +2206,7 @@ fn injection_script_keeps_plugin_marketplace_unlock_separate_from_entry_unlock()
     assert!(script.contains("pluginMarketplaceUnlock: true"));
     assert!(script.contains("pluginMarketplaceUnlock: \"codexAppPluginMarketplaceUnlock\""));
     assert!(script.contains("if (!codexPlusSettings().pluginMarketplaceUnlock) return"));
-    assert!(script.contains("installPluginBuildFlavorFilterPatch"));
+    assert!(script.contains("restoreHistoricalPluginArrayFilterPatch"));
     assert!(script.contains("installPluginMarketplaceRequestPatch"));
 }
 
@@ -2193,14 +2258,10 @@ fn injection_script_does_not_bypass_plugin_marketplace_search_filters() {
     let script = assets::injection_script(57321);
 
     assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"15\""));
-    assert!(script.contains("codexPluginFilterSourceCache = new WeakMap()"));
-    assert!(script.contains("function codexPluginFilterCallbackSource(callback)"));
-    assert!(script.contains("isCodexPluginBuildFlavorFilter"));
-    assert!(script.contains("source.includes(\"!u(e.marketplaceName)||e.marketplaceName===r\")"));
-    assert!(script.contains("source.includes(\"!Eu(e.marketplaceName)||e.marketplaceName===n\")"));
-    assert!(script.contains("source.includes(\"!t.includes(e.name)\")"));
-    assert!(!script.contains("if (!source.includes(\"marketplaceName\")) return false"));
-    assert!(!script.contains("if (!source.includes(\"name\")) return false"));
+    assert!(!script.contains("function isCodexPluginBuildFlavorFilter"));
+    assert!(!script.contains("function isCodexPluginMarketplaceHiddenFilter"));
+    assert!(!script.contains("Array.prototype.filter = patchedFilter"));
+    assert!(script.contains("Array.prototype.filter = originalFilter"));
 }
 
 #[test]
@@ -2210,14 +2271,8 @@ fn injection_script_expands_api_key_plugin_marketplace_requests() {
     assert!(script.contains("codexPluginMarketplaceUnlockVersion = \"15\""));
     assert!(script.contains("installPluginMarketplaceRequestPatch"));
     assert!(script.contains("installPluginMarketplaceBridgePatch"));
-    assert!(script.contains("installPluginBuildFlavorFilterPatch"));
-    assert!(script.contains("Array.prototype.filter"));
-    assert!(script.contains("codexPluginBuildFlavorFilterPatch"));
-    assert!(script.contains("isCodexPluginBuildFlavorFilter"));
-    assert!(script.contains("!filtered.includes(plugin) : !callback(plugin)"));
-    assert!(script.contains("isCodexPluginMarketplaceHiddenFilter"));
-    assert!(script.contains("!filtered.includes(marketplace) : !callback(marketplace)"));
-    assert!(script.contains("plugin_marketplace_hidden_filter_bypassed"));
+    assert!(script.contains("restoreHistoricalPluginArrayFilterPatch"));
+    assert!(!script.contains("plugin_marketplace_hidden_filter_bypassed"));
     assert!(script.contains("method === \"list-plugins\""));
     assert!(script.contains("method === \"vscode://codex/list-plugins\""));
     assert!(script.contains("message.type === \"fetch\""));
@@ -2264,7 +2319,7 @@ fn injection_script_expands_api_key_plugin_marketplace_requests() {
     assert!(script.contains("OpenAI插件3(Codex++)"));
     assert!(script.contains("method === \"install-plugin\""));
     assert!(script.contains("plugin_marketplace_response_expanded"));
-    assert!(script.contains("plugin_build_flavor_filter_bypassed"));
+    assert!(!script.contains("plugin_build_flavor_filter_bypassed"));
     assert!(script.contains("plugin_install_request_debug"));
     assert!(script.contains("plugin_install_request_failed"));
     assert!(!script.contains("marketplace.path ="));
@@ -2297,12 +2352,10 @@ fn injection_script_logs_marketplace_grouping_diagnostics() {
 fn injection_script_recovers_plugin_search_from_remote_auth_errors() {
     let cases = run_plugin_marketplace_search_contract_harness();
 
-    assert_eq!(cases["ordinaryBuildMatched"], false);
-    assert_eq!(cases["ordinaryHiddenMatched"], false);
-    assert_eq!(cases["ordinaryFunctionToStringCalls"], 0);
-    assert_eq!(cases["buildFlavorMatched"], true);
-    assert_eq!(cases["buildFlavorMatchedAgain"], true);
-    assert_eq!(cases["cachedFunctionToStringCalls"], 1);
+    assert_eq!(cases["nativeFilterPreserved"], true);
+    assert_eq!(cases["legacyFilterRestored"], true);
+    assert_eq!(cases["ordinaryFiltered"], json!([2, 3]));
+    assert_eq!(cases["hiddenMarketplaces"], json!([]));
     assert_eq!(cases["initialKinds"], json!(["local", "vertical"]));
     assert_eq!(cases["latestBroadOmittedHasKinds"], false);
     assert_eq!(cases["latestBroadOmittedKinds"], serde_json::Value::Null);
@@ -2389,25 +2442,18 @@ window.__CODEX_PLUS_PLUGIN_MARKETPLACES__ = [{{
 }}];
 const api = window.__codexPlusPluginMarketplaceTest;
 api.reset();
-const nativeFunctionToString = Function.prototype.toString;
-let functionToStringCalls = 0;
-Function.prototype.toString = function(...args) {{
-  functionToStringCalls += 1;
-  return nativeFunctionToString.apply(this, args);
-}};
-const ordinaryFilter = (value) => value > 1;
-const ordinaryBuildMatched = api.isBuildFlavorFilter(ordinaryFilter, [1, 2, 3]);
-const ordinaryHiddenMatched = api.isHiddenMarketplaceFilter(ordinaryFilter, [1, 2, 3]);
-const ordinaryFunctionToStringCalls = functionToStringCalls;
-const buildFlavorFilter = function(e) {{
-  /* !u(e.marketplaceName)||e.marketplaceName===r */
-  return false;
-}};
-const officialPlugins = [{{ name: "product-design", marketplaceName: "openai-bundled" }}];
-const buildFlavorMatched = api.isBuildFlavorFilter(buildFlavorFilter, officialPlugins);
-const buildFlavorMatchedAgain = api.isBuildFlavorFilter(buildFlavorFilter, officialPlugins);
-const cachedFunctionToStringCalls = functionToStringCalls - ordinaryFunctionToStringCalls;
-Function.prototype.toString = nativeFunctionToString;
+const nativeFilter = Array.prototype.filter;
+api.restoreHistoricalArrayFilterPatch();
+const nativeFilterPreserved = Array.prototype.filter === nativeFilter;
+const legacyFilter = function() {{ return Array.from(this); }};
+legacyFilter.__codexPluginBuildFlavorPatched = "15";
+Object.defineProperty(Array.prototype, "__codexPluginBuildFlavorOriginalFilter", {{ value: nativeFilter, configurable: true }});
+Array.prototype.filter = legacyFilter;
+api.restoreHistoricalArrayFilterPatch();
+const legacyFilterRestored = Array.prototype.filter === nativeFilter;
+const ordinaryFiltered = [1, 2, 3].filter(value => value > 1);
+const t = ["openai-curated"];
+const hiddenMarketplaces = [{{ name: "openai-curated" }}].filter(e => !t.includes(e.name));
 const initial = api.patchRequestParams("list-plugins", {{ cwds: ["C:/workspace"] }});
 api.setCodexAppVersion("26.803.41515");
 const latestBroadOmitted = api.patchRequestParams("list-plugins", {{ cwds: ["C:/workspace"] }});
@@ -2438,12 +2484,10 @@ const remoteUnavailable = api.remoteCatalogUnavailable();
 api.reset();
 const chatGpt = api.patchRequestParams("list-plugins", {{ marketplaceKinds: ["created-by-me-remote"] }});
 const cases = {{
-  ordinaryBuildMatched,
-  ordinaryHiddenMatched,
-  ordinaryFunctionToStringCalls,
-  buildFlavorMatched,
-  buildFlavorMatchedAgain,
-  cachedFunctionToStringCalls,
+  nativeFilterPreserved,
+  legacyFilterRestored,
+  ordinaryFiltered,
+  hiddenMarketplaces,
   initialKinds: initial.marketplaceKinds,
   latestBroadOmittedHasKinds: Object.prototype.hasOwnProperty.call(latestBroadOmitted, "marketplaceKinds"),
   latestBroadOmittedKinds: latestBroadOmitted.marketplaceKinds ?? null,
@@ -4113,6 +4157,23 @@ fn injection_script_installs_upstream_branch_dropdown_adapter() {
 }
 
 #[test]
+fn injection_script_replaces_historical_renderer_resources() {
+    let script = assets::injection_script(57321);
+
+    assert!(script.contains("__codexDictationDomEnforcementTimer"));
+    assert!(script.contains("__codexPlusImageOverlayDOMContentLoadedHandler"));
+    assert!(script.contains("__codexPlusImageOverlayTimer"));
+    assert!(script.contains("__codexUpstreamBranchDropdownClickHandler"));
+    assert!(script.contains("__codexUpstreamBranchDropdownInjectTimer"));
+    assert!(script.contains("__codexUpstreamWorktreeNativeAdapterHandler"));
+    assert!(script.contains("__codexPluginMarketplaceResponseListener"));
+    assert!(script.contains("__codexPlusModelRequestHandler"));
+    assert!(script.contains("__codexPlusModelResponseHandler"));
+    assert!(script.contains("__codexPasteFixHandler"));
+    assert!(script.contains("window.removeEventListener(\"message\", window.__codexPlusModelResponseHandler, true)"));
+}
+
+#[test]
 fn injection_script_prevents_switching_to_branches_used_by_other_worktrees() {
     let script = assets::injection_script(57321);
 
@@ -4202,13 +4263,49 @@ fn runtime_evaluate_params_can_await_promise_for_bridge_health_checks() {
 }
 
 #[test]
-fn bridge_health_check_script_uses_real_backend_round_trip() {
+fn bridge_health_check_script_checks_binding_presence() {
     let script = bridge::bridge_health_check_script();
 
     assert!(script.contains("__codexSessionDeleteBridge"));
-    assert!(script.contains("/backend/status"));
-    assert!(script.contains("Promise.race"));
-    assert!(script.contains("setTimeout"));
+    assert!(script.contains("typeof window.__codexSessionDeleteBridge === \"function\""));
+    assert!(!script.contains("lastSuccessAt"));
+    assert!(!script.contains("lastInjectionAt"));
+    assert!(!script.contains("/backend/status"));
+}
+
+#[test]
+fn bridge_health_check_script_does_not_reinject_when_background_timers_are_throttled() {
+    let script = serde_json::to_string(bridge::bridge_health_check_script())
+        .expect("health script should serialize");
+    let harness = format!(
+        r#"
+const vm = require("node:vm");
+const source = {script};
+const bridge = () => Promise.resolve({{ status: "failed" }});
+const run = (health, hasBridge = true) => vm.runInNewContext(source, {{
+  window: {{ __codexSessionDeleteBridge: hasBridge ? bridge : null, __codexPlusBridgeHealth: health }},
+}});
+const now = Date.now();
+if (run({{ lastInjectionAt: 0, lastSuccessAt: 1 }}) !== true) process.exit(1);
+if (run({{ lastInjectionAt: 0, lastSuccessAt: now }}) !== true) process.exit(2);
+if (run({{ lastInjectionAt: now, lastSuccessAt: 0 }}) !== true) process.exit(3);
+if (run({{ lastInjectionAt: now - 6000, lastSuccessAt: 0 }}) !== true) process.exit(4);
+if (run({{ lastInjectionAt: 1, lastSuccessAt: now - 16000 }}) !== true) process.exit(5);
+if (run({{ lastInjectionAt: now, lastSuccessAt: now }}, false) !== false) process.exit(6);
+"#,
+        script = script
+    );
+    let output = Command::new("node")
+        .arg("-e")
+        .arg(harness)
+        .output()
+        .expect("node should run bridge health harness");
+    assert!(
+        output.status.success(),
+        "bridge health harness failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]
@@ -4806,6 +4903,108 @@ async fn install_bridge_immediately_evaluates_new_document_scripts() {
     request_rx
         .await
         .expect("server task should finish without panicking");
+}
+
+#[tokio::test]
+async fn reinstall_replaces_registered_new_document_scripts() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("test listener should bind");
+    let address = listener.local_addr().expect("listener should have address");
+    let server = tokio::spawn(async move {
+        let (first_stream, _) = listener
+            .accept()
+            .await
+            .expect("first bridge client should connect");
+        let mut first = accept_async(first_stream)
+            .await
+            .expect("first websocket should upgrade");
+        for expected_id in 1..=3 {
+            let command = recv_json(&mut first).await;
+            assert_eq!(command["id"], expected_id);
+            send_json(&mut first, json!({ "id": expected_id, "result": {} })).await;
+        }
+        let bridge_add = recv_json(&mut first).await;
+        assert_eq!(bridge_add["method"], "Page.addScriptToEvaluateOnNewDocument");
+        send_json(
+            &mut first,
+            json!({ "id": bridge_add["id"], "result": { "identifier": "bridge-v1" } }),
+        )
+        .await;
+        let bridge_eval = recv_json(&mut first).await;
+        assert_eq!(bridge_eval["method"], "Runtime.evaluate");
+        send_json(&mut first, json!({ "id": bridge_eval["id"], "result": {} })).await;
+        let renderer_add = recv_json(&mut first).await;
+        assert_eq!(renderer_add["method"], "Page.addScriptToEvaluateOnNewDocument");
+        send_json(
+            &mut first,
+            json!({ "id": renderer_add["id"], "result": { "identifier": "renderer-v1" } }),
+        )
+        .await;
+        let renderer_eval = recv_json(&mut first).await;
+        assert_eq!(renderer_eval["method"], "Runtime.evaluate");
+        send_json(&mut first, json!({ "id": renderer_eval["id"], "result": {} })).await;
+
+        let (second_stream, _) = listener
+            .accept()
+            .await
+            .expect("second bridge client should connect");
+        let mut second = accept_async(second_stream)
+            .await
+            .expect("second websocket should upgrade");
+        for expected_id in 1..=3 {
+            let command = recv_json(&mut second).await;
+            assert_eq!(command["id"], expected_id);
+            send_json(&mut second, json!({ "id": expected_id, "result": {} })).await;
+        }
+        for identifier in ["bridge-v1", "renderer-v1"] {
+            let remove = recv_json(&mut second).await;
+            assert_eq!(remove["method"], "Page.removeScriptToEvaluateOnNewDocument");
+            assert_eq!(remove["params"]["identifier"], identifier);
+            send_json(&mut second, json!({ "id": remove["id"], "result": {} })).await;
+        }
+        let bridge_add = recv_json(&mut second).await;
+        assert_eq!(bridge_add["method"], "Page.addScriptToEvaluateOnNewDocument");
+        send_json(
+            &mut second,
+            json!({ "id": bridge_add["id"], "result": { "identifier": "bridge-v2" } }),
+        )
+        .await;
+        let bridge_eval = recv_json(&mut second).await;
+        assert_eq!(bridge_eval["method"], "Runtime.evaluate");
+        send_json(&mut second, json!({ "id": bridge_eval["id"], "result": {} })).await;
+        let renderer_add = recv_json(&mut second).await;
+        assert_eq!(renderer_add["method"], "Page.addScriptToEvaluateOnNewDocument");
+        send_json(
+            &mut second,
+            json!({ "id": renderer_add["id"], "result": { "identifier": "renderer-v2" } }),
+        )
+        .await;
+        let renderer_eval = recv_json(&mut second).await;
+        assert_eq!(renderer_eval["method"], "Runtime.evaluate");
+        send_json(&mut second, json!({ "id": renderer_eval["id"], "result": {} })).await;
+        close_socket(&mut first).await;
+        close_socket(&mut second).await;
+    });
+
+    let url = websocket_url(address);
+    bridge::install_bridge(
+        &url,
+        BRIDGE_BINDING_NAME,
+        noop_handler(),
+        &["window.rendererV1 = true;".to_string()],
+    )
+    .await
+    .expect("first bridge install should succeed");
+    bridge::install_bridge(
+        &url,
+        BRIDGE_BINDING_NAME,
+        noop_handler(),
+        &["window.rendererV2 = true;".to_string()],
+    )
+    .await
+    .expect("second bridge install should replace old registrations");
+    server.await.expect("server task should finish without panicking");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## 现象

Codex++ 页面会在运行中卡死或白屏；异常时渲染进程持续占用 CPU，并伴随内存增长。

## 原因

桥接健康检查将后台计时器节流误判为桥接失效，进而重复注入完整渲染包。新文档脚本、监听器和定时器不断累积；部分渲染补丁的重复探测与全局行为改写进一步放大页面更新压力。

## 解决方案

- 以桥接函数存在性作为健康信号，避免因后台计时器节流误触发重注入。
- 重装桥接前回收已注册的新文档脚本，避免每次导航重复执行渲染包。
- 为渲染注入补充可重入清理、并发去重、限次重试和诊断上限。
- 移除插件市场的全局数组过滤改写，保留原生筛选语义。
- 补充桥接重装与渲染生命周期回归测试。

## 验证

- `npm test`：163 通过，0 失败。
- `cargo test -p codex-plus-core --test cdp_bridge --release`：157 通过，0 失败。
- `node --check assets/inject/renderer-inject.js` 与 `git diff --check` 通过。