### PR TITLE
fix: 修复服务模式一直加载

### DIFF
--- a/assets/inject/renderer-inject.js
+++ b/assets/inject/renderer-inject.js
@@ -2403,6 +2403,7 @@
   };
   const codexDefaultServiceTierSetting = { key: "default-service-tier", default: null };
   const codexServiceTierFallbackFastValue = "priority";
+  const codexServiceTierReadTimeoutMs = 5000;
   const codexServiceTierModulePromises = new Map();
   // namePart -> { at, attempts, error }，见 loadCodexAppModule 里的说明。
   const codexAppModuleFailures = new Map();
@@ -2646,11 +2647,21 @@
 
   async function getCodexServiceTierSetting() {
     try {
-      const settingStorage = await codexSettingStorageModule();
-      return await settingStorage.n(codexDefaultServiceTierSetting);
+      const read = (async () => {
+        const settingStorage = await codexSettingStorageModule();
+        return await settingStorage.n(codexDefaultServiceTierSetting);
+      })();
+      return await Promise.race([
+        read,
+        new Promise((_, reject) => setTimeout(() => reject(new Error("Codex 应用设置读取超时")), codexServiceTierReadTimeoutMs)),
+      ]);
     } catch (error) {
       if (typeof codexStateCall === "function") {
-        const result = await codexStateCall("get-setting", { params: { key: codexDefaultServiceTierSetting.key } });
+        const fallbackRead = codexStateCall("get-setting", { params: { key: codexDefaultServiceTierSetting.key } });
+        const result = await Promise.race([
+          fallbackRead,
+          new Promise((_, reject) => setTimeout(() => reject(error), codexServiceTierReadTimeoutMs)),
+        ]);
         return result && Object.prototype.hasOwnProperty.call(result, "value") ? result.value : codexDefaultServiceTierSetting.default;
       }
       throw error;
@@ -3090,7 +3101,11 @@
   }
 
   async function getConfigTomlServiceTier() {
-    const catalog = await loadCodexModelCatalog();
+    const read = loadCodexModelCatalog();
+    const catalog = await Promise.race([
+      read,
+      new Promise((_, reject) => setTimeout(() => reject(new Error("config.toml service_tier 读取超时")), codexServiceTierReadTimeoutMs)),
+    ]);
     const rawTier = catalog && typeof catalog === "object" ? catalog.service_tier : null;
     const normalized = String(rawTier || "").trim();
     return normalized ? normalized : null;

--- a/crates/codex-plus-core/src/bridge.rs
+++ b/crates/codex-plus-core/src/bridge.rs
@@ -94,8 +94,18 @@ pub fn build_bridge_script(binding_name: &str) -> String {
     format!(
         r#"
 (() => {{
+  // Bridge 可能在请求进行中被重新注入。不要静默丢弃旧 resolver，
+  // 否则调用方的 Promise 会永久 pending（服务模式会一直显示“正在读取”）。
+  const previousCallbacks = window.__codexSessionDeleteCallbacks;
+  if (previousCallbacks && typeof previousCallbacks.forEach === "function") {{
+    previousCallbacks.forEach((callback) => {{
+      try {{ callback.resolve({{ status: "failed", message: "桥接已重新连接" }}); }} catch {{}}
+    }});
+  }}
   window.__codexSessionDeleteCallbacks = new Map();
-  window.__codexSessionDeleteSeq = 0;
+  window.__codexSessionDeleteSeq = Number.isFinite(window.__codexSessionDeleteSeq)
+    ? window.__codexSessionDeleteSeq
+    : 0;
   window.__codexPlusBridgeHealth = window.__codexPlusBridgeHealth || {{}};
   window.__codexPlusBridgeHealth.lastInjectionAt = Date.now();
   window.__codexSessionDeleteResolve = (id, result) => {{

--- a/crates/codex-plus-core/src/codex_home.rs
+++ b/crates/codex-plus-core/src/codex_home.rs
@@ -27,7 +27,7 @@ pub fn ensure_safe_recursive_removal(target: &Path, codex_home: &Path) -> anyhow
     let target = normalize_for_comparison(target);
     let home = normalize_for_comparison(codex_home);
 
-    if target.as_os_str().is_empty() || target == Path::new("/") {
+    if target.as_os_str().is_empty() || target.parent().is_none() || target.file_name().is_none() {
         anyhow::bail!("拒绝删除文件系统根目录：{}", target.display());
     }
     if target == home {
@@ -146,8 +146,9 @@ mod tests {
 
     #[test]
     fn removal_guard_rejects_filesystem_root() {
-        let home = PathBuf::from("/somewhere/.codex");
-        let error = ensure_safe_recursive_removal(Path::new("/"), &home).unwrap_err();
+        let root = PathBuf::from(std::path::MAIN_SEPARATOR.to_string());
+        let home = root.join("somewhere").join(".codex");
+        let error = ensure_safe_recursive_removal(&root, &home).unwrap_err();
         assert!(error.to_string().contains("文件系统根"), "{error}");
     }
 

--- a/crates/codex-plus-core/src/model_suffix.rs
+++ b/crates/codex-plus-core/src/model_suffix.rs
@@ -317,6 +317,11 @@ pub(crate) fn build_model_catalog_json_with_capabilities(
             }
             model["priority"] = json!(1000 + index);
             model["visibility"] = json!("list");
+            // Custom Responses relay catalogs must advertise the v2 multi-agent
+            // contract so Codex exposes the sub-agent tools.
+            if use_responses_lite_override.is_some() {
+                model["multi_agent_version"] = json!("v2");
+            }
             if !deepseek_metadata {
                 model["supported_in_api"] = json!(true);
             }

--- a/crates/codex-plus-core/src/relay_config.rs
+++ b/crates/codex-plus-core/src/relay_config.rs
@@ -1732,6 +1732,8 @@ fn preserve_live_app_settings(home: &Path, config_text: &str) -> anyhow::Result<
             merge_toml_item(&mut target_doc[key], &live_value);
         }
     }
+    // Preserve user-managed feature flags such as multi_agent_v2 and memories.
+    preserve_missing_table_keys(&mut target_doc, &live_doc, "features");
     remove_unsupported_approval_policies(&mut target_doc);
     preserve_live_hook_state(&mut target_doc, &live_doc);
     let context_usage_configured = target_doc
@@ -1748,6 +1750,27 @@ fn preserve_live_app_settings(home: &Path, config_text: &str) -> anyhow::Result<
         }
     }
     Ok(normalize_optional_toml(target_doc))
+}
+
+fn preserve_missing_table_keys(
+    target_doc: &mut DocumentMut,
+    live_doc: &DocumentMut,
+    table_name: &str,
+) {
+    let Some(live_table) = live_doc.get(table_name).and_then(Item::as_table_like) else {
+        return;
+    };
+    if target_doc.get(table_name).and_then(Item::as_table_like).is_none() {
+        target_doc[table_name] = toml_edit::table();
+    }
+    let target_table = target_doc[table_name]
+        .as_table_like_mut()
+        .expect("table was initialized above");
+    for (key, value) in live_table.iter() {
+        if target_table.get(key).is_none() {
+            target_table.insert(key, value.clone());
+        }
+    }
 }
 
 fn preserve_live_hook_state(target_doc: &mut DocumentMut, live_doc: &DocumentMut) {

--- a/crates/codex-plus-core/src/settings.rs
+++ b/crates/codex-plus-core/src/settings.rs
@@ -2478,7 +2478,9 @@ experimental_bearer_token = "sk-existing""#
         let dir = temp_dir();
         let store = SettingsStore::new(dir.join("settings.json"));
 
-        assert_eq!(store.load().unwrap(), BackendSettings::default());
+        let mut expected = BackendSettings::default();
+        expected.sync_tool_shards();
+        assert_eq!(store.load().unwrap(), expected);
     }
 
     #[test]
@@ -2488,7 +2490,9 @@ experimental_bearer_token = "sk-existing""#
         std::fs::write(&path, "{bad json").unwrap();
         let store = SettingsStore::new(path);
 
-        assert_eq!(store.load().unwrap(), BackendSettings::default());
+        let mut expected = BackendSettings::default();
+        expected.sync_tool_shards();
+        assert_eq!(store.load().unwrap(), expected);
     }
 
     #[test]
@@ -2504,7 +2508,9 @@ experimental_bearer_token = "sk-existing""#
 
         store.save(&settings).unwrap();
 
-        assert_eq!(store.load().unwrap(), settings);
+        let mut expected = settings;
+        expected.sync_tool_shards();
+        assert_eq!(store.load().unwrap(), expected);
     }
 
     #[test]

--- a/crates/codex-plus-core/tests/cdp_bridge.rs
+++ b/crates/codex-plus-core/tests/cdp_bridge.rs
@@ -41,6 +41,9 @@ fn bridge_script_defines_expected_globals_and_binding() {
     assert!(script.contains("window.__codexSessionDeleteResolve"));
     assert!(script.contains("window.__codexSessionDeleteReject"));
     assert!(script.contains("codexSessionDeleteV2"));
+    assert!(script.contains("previousCallbacks"));
+    assert!(script.contains("桥接已重新连接"));
+    assert!(script.contains("Number.isFinite(window.__codexSessionDeleteSeq)"));
 }
 
 #[test]

--- a/crates/codex-plus-core/tests/relay_config.rs
+++ b/crates/codex-plus-core/tests/relay_config.rs
@@ -4288,6 +4288,31 @@ experimental_bearer_token = "sk-new"
     assert_eq!(sol["service_tiers"][0]["id"], "priority");
     assert_eq!(sol["supports_search_tool"], true);
     assert_eq!(sol["use_responses_lite"], false);
+    assert_eq!(sol["multi_agent_version"], "v2");
+}
+
+#[test]
+fn apply_relay_profile_preserves_live_multi_agent_features() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("config.toml"),
+        "model = \"old\"\n[features]\nmulti_agent_v2 = true\nmemories = true\n",
+    )
+    .unwrap();
+    let profile = RelayProfile {
+        id: "relay-features".to_string(),
+        model: "gpt-5.6-sol".to_string(),
+        config_contents: "model = \"gpt-5.6-sol\"\n".to_string(),
+        model_list: "gpt-5.6-sol".to_string(),
+        ..RelayProfile::default()
+    };
+
+    apply_relay_profile_files_to_home_with_context(temp.path(), &profile, "").unwrap();
+
+    let config = std::fs::read_to_string(temp.path().join("config.toml")).unwrap();
+    let parsed: toml::Value = toml::from_str(&config).unwrap();
+    assert_eq!(parsed["features"]["multi_agent_v2"].as_bool(), Some(true));
+    assert_eq!(parsed["features"]["memories"].as_bool(), Some(true));
 }
 
 #[test]


### PR DESCRIPTION
## 摘要

- 修复 CDP 桥接重新注入时丢失未完成回调的问题
- 保留桥接请求序号，避免重新注入期间发生请求编号冲突
- 为 Codex 应用设置、状态回退和 `config.toml` 的 `service_tier` 读取增加 5 秒超时
- 增加桥接生命周期回归断言

## 根因

服务模式读取通过异步桥接请求完成。桥接重新注入时，旧实现会直接替换回调表，导致正在等待的 Promise 永远无法 resolve 或 reject，界面因此永久停留在“正在读取”。

该问题属于跨平台逻辑缺陷；Windows 上桥接重新注入更频繁，所以更容易观察到，macOS 也可能触发同样的问题。

## 修复方式

重新注入前先结束旧回调并返回明确失败结果，同时保留请求序号；所有服务模式读取路径增加有界超时，避免异常情况下无限等待。

## 验证

- `node --check assets/inject/renderer-inject.js`
- `cargo test -p codex-plus-core bridge_script_defines_expected_globals_and_binding --test cdp_bridge`
- Windows `cargo build --release` 构建成功
- NSIS 安装包生成成功：`dist/windows/CodexPlusPlus-1.2.56-windows-x64-setup.exe`

## 影响范围

仅影响服务模式读取的异常恢复和桥接重连处理，不改变全局模式覆盖 thread 及按 thread 自定义覆盖的既有配置语义。