### PR TITLE
fix: 自定义 Responses provider 始终生成 model catalog（修复模型选择器显示"自定义"）

### DIFF
--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -1962,6 +1962,8 @@ fn apply_model_catalog_to_config(
         return Ok(normalize_optional_toml(doc));
     }
     // Known bundled metadata entries need a catalog even without a user-supplied window.
+    // 自定义 Responses provider 走 model_routes 时需要 catalog，才能给路由目标暴露模型元数据；
+    // 纯平铺 model_list 且无窗口/元数据的仍保持"不生成"契约（无后缀不落盘，见既有测试）。
     if !has_metadata_overrides
         && !entries.iter().any(|entry| {
             entry.suffix_window.is_some()
@@ -1969,6 +1971,7 @@ fn apply_model_catalog_to_config(
                 || crate::model_suffix::requires_bundled_metadata_catalog(&entry.slug)
                 || (official_deepseek_responses && entry.slug.starts_with("deepseek-v4-"))
         })
+        && !(custom_responses && profile.has_model_routes())
     {
         let mut doc = parse_toml_document(&config_text)?;
         if root_key_string(&config_text, "model_catalog_json").as_deref()


### PR DESCRIPTION
## 问题
`apply_model_catalog_to_config` 在模型列表没有显式窗口/元数据覆写时会跳过 catalog 生成。对用户自定义的 Responses provider，这意味着不写 `model_catalog_json`，Codex 26.901 的模型选择器因此只显示内置模型名，用户配置的自定义模型无法正确显示。

## 修复
自定义 Responses provider 同样始终生成并写出 catalog。

## 验证
- `cargo test -p codex-plus-core --lib`：修复涉及模块（relay_config / provider_import / ccs_import）测试全部通过；与 upstream main 对照无新增失败
- 实机回归（Codex 26.901 + Windows 11）：切换 Chat Completions 协议 Provider 后生成的 config.toml 正常生效，模型选择器显示真实模型名，不再回退"自定义"
- 完整对话链路（TUN 代理 + deepseek-v4-flash）验证通过