### PR TITLE
fix: clear relay context limits for official mode

### DIFF
--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -829,6 +829,8 @@ pub fn clear_relay_config_to_home_with_auth(
         "OPENAI_API_KEY",
         "model_provider",
         "model_catalog_json",
+        "model_context_window",
+        "model_auto_compact_token_limit",
         "base_url",
         "experimental_bearer_token",
         "env_key",

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -2601,6 +2601,8 @@ fn clear_relay_config_removes_model_provider_and_preserves_other_config() {
         temp.path().join("config.toml"),
         r#"model = "gpt-5"
 model_provider = "custom"
+model_context_window = 262144
+model_auto_compact_token_limit = 200000
 [model_providers.custom]
 name = "custom"
 wire_api = "responses"
@@ -2637,6 +2639,8 @@ model = "gpt-5-mini"
     assert!(updated.contains(r#"model = "gpt-5""#));
     assert!(!updated.contains("model_provider ="));
     assert!(!updated.contains("model_catalog_json"));
+    assert!(!updated.contains("model_context_window"));
+    assert!(!updated.contains("model_auto_compact_token_limit"));
     assert!(!updated.contains("OPENAI_API_KEY"));
     assert!(updated.contains("[model_providers.custom]"));
     assert!(updated.contains(r#"wire_api = "responses""#));


### PR DESCRIPTION
## 问题

从中转 provider 切换到纯官方登录时，`clear_relay_config_to_home_with_auth()` 会移除 `model_catalog_json`，但会保留此前中转写入的 `model_context_window` 和 `model_auto_compact_token_limit`。

例如中转站 A 使用 256K 上下文后，切换到官方模式仍可能继续使用该全局上限，而不是恢复官方模式自己的配置。

## 修改

在清理纯官方模式的中转配置时，同时移除：

- `model_context_window`
- `model_auto_compact_token_limit`

并扩展现有回归测试，验证 256K 中转上下文与自动压缩阈值均会被清理。

## 验证

```powershell
cargo test -p codex-plus-core --test relay_config clear_relay_config_removes_model_provider_and_preserves_other_config
```

结果：`1 passed; 0 failed`。
