### PR TITLE
fix: 对 Codex 恒写出 wire_api = "responses"（修复 26.901 整份配置失效回退默认模型）

### DIFF
--- a/crates/codex-plus-core/src/ccs_import.rs
+++ b/crates/codex-plus-core/src/ccs_import.rs
@@ -322,10 +322,10 @@ fn extract_toml_string_value(text: &str, key: &str) -> Option<String> {
 }
 
 fn build_config_toml(base_url: &str, api_key: &str, protocol: RelayProtocol) -> String {
-    let wire_api = match protocol {
-        RelayProtocol::Responses => "responses",
-        RelayProtocol::ChatCompletions => "chat",
-    };
+    // Codex 26.901+ 不再支持 wire_api = "chat"（openai/codex discussion #7782），
+    // Chat Completions 上游由本地协议代理转换，对 Codex 始终暴露 "responses"。
+    let _ = protocol;
+    let wire_api = "responses";
     [
         "model_provider = \"CodexPlusPlus\"".to_string(),
         String::new(),

--- a/crates/codex-plus-core/src/provider_import.rs
+++ b/crates/codex-plus-core/src/provider_import.rs
@@ -255,10 +255,11 @@ fn relay_mode(value: &str) -> RelayMode {
 }
 
 fn build_config_toml(base_url: &str, api_key: &str, protocol: RelayProtocol) -> String {
-    let wire_api = match protocol {
-        RelayProtocol::Responses => "responses",
-        RelayProtocol::ChatCompletions => "chat",
-    };
+    // Codex 26.901+ 不再支持 wire_api = "chat"（openai/codex discussion #7782），
+    // 写出 "chat" 会导致整份 config.toml 无效并回退默认。Chat Completions 上游
+    // 一律经由本地协议代理转换，对 Codex 始终暴露 "responses"。
+    let _ = protocol;
+    let wire_api = "responses";
     [
         "model_provider = \"CodexPlusPlus\"".to_string(),
         String::new(),

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -2911,14 +2911,11 @@ fn complete_relay_profile_config(profile: &RelayProfile) -> anyhow::Result<Strin
     {
         provider["name"] = toml_edit::value(transport_provider_id.as_str());
     }
-    if provider
-        .get("wire_api")
-        .and_then(Item::as_str)
-        .map(str::trim)
-        .is_none_or(str::is_empty)
-    {
-        provider["wire_api"] = toml_edit::value("responses");
-    }
+    // Codex 26.901 起不再支持 `wire_api = "chat"`（见 openai/codex discussion #7782），
+    // 一旦出现会导致整份 config.toml 被判为无效并回退内置默认模型。
+    // Chat Completions 上游由本地协议代理（protocol_proxy）负责 responses→chat 转换，
+    // 因此对 Codex 暴露的 wire_api 必须恒为 "responses"。
+    provider["wire_api"] = toml_edit::value("responses");
     if profile.relay_mode != crate::settings::RelayMode::PureApi
         && provider
             .get("requires_openai_auth")

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -1896,7 +1896,12 @@ fn apply_model_catalog_to_config(
         || entries
             .iter()
             .any(|entry| entry.suffix_window.is_some() || entry.auto_compact_percent.is_some());
-    let custom_responses = custom_responses_provider(&config_text);
+    // custom_responses_provider(&config_text) 读取的是生成后 config 里的 wire_api；
+    // 自对 Codex 恒写 "responses" 起，该信号已失真（chat 上游也会读到 responses）。
+    // catalog 是否按 Responses 语义生成取决于真实上游协议，只能由 profile.protocol 判定。
+    let custom_responses = profile.protocol == RelayProtocol::Responses
+        && active_provider_id(&parse_toml_document(&config_text)?)
+            .is_some_and(|provider_id| is_custom_provider_id(&provider_id));
     // Catalog capabilities must follow the effective config, not stale profile URLs.
     let official_deepseek_responses =
         uses_official_deepseek_responses_for_config(profile, &config_text);
@@ -2191,25 +2196,6 @@ fn uses_official_deepseek_responses_for_config(profile: &RelayProfile, config_te
     }
 
     uses_official_deepseek_responses(profile)
-}
-
-fn custom_responses_provider(config_text: &str) -> bool {
-    let Ok(doc) = parse_toml_document(config_text) else {
-        return false;
-    };
-    let Some(provider_id) = active_provider_id(&doc) else {
-        return false;
-    };
-    if !is_custom_provider_id(&provider_id) {
-        return false;
-    }
-    doc.get("model_providers")
-        .and_then(Item::as_table)
-        .and_then(|providers| providers.get(&provider_id))
-        .and_then(Item::as_table_like)
-        .and_then(|provider| provider.get("wire_api"))
-        .and_then(Item::as_str)
-        .is_some_and(|wire_api| wire_api.trim().eq_ignore_ascii_case("responses"))
 }
 
 fn copy_standard_responses_catalog(

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -4786,6 +4786,9 @@ fn apply_custom_chat_profile_preserves_generated_catalog_lite_behavior() {
         id: "relay-gpt56-chat".to_string(),
         model: "gpt-5.6-sol".to_string(),
         relay_mode: RelayMode::PureApi,
+        // 恒写 wire_api="responses" 后，生成 config 不再携带真实上游协议；
+        // catalog 的 Lite 判定改由 profile.protocol 驱动，故此处必须显式声明 Chat。
+        protocol: RelayProtocol::ChatCompletions,
         config_contents: r#"model = "gpt-5.6-sol"
 model_provider = "custom"
 


### PR DESCRIPTION
## 问题
Codex 26.901 起不再支持 `wire_api = "chat"`（见 openai/codex discussion #7782）。一旦生成的 config.toml 中出现该字段，**整份配置被判为无效**，Codex 静默回退到内置默认模型，用户侧表现为模型显示"自定义"、连接异常。

## 修复
Chat Completions 上游由本地协议代理（protocol_proxy）负责 responses→chat 转换，对 Codex 暴露的 wire_api 恒为 `"responses"`，覆盖全部三处写出路径：
- `relay_config.rs` `complete_relay_profile_config`：由"仅在为空时填充"改为无条件写出
- `provider_import.rs` `build_config_toml`：移除按协议分支写出 "chat" 的逻辑
- `ccs_import.rs` `build_config_toml`：同上

## 验证
- `cargo test -p codex-plus-core --lib`：修复涉及模块（relay_config / provider_import / ccs_import）测试全部通过；与 upstream main 对照无新增失败
- 实机回归（Codex 26.901 + Windows 11）：切换 Chat Completions 协议 Provider 后生成的 config.toml 正常生效，模型选择器显示真实模型名，不再回退"自定义"
- 完整对话链路（TUN 代理 + deepseek-v4-flash）验证通过