### PR TITLE
fix(floating-panel): hide content until shell morph settles

### DIFF
--- a/apps/codex-plus-manager/src/renderer-inject.test.ts
+++ b/apps/codex-plus-manager/src/renderer-inject.test.ts
@@ -30,6 +30,31 @@ async function readStepwiseSource() {
   return `(() => {\n${fragments.join("\n")}\n})();\n`;
 }
 
+it("only reveals floating-panel content after the shell has settled open", async () => {
+  const source = await readFile(
+    new URL("../../../assets/inject/floating-panel/core/appearance.js", import.meta.url),
+    "utf8",
+  );
+  const panelRules = Array.from(
+    source.replace(/\$\{[^}]+\}/g, "0").matchAll(/(?:^|\n)\s*([^{}\n]*\.csw-panel)\s*\{([^}]+)\}/g),
+    ([, selector, declarations]) => ({ selector: selector.trim(), declarations }),
+  );
+  const hidden = panelRules.find((rule) => rule.selector === ".csw-panel");
+  assert.ok(hidden, "panel needs a hidden default for collapsed and interrupted states");
+  assert.match(hidden.declarations, /opacity:\s*0\s*;/);
+  assert.match(hidden.declarations, /visibility:\s*hidden\s*;/);
+  assert.match(hidden.declarations, /transition:\s*none\s*!important\s*;/);
+
+  const visible = panelRules.filter((rule) =>
+    /opacity:\s*1\s*;|visibility:\s*visible\s*;/.test(rule.declarations),
+  );
+  assert.ok(visible.length > 0, "settled content must remain visible");
+  for (const rule of visible) {
+    assert.ok(rule.selector.includes('[data-open="true"]'), rule.selector);
+    assert.ok(rule.selector.includes('[data-morphing="false"]'), rule.selector);
+  }
+});
+
 type FakeElementOptions = {
   className?: string;
   dismissLabel?: string;

--- a/assets/inject/floating-panel/core/appearance.js
+++ b/assets/inject/floating-panel/core/appearance.js
@@ -731,6 +731,8 @@
         pointer-events: none;
         position: absolute;
         inset: 0;
+        /* Host-wide transitions must not delay hiding or revealing panel content. */
+        transition: none !important;
         visibility: hidden;
         will-change: clip-path;
         z-index: 2;
@@ -745,15 +747,11 @@
         filter: none !important;
       }
 
+      /* Reveal content only after the shell settles. During either morph direction,
+         clip-path alone can leave composited text painted outside the moving shell. */
       .csw-popover[data-open="true"][data-morphing="false"] .csw-panel {
         opacity: 1;
         pointer-events: auto;
-        visibility: visible;
-      }
-
-      .csw-popover[data-morphing="true"] .csw-panel {
-        opacity: 1;
-        pointer-events: none;
         visibility: visible;
       }
 

--- a/assets/inject/floating-panel/runtime/state.js
+++ b/assets/inject/floating-panel/runtime/state.js
@@ -31,7 +31,7 @@
   const PAYLOAD_ATTR = "data-codex-stepwise-payload";
   const MARK_ATTR = "data-codex-stepwise-outline-id";
   const HIGHLIGHT_CLASS = "codex-stepwise-outline-target-flash";
-  const SCRIPT_VERSION = "2.0.7";
+  const SCRIPT_VERSION = "2.0.8";
   const PAGE_BRIDGE = "__codexSessionDeleteBridge";
   const CONVERSATION_TURN_SELECTOR = "div.contents[data-content-search-turn-key]";
   const POPOVER_ID = "codex-stepwise-popover";


### PR DESCRIPTION
展开悬浮窗时，内容会在外壳展开完成前提前出现；收拢时，即使计算样式中的 `clip-path` 已随外壳缩小，设置文字仍可能残留在外壳之外。

本次修复让内容默认隐藏，仅在外壳完全展开后显示，并禁用面板自身的 CSS 过渡，避免宿主的全局过渡规则延迟内容显隐。保留现有外壳动画的速度和路径，将注入脚本版本更新为 `2.0.8`，并补充显隐规则的回归检查。
