### PR TITLE
fix: Windows 下从 AppxManifest.xml 读取 Application Id,修复重启报错 0x80270254 (#2148)

### DIFF
--- a/crates/codex-plus-core/src/app_paths.rs
+++ b/crates/codex-plus-core/src/app_paths.rs
@@ -491,7 +491,54 @@ pub fn packaged_app_user_model_id(app_dir: &Path) -> Option<String> {
     if publisher_id.is_empty() {
         return None;
     }
-    Some(format!("{}_{publisher_id}!{}", spec.identity, spec.app_id))
+    // 新版 ChatGPT-Desktop 可能改变包内 Application Id（参见 #2148 的 0x80270254 报错），
+    // 这里优先读取真实 manifest，读取失败再回退到历史硬编码值。
+    let app_id = packaged_manifest_app_id(app_dir).unwrap_or_else(|| spec.app_id.to_string());
+    Some(format!("{}_{publisher_id}!{app_id}", spec.identity))
+}
+
+fn packaged_manifest_app_id(app_dir: &Path) -> Option<String> {
+    let package_dir = if app_dir
+        .file_name()
+        .is_some_and(|name| name.eq_ignore_ascii_case("app"))
+    {
+        app_dir.parent()?
+    } else {
+        app_dir
+    };
+    let manifest = std::fs::read_to_string(package_dir.join("AppxManifest.xml")).ok()?;
+    manifest_first_application_id(&manifest)
+}
+
+// AppxManifest.xml 中第一个 <Application> 节点的 Id，即 AUMID 感叹号后的部分。
+fn manifest_first_application_id(manifest: &str) -> Option<String> {
+    let mut rest = manifest;
+    while let Some(pos) = rest.find("<Application") {
+        rest = &rest[pos + "<Application".len()..];
+        // 跳过 <Applications> 等容器节点，只处理 <Application ...>。
+        if !rest.chars().next().is_some_and(char::is_whitespace) {
+            continue;
+        }
+        let tag_end = rest.find('>')?;
+        if let Some(id) = xml_attribute_value(&rest[..tag_end], "Id") {
+            return Some(id);
+        }
+        rest = &rest[tag_end..];
+    }
+    None
+}
+
+fn xml_attribute_value(tag: &str, name: &str) -> Option<String> {
+    for segment in tag.split_whitespace() {
+        let Some((attr, value)) = segment.split_once('=') else {
+            continue;
+        };
+        if attr != name {
+            continue;
+        }
+        return Some(value.trim_matches('"').trim_matches('\'').to_string());
+    }
+    None
 }
 
 fn package_name_from_app_dir(app_dir: &Path) -> Option<String> {

--- a/crates/codex-plus-core/tests/launcher.rs
+++ b/crates/codex-plus-core/tests/launcher.rs
@@ -686,6 +686,49 @@ fn launcher_packaged_activation_appends_extra_codex_arguments() {
 }
 
 #[test]
+fn packaged_app_user_model_id_reads_application_id_from_manifest() {
+    // 新版 ChatGPT Desktop 可能调整 manifest 中的 Application Id（见 issue #2148）。
+    let temp = tempfile::tempdir().unwrap();
+    let package_dir = temp
+        .path()
+        .join("OpenAI.ChatGPT-Desktop_1.2026.190.0_x64__2p2nqsd0c76g0");
+    let app_dir = package_dir.join("app");
+    std::fs::create_dir_all(&app_dir).unwrap();
+    std::fs::write(
+        package_dir.join("AppxManifest.xml"),
+        concat!(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+            "<Package xmlns=\"http://schemas.microsoft.com/appx/manifest/foundation/windows10\"> ",
+            "<Applications><Application Id=\"ChatGPTDesktop\" ",
+            "Executable=\"app\\ChatGPT.exe\" EntryPoint=\"Windows.FullTrustApplication\"/>",
+            "</Applications></Package>"
+        ),
+    )
+    .unwrap();
+
+    assert_eq!(
+        packaged_app_user_model_id(&app_dir).as_deref(),
+        Some("OpenAI.ChatGPT-Desktop_2p2nqsd0c76g0!ChatGPTDesktop")
+    );
+}
+
+#[test]
+fn packaged_app_user_model_id_falls_back_to_default_id_without_manifest() {
+    // manifest 缺失/不可读时保持旧行为（仍使用历史默认值 "App"）。
+    let temp = tempfile::tempdir().unwrap();
+    let package_dir = temp
+        .path()
+        .join("OpenAI.Codex_26.506.2212.0_x64__2p2nqsd0c76g0");
+    let app_dir = package_dir.join("app");
+    std::fs::create_dir_all(&app_dir).unwrap();
+
+    assert_eq!(
+        packaged_app_user_model_id(&app_dir).as_deref(),
+        Some("OpenAI.Codex_2p2nqsd0c76g0!App")
+    );
+}
+
+#[test]
 fn launcher_packaged_activation_adds_native_menu_inspector_argument() {
     let app_dir = PathBuf::from(
         r"C:\Program Files\WindowsApps\OpenAI.Codex_26.506.2212.0_x64__2p2nqsd0c76g0\app",


### PR DESCRIPTION
## 问题

Windows 上升级 Codex++ 到 1.30 后,点击「重启 Codex++」报错
`此应用不支持指定的合约或未安装该应用。 (0x80270254)`,
Codex 无法通过管理工具启动(见 #2148)。

## 根因

`packaged_app_user_model_id` 将 AUMID 的应用段硬编码为 `App`
(如 `OpenAI.ChatGPT-Desktop_2p2nqsd0c76g0!App`)。而用户环境里的
ChatGPT Desktop `1.2026.190.0` 更新后,包内 `AppxManifest.xml`
声明的 `<Application Id=...>` 已不再是 `App`,于是
`IApplicationActivationManager::ActivateApplication`
找不到该合约,直接返回 0x80270254。

## 修复

`packaged_app_user_model_id` 改为优先读取已安装包的
`AppxManifest.xml`,取第一个 `<Application>` 节点的 `Id`
(正确跳过 `<Applications>` 容器节点),动态拼接 AUMID;

- manifest 缺失或读取失败时,回退到原有的 `spec.app_id` 默认值,
  行为与之前完全一致(对 `OpenAI.Codex` / `CodexBeta` 无影响);
- 错误路径比原来多了一次同包内文件的 `read_to_string`,
  无额外权限要求(WindowsApps 下的 manifest 本来就对本地用户可读)。

## 测试

- 新增 `packaged_app_user_model_id_reads_application_id_from_manifest`:
  在临时目录构造 `ChatGPT-Desktop_1.2026.190.0` 包,
  manifest 里 `Id="ChatGPTDesktop"`,验证 AUMID 以新值结尾;
- 新增 `packaged_app_user_model_id_falls_back_to_default_id_without_manifest`:
  无 manifest 时仍返回 `...!App`,保证向后兼容;
- `cargo test -p codex-plus-core --test launcher` 全部通过
  (本地 `app_paths_resolves_portable_current_link_to_directory_version`
  在未修改的基线上同样失败,与本次改动无关)。

## 局限说明

若上游更新还同步修改了其他激活契约(如包名本身变化),本 PR 不覆盖;
但当前报错用户环境的 manifest Id 变更已由本 PR 覆盖,
且回退路径保持原行为,不会引入回归。
