### PR TITLE
fix(proxy): use adaptive thinking for Kimi K3

### DIFF
--- a/crates/codex-plus-core/src/protocol_proxy.rs
+++ b/crates/codex-plus-core/src/protocol_proxy.rs
@@ -4945,7 +4945,11 @@ fn apply_chat_reasoning_options(result: &mut Value, body: &Value, model: &str) {
     match style {
         ChatReasoningStyle::Thinking => {
             result["thinking"] = json!({
-                "type": if reasoning_enabled { "enabled" } else { "disabled" }
+                "type": if reasoning_enabled {
+                    kimi_thinking_enabled_type(model)
+                } else {
+                    "disabled"
+                }
             });
         }
         ChatReasoningStyle::EnableThinking => {
@@ -5085,7 +5089,15 @@ fn map_chat_reasoning_effort(effort: &str, style: ChatReasoningStyle) -> Option<
 /// 仍只发 thinking 开关。
 fn is_kimi_coding_model(model: &str) -> bool {
     let model = model.to_ascii_lowercase();
-    model.starts_with("k3") || model.contains("for-coding")
+    model.starts_with("k3") || model.contains("kimi-k3") || model.contains("for-coding")
+}
+
+fn kimi_thinking_enabled_type(model: &str) -> &'static str {
+    if is_kimi_coding_model(model) {
+        "adaptive"
+    } else {
+        "enabled"
+    }
 }
 
 fn supports_reasoning_effort(model: &str) -> bool {

--- a/crates/codex-plus-core/tests/protocol_proxy.rs
+++ b/crates/codex-plus-core/tests/protocol_proxy.rs
@@ -309,9 +309,18 @@ fn responses_request_maps_kimi_coding_reasoning_effort_per_official_spec() {
             "input": "hi"
         }))
         .unwrap();
-        assert_eq!(converted["thinking"]["type"], "enabled", "{effort}");
+        assert_eq!(converted["thinking"]["type"], "adaptive", "{effort}");
         assert_eq!(converted["reasoning_effort"], expected, "{effort}");
     }
+
+    let kimi_k3 = responses_to_chat_completions(json!({
+        "model": "kimi-k3",
+        "reasoning": { "effort": "xhigh" },
+        "input": "hi"
+    }))
+    .unwrap();
+    assert_eq!(kimi_k3["thinking"]["type"], "adaptive");
+    assert_eq!(kimi_k3["reasoning_effort"], "max");
 
     let k2_coding = responses_to_chat_completions(json!({
         "model": "kimi-for-coding",


### PR DESCRIPTION
## ??

Chat Completions ????????,? `kimi-k3` ???? `thinking.type = "enabled"`?????/??????? `adaptive` ? `disabled`,???????:

```text
invalid params, invalid thinking.type: "enabled" (allowed: adaptive, disabled)
```

## ??

- ? `kimi-k3` ?? Kimi coding ?????
- Kimi coding ????????? `thinking.type = "adaptive"`?
- ????????????? `"enabled"` ???
- ? `kimi-k3` ? `xhigh -> reasoning_effort = "max"` ???????

## ??

```text
cargo test -p codex-plus-core --test protocol_proxy
test result: ok. 96 passed; 0 failed
```