### PR TITLE
feat: 激活失败回退到直接执行并记录诊断 aumid (#2148)

### DIFF
--- a/apps/codex-plus-launcher/src/main.rs
+++ b/apps/codex-plus-launcher/src/main.rs
@@ -66,6 +66,7 @@ async fn main() -> Result<()> {
                 codex_app: options
                     .app_dir
                     .map(|path| path.to_string_lossy().to_string()),
+                aumid: None,
             });
         }
         return Err(error);
@@ -92,6 +93,7 @@ async fn launcher_main(args: Vec<String>, helper_only: bool, options: LaunchOpti
             codex_app: options
                 .app_dir
                 .map(|path| path.to_string_lossy().to_string()),
+            aumid: None,
         })?;
         return Ok(());
     };

--- a/apps/codex-plus-manager/src-tauri/src/commands.rs
+++ b/apps/codex-plus-manager/src-tauri/src/commands.rs
@@ -972,6 +972,7 @@ fn requested_launch_status(
         helper_port: Some(request.helper_port),
         codex_app: (!request.app_path.trim().is_empty())
             .then(|| request.app_path.trim().to_string()),
+        aumid: None,
     }
 }
 

--- a/apps/codex-plus-manager/src/App.tsx
+++ b/apps/codex-plus-manager/src/App.tsx
@@ -182,6 +182,7 @@ type LaunchStatus = {
   debug_port: number | null;
   helper_port: number | null;
   codex_app: string | null;
+  aumid: string | null;
 };
 
 type OverviewResult = CommandResult<{
@@ -9435,6 +9436,7 @@ function LatestLaunch({ status }: { status: LaunchStatus | null }) {
       <Metric label="Debug" value={String(status.debug_port ?? "-")} />
       <Metric label="Helper" value={String(status.helper_port ?? "-")} />
       <Metric label={t("时间")} value={formatTime(status.started_at_ms)} />
+      {status.aumid && <Metric label="AUMID" value={status.aumid} />}
     </div>
   );
 }

--- a/crates/codex-plus-core/src/launcher.rs
+++ b/crates/codex-plus-core/src/launcher.rs
@@ -829,23 +829,38 @@ impl LaunchHooks for DefaultLaunchHooks {
                 else {
                     unreachable!();
                 };
-                let process_id = activate_packaged_app(app_user_model_id, arguments).await?;
-                apply_codexplusplus_window_icon_after_launch(process_id);
-                if let Some(inspector_port) = native_menu_inspector_port {
-                    start_native_menu_localizer(inspector_port);
+                match activate_packaged_app(app_user_model_id, arguments).await {
+                    Ok(process_id) => {
+                        apply_codexplusplus_window_icon_after_launch(process_id);
+                        if let Some(inspector_port) = native_menu_inspector_port {
+                            start_native_menu_localizer(inspector_port);
+                        }
+                        return Ok(match activation {
+                            CodexLaunch::PackagedActivation {
+                                app_user_model_id,
+                                arguments,
+                                ..
+                            } => CodexLaunch::PackagedActivation {
+                                app_user_model_id,
+                                arguments,
+                                process_id: Some(process_id),
+                            },
+                            CodexLaunch::Process { .. } => unreachable!(),
+                        });
+                    }
+                    Err(error) => {
+                        // AUMID 激活失败（例如清单 Application Id 变化）时回退到
+                        // 直接执行应用，避免整份配置无法启动。
+                        let _ = crate::diagnostic_log::append_diagnostic_log(
+                            "launcher.packaged_activation_fallback",
+                            serde_json::json!({
+                                "app_user_model_id": app_user_model_id,
+                                "app_dir": app_dir,
+                                "error": error.to_string()
+                            }),
+                        );
+                    }
                 }
-                return Ok(match activation {
-                    CodexLaunch::PackagedActivation {
-                        app_user_model_id,
-                        arguments,
-                        ..
-                    } => CodexLaunch::PackagedActivation {
-                        app_user_model_id,
-                        arguments,
-                        process_id: Some(process_id),
-                    },
-                    CodexLaunch::Process { .. } => unreachable!(),
-                });
             }
         }
 
@@ -3131,6 +3146,7 @@ fn launch_status(
         debug_port: Some(debug_port),
         helper_port: Some(helper_port),
         codex_app: Some(app_dir.to_string_lossy().to_string()),
+        aumid: crate::app_paths::packaged_app_user_model_id(app_dir),
     }
 }
 

--- a/crates/codex-plus-core/src/status.rs
+++ b/crates/codex-plus-core/src/status.rs
@@ -11,6 +11,7 @@ pub struct LaunchStatus {
     pub debug_port: Option<u16>,
     pub helper_port: Option<u16>,
     pub codex_app: Option<String>,
+    pub aumid: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -77,6 +78,7 @@ mod tests {
             debug_port: Some(9222),
             helper_port: Some(4545),
             codex_app: Some("Codex".to_string()),
+            aumid: Some("OpenAI.Codex_abc!App".to_string()),
         };
 
         store.save_latest(&status).unwrap();


### PR DESCRIPTION
这是对已合并的 #2154 (manifest Application Id 动态读取) 的增量增强,基于上游最新 main。

## 变更内容

1. **PackagedActivation 激活失败时回退到直接启动 Codex exe**
   - `launch_codex` 中 `activate_packaged_app` 失败不再 `?` 直接抛错,而是记录一条 `launcher.packaged_activation_fallback` 诊断日志后,落到后面的 `Process` 分支直接启动应用。
   - 即使未来 OpenAI 再调整 Application Id / 激活契约,Codex++ 也不会卡死在 0x80270254,而是至少能启动并让用户继续用。

2. **启动状态/诊断报告新增 `aumid` 字段**
   - `LaunchStatus` 新增 `aumid: Option<String>`,`launch_status()` 从 `app_dir` 自动推导 AUMID(老包 `OpenAI.Codex_...!App`、新包 `OpenAI.ChatGPT-Desktop_...!ChatGPT`)。
   - `latest-status.json` 与概览诊断 JSON 的 `overview.latest_launch` 会直接带出真实 AUMID,管理器概览页也会显示 AUMID;用户贴诊断报告即可定位,无需再手动跑 PowerShell。

## 测试

- `cargo test -p codex-plus-core --all-features --test launcher`:88 passed(含 #2154 新增的 manifest 读取/回退测试,以及现有激活流程测试)
- `cargo test -p codex-plus-core --lib status`:14 passed

关联: #2148 #2154